### PR TITLE
Solves the issues #241 and #264

### DIFF
--- a/Goobi/config/goobi_config.properties
+++ b/Goobi/config/goobi_config.properties
@@ -83,9 +83,17 @@ DIRECTORY_SUFFIX=media
 
 importUseOldConfiguration=false
 
-# creation of process sub-directories
+# creation and export of process sub-directories
 # e.g. images/(processtitle)_tif&ocr/(processtitle)_pdf
-processDirs=
+# (processtitle) is a placeholder for the process title
+# If you comment in the parameter processDirs without a value,
+# the result is that the whole process directory
+# will be exported and no directory well be created.
+# If you leave the parameter commented out,
+# the whole functionality is disabled.
+# Using the processDirs parameter is always an addition
+# to the existing folder creating and exporting functions of goobi.production.
+# processDirs=
 
 # set if Master-Images-Folder 'orig_' should be used at all
 useOrigFolder=true

--- a/Goobi/src/de/sub/goobi/config/ConfigMain.java
+++ b/Goobi/src/de/sub/goobi/config/ConfigMain.java
@@ -59,7 +59,7 @@ public class ConfigMain {
 			myLogger.warn("Loading of " + FileNames.CONFIG_FILE + " failed. Trying to start with empty configuration.", e);
 			config = new PropertiesConfiguration();
 		}
-		config.setListDelimiter('|');
+		config.setListDelimiter('&');
 		config.setReloadingStrategy(new FileChangedReloadingStrategy());
 		return config;
 	}


### PR DESCRIPTION
Adds additional documentation to the processDirs parameter within goobi_config.properties and
the parameter is now commented out by default (#241). Additionally solves the issue of different list delimiters used in method de.sub.goobi.config.getConfig() (#264).
