### PR TITLE
Fix null pointer exception on context destroying.

### DIFF
--- a/Goobi/src/org/goobi/mq/ActiveMQDirector.java
+++ b/Goobi/src/org/goobi/mq/ActiveMQDirector.java
@@ -215,7 +215,9 @@ public class ActiveMQDirector implements ServletContextListener, ExceptionListen
 
 		// shut down connection
 		try {
-			connection.close();
+			if (connection != null) {
+				connection.close();
+			}
 		} catch (JMSException e) {
 			logger.error(e);
 		}


### PR DESCRIPTION
Fix for recurrent error message on tomcat shutdown:

org.apache.catalina.core.StandardContext listenerStop
SEVERE: Exception sending context destroyed event to listener instance of class org.goobi.mq.ActiveMQDirector
java.lang.NullPointerException
        at org.goobi.mq.ActiveMQDirector.contextDestroyed(Unknown Source)
        at org.apache.catalina.core.StandardContext.listenerStop(StandardContext.java:4830)
        at org.apache.catalina.core.StandardContext.stopInternal(StandardContext.java:5477)
        at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:232)
        at org.apache.catalina.core.ContainerBase$StopChild.call(ContainerBase.java:1611)
        at org.apache.catalina.core.ContainerBase$StopChild.call(ContainerBase.java:1600)
        at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
        at java.util.concurrent.FutureTask.run(FutureTask.java:166)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:724)

Fix similar to Goobi 1.8.x: https://github.com/goobi/goobi-production/commit/f8715b6dd85b299828692cf8b5daf02bf69fa9fb
