### PR TITLE
Adds the parameter MetsEditorDisplayFileManipulation

### DIFF
--- a/Goobi/config/goobi_config.properties
+++ b/Goobi/config/goobi_config.properties
@@ -328,6 +328,9 @@ MetsEditorMaxTitleLength=0
 # initialise all sub elements in Mets editor to assign default values, default value is true
 MetsEditorEnableDefaultInitialisation=true
 
+# display the file manipulation dialog within the mets editor
+MetsEditorDisplayFileManipulation=true
+
 # indicates whether the source folder should be created automatically or not, default is false
 createSourceFolder=false
 


### PR DESCRIPTION
Adds the parameter MetsEditorDisplayFileManipulation=true to display the file manipulation dialog within the mets editor.
