### PR TITLE
Exclude empty packages from build (fix javac warnings)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -247,6 +247,7 @@
 			debuglevel="lines,vars,source"
 			classpathref="compile.classpath">
             <compilerarg value="${build.javac.args}" />
+            <exclude name="**/package-info.java"/>
         </javac>
     </target>
 
@@ -302,6 +303,7 @@
 				<path refid="compile.classpath"/>
 			</classpath>
 			<compilerarg value="${build.javac.args}"/>
+			<exclude name="**/package-info.java"/>
 		</javac>
 	</target>
 


### PR DESCRIPTION
javac reports that it is creating empty classes. Remove them.

Signed-off-by: Stefan Weil <sw@weilnetz.de>