### PR TITLE
bugfix lp:1158811

### DIFF
--- a/src/de/unigoettingen/sub/search/opac/GetOpac.java
+++ b/src/de/unigoettingen/sub/search/opac/GetOpac.java
@@ -25,7 +25,6 @@ package de.unigoettingen.sub.search.opac;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -445,7 +444,7 @@ public class GetOpac {
 		// get pica longtitle
 		int retrieveNumber = numberOfHits + 1;
 		return retrieveDataFromOPAC(DATABASE_URL + cat.getDataBase() + PICAPLUS_XML_URL + data_character_encoding + SET_ID_URL
-				+ lastOpacResult.getSet() + SESSIONID_URL + URLEncoder.encode(lastOpacResult.getSessionId(), URL_CHARACTER_ENCODING)
+				+ lastOpacResult.getSet() + SESSIONID_URL + lastOpacResult.getSessionId()
 				+ SHOW_LONGTITLE_NR_URL + retrieveNumber);
 	}
 

--- a/src/de/unigoettingen/sub/search/opac/OpacResponseHandler.java
+++ b/src/de/unigoettingen/sub/search/opac/OpacResponseHandler.java
@@ -23,6 +23,8 @@
 package de.unigoettingen.sub.search.opac;
 
 import java.util.ArrayList;
+import java.net.URLEncoder;
+import java.io.UnsupportedEncodingException;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -123,12 +125,15 @@ public class OpacResponseHandler extends DefaultHandler {
 	}
 
 
-	public String getSessionId() {
+	public String getSessionId() throws UnsupportedEncodingException {
 		//TODO HACK
+		String sessionIdUrlencoded = URLEncoder.encode(sessionId, GetOpac.URL_CHARACTER_ENCODING);
+
 		if (!cookie.equals("")){
-			return sessionId + "/COOKIE=" + cookie;
+			sessionIdUrlencoded = sessionIdUrlencoded + "/COOKIE=" + URLEncoder.encode(cookie, GetOpac.URL_CHARACTER_ENCODING);
 		}
-		return sessionId;
+
+		return sessionIdUrlencoded;
 	}
 
 


### PR DESCRIPTION
Launchpad Link: https://bugs.launchpad.net/goobi-production/+bug/1158811
Patch provided by Benjamin Moedinger (https://launchpad.net/~moedinger).

"The slash between the SID and COOKIE parts of the opac request url is urlencoded (GetOpac.retrievePicaTitle). Obviously the SWB interface doesn't accept this any more. Only the values for SID and COOKIE should be urlencoded (see attached patch for Goobi Version 1.8.4)."
