### PR TITLE
Fix incomplete imagelinks in metsfiles after export #110

### DIFF
--- a/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Details.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Details.jsp
@@ -122,7 +122,7 @@
 
 						<h:outputText value="#{msgs.modulSchritt}, "
 							rendered="#{ProzessverwaltungForm.mySchritt.typModulName!=null && ProzessverwaltungForm.mySchritt.typModulName!=''}" />
-						<h:outputText value="#{msgs.typAutomatisch}" rendered="#{ProzessverwaltungForm.mySchritt.typAutomatisch" />
+						<h:outputText value="#{msgs.typAutomatisch}" rendered="#{ProzessverwaltungForm.mySchritt.typAutomatisch}" />
 						<h:outputText value="#{msgs.batchStep}" rendered="#{ProzessverwaltungForm.mySchritt.batchStep}" />
 
 					</htm:td>

--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -2931,7 +2931,7 @@ public class Metadaten {
                 File tempFileName = new File(imageDirectory + folder, fileToSort.getName() + "_bak");
                 File sortedName = new File(imageDirectory + folder, newfilenamePrefix + fileExtension.toLowerCase());
                 tempFileName.renameTo(sortedName);
-                mydocument.getPhysicalDocStruct().getAllChildren().get(counter - 1).setImageName(sortedName.getName());
+                mydocument.getPhysicalDocStruct().getAllChildren().get(counter - 1).setImageName("file://" + imageDirectory + folder + "/" + sortedName.getName());
             }
             try {
                 File ocr = new File(myProzess.getOcrDirectory());


### PR DESCRIPTION
Add missing parts of resulting imagespath in function reOrderPagination ( 2014-04-10 , jl, #110 )
