### PR TITLE
Bug fix for bug # 1124212

### DIFF
--- a/src/org/goobi/mq/processors/CreateNewProcessProcessor.java
+++ b/src/org/goobi/mq/processors/CreateNewProcessProcessor.java
@@ -368,14 +368,15 @@ public class CreateNewProcessProcessor extends ActiveMQProcessor {
 	 */
 	protected void setAdditionalField(ProzesskopieForm inputForm, String key, String value) throws RuntimeException {
 
+		boolean unknownField = true;
 		for (AdditionalField field : inputForm.getAdditionalFields()) {
 			if (key.equals(field.getTitel())) {
 				field.setWert(value);
-				return;
+				unknownField = false;
 			}
 		}
 
-		throw new RuntimeException("Couldn’t set “" + key + "” to “" + value + "”: No such field in record.");
+		if (unknownField) throw new RuntimeException("Couldn’t set “" + key + "” to “" + value + "”: No such field in record.");
 	}
 
 }


### PR DESCRIPTION
CreateNewProcessProcessor.setAdditionalField() was based on the
assumption that each entry in List ProzesskopieForm.additionalField
would exist at most once. This is not always true, and in this case only
the first occurence got populated. This fix seems to do it right now.
