### PR TITLE
Update Java version for source and target from 1.5 to 1.7

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -35,8 +35,8 @@
     <property name="build.classes" value="${build.dir}/WEB-INF/classes"/>
     <property name="build.classes.test" value="${build.dir}/test-classes"/>
     <property name="build.jsp.src" value="${build.dir}/WEB-INF/src"/>
-    <property name="build.javac.target" value="1.5"/>
-    <property name="build.javac.source" value="1.5"/>
+    <property name="build.javac.target" value="1.7"/>
+    <property name="build.javac.source" value="1.7"/>
     <property name="build.javac.args" value="-Xpkginfo:nonempty"/>
     <property name="doc.javadocs.dir" value="${build.dir}/javadoc"/>
     <property name="test.report.dir" value="${build.dir}/test-reports/"/>
@@ -162,9 +162,9 @@
         <fail message="Servlet API is missing."/>
     </target>
 
-    <!-- Check for Java version 1.5 -->
+    <!-- Check for Java version 1.7 -->
     <target name="check-java-version">
-        <fail message="Build required at least version 1.5 of the Java compiler ">
+        <fail message="Build required at least version 1.7 of the Java compiler ">
             <condition>
                 <and>
                     <contains string="${java.version}" substring="1.0"/>
@@ -172,6 +172,8 @@
                     <contains string="${java.version}" substring="1.2"/>
                     <contains string="${java.version}" substring="1.3"/>
                     <contains string="${java.version}" substring="1.4"/>
+                    <contains string="${java.version}" substring="1.5"/>
+                    <contains string="${java.version}" substring="1.6"/>
                 </and>
             </condition>
         </fail>


### PR DESCRIPTION
Older versions of Java are unsupported.

This patch also fixes 3 Java compiler warnings:
  [javac] warning:
    [options] bootstrap class path not set in conjunction with -source 1.5

Signed-off-by: Stefan Weil <sw@weilnetz.de>