### PR TITLE
scripts: Replace /bin/bash by /bin/sh

### DIFF
--- a/Goobi/scripts/script_createDirMeta.sh
+++ b/Goobi/scripts/script_createDirMeta.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # * This file is part of the Goobi Application - a Workflow tool for the support of mass digitization.
 # * 
@@ -33,4 +33,3 @@
 Directory="$1"
 
 /bin/mkdir -vm 0775 "$Directory"
-

--- a/Goobi/scripts/script_createDirUserHome.sh
+++ b/Goobi/scripts/script_createDirUserHome.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # * This file is part of the Goobi Application - a Workflow tool for the support of mass digitization.
 # * 
@@ -37,4 +37,3 @@ Home="$2"
 /bin/chmod g+w "$Home"
 /bin/chown $User "$Home"
 /bin/chgrp tomcat "$Home"
-

--- a/Goobi/scripts/script_createSymLink.sh
+++ b/Goobi/scripts/script_createSymLink.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # * This file is part of the Goobi Application - a Workflow tool for the support of mass digitization.
 # * 

--- a/Goobi/scripts/script_deleteSymLink.sh
+++ b/Goobi/scripts/script_deleteSymLink.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # * This file is part of the Goobi Application - a Workflow tool for the support of mass digitization.
 # * 


### PR DESCRIPTION
/bin/sh is the standard shell which is available on all systems, and it
is usually smaller, faster und less complex (= potentially less bugs).

The scripts don't use bash features, so /bin/sh is sufficient.

Signed-off-by: Stefan Weil sw@weilnetz.de
