### PR TITLE
Replace Launchpad URL by GitHub URL

### DIFF
--- a/Goobi/WEB-INF/faces-config.xml
+++ b/Goobi/WEB-INF/faces-config.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/WEB-INF/metadata-editor-config.xml
+++ b/Goobi/WEB-INF/metadata-editor-config.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/config/c3p0.properties
+++ b/Goobi/config/c3p0.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/config/contentServerConfig.xml
+++ b/Goobi/config/contentServerConfig.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/config/docket.xsl
+++ b/Goobi/config/docket.xsl
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/config/docket_multipage.xsl
+++ b/Goobi/config/docket_multipage.xsl
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/config/ehcache.xml
+++ b/Goobi/config/ehcache.xml
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/config/goobi_config.properties
+++ b/Goobi/config/goobi_config.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/config/goobi_metadataDisplayRules.xml
+++ b/Goobi/config/goobi_metadataDisplayRules.xml
@@ -6,7 +6,7 @@
   ~ Visit the websites for more information.
   ~     - http://gdz.sub.uni-goettingen.de
   ~     - http://www.goobi.org
-  ~     - http://launchpad.net/goobi-production
+  ~     - https://github.com/goobi/goobi-production
   ~
   ~ This program is free software; you can redistribute it and/or modify it under
   ~ the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/config/hibernate.cfg.xml
+++ b/Goobi/config/hibernate.cfg.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/config/log4j.properties
+++ b/Goobi/config/log4j.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/config/modules.xml
+++ b/Goobi/config/modules.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/config/quartz.properties
+++ b/Goobi/config/quartz.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/css/classic.css
+++ b/Goobi/css/classic.css
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/css/default.css
+++ b/Goobi/css/default.css
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/css/goobistyles_bluered.css
+++ b/Goobi/css/goobistyles_bluered.css
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/css/goobistyles_bluered_soft2.css
+++ b/Goobi/css/goobistyles_bluered_soft2.css
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/css/system/print.css
+++ b/Goobi/css/system/print.css
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/css/tabbedPane.css
+++ b/Goobi/css/tabbedPane.css
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/index.jsp
+++ b/Goobi/index.jsp
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/AktuelleSchritteAlle.jsp
+++ b/Goobi/newpages/AktuelleSchritteAlle.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/AktuelleSchritteBearbeiten.jsp
+++ b/Goobi/newpages/AktuelleSchritteBearbeiten.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BatchProperties.jsp
+++ b/Goobi/newpages/BatchProperties.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BatchesAll.jsp
+++ b/Goobi/newpages/BatchesAll.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BatchesEdit.jsp
+++ b/Goobi/newpages/BatchesEdit.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BenutzerAlle.jsp
+++ b/Goobi/newpages/BenutzerAlle.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BenutzerBearbeiten.jsp
+++ b/Goobi/newpages/BenutzerBearbeiten.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BenutzerBearbeitenPopup.jsp
+++ b/Goobi/newpages/BenutzerBearbeitenPopup.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BenutzerBearbeitenPopupProjekte.jsp
+++ b/Goobi/newpages/BenutzerBearbeitenPopupProjekte.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BenutzerKonfiguration.jsp
+++ b/Goobi/newpages/BenutzerKonfiguration.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BenutzergruppenAlle.jsp
+++ b/Goobi/newpages/BenutzergruppenAlle.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/BenutzergruppenBearbeiten.jsp
+++ b/Goobi/newpages/BenutzergruppenBearbeiten.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/DocketEdit.jsp
+++ b/Goobi/newpages/DocketEdit.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/DocketList.jsp
+++ b/Goobi/newpages/DocketList.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/ExtendedSearch.jsp
+++ b/Goobi/newpages/ExtendedSearch.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/LdapGruppenAlle.jsp
+++ b/Goobi/newpages/LdapGruppenAlle.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/LdapGruppenBearbeiten.jsp
+++ b/Goobi/newpages/LdapGruppenBearbeiten.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/Main.jsp
+++ b/Goobi/newpages/Main.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/MassImport.jsp
+++ b/Goobi/newpages/MassImport.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/MassImportPage2.jsp
+++ b/Goobi/newpages/MassImportPage2.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/MassImportPage3.jsp
+++ b/Goobi/newpages/MassImportPage3.jsp
@@ -13,7 +13,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/MultiMassImportPage2.jsp
+++ b/Goobi/newpages/MultiMassImportPage2.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/NewProcess/Page1.jsp
+++ b/Goobi/newpages/NewProcess/Page1.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/NewProcess/Page2.jsp
+++ b/Goobi/newpages/NewProcess/Page2.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/NewProcess/Page3.jsp
+++ b/Goobi/newpages/NewProcess/Page3.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/NewProcess/inc_config.jsp
+++ b/Goobi/newpages/NewProcess/inc_config.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/NewProcess/inc_process.jsp
+++ b/Goobi/newpages/NewProcess/inc_process.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/PasswortAendern.jsp
+++ b/Goobi/newpages/PasswortAendern.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/ProjektFilegroupPopup.jsp
+++ b/Goobi/newpages/ProjektFilegroupPopup.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/ProjekteAlle.jsp
+++ b/Goobi/newpages/ProjekteAlle.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/ProjekteBearbeiten.jsp
+++ b/Goobi/newpages/ProjekteBearbeiten.jsp
@@ -13,7 +13,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/ProzessverwaltungAlle.jsp
+++ b/Goobi/newpages/ProzessverwaltungAlle.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/ProzessverwaltungBearbeiten.jsp
+++ b/Goobi/newpages/ProzessverwaltungBearbeiten.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/ProzessverwaltungSuche.jsp
+++ b/Goobi/newpages/ProzessverwaltungSuche.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/RegelsaetzeAlle.jsp
+++ b/Goobi/newpages/RegelsaetzeAlle.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/RegelsaetzeBearbeiten.jsp
+++ b/Goobi/newpages/RegelsaetzeBearbeiten.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/admin.jsp
+++ b/Goobi/newpages/admin.jsp
@@ -13,7 +13,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/aktiveNutzer.jsp
+++ b/Goobi/newpages/aktiveNutzer.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/error.jsp
+++ b/Goobi/newpages/error.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/Login.jsp
+++ b/Goobi/newpages/inc/Login.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/Process_Filter.jsp
+++ b/Goobi/newpages/inc/Process_Filter.jsp
@@ -6,7 +6,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/ProgressChart.jsp
+++ b/Goobi/newpages/inc/ProgressChart.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/Step_Filter.jsp
+++ b/Goobi/newpages/inc/Step_Filter.jsp
@@ -6,7 +6,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/ajaxPlusMinusButton.jsp
+++ b/Goobi/newpages/inc/ajaxPlusMinusButton.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/box2_Navigation.jsp
+++ b/Goobi/newpages/inc/box2_Navigation.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/box_Fuss.jsp
+++ b/Goobi/newpages/inc/box_Fuss.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/box_Navigation.jsp
+++ b/Goobi/newpages/inc/box_Navigation.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/box_head.jsp
+++ b/Goobi/newpages/inc/box_head.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/datascroller.jsp
+++ b/Goobi/newpages/inc/datascroller.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/head.jsp
+++ b/Goobi/newpages/inc/head.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/tbl_Fuss.jsp
+++ b/Goobi/newpages/inc/tbl_Fuss.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/tbl_Kopf.jsp
+++ b/Goobi/newpages/inc/tbl_Kopf.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc/tbl_Navigation.jsp
+++ b/Goobi/newpages/inc/tbl_Navigation.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_AktuelleSchritte/Schritte_Liste.jsp
+++ b/Goobi/newpages/inc_AktuelleSchritte/Schritte_Liste.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_AktuelleSchritte/Schritte_Liste_Action.jsp
+++ b/Goobi/newpages/inc_AktuelleSchritte/Schritte_Liste_Action.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_AktuelleSchritte/Schritte_Liste_DetailsKlein.jsp
+++ b/Goobi/newpages/inc_AktuelleSchritte/Schritte_Liste_DetailsKlein.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Action.jsp
+++ b/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Action.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Details.jsp
+++ b/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Details.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Eigenschaften.jsp
+++ b/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Eigenschaften.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Properties.jsp
+++ b/Goobi/newpages/inc_AktuelleSchritte/schritt_box_Properties.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Batches/Batches_List.jsp
+++ b/Goobi/newpages/inc_Batches/Batches_List.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Batches/batch_box_Action.jsp
+++ b/Goobi/newpages/inc_Batches/batch_box_Action.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Batches/batch_box_Details.jsp
+++ b/Goobi/newpages/inc_Batches/batch_box_Details.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Batches/batch_box_Properties.jsp
+++ b/Goobi/newpages/inc_Batches/batch_box_Properties.jsp
@@ -13,7 +13,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Main/box1.jsp
+++ b/Goobi/newpages/inc_Main/box1.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Main/box2.jsp
+++ b/Goobi/newpages/inc_Main/box2.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Main/box3.jsp
+++ b/Goobi/newpages/inc_Main/box3.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/Context_Prozesse_Liste.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/Context_Prozesse_Liste.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste_Action.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste_Action.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste_Anzahlen.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste_Anzahlen.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste_Statistik.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste_Statistik.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Properties.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Properties.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Prozessdetails.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Prozessdetails.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Prozesseigenschaften.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Prozesseigenschaften.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Schritte.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Schritte.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Schritte_box_DetailsKlein.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Schritte_box_DetailsKlein.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Vorlagen.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Vorlagen.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Werkstuecke.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/prozess_box_Werkstuecke.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/schritt.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Benutzer.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Benutzer.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/schritt_box_BenutzerPopup.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt_box_BenutzerPopup.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Benutzergruppen.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Benutzergruppen.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/schritt_box_BenutzergruppenPopup.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt_box_BenutzergruppenPopup.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Details.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Details.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Eigenschaften.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/schritt_box_Eigenschaften.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/vorlage.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/vorlage.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/vorlage_box_Details.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/vorlage_box_Details.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/vorlage_box_Eigenschaften.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/vorlage_box_Eigenschaften.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/werkstueck.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/werkstueck.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/werkstueck_box_Details.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/werkstueck_box_Details.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_Prozessverwaltung/werkstueck_box_Eigenschaften.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/werkstueck_box_Eigenschaften.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_statistic/StatisticCorrection.jsp
+++ b/Goobi/newpages/inc_statistic/StatisticCorrection.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_statistic/StatisticProduction.jsp
+++ b/Goobi/newpages/inc_statistic/StatisticProduction.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_statistic/StatisticStorage.jsp
+++ b/Goobi/newpages/inc_statistic/StatisticStorage.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/inc_statistic/StatisticThroughput.jsp
+++ b/Goobi/newpages/inc_statistic/StatisticThroughput.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/index.jsp
+++ b/Goobi/newpages/index.jsp
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/meminfo.jsp
+++ b/Goobi/newpages/meminfo.jsp
@@ -5,7 +5,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/modulemanager.jsp
+++ b/Goobi/newpages/modulemanager.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/plugins/MultipleManifestationMillenniumImport.jsp
+++ b/Goobi/newpages/plugins/MultipleManifestationMillenniumImport.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/plugins/SotonImport.jsp
+++ b/Goobi/newpages/plugins/SotonImport.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/statischBedienung.jsp
+++ b/Goobi/newpages/statischBedienung.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/statischImpressum.jsp
+++ b/Goobi/newpages/statischImpressum.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/statischTechnischerHintergrund.jsp
+++ b/Goobi/newpages/statischTechnischerHintergrund.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/taskmanager.jsp
+++ b/Goobi/newpages/taskmanager.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/newpages/version.jsp
+++ b/Goobi/newpages/version.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/Metadaten2.jsp
+++ b/Goobi/pages/Metadaten2.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/Metadaten2oben.jsp
+++ b/Goobi/pages/Metadaten2oben.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/Metadaten2rechts.jsp
+++ b/Goobi/pages/Metadaten2rechts.jsp
@@ -12,7 +12,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/Metadaten3links.jsp
+++ b/Goobi/pages/Metadaten3links.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/MetadatenGesperrt.jsp
+++ b/Goobi/pages/MetadatenGesperrt.jsp
@@ -10,7 +10,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/incMeta/BaumZumVerschieben.jsp
+++ b/Goobi/pages/incMeta/BaumZumVerschieben.jsp
@@ -7,7 +7,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/incMeta/Bild.jsp
+++ b/Goobi/pages/incMeta/Bild.jsp
@@ -11,7 +11,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/incMeta/NeuMeta.jsp
+++ b/Goobi/pages/incMeta/NeuMeta.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/incMeta/NeuPerson.jsp
+++ b/Goobi/pages/incMeta/NeuPerson.jsp
@@ -7,7 +7,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/incMeta/Paginierung.jsp
+++ b/Goobi/pages/incMeta/Paginierung.jsp
@@ -8,7 +8,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/incMeta/PersonenUndMetadaten.jsp
+++ b/Goobi/pages/incMeta/PersonenUndMetadaten.jsp
@@ -9,7 +9,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/pages/incMeta/Strukturdaten.jsp
+++ b/Goobi/pages/incMeta/Strukturdaten.jsp
@@ -13,7 +13,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/scripts/script_createDirMeta.sh
+++ b/Goobi/scripts/script_createDirMeta.sh
@@ -4,7 +4,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/scripts/script_createDirUserHome.sh
+++ b/Goobi/scripts/script_createDirUserHome.sh
@@ -4,7 +4,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/scripts/script_createSymLink.sh
+++ b/Goobi/scripts/script_createSymLink.sh
@@ -4,7 +4,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/scripts/script_deleteSymLink.sh
+++ b/Goobi/scripts/script_deleteSymLink.sh
@@ -4,7 +4,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/setup/default.sql
+++ b/Goobi/setup/default.sql
@@ -2,7 +2,7 @@
 -- 
 -- Visit the websites for more information. 
 --     		- http://www.goobi.org
---    		- http://launchpad.net/goobi-production
+--    		- https://github.com/goobi/goobi-production
 -- 		    - http://gdz.sub.uni-goettingen.de
 --			- http://www.intranda.com
 --			- http://digiverso.com 

--- a/Goobi/setup/schema.sql
+++ b/Goobi/setup/schema.sql
@@ -2,7 +2,7 @@
 -- 
 -- Visit the websites for more information. 
 --     		- http://www.goobi.org
---    		- http://launchpad.net/goobi-production
+--    		- https://github.com/goobi/goobi-production
 -- 		    - http://gdz.sub.uni-goettingen.de
 --			- http://www.intranda.com
 --			- http://digiverso.com 

--- a/Goobi/src/c3p0.properties
+++ b/Goobi/src/c3p0.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/src/contentServerConfig.xml
+++ b/Goobi/src/contentServerConfig.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Benutzer.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Benutzer.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Benutzer.java
+++ b/Goobi/src/de/sub/goobi/beans/Benutzer.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Benutzereigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Benutzereigenschaft.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Benutzereigenschaft.java
+++ b/Goobi/src/de/sub/goobi/beans/Benutzereigenschaft.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Benutzergruppe.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Benutzergruppe.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Benutzergruppe.java
+++ b/Goobi/src/de/sub/goobi/beans/Benutzergruppe.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Docket.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Docket.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Docket.java
+++ b/Goobi/src/de/sub/goobi/beans/Docket.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/HistoryEvent.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/HistoryEvent.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/HistoryEvent.java
+++ b/Goobi/src/de/sub/goobi/beans/HistoryEvent.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/LdapGruppe.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/LdapGruppe.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/LdapGruppe.java
+++ b/Goobi/src/de/sub/goobi/beans/LdapGruppe.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.java
+++ b/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Projekt.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Projekt.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Projekt.java
+++ b/Goobi/src/de/sub/goobi/beans/Projekt.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Prozess.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Prozess.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Prozess.java
+++ b/Goobi/src/de/sub/goobi/beans/Prozess.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Prozesseigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Prozesseigenschaft.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Prozesseigenschaft.java
+++ b/Goobi/src/de/sub/goobi/beans/Prozesseigenschaft.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Regelsatz.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Regelsatz.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Regelsatz.java
+++ b/Goobi/src/de/sub/goobi/beans/Regelsatz.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Schritt.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Schritt.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Schritt.java
+++ b/Goobi/src/de/sub/goobi/beans/Schritt.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Schritteigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Schritteigenschaft.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Schritteigenschaft.java
+++ b/Goobi/src/de/sub/goobi/beans/Schritteigenschaft.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Vorlage.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Vorlage.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Vorlage.java
+++ b/Goobi/src/de/sub/goobi/beans/Vorlage.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Vorlageeigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Vorlageeigenschaft.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Vorlageeigenschaft.java
+++ b/Goobi/src/de/sub/goobi/beans/Vorlageeigenschaft.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Werkstueck.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Werkstueck.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Werkstueck.java
+++ b/Goobi/src/de/sub/goobi/beans/Werkstueck.java
@@ -5,7 +5,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Werkstueckeigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Werkstueckeigenschaft.hbm.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/Werkstueckeigenschaft.java
+++ b/Goobi/src/de/sub/goobi/beans/Werkstueckeigenschaft.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/beans/property/IGoobiProperty.java
+++ b/Goobi/src/de/sub/goobi/beans/property/IGoobiProperty.java
@@ -4,7 +4,7 @@ package de.sub.goobi.beans.property;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/config/ConfigMain.java
+++ b/Goobi/src/de/sub/goobi/config/ConfigMain.java
@@ -5,7 +5,7 @@ package de.sub.goobi.config;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/config/ConfigPlugins.java
+++ b/Goobi/src/de/sub/goobi/config/ConfigPlugins.java
@@ -4,7 +4,7 @@ package de.sub.goobi.config;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/config/ConfigProjects.java
+++ b/Goobi/src/de/sub/goobi/config/ConfigProjects.java
@@ -4,7 +4,7 @@ package de.sub.goobi.config;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/config/DigitalCollections.java
+++ b/Goobi/src/de/sub/goobi/config/DigitalCollections.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/src/de/sub/goobi/converter/DocketConverter.java
+++ b/Goobi/src/de/sub/goobi/converter/DocketConverter.java
@@ -4,7 +4,7 @@ package de.sub.goobi.converter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/converter/ProcessConverter.java
+++ b/Goobi/src/de/sub/goobi/converter/ProcessConverter.java
@@ -5,7 +5,7 @@ package de.sub.goobi.converter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/converter/RegelsatzConverter.java
+++ b/Goobi/src/de/sub/goobi/converter/RegelsatzConverter.java
@@ -4,7 +4,7 @@ package de.sub.goobi.converter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/converter/StatisticsCalculationUnitConverter.java
+++ b/Goobi/src/de/sub/goobi/converter/StatisticsCalculationUnitConverter.java
@@ -5,7 +5,7 @@ package de.sub.goobi.converter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/converter/StatisticsResultOutputConverter.java
+++ b/Goobi/src/de/sub/goobi/converter/StatisticsResultOutputConverter.java
@@ -4,7 +4,7 @@ package de.sub.goobi.converter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/converter/StatisticsTimeUnitConverter.java
+++ b/Goobi/src/de/sub/goobi/converter/StatisticsTimeUnitConverter.java
@@ -4,7 +4,7 @@ package de.sub.goobi.converter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExport.java
+++ b/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExport.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.dms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.dms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/dms/DmsImportThread.java
+++ b/Goobi/src/de/sub/goobi/export/dms/DmsImportThread.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.dms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
+++ b/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.dms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/dms/ExportDms_CorrectRusdml.java
+++ b/Goobi/src/de/sub/goobi/export/dms/ExportDms_CorrectRusdml.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.dms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/download/ExportMets.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMets.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.download;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.download;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.download;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/download/Multipage.java
+++ b/Goobi/src/de/sub/goobi/export/download/Multipage.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.download;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/export/download/TiffHeader.java
+++ b/Goobi/src/de/sub/goobi/export/download/TiffHeader.java
@@ -5,7 +5,7 @@ package de.sub.goobi.export.download;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/AdditionalField.java
+++ b/Goobi/src/de/sub/goobi/forms/AdditionalField.java
@@ -4,7 +4,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/AdministrationForm.java
+++ b/Goobi/src/de/sub/goobi/forms/AdministrationForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
+++ b/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/BasisForm.java
+++ b/Goobi/src/de/sub/goobi/forms/BasisForm.java
@@ -4,7 +4,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/BatchForm.java
+++ b/Goobi/src/de/sub/goobi/forms/BatchForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Goobi/src/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/DocketForm.java
+++ b/Goobi/src/de/sub/goobi/forms/DocketForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/HelperForm.java
+++ b/Goobi/src/de/sub/goobi/forms/HelperForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/LdapGruppenForm.java
+++ b/Goobi/src/de/sub/goobi/forms/LdapGruppenForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/LoginForm.java
+++ b/Goobi/src/de/sub/goobi/forms/LoginForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/LongRunningTasksForm.java
+++ b/Goobi/src/de/sub/goobi/forms/LongRunningTasksForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/MassImportForm.java
+++ b/Goobi/src/de/sub/goobi/forms/MassImportForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/ModuleServerForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ModuleServerForm.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/NavigationForm.java
+++ b/Goobi/src/de/sub/goobi/forms/NavigationForm.java
@@ -4,7 +4,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/ProjekteForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProjekteForm.java
@@ -4,7 +4,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/RegelsaetzeForm.java
+++ b/Goobi/src/de/sub/goobi/forms/RegelsaetzeForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/SearchForm.java
+++ b/Goobi/src/de/sub/goobi/forms/SearchForm.java
@@ -4,7 +4,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/SessionForm.java
+++ b/Goobi/src/de/sub/goobi/forms/SessionForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/SpracheForm.java
+++ b/Goobi/src/de/sub/goobi/forms/SpracheForm.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/forms/StatistikForm.java
+++ b/Goobi/src/de/sub/goobi/forms/StatistikForm.java
@@ -5,7 +5,7 @@ package de.sub.goobi.forms;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/Batch.java
+++ b/Goobi/src/de/sub/goobi/helper/Batch.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/BatchProcessHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/BatchProcessHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/BatchStepHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/BatchStepHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/BeanHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/BeanHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/CopyFile.java
+++ b/Goobi/src/de/sub/goobi/helper/CopyFile.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/FileUtils.java
+++ b/Goobi/src/de/sub/goobi/helper/FileUtils.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/FilesystemHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/FilesystemHelper.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/GoobiScript.java
+++ b/Goobi/src/de/sub/goobi/helper/GoobiScript.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/Helper.java
+++ b/Goobi/src/de/sub/goobi/helper/Helper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/HelperComparator.java
+++ b/Goobi/src/de/sub/goobi/helper/HelperComparator.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/HelperSchritteWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/helper/HelperSchritteWithoutHibernate.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/Page.java
+++ b/Goobi/src/de/sub/goobi/helper/Page.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/PaginatingCriteria.java
+++ b/Goobi/src/de/sub/goobi/helper/PaginatingCriteria.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/ProjectHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/ProjectHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/PropertyListObject.java
+++ b/Goobi/src/de/sub/goobi/helper/PropertyListObject.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/RefreshObject.java
+++ b/Goobi/src/de/sub/goobi/helper/RefreshObject.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/ScriptThreadWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/helper/ScriptThreadWithoutHibernate.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/ShellScript.java
+++ b/Goobi/src/de/sub/goobi/helper/ShellScript.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/Transliteration.java
+++ b/Goobi/src/de/sub/goobi/helper/Transliteration.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/TreeNode.java
+++ b/Goobi/src/de/sub/goobi/helper/TreeNode.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/UghHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/UghHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/Util.java
+++ b/Goobi/src/de/sub/goobi/helper/Util.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/VariableReplacer.java
+++ b/Goobi/src/de/sub/goobi/helper/VariableReplacer.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/VariableReplacerWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/helper/VariableReplacerWithoutHibernate.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/WebDav.java
+++ b/Goobi/src/de/sub/goobi/helper/WebDav.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/XmlArtikelZaehlen.java
+++ b/Goobi/src/de/sub/goobi/helper/XmlArtikelZaehlen.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/enums/HistoryEventType.java
+++ b/Goobi/src/de/sub/goobi/helper/enums/HistoryEventType.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/enums/MetadataFormat.java
+++ b/Goobi/src/de/sub/goobi/helper/enums/MetadataFormat.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/enums/PropertyType.java
+++ b/Goobi/src/de/sub/goobi/helper/enums/PropertyType.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/enums/ReportLevel.java
+++ b/Goobi/src/de/sub/goobi/helper/enums/ReportLevel.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/src/de/sub/goobi/helper/enums/StepEditType.java
+++ b/Goobi/src/de/sub/goobi/helper/enums/StepEditType.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/enums/StepStatus.java
+++ b/Goobi/src/de/sub/goobi/helper/enums/StepStatus.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/DAOException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/DAOException.java
@@ -7,7 +7,7 @@ import dubious.sub.goobi.helper.encryption.exceptions.AbstractGoobiException;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/ExportFileException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/ExportFileException.java
@@ -7,7 +7,7 @@ import dubious.sub.goobi.helper.encryption.exceptions.AbstractGoobiException;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/GUIExceptionWrapper.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/GUIExceptionWrapper.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.exceptions;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/ImportPluginException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/ImportPluginException.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper.exceptions;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/InvalidImagesException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/InvalidImagesException.java
@@ -7,7 +7,7 @@ import dubious.sub.goobi.helper.encryption.exceptions.AbstractGoobiException;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/ShellException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/ShellException.java
@@ -7,7 +7,7 @@ import dubious.sub.goobi.helper.encryption.exceptions.AbstractGoobiException;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/SwapException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/SwapException.java
@@ -7,7 +7,7 @@ import dubious.sub.goobi.helper.encryption.exceptions.AbstractGoobiException;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/UghHelperException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/UghHelperException.java
@@ -7,7 +7,7 @@ import dubious.sub.goobi.helper.encryption.exceptions.AbstractGoobiException;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/exceptions/WrongImportFileException.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/WrongImportFileException.java
@@ -7,7 +7,7 @@ import dubious.sub.goobi.helper.encryption.exceptions.AbstractGoobiException;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
+++ b/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper.ldap;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/ldap/LdapUser.java
+++ b/Goobi/src/de/sub/goobi/helper/ldap/LdapUser.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper.ldap;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/servletfilter/HibernateSessionFilter2.java
+++ b/Goobi/src/de/sub/goobi/helper/servletfilter/HibernateSessionFilter2.java
@@ -5,7 +5,7 @@ package de.sub.goobi.helper.servletfilter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/servletfilter/SecurityCheckFilter.java
+++ b/Goobi/src/de/sub/goobi/helper/servletfilter/SecurityCheckFilter.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.servletfilter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/servletfilter/SessionCounterFilter.java
+++ b/Goobi/src/de/sub/goobi/helper/servletfilter/SessionCounterFilter.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.servletfilter;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.tasks;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.tasks;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTaskManager.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTaskManager.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.tasks;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapInTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapInTask.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.tasks;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.tasks;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/helper/tasks/TiffWriterTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/TiffWriterTask.java
@@ -4,7 +4,7 @@ package de.sub.goobi.helper.tasks;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/importer/Import.java
+++ b/Goobi/src/de/sub/goobi/importer/Import.java
@@ -4,7 +4,7 @@ package de.sub.goobi.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/importer/ImportRussland.java
+++ b/Goobi/src/de/sub/goobi/importer/ImportRussland.java
@@ -4,7 +4,7 @@ package de.sub.goobi.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/importer/ImportZentralblatt.java
+++ b/Goobi/src/de/sub/goobi/importer/ImportZentralblatt.java
@@ -5,7 +5,7 @@ package de.sub.goobi.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/MetaPerson.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetaPerson.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenHelper.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenSperrung.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenSperrung.java
@@ -4,7 +4,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenVerifizierung.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenVerifizierung.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenVerifizierungWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenVerifizierungWithoutHibernate.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatumImpl.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatumImpl.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/Pagination.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Pagination.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/metadaten/Paginator.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Paginator.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *    - http://gdz.sub.uni-goettingen.de
  *    - http://www.goobi.org
- *    - http://launchpad.net/goobi-production
+ *    - https://github.com/goobi/goobi-production
  *
  * Copyright 2011, Center for Retrospective Digitization, Göttingen (GDZ),
  *

--- a/Goobi/src/de/sub/goobi/metadaten/TreeNodeStruct3.java
+++ b/Goobi/src/de/sub/goobi/metadaten/TreeNodeStruct3.java
@@ -5,7 +5,7 @@ package de.sub.goobi.metadaten;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/modul/ExtendedDataImpl.java
+++ b/Goobi/src/de/sub/goobi/modul/ExtendedDataImpl.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/modul/ExtendedProzessImpl.java
+++ b/Goobi/src/de/sub/goobi/modul/ExtendedProzessImpl.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/modul/ModulListener.java
+++ b/Goobi/src/de/sub/goobi/modul/ModulListener.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/ConnectionManager.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/ConnectionManager.java
@@ -4,7 +4,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/FolderInformation.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/FolderInformation.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/MySQLHelper.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/MySQLHelper.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/MySQLUtils.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/MySQLUtils.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/ProcessManager.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/ProcessManager.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/ProcessObject.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/ProcessObject.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/ProjectManager.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/ProjectManager.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/ProjectObject.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/ProjectObject.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/Property.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/Property.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/SqlConfiguration.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/SqlConfiguration.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/StepManager.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/StepManager.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/StepObject.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/StepObject.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/persistence/apache/UserManager.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/UserManager.java
@@ -5,7 +5,7 @@ package de.sub.goobi.persistence.apache;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/statistik/StatistikBenutzergruppen.java
+++ b/Goobi/src/de/sub/goobi/statistik/StatistikBenutzergruppen.java
@@ -5,7 +5,7 @@ package de.sub.goobi.statistik;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/statistik/StatistikLaufzeitSchritte.java
+++ b/Goobi/src/de/sub/goobi/statistik/StatistikLaufzeitSchritte.java
@@ -5,7 +5,7 @@ package de.sub.goobi.statistik;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/sub/goobi/statistik/StatistikStatus.java
+++ b/Goobi/src/de/sub/goobi/statistik/StatistikStatus.java
@@ -5,7 +5,7 @@ package de.sub.goobi.statistik;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/Catalogue.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/Catalogue.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpac.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpac.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacCatalogue.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacCatalogue.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacCatalogueBeautifier.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacCatalogueBeautifier.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacCatalogueBeautifierElement.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacCatalogueBeautifierElement.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacDoctype.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpacDoctype.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/GetOpac.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/GetOpac.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/IllegalQueryException.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/IllegalQueryException.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/OpacResponseHandler.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/OpacResponseHandler.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/de/unigoettingen/sub/search/opac/Query.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/Query.java
@@ -5,7 +5,7 @@ package de.unigoettingen.sub.search.opac;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/ehcache.xml
+++ b/Goobi/src/ehcache.xml
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/goobi_config.properties
+++ b/Goobi/src/goobi_config.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/src/hibernate.cfg.xml
+++ b/Goobi/src/hibernate.cfg.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/log4j.properties
+++ b/Goobi/src/log4j.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/src/messages/messages_de.properties
+++ b/Goobi/src/messages/messages_de.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/src/messages/messages_en.properties
+++ b/Goobi/src/messages/messages_en.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/api/display/DisplayCase.java
+++ b/Goobi/src/org/goobi/api/display/DisplayCase.java
@@ -5,7 +5,7 @@ package org.goobi.api.display;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/api/display/Item.java
+++ b/Goobi/src/org/goobi/api/display/Item.java
@@ -5,7 +5,7 @@ package org.goobi.api.display;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/api/display/Modes.java
+++ b/Goobi/src/org/goobi/api/display/Modes.java
@@ -5,7 +5,7 @@ package org.goobi.api.display;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/api/display/enums/BindState.java
+++ b/Goobi/src/org/goobi/api/display/enums/BindState.java
@@ -5,7 +5,7 @@ package org.goobi.api.display.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/api/display/enums/DisplayType.java
+++ b/Goobi/src/org/goobi/api/display/enums/DisplayType.java
@@ -5,7 +5,7 @@ package org.goobi.api.display.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/api/display/helper/ConfigDispayRules.java
+++ b/Goobi/src/org/goobi/api/display/helper/ConfigDispayRules.java
@@ -5,7 +5,7 @@ package org.goobi.api.display.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/io/BackupFileRotation.java
+++ b/Goobi/src/org/goobi/io/BackupFileRotation.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/io/FileListFilter.java
+++ b/Goobi/src/org/goobi/io/FileListFilter.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/mq/ActiveMQDirector.java
+++ b/Goobi/src/org/goobi/mq/ActiveMQDirector.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/mq/ActiveMQProcessor.java
+++ b/Goobi/src/org/goobi/mq/ActiveMQProcessor.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/mq/MapMessageObjectReader.java
+++ b/Goobi/src/org/goobi/mq/MapMessageObjectReader.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/mq/WebServiceResult.java
+++ b/Goobi/src/org/goobi/mq/WebServiceResult.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/mq/processors/CreateNewProcessProcessor.java
+++ b/Goobi/src/org/goobi/mq/processors/CreateNewProcessProcessor.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/mq/processors/FinaliseStepProcessor.java
+++ b/Goobi/src/org/goobi/mq/processors/FinaliseStepProcessor.java
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/pagination/IntegerSequence.java
+++ b/Goobi/src/org/goobi/pagination/IntegerSequence.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *    - http://gdz.sub.uni-goettingen.de
  *    - http://www.goobi.org
- *    - http://launchpad.net/goobi-production
+ *    - https://github.com/goobi/goobi-production
  *
  * Copyright 2011, Center for Retrospective Digitization, Göttingen (GDZ),
  *

--- a/Goobi/src/org/goobi/pagination/RomanNumberSequence.java
+++ b/Goobi/src/org/goobi/pagination/RomanNumberSequence.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *    - http://gdz.sub.uni-goettingen.de
  *    - http://www.goobi.org
- *    - http://launchpad.net/goobi-production
+ *    - https://github.com/goobi/goobi-production
  *
  * Copyright 2011, Center for Retrospective Digitization, Göttingen (GDZ),
  *

--- a/Goobi/src/org/goobi/production/GoobiVersion.java
+++ b/Goobi/src/org/goobi/production/GoobiVersion.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/GoobiVersionListener.java
+++ b/Goobi/src/org/goobi/production/GoobiVersionListener.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/IProcessDataExport.java
+++ b/Goobi/src/org/goobi/production/IProcessDataExport.java
@@ -5,7 +5,7 @@ package org.goobi.production;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/ImageIOInitializer.java
+++ b/Goobi/src/org/goobi/production/ImageIOInitializer.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/ChartColor.java
+++ b/Goobi/src/org/goobi/production/chart/ChartColor.java
@@ -5,7 +5,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/HibernateProjectTaskList.java
+++ b/Goobi/src/org/goobi/production/chart/HibernateProjectTaskList.java
@@ -5,7 +5,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/HibernateProjectionProjectTaskList.java
+++ b/Goobi/src/org/goobi/production/chart/HibernateProjectionProjectTaskList.java
@@ -5,7 +5,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/IProjectTask.java
+++ b/Goobi/src/org/goobi/production/chart/IProjectTask.java
@@ -4,7 +4,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/IProvideProjectTaskList.java
+++ b/Goobi/src/org/goobi/production/chart/IProvideProjectTaskList.java
@@ -5,7 +5,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/ProjectStatusDataTable.java
+++ b/Goobi/src/org/goobi/production/chart/ProjectStatusDataTable.java
@@ -5,7 +5,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/ProjectStatusDraw.java
+++ b/Goobi/src/org/goobi/production/chart/ProjectStatusDraw.java
@@ -5,7 +5,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/ProjectTask.java
+++ b/Goobi/src/org/goobi/production/chart/ProjectTask.java
@@ -4,7 +4,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/chart/WorkflowProjectTaskList.java
+++ b/Goobi/src/org/goobi/production/chart/WorkflowProjectTaskList.java
@@ -5,7 +5,7 @@ package org.goobi.production.chart;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/cli/CommandResponse.java
+++ b/Goobi/src/org/goobi/production/cli/CommandResponse.java
@@ -5,7 +5,7 @@ package org.goobi.production.cli;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/cli/WebInterface.java
+++ b/Goobi/src/org/goobi/production/cli/WebInterface.java
@@ -5,7 +5,7 @@ package org.goobi.production.cli;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/cli/WebInterfaceConfig.java
+++ b/Goobi/src/org/goobi/production/cli/WebInterfaceConfig.java
@@ -5,7 +5,7 @@ package org.goobi.production.cli;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/cli/helper/CopyProcess.java
+++ b/Goobi/src/org/goobi/production/cli/helper/CopyProcess.java
@@ -5,7 +5,7 @@ package org.goobi.production.cli.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/cli/helper/WikiFieldHelper.java
+++ b/Goobi/src/org/goobi/production/cli/helper/WikiFieldHelper.java
@@ -4,7 +4,7 @@ package org.goobi.production.cli.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/enums/ImportFormat.java
+++ b/Goobi/src/org/goobi/production/enums/ImportFormat.java
@@ -5,7 +5,7 @@ package org.goobi.production.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/enums/ImportReturnValue.java
+++ b/Goobi/src/org/goobi/production/enums/ImportReturnValue.java
@@ -4,7 +4,7 @@ package org.goobi.production.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/enums/ImportType.java
+++ b/Goobi/src/org/goobi/production/enums/ImportType.java
@@ -4,7 +4,7 @@ package org.goobi.production.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/enums/PluginGuiType.java
+++ b/Goobi/src/org/goobi/production/enums/PluginGuiType.java
@@ -4,7 +4,7 @@ package org.goobi.production.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/enums/PluginType.java
+++ b/Goobi/src/org/goobi/production/enums/PluginType.java
@@ -4,7 +4,7 @@ package org.goobi.production.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/enums/StepReturnValue.java
+++ b/Goobi/src/org/goobi/production/enums/StepReturnValue.java
@@ -4,7 +4,7 @@ package org.goobi.production.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/export/ExportDocket.java
+++ b/Goobi/src/org/goobi/production/export/ExportDocket.java
@@ -5,7 +5,7 @@ package org.goobi.production.export;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/export/ExportXmlLog.java
+++ b/Goobi/src/org/goobi/production/export/ExportXmlLog.java
@@ -5,7 +5,7 @@ package org.goobi.production.export;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/IlikeExpression.java
+++ b/Goobi/src/org/goobi/production/flow/IlikeExpression.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/helper/BatchDisplayHelper.java
+++ b/Goobi/src/org/goobi/production/flow/helper/BatchDisplayHelper.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/helper/BatchDisplayItem.java
+++ b/Goobi/src/org/goobi/production/flow/helper/BatchDisplayItem.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/helper/JobCreation.java
+++ b/Goobi/src/org/goobi/production/flow/helper/JobCreation.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/helper/SearchResultGeneration.java
+++ b/Goobi/src/org/goobi/production/flow/helper/SearchResultGeneration.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.helper;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/jobs/AbstractGoobiJob.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/AbstractGoobiJob.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.jobs;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/jobs/HistoryAnalyserJob.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/HistoryAnalyserJob.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.jobs;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/jobs/HotfolderJob.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/HotfolderJob.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.jobs;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/jobs/IGoobiJob.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/IGoobiJob.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.jobs;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/jobs/JobManager.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/JobManager.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.jobs;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/IDataSource.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/IDataSource.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/IStatisticalQuestion.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/IStatisticalQuestion.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/IStatisticalQuestionLimitedTimeframe.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/IStatisticalQuestionLimitedTimeframe.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/StatisticsManager.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/StatisticsManager.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/StatisticsRenderingElement.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/StatisticsRenderingElement.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/StepInformation.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/StepInformation.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/enums/CalculationUnit.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/enums/CalculationUnit.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/enums/ResultOutput.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/enums/ResultOutput.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/enums/StatisticsMode.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/enums/StatisticsMode.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/enums/TimeUnit.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/enums/TimeUnit.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.enums;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/Converter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/Converter.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterHelper.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterHelper.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterString.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterString.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/IEvaluableFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/IEvaluableFilter.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/ImprovedSQLProduction.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/ImprovedSQLProduction.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/ParametersData.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/ParametersData.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLGenerator.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLGenerator.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLProduction.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLProduction.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequestByName.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequestByName.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequests.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequests.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequestsImprovedDiscrimination.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequestsImprovedDiscrimination.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStorage.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStorage.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestCorrections.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestCorrections.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProduction.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProduction.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectAssociations.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectAssociations.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestStorage.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestStorage.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestUsergroups.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestUsergroups.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestVolumeStatus.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestVolumeStatus.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilter.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedStepFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedStepFilter.java
@@ -4,7 +4,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserProcessesFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserProcessesFilter.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserProjectFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserProjectFilter.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserTemplatesFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserTemplatesFilter.java
@@ -5,7 +5,7 @@ package org.goobi.production.flow.statistics.hibernate;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/DocstructElement.java
+++ b/Goobi/src/org/goobi/production/importer/DocstructElement.java
@@ -3,7 +3,7 @@ package org.goobi.production.importer;
 /**
  * This file is part of the Goobi Application - a Workflow tool for the support of mass digitization.
  * 
- * Visit the websites for more information. - http://www.goobi.org - http://launchpad.net/goobi-production - http://gdz.sub.uni-goettingen.de -
+ * Visit the websites for more information. - http://www.goobi.org - https://github.com/goobi/goobi-production - http://gdz.sub.uni-goettingen.de -
  * http://www.intranda.com - http://digiverso.com
  * 
  * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free

--- a/Goobi/src/org/goobi/production/importer/FireburnDataImport.java
+++ b/Goobi/src/org/goobi/production/importer/FireburnDataImport.java
@@ -5,7 +5,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/FireburnProperty.java
+++ b/Goobi/src/org/goobi/production/importer/FireburnProperty.java
@@ -5,7 +5,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/GoobiHotfolder.java
+++ b/Goobi/src/org/goobi/production/importer/GoobiHotfolder.java
@@ -5,7 +5,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/ImportConflicts.java
+++ b/Goobi/src/org/goobi/production/importer/ImportConflicts.java
@@ -5,7 +5,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/ImportObject.java
+++ b/Goobi/src/org/goobi/production/importer/ImportObject.java
@@ -5,7 +5,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/ProductionData.java
+++ b/Goobi/src/org/goobi/production/importer/ProductionData.java
@@ -6,7 +6,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
+++ b/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
@@ -6,7 +6,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/importer/Record.java
+++ b/Goobi/src/org/goobi/production/importer/Record.java
@@ -5,7 +5,7 @@ package org.goobi.production.importer;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/ImportPluginLoader.java
+++ b/Goobi/src/org/goobi/production/plugin/ImportPluginLoader.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/PluginLoader.java
+++ b/Goobi/src/org/goobi/production/plugin/PluginLoader.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/interfaces/AbstractStepPlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/interfaces/AbstractStepPlugin.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin.interfaces;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/interfaces/ICommandPlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/interfaces/ICommandPlugin.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin.interfaces;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/interfaces/IGoobiHotfolder.java
+++ b/Goobi/src/org/goobi/production/plugin/interfaces/IGoobiHotfolder.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin.interfaces;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/interfaces/IImportPlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/interfaces/IImportPlugin.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin.interfaces;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/interfaces/IPlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/interfaces/IPlugin.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin.interfaces;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/interfaces/IStepPlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/interfaces/IStepPlugin.java
@@ -5,7 +5,7 @@ package org.goobi.production.plugin.interfaces;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/plugin/interfaces/IValidatorPlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/interfaces/IValidatorPlugin.java
@@ -4,7 +4,7 @@ package org.goobi.production.plugin.interfaces;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/properties/AccessCondition.java
+++ b/Goobi/src/org/goobi/production/properties/AccessCondition.java
@@ -5,7 +5,7 @@ package org.goobi.production.properties;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/properties/IProperty.java
+++ b/Goobi/src/org/goobi/production/properties/IProperty.java
@@ -4,7 +4,7 @@ package org.goobi.production.properties;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/properties/ImportProperty.java
+++ b/Goobi/src/org/goobi/production/properties/ImportProperty.java
@@ -5,7 +5,7 @@ package org.goobi.production.properties;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/properties/ProcessProperty.java
+++ b/Goobi/src/org/goobi/production/properties/ProcessProperty.java
@@ -5,7 +5,7 @@ package org.goobi.production.properties;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/properties/PropertyParser.java
+++ b/Goobi/src/org/goobi/production/properties/PropertyParser.java
@@ -4,7 +4,7 @@ package org.goobi.production.properties;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/properties/ShowStepCondition.java
+++ b/Goobi/src/org/goobi/production/properties/ShowStepCondition.java
@@ -5,7 +5,7 @@ package org.goobi.production.properties;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/properties/Type.java
+++ b/Goobi/src/org/goobi/production/properties/Type.java
@@ -5,7 +5,7 @@ package org.goobi.production.properties;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/search/api/IIndexer.java
+++ b/Goobi/src/org/goobi/production/search/api/IIndexer.java
@@ -4,7 +4,7 @@ package org.goobi.production.search.api;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/production/search/api/ISearch.java
+++ b/Goobi/src/org/goobi/production/search/api/ISearch.java
@@ -4,7 +4,7 @@ package org.goobi.production.search.api;
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/webapi/beans/Field.java
+++ b/Goobi/src/org/goobi/webapi/beans/Field.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/src/org/goobi/webapi/beans/GoobiProcess.java
+++ b/Goobi/src/org/goobi/webapi/beans/GoobiProcess.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/webapi/beans/GoobiProcessStep.java
+++ b/Goobi/src/org/goobi/webapi/beans/GoobiProcessStep.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/webapi/beans/IdentifierPPN.java
+++ b/Goobi/src/org/goobi/webapi/beans/IdentifierPPN.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/webapi/beans/Label.java
+++ b/Goobi/src/org/goobi/webapi/beans/Label.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/src/org/goobi/webapi/beans/ProjectsRootNode.java
+++ b/Goobi/src/org/goobi/webapi/beans/ProjectsRootNode.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/src/org/goobi/webapi/dao/GoobiProcessDAO.java
+++ b/Goobi/src/org/goobi/webapi/dao/GoobiProcessDAO.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/webapi/provider/ParamExceptionMapper.java
+++ b/Goobi/src/org/goobi/webapi/provider/ParamExceptionMapper.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/webapi/resources/CatalogueConfiguration.java
+++ b/Goobi/src/org/goobi/webapi/resources/CatalogueConfiguration.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/src/org/goobi/webapi/resources/Processes.java
+++ b/Goobi/src/org/goobi/webapi/resources/Processes.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/src/org/goobi/webapi/resources/Projects.java
+++ b/Goobi/src/org/goobi/webapi/resources/Projects.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/src/quartz.properties
+++ b/Goobi/src/quartz.properties
@@ -2,7 +2,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/Goobi/test/src/de/sub/goobi/helper/FilesystemHelperTest.java
+++ b/Goobi/test/src/de/sub/goobi/helper/FilesystemHelperTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/de/sub/goobi/helper/archive/ProcessSwapOutTaskTest.java
+++ b/Goobi/test/src/de/sub/goobi/helper/archive/ProcessSwapOutTaskTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/de/sub/goobi/helper/encryption/DesEncrypterTest.java
+++ b/Goobi/test/src/de/sub/goobi/helper/encryption/DesEncrypterTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/de/sub/goobi/helper/importer/ImportOpacTest.java
+++ b/Goobi/test/src/de/sub/goobi/helper/importer/ImportOpacTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/de/sub/goobi/metadaten/MockMetadatum.java
+++ b/Goobi/test/src/de/sub/goobi/metadaten/MockMetadatum.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/test/src/de/sub/goobi/metadaten/PaginatorTest.java
+++ b/Goobi/test/src/de/sub/goobi/metadaten/PaginatorTest.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *	   - http://gdz.sub.uni-goettingen.de
  *	   - http://www.goobi.org
- *	   - http://launchpad.net/goobi-production
+ *	   - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/Goobi/test/src/de/sub/goobi/samples/BenutzerTest.java
+++ b/Goobi/test/src/de/sub/goobi/samples/BenutzerTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/de/sub/goobi/samples/BenutzergruppenTest.java
+++ b/Goobi/test/src/de/sub/goobi/samples/BenutzergruppenTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/de/sub/goobi/samples/UnitRunner.java
+++ b/Goobi/test/src/de/sub/goobi/samples/UnitRunner.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/io/BackupFileRotationTest.java
+++ b/Goobi/test/src/org/goobi/io/BackupFileRotationTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/pagination/IntegerSequenceTest.java
+++ b/Goobi/test/src/org/goobi/pagination/IntegerSequenceTest.java
@@ -5,7 +5,7 @@
 // * Visit the websites for more information.
 // *    - http://gdz.sub.uni-goettingen.de
 // *    - http://www.goobi.org
-// *    - http://launchpad.net/goobi-production
+// *    - https://github.com/goobi/goobi-production
 // *
 // * Copyright 2011, Center for Retrospective Digitization, Göttingen (GDZ),
 // *

--- a/Goobi/test/src/org/goobi/pagination/RomanNumberSequenceTest.java
+++ b/Goobi/test/src/org/goobi/pagination/RomanNumberSequenceTest.java
@@ -5,7 +5,7 @@
 // * Visit the websites for more information.
 // *    - http://gdz.sub.uni-goettingen.de
 // *    - http://www.goobi.org
-// *    - http://launchpad.net/goobi-production
+// *    - https://github.com/goobi/goobi-production
 // *
 // * Copyright 2011, Center for Retrospective Digitization, Göttingen (GDZ),
 // *

--- a/Goobi/test/src/org/goobi/production/GoobiVersionTest.java
+++ b/Goobi/test/src/org/goobi/production/GoobiVersionTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/StatisticsManagerTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/StatisticsManagerTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/StatisticsRenderingElementTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/StatisticsRenderingElementTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/enums/CalculationUnitTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/enums/CalculationUnitTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/enums/ResultOutputTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/enums/ResultOutputTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/enums/StatisticsModeTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/enums/StatisticsModeTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/enums/TimeUnitTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/enums/TimeUnitTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/ConverterTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/ConverterTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLHelperTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLHelperTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLProductionTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLProductionTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequestsTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLStepRequestsTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLStorageTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/SQLStorageTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestCorrectionsTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestCorrectionsTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestProductionTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestProductionTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectAssociationsTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectAssociationsTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestStorageTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestStorageTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughputTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughputTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilterTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilterTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/UserProcessesFilterTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/UserProcessesFilterTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/UserTemplatesFilterTest.java
+++ b/Goobi/test/src/org/goobi/production/flow/statistics/hibernate/UserTemplatesFilterTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/Goobi/test/src/org/goobi/webapi/beans/IdentifierPPNTest.java
+++ b/Goobi/test/src/org/goobi/webapi/beans/IdentifierPPNTest.java
@@ -3,7 +3,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 

--- a/build.properties.template
+++ b/build.properties.template
@@ -3,7 +3,7 @@
 # * 
 # * Visit the websites for more information. 
 # *     		- http://www.goobi.org
-# *     		- http://launchpad.net/goobi-production
+# *     		- https://github.com/goobi/goobi-production
 # * 		    - http://gdz.sub.uni-goettingen.de
 # * 			- http://www.intranda.com
 # * 			- http://digiverso.com 

--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
   ~ Visit the websites for more information.
   ~     - http://gdz.sub.uni-goettingen.de
   ~     - http://www.goobi.org
-  ~     - http://launchpad.net/goobi-production
+  ~     - https://github.com/goobi/goobi-production
   ~
   ~ This program is free software; you can redistribute it and/or modify it under
   ~ the terms of the GNU General Public License as published by the Free Software

--- a/deploy.properties.template
+++ b/deploy.properties.template
@@ -5,7 +5,7 @@
 # Visit the websites for more information.
 #     - http://gdz.sub.uni-goettingen.de
 #     - http://www.goobi.org
-#     - http://launchpad.net/goobi-production
+#     - https://github.com/goobi/goobi-production
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software

--- a/deploy.xml
+++ b/deploy.xml
@@ -4,7 +4,7 @@
  * 
  * Visit the websites for more information. 
  *     		- http://www.goobi.org
- *     		- http://launchpad.net/goobi-production
+ *     		- https://github.com/goobi/goobi-production
  * 		    - http://gdz.sub.uni-goettingen.de
  * 			- http://www.intranda.com
  * 			- http://digiverso.com 


### PR DESCRIPTION
It is misleading if readers are told to visit the launchpad website.

Maybe those comments should be removed from all source files (488!).
IMHO it would be sufficient to show them once in README.md.
