### PR TITLE
Merge: A fix for the broken test

### DIFF
--- a/Goobi/test/src/de/sub/goobi/helper/archive/ProcessSwapOutTaskTest.java
+++ b/Goobi/test/src/de/sub/goobi/helper/archive/ProcessSwapOutTaskTest.java
@@ -38,9 +38,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import de.sub.goobi.beans.Prozess;
-import de.sub.goobi.persistence.ProzessDAO;
 import de.sub.goobi.helper.tasks.ProcessSwapInTask;
 import de.sub.goobi.helper.tasks.ProcessSwapOutTask;
+import de.sub.goobi.persistence.ProzessDAO;
 
 @Ignore("Crashing") 
 public class ProcessSwapOutTaskTest {
@@ -73,14 +73,15 @@ public class ProcessSwapOutTaskTest {
    private void swapOut() {
       ProcessSwapOutTask psot = new ProcessSwapOutTask();
       psot.initialize(proz);
-      psot.execute();
+		psot.run();
       assertTrue(proz.isSwappedOutGui());
    }
 
+	@SuppressWarnings("unused")
    private void swapIn() {
       ProcessSwapInTask psot = new ProcessSwapInTask();
       psot.initialize(proz);
-      psot.execute();
+		psot.run();
       assertFalse(proz.isSwappedOutGui());
    }
 


### PR DESCRIPTION
This will fix the broken test. I however do recommend never to run it. It will swap out the goobi process with id = 119 whatever that is, and will not swap it back in.
