### PR TITLE
Fixes #275: Missing not null check in MetadatenImagesHelper.createPagination()

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
@@ -192,9 +192,11 @@ public class MetadatenImagesHelper {
         }
         try {
             List<String> imageNamesInMediaFolder = getDataFiles(inProzess);
-            for (String imageName : imageNamesInMediaFolder) {
-                if (!assignedImages.containsKey(imageName)) {
-                    imagesWithoutPageElements.add(imageName);
+            if (imageNamesInMediaFolder != null) {
+                for (String imageName : imageNamesInMediaFolder) {
+                    if (!assignedImages.containsKey(imageName)) {
+                        imagesWithoutPageElements.add(imageName);
+                    }
                 }
             }
         } catch (InvalidImagesException e1) {


### PR DESCRIPTION
 Prevent null pointer exception.
