### PR TITLE
Fix: Set batch type automatically in loop, too

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/tasks/CreateProcessesTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/CreateProcessesTask.java
@@ -445,7 +445,7 @@ public class CreateProcessesTask extends EmptyTask {
 		if (logisticsBatch.size() > 0) {
 			logisticsBatch.setTitle(firstGroupFrom(processTitle) + " (" + batchLabel + ')');
 			BatchDAO.save(logisticsBatch);
-			logisticsBatch = new Batch();
+			logisticsBatch = new Batch(Type.LOGISTIC);
 		}
 		currentBreakMark = null;
 		batchLabel = null;


### PR DESCRIPTION
When several logistics batches are created during newspaper process creation, they shall automatically be classified as logistics batch.
