### PR TITLE
Fix warning from FindBugs ("Dead store to local variable")

### DIFF
--- a/Kitodo/src/main/webapp/plugins/import/PicaMassImport/com/googlecode/fascinator/redbox/sru/SRUClient.java
+++ b/Kitodo/src/main/webapp/plugins/import/PicaMassImport/com/googlecode/fascinator/redbox/sru/SRUClient.java
@@ -145,8 +145,7 @@ public class SRUClient {
             String version) throws MalformedURLException {
         // Make sure our URL is valid first
         try {
-            @SuppressWarnings("unused")
-			URL url = new URL(baseUrl);
+            new URL(baseUrl);
             this.baseUrl = baseUrl;
         } catch (MalformedURLException ex) {
             log.error("Invalid URL passed to constructor: ", ex);


### PR DESCRIPTION
The constructor of URL is only called to test whether it raises an
exception – no need to store the returned value in a local variable.

Signed-off-by: Stefan Weil sw@weilnetz.de
