### PR TITLE
Bug fix for bug # 1124129

### DIFF
--- a/config/hibernate.cfg.xml
+++ b/config/hibernate.cfg.xml
@@ -29,7 +29,7 @@
 <!DOCTYPE hibernate-configuration PUBLIC
         "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
 
- "http://www.hibernate.org/dtd/">
+ "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 


### PR DESCRIPTION
The DTD path was changed from http://hibernate.sourceforge.net/ to http://www.hibernate.org/dtd/ in 1.10.x, but the DTD file name got lost. This results in runtime and validation errors. I re-added the DTD file name.
