### PR TITLE
Fix #107: Show different image directories in METS editor

### DIFF
--- a/Goobi/pages/incMeta/Bild.jsp
+++ b/Goobi/pages/incMeta/Bild.jsp
@@ -233,7 +233,7 @@
 
 
 
-<h:form id="formularOrdner" rendered="#{Metadaten.bildNummer != '-1'}" style="margin-top:15px">
+<h:form id="formularOrdner" style="margin-top:15px">
 	<h:panelGrid columns="3">
 
 		<h:outputText value="#{msgs.aktuellerOrdner}: " />


### PR DESCRIPTION
Show always list of image directories to be able to switch from an empty directory to a directory with image files.
