### PR TITLE
export: Fix some warnings (FindBugs)

### DIFF
--- a/Goobi/src/org/goobi/production/export/ExportXmlLog.java
+++ b/Goobi/src/org/goobi/production/export/ExportXmlLog.java
@@ -91,11 +91,15 @@ public class ExportXmlLog implements IProcessDataExport {
 	 */
 
 	public void startExport(Prozess p, String destination) throws FileNotFoundException, IOException {
-		startExport(p, new FileOutputStream(destination), null);
+		try (FileOutputStream ostream = new FileOutputStream(destination)) {
+			startExport(p, ostream, null);
+		}
 	}
 
 	public void startExport(Prozess p, File dest) throws FileNotFoundException, IOException {
-		startExport(p, new FileOutputStream(dest), null);
+		try (FileOutputStream ostream = new FileOutputStream(dest)) {
+			startExport(p, ostream, null);
+		}
 	}
 
 	/**


### PR DESCRIPTION
FindBugs warnings:
* Method may fail to clean up stream or resource

Fix it by using try-with-resources statements (supported since Java 7).

Signed-off-by: Stefan Weil <sw@weilnetz.de>