### PR TITLE
Fix some comments in configuration file

### DIFF
--- a/Goobi/config/goobi_config.properties
+++ b/Goobi/config/goobi_config.properties
@@ -31,8 +31,8 @@
 # Directories
 # -----------------------------------
 
-# Absolute path to the directory that the configuration files are stored in.
-# The path must end in the file separator.
+# Absolute path to the directory that the configuration files are stored in,
+# terminated by a directory separator ("/").
 # Note: Several, but not all configuration files are read from that directory.
 #       You may want to decide to point this path to the directory where
 #       the servlet container will extract the configuration files to (like
@@ -40,30 +40,32 @@
 KonfigurationVerzeichnis=/usr/local/goobi/config/
 
 # Absolute path to the directory that the rule set definition files will be
-# read from. The path must end in the file separator.
+# read from. It must be terminated by a directory separator ("/").
 RegelsaetzeVerzeichnis=/usr/local/goobi/rulesets/
 
 # Absolute path to the directory that XSLT files are stored in which are used
 # to transform the "XML log" (as visible from the XML button in the processes
 # list) to a downloadable PDF docket which can be enclosed with the physical
-# binding units to digitise. The path must end in the file separator.
+# binding units to digitise.
+# The path must be terminated by a directory separator ("/").
 xsltFolder=/usr/local/goobi/xslt/
 
-# Absolute path to the directory that process directories will be created in.
-# The servlet container must have write permission to that directory and the
-# path configuerd must end in the file separator.
+# Absolute path to the directory that process directories will be created in,
+# terminated by a directory separator ("/").
+# The servlet container must have write permission to that directory.
 MetadatenVerzeichnis=/usr/local/goobi/metadata/
 
-# Absolute path to the base directory of the users' home directories. The path
-# must end in the file separator. If a user accepts a task to work on which
+# Absolute path to the base directory of the users' home directories,
+# terminated by a directory separator ("/").
+# If a user accepts a task to work on which
 # will require him or her to have access permission to the data of a process,
 # a symbolic link to the process directory in question will be created in his
 # or her home directory that will be removed again after finishing the task.
 # Note: If LDAP is used, the users' home dirs will instead be read from LDAP
 dir_Users=/home/
 
-# Absolute path to a folder the application can temporarily create files in.
-# The path must end in the file separator.
+# Absolute path to a folder the application can temporarily create files in,
+# terminated by a directory separator ("/").
 tempfolder=/usr/local/goobi/tmp/
 
 
@@ -178,8 +180,8 @@ ApplicationIndividualHeader=<table><tr><tr><td><a style\="color\:white" target\=
 # Internationalization
 # -----------------------------------
 
-# Absolute path to the directory that the resource bundle files are stored in.
-# The path must end in the file separator.
+# Absolute path to the directory that the resource bundle files are stored in,
+# terminated by a directory separator ("/").
 # Note: If this directory DOESN'T EXIST, the internal resource bundles will be
 #       used. If this directory exists BUT DOES NOT CONTAIN suitable resources,
 #       the screens will not work as expected.
@@ -629,9 +631,10 @@ ocrUrl=
 # Plug-in interface
 # -----------------------------------
 
-# Absolute path to the plugins directory, must end in the file separator. The
-# plugins directory must contain a subfolder for each plugin type, which must
-# be named "command", "import", "opac", "step" and "validation", resp.
+# Absolute path to the plugins directory,
+# terminated by a directory separator ("/").
+# The plugins directory must contain a subfolder for each plugin type, which
+# must be named "command", "import", "opac", "step" and "validation", resp.
 # In each folder .jar files containing plugin implementations can be placed.
 pluginFolder=/usr/local/goobi/plugins/
 


### PR DESCRIPTION
While looking for a typo ("configuerd"), I noticed that some comments
used "file separator" (which is ASCII FS) instead of "directory separator".

Maybe the confusion was caused by Java's File.separator.

Signed-off-by: Stefan Weil <sw@weilnetz.de>