### PR TITLE
Use a final object to lock on

### DIFF
--- a/Goobi/src/de/sub/goobi/persistence/HibernateUtilOld.java
+++ b/Goobi/src/de/sub/goobi/persistence/HibernateUtilOld.java
@@ -37,8 +37,6 @@ import org.hibernate.Transaction;
 import org.hibernate.auction.exceptions.InfrastructureException;
 import org.hibernate.cfg.Configuration;
 
-import com.sun.org.apache.bcel.internal.generic.NEW;
-
 //TODO: Fix for Hibernate-Session-Management, replaced with older version, 
 // the newer version follows on bottom  of this class
 

--- a/Goobi/src/de/sub/goobi/persistence/HibernateUtilOld.java
+++ b/Goobi/src/de/sub/goobi/persistence/HibernateUtilOld.java
@@ -37,6 +37,8 @@ import org.hibernate.Transaction;
 import org.hibernate.auction.exceptions.InfrastructureException;
 import org.hibernate.cfg.Configuration;
 
+import com.sun.org.apache.bcel.internal.generic.NEW;
+
 //TODO: Fix for Hibernate-Session-Management, replaced with older version, 
 // the newer version follows on bottom  of this class
 
@@ -58,6 +60,7 @@ public class HibernateUtilOld {
 	private static final ThreadLocal<Session> threadSession = new ThreadLocal<Session>();
 	private static final ThreadLocal<Transaction> threadTransaction = new ThreadLocal<Transaction>();
 	private static final ThreadLocal<Interceptor> threadInterceptor = new ThreadLocal<Interceptor>();
+	private static final Object sessionFactoryRebuildLock = new Object();
 
 	// Create the initial SessionFactory from the default configuration files
 	static {
@@ -98,7 +101,7 @@ public class HibernateUtilOld {
 	 * 
 	 */
 	public static void rebuildSessionFactory() throws InfrastructureException {
-		synchronized (sessionFactory) {
+		synchronized (sessionFactoryRebuildLock) {
 			try {
 				sessionFactory = getConfiguration().buildSessionFactory();
 			} catch (Exception ex) {
@@ -113,7 +116,7 @@ public class HibernateUtilOld {
 	 * @param cfg
 	 */
 	public static void rebuildSessionFactory(Configuration cfg) throws InfrastructureException {
-		synchronized (sessionFactory) {
+		synchronized (sessionFactoryRebuildLock) {
 			try {
 				sessionFactory = cfg.buildSessionFactory();
 				configuration = cfg;


### PR DESCRIPTION
Java locks on _objects_ that are held in variables. It does _not_ lock on the variable. If the variable is changed in the `synchronized` block, a concurrent thread will lock on the other object, making the locking not working as expected.

Fix for Coverity IDs 44438, 44440