### PR TITLE
Fix #142: Repeating warning message about missing target component

### DIFF
--- a/Goobi/pages/incMeta/Bild.jsp
+++ b/Goobi/pages/incMeta/Bild.jsp
@@ -255,3 +255,6 @@
 
 </h:form>
 
+<h:form id="imageform">
+	<x:inputHidden id="hiddenBildNummer" forceId="true" value=" #{Metadaten.bildNummer}" />
+</h:form>


### PR DESCRIPTION
Added lost element with id imageform as inside hidden element is used in Goobi/pages/Metadaten2rechts.jsp
