### PR TITLE
Adding parameter MetsEditorDisplayFileManipulation

### DIFF
--- a/Goobi/src/goobi_config.properties
+++ b/Goobi/src/goobi_config.properties
@@ -271,6 +271,11 @@ MetsEditorMaxTitleLength=0
 # initialise all sub elements in Mets editor to assign default values, default value is true
 MetsEditorEnableDefaultInitialisation=true
 
+# Display the file manipulation functions within the mets editor:
+# renaming images, deleting images,
+# adding images and moving images between processes
+MetsEditorDisplayFileManipulation=true
+
 # indicates whether the source folder should be created automatically or not, default is false
 createSourceFolder=false
 
@@ -285,7 +290,7 @@ importUseOldConfiguration=false
 showStatisticsOnStartPage=true
 
 # number of maximal items per batch, if not configured the default is 100
-batchMaxSize=500
+batchMaxSize=100
 
 # -----------------------------------
 # ActiveMQ web services


### PR DESCRIPTION
This adds the paramter MetsEditorDisplayFileManipulation to goobi_config.properties to display the file manipulation functions within the mets editor. The second small thing is the adaption of the parameter batchMaxSize to the default value.
