### PR TITLE
Fix #61: Laufzetteldruck mit deutschen Sonderzeichen bricht ab

### DIFF
--- a/Goobi/src/de/sub/goobi/beans/Prozess.java
+++ b/Goobi/src/de/sub/goobi/beans/Prozess.java
@@ -47,7 +47,6 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
-import de.sub.goobi.helper.exceptions.GUIExceptionWrapper;
 import org.apache.log4j.Logger;
 import org.goobi.io.BackupFileRotation;
 import org.goobi.production.export.ExportDocket;


### PR DESCRIPTION
German Umlauts or other non ascii characters are not allowed according [bar code type 128](http://en.wikipedia.org/wiki/Code128). Replacement should be happen inside metadata.
