### PR TITLE
Rewrite try-with-resources to try-catch blocks

### DIFF
--- a/Goobi/src/de/sub/goobi/export/dms/DmsImportThread.java
+++ b/Goobi/src/de/sub/goobi/export/dms/DmsImportThread.java
@@ -31,13 +31,12 @@ import java.io.BufferedReader;
 import java.io.File;
 
 import org.goobi.io.SafeFile;
-import java.io.FileReader;
+import java.io.IOException;
 
 import org.apache.log4j.Logger;
 
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
-import de.sub.goobi.helper.Helper;
 
 public class DmsImportThread extends Thread {
 	private static final Logger myLogger = Logger.getLogger(DmsImportThread.class);
@@ -88,12 +87,22 @@ public class DmsImportThread extends Thread {
 						/* die Logdatei mit der Fehlerbeschreibung einlesen */
 						StringBuffer myBuf = new StringBuffer();
 						myBuf.append("Beim Import ist ein Importfehler aufgetreten: ");
-						try (BufferedReader r = new BufferedReader(this.fileError.createFileReader())) {
+						BufferedReader r = null;
+						try {
+							r = new BufferedReader(this.fileError.createFileReader());
 							String aLine = r.readLine();
 							while (aLine != null) {
 								myBuf.append(aLine);
 								myBuf.append(" ");
 								aLine = r.readLine();
+							}
+						} finally {
+							if (r != null) {
+								try {
+									r.close();
+								} catch (IOException e) {
+									myLogger.error(e);
+								}
 							}
 						}
 						this.rueckgabe = myBuf.toString();

--- a/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
@@ -31,7 +31,6 @@ import java.io.BufferedWriter;
 import org.goobi.io.SafeFile;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.Writer;
 import java.net.URL;
 import java.util.TreeSet;
 
@@ -195,9 +194,20 @@ public class ExportPdf extends ExportMets {
 				 */
 				String text = "error while pdf creation: " + e.getMessage();
 				SafeFile file = new SafeFile(zielVerzeichnis, myProzess.getTitel() + ".PDF-ERROR.log");
-				try (BufferedWriter output = new BufferedWriter(file.createFileWriter())) {
+				BufferedWriter output = null;
+				try {
+					output = new BufferedWriter(file.createFileWriter());
 					output.write(text);
 				} catch (IOException e1) {
+					myLogger.error(e1);
+				} finally {
+					if (output != null) {
+						try {
+							output.close();
+						} catch (IOException e1) {
+							myLogger.error(e1);
+						}
+					}
 				}
 				return false;
 			} finally {

--- a/Goobi/src/de/sub/goobi/helper/CopyFile.java
+++ b/Goobi/src/de/sub/goobi/helper/CopyFile.java
@@ -27,16 +27,18 @@ package de.sub.goobi.helper;
  * library, you may extend this exception to your version of the library, but you are not obliged to do so. If you do not wish to do so, delete this
  * exception statement from your version.
  */
-import org.goobi.io.SafeFile;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.zip.CRC32;
 
+import org.apache.log4j.Logger;
+import org.goobi.io.SafeFile;
+
 // Only usage: in de.sub.goobi.helper.tasks.ProcessSwapOutTask
 public class CopyFile {
+
+	private static final Logger logger = Logger.getLogger(CopyFile.class);
 
    // program options initialized to default values
    private static final int BUFFER_SIZE = 4 * 1024;
@@ -46,16 +48,32 @@ public class CopyFile {
       CRC32 checksum = new CRC32();
       checksum.reset();
 
-      try (
-         InputStream in = srcFile.createFileInputStream();
-         OutputStream out = destFile.createFileOutputStream();
-      ) {
+		InputStream in = null;
+		OutputStream out = null;
+		try {
+			in = srcFile.createFileInputStream();
+			out = destFile.createFileOutputStream();
          byte[] buffer = new byte[BUFFER_SIZE];
          int bytesRead;
          while ((bytesRead = in.read(buffer)) >= 0) {
             checksum.update(buffer, 0, bytesRead);
             out.write(buffer, 0, bytesRead);
          }
+		} finally {
+			if (in != null) {
+				try {
+					in.close();
+				} catch (IOException e) {
+					logger.error(e);
+				}
+			}
+			if (out != null) {
+				try {
+					out.close();
+				} catch (IOException e) {
+					logger.error(e);
+				}
+			}
       }
       return Long.valueOf(checksum.getValue());
 
@@ -64,12 +82,22 @@ public class CopyFile {
    private static Long createChecksum(SafeFile file) throws IOException {
       CRC32 checksum = new CRC32();
       checksum.reset();
-      try (InputStream in = file.createFileInputStream()) {
+		InputStream in = null;
+		try {
+			in = file.createFileInputStream();
          byte[] buffer = new byte[BUFFER_SIZE];
          int bytesRead;
          while ((bytesRead = in.read(buffer)) >= 0) {
             checksum.update(buffer, 0, bytesRead);
          }
+		} finally {
+			if (in != null) {
+				try {
+					in.close();
+				} catch (IOException e) {
+					logger.error(e);
+				}
+			}
       }
       return Long.valueOf(checksum.getValue());
    }

--- a/Goobi/src/de/sub/goobi/helper/WebDav.java
+++ b/Goobi/src/de/sub/goobi/helper/WebDav.java
@@ -33,6 +33,7 @@ import java.io.File;
 import org.goobi.io.SafeFile;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -249,12 +250,20 @@ public class WebDav implements Serializable {
 				return;
 			}
 			TiffHeader tif = new TiffHeader(inProzess);
-			try (
-				BufferedWriter outfile =
+			BufferedWriter outfile = null;
+			try {
+				outfile =
 					new BufferedWriter(new OutputStreamWriter(new FileOutputStream(inProzess.getImagesDirectory()
 						+ "tiffwriter.conf"), "utf-8"));
-			) {
 				outfile.write(tif.getTiffAlles());
+			} finally {
+				if (outfile != null) {
+					try {
+						outfile.close();
+					} catch (IOException e) {
+						myLogger.error(e);
+					}
+				}
 			}
 		} catch (Exception e) {
 			Helper.setFehlerMeldung("Download aborted", e);

--- a/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
+++ b/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
@@ -544,12 +544,14 @@ public class Ldap {
 		/* wenn die Zertifikate noch nicht im Keystore sind, jetzt einlesen */
 		File myPfad = new File(path);
 		if (!myPfad.exists()) {
-			try (
-				FileOutputStream ksos = new FileOutputStream(path);
+			FileOutputStream ksos = null;
+			FileInputStream cacertFile = null;
+			FileInputStream certFile2 = null;
+			try {
+				ksos = new FileOutputStream(path);
 				// TODO: Rename parameters to something more meaningful, this is quite specific for the GDZ
-				FileInputStream cacertFile = new FileInputStream(ConfigMain.getParameter("ldap_cert_root"));
-				FileInputStream certFile2 = new FileInputStream(ConfigMain.getParameter("ldap_cert_pdc"))
-			) {
+				cacertFile = new FileInputStream(ConfigMain.getParameter("ldap_cert_root"));
+				certFile2 = new FileInputStream(ConfigMain.getParameter("ldap_cert_pdc"));
 
 				CertificateFactory cf = CertificateFactory.getInstance("X.509");
 				X509Certificate cacert = (X509Certificate) cf.generateCertificate(cacertFile);
@@ -567,8 +569,29 @@ public class Ldap {
 				ks.store(ksos, password);
 			} catch (Exception e) {
 				myLogger.error(e);
+			} finally {
+				if (ksos != null) {
+					try {
+						ksos.close();
+					} catch (IOException e) {
+						myLogger.error(e);
+					}
+				}
+				if (cacertFile != null) {
+					try {
+						cacertFile.close();
+					} catch (IOException e) {
+						myLogger.error(e);
+					}
+				}
+				if (certFile2 != null) {
+					try {
+						certFile2.close();
+					} catch (IOException e) {
+						myLogger.error(e);
+					}
+				}
 			}
-
 		}
 	}
 

--- a/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
@@ -210,7 +210,9 @@ public void run() {
       * -------------------*/
       Format format = Format.getPrettyFormat();
       format.setEncoding("UTF-8");
-      try (FileOutputStream fos = new FileOutputStream(processDirectory + File.separator + "swapped.xml")) {
+		FileOutputStream fos = null;
+		try {
+			fos = new FileOutputStream(processDirectory + File.separator + "swapped.xml");
          setStatusMessage("writing swapped.xml");
          XMLOutputter xmlOut = new XMLOutputter(format);
          xmlOut.output(doc, fos);
@@ -220,6 +222,14 @@ public void run() {
          setStatusMessage(e.getClass().getName() + " in xmlOut.output: " + e.getMessage());
          setStatusProgress(-1);
          return;
+		} finally {
+			if (fos != null) {
+				try {
+					fos.close();
+				} catch (IOException e) {
+					logger.error(e);
+				}
+			}
       }
       setStatusProgress(90);
 

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
@@ -405,7 +405,9 @@ public class MetadatenImagesHelper {
             logger.trace("inStream");
             BufferedInputStream bis = new BufferedInputStream(inStream);
             logger.trace("BufferedInputStream");
-            try (FileOutputStream fos = new FileOutputStream(outFileName)) {
+			FileOutputStream fos = null;
+			try {
+				fos = new FileOutputStream(outFileName);
                 logger.trace("FileOutputStream");
                 byte[] bytes = new byte[8192];
                 int count = bis.read(bytes);
@@ -416,6 +418,14 @@ public class MetadatenImagesHelper {
                 if (count != -1) {
                     fos.write(bytes, 0, count);
                 }
+			} finally {
+				if (fos != null) {
+					try {
+						fos.close();
+					} catch (IOException e) {
+						logger.error(e);
+					}
+				}
             }
             logger.trace("write");
             bis.close();

--- a/Goobi/src/org/goobi/production/export/ExportXmlLog.java
+++ b/Goobi/src/org/goobi/production/export/ExportXmlLog.java
@@ -65,7 +65,6 @@ import de.sub.goobi.beans.Werkstueck;
 import de.sub.goobi.beans.Werkstueckeigenschaft;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.exceptions.DAOException;
-import de.sub.goobi.helper.exceptions.ExportFileException;
 import de.sub.goobi.helper.exceptions.SwapException;
 
 /**
@@ -91,14 +90,34 @@ public class ExportXmlLog implements IProcessDataExport {
 	 */
 
 	public void startExport(Prozess p, String destination) throws FileNotFoundException, IOException {
-		try (FileOutputStream ostream = new FileOutputStream(destination)) {
+		FileOutputStream ostream = null;
+		try {
+			ostream = new FileOutputStream(destination);
 			startExport(p, ostream, null);
+		} finally {
+			if (ostream != null) {
+				try {
+					ostream.close();
+				} catch (IOException e) {
+					logger.error(e);
+				}
+			}
 		}
 	}
 
 	public void startExport(Prozess p, File dest) throws FileNotFoundException, IOException {
-		try (FileOutputStream ostream = new FileOutputStream(dest)) {
+		FileOutputStream ostream = null;
+		try {
+			ostream = new FileOutputStream(dest);
 			startExport(p, ostream, null);
+		} finally {
+			if (ostream != null) {
+				try {
+					ostream.close();
+				} catch (IOException e) {
+					logger.error(e);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Recent changes introduced try-with-resources statements that do not compile with Java 1.6. Since the content server does not work with Java > 1.6 under certain circumstances, this needs to be fixed.

@henning-gerhardt Do the build scripts create byte code compliant to Java 1.6? I fear not, since the Travis CI build should have failed for the branches that introduced the try-with-resources statements. Could you please check for this and fix it if necessary?
