### PR TITLE
Add possibility to delay page loading after a step was finished

### DIFF
--- a/Goobi/config/goobi_config.properties
+++ b/Goobi/config/goobi_config.properties
@@ -216,6 +216,21 @@ ApplicationWebsiteMsg=goobiWebseite
 
 
 # -----------------------------------
+# Closing of steps
+# -----------------------------------
+# Closing a step after some user chose to finish the task is done
+# asynchronously. Unless in case of time-taking automatic tasks, this usually
+# only takes fractions of a second. However, the result page is usually
+# rendered just in the moment before the step is closed, still showing the task
+# and thus giving the user the feeling of a caching problem: It requires to
+# reload the page to gain access the next step which one would expect to be
+# available right away. Setting this property (in milliseconds) allows to
+# retard the loading of the next page in favour of hopefully getting access
+# to the next step. Set to 0 or comment out to disable.
+waitOnCloseStepMillis=200
+
+
+# -----------------------------------
 # Data protection
 # -----------------------------------
 

--- a/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
+++ b/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 import javax.faces.context.FacesContext;
 import javax.servlet.http.HttpServletResponse;
@@ -47,6 +48,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 import org.goobi.production.cli.helper.WikiFieldHelper;
+import org.goobi.production.constants.Parameters;
 import org.goobi.production.enums.PluginType;
 import org.goobi.production.flow.jobs.HistoryAnalyserJob;
 import org.goobi.production.flow.statistics.hibernate.IEvaluableFilter;
@@ -529,7 +531,14 @@ public class AktuelleSchritteForm extends BasisForm {
 		this.mySchritt.setEditTypeEnum(StepEditType.MANUAL_SINGLE);
 		StepObject so = StepManager.getStepById(this.mySchritt.getId());
 		new HelperSchritteWithoutHibernate().CloseStepObjectAutomatic(so, true);
-		// new HelperSchritte().SchrittAbschliessen(this.mySchritt, true);
+		long millisToWait = ConfigMain.getLongParameter(Parameters.WAIT_ON_CLOSE_STEP, 0);
+		if (millisToWait > 0) {
+			try {
+				TimeUnit.MILLISECONDS.sleep(millisToWait);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
 		return FilterAlleStart();
 	}
 

--- a/Goobi/src/org/goobi/production/constants/Parameters.java
+++ b/Goobi/src/org/goobi/production/constants/Parameters.java
@@ -133,4 +133,17 @@ public class Parameters {
 	 * given they have the same meta data type addable. Defaults to false.
 	 */
 	public static final String USE_METADATA_ENRICHMENT = "useMetadataEnrichment";
+
+	/**
+	 * Milliseconds. Closing a step after some user chose to finish the task is
+	 * done asynchronously. Unless in case of time-taking automatic tasks, this
+	 * usually only takes fractions of a second. However, the result page is
+	 * usually rendered just in the moment before the step is closed, still
+	 * showing the task and thus giving the user the feeling of a caching
+	 * problem: It requires to reload the page to gain access the next step
+	 * which one would expect to be available right away. The property
+	 * "waitOnCloseStepMillis" allows to manually retard the loading of the next
+	 * page in favour of hopefully getting access to the next step.
+	 */
+	public static final String WAIT_ON_CLOSE_STEP = "waitOnCloseStepMillis";
 }


### PR DESCRIPTION
Closing a step after some user chose to finish the task is done asynchronously. Unless in case of time-taking automatic tasks, this usually only takes fractions of a second. However, the result page is usually rendered just in the moment before the step is closed, still showing the task and thus giving the user the feeling of a caching problem: It requires to reload the page to gain access the next step which one would expect to be available right away. This commit adds the possibility to set a property to delay the loading of the next page for some milliseconds to increase the probability ot get access to the next step just in turn.

I’ve put a value of 200 ms in the sample goobi_config.properties file. On my local installation, this doesn’t cause a notable difference in response speed when closing a step, but fixes the “caching problem”.
