### PR TITLE
Fix method name

### DIFF
--- a/Goobi/newpages/MassImportPage3.jsp
+++ b/Goobi/newpages/MassImportPage3.jsp
@@ -99,7 +99,7 @@
 														<h:outputText value="#{msgs.laufzettelDrucken}" />
 													</h:commandLink>
 
-													<h:commandLink id="utid20" action="#{MassImportForm.Prepare}">
+													<h:commandLink id="utid20" action="#{MassImportForm.prepare}">
 														<h:graphicImage id="utid25" alt="/newpages/images/buttons/star_blue.gif" 
 														value="/newpages/images/buttons/star_blue.gif"
 															style="vertical-align:middle" />

--- a/Goobi/newpages/NewProcess/Page3.jsp
+++ b/Goobi/newpages/NewProcess/Page3.jsp
@@ -103,7 +103,7 @@
 												</h:commandLink>
 
 												<h:commandLink id="utid20"
-													action="#{ProzesskopieForm.Prepare}">
+													action="#{ProzesskopieForm.prepare}">
 													<h:graphicImage id="utid25"
 														alt="/newpages/images/buttons/star_blue.gif"
 														value="/newpages/images/buttons/star_blue.gif"

--- a/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste.jsp
+++ b/Goobi/newpages/inc_Prozessverwaltung/Prozesse_Liste.jsp
@@ -466,7 +466,7 @@
 				value="/newpages/images/buttons/dmsGreyed.png" style="margin-right:2px" title="#{msgs.importDms}" />
 
 			<%-- ProzessKopie-Schaltknopf --%>
-			<h:commandLink action="#{ProzesskopieForm.Prepare}" id="action22"
+			<h:commandLink action="#{ProzesskopieForm.prepare}" id="action22"
 				title="#{item.containsUnreachableSteps?msgs.prozessvorlageMitUnvollstaendigenSchrittdetails:msgs.eineKopieDieserProzessvorlageAnlegen}"
 				rendered="#{ProzessverwaltungForm.modusAnzeige=='vorlagen'}">
 				<h:graphicImage value="/newpages/images/buttons/star_blue.gif" style="margin-right:3px" rendered="#{!item.containsUnreachableSteps}" />
@@ -475,7 +475,7 @@
 			</h:commandLink>
 
 			<%-- MassenImport --%>
-			<h:commandLink action="#{MassImportForm.Prepare}" id="action222" title="#{msgs.MassenImport}"
+			<h:commandLink action="#{MassImportForm.prepare}" id="action222" title="#{msgs.MassenImport}"
 				rendered="#{ProzessverwaltungForm.modusAnzeige=='vorlagen' && HelperForm.massImportAllowed}">
 				<h:graphicImage value="/newpages/images/buttons/star_blue_multi.png" style="margin-right:3px" rendered="#{!item.containsUnreachableSteps}" />
 				<h:graphicImage value="/newpages/images/buttons/star_red.gif" style="margin-right:3px" rendered="#{item.containsUnreachableSteps}" />

--- a/Goobi/src/de/sub/goobi/forms/MassImportForm.java
+++ b/Goobi/src/de/sub/goobi/forms/MassImportForm.java
@@ -111,7 +111,7 @@ public class MassImportForm {
 				.getImportPluginsForType(ImportType.FOLDER);
 	}
 
-	public String Prepare() {
+	public String prepare() {
 		if (this.template.getContainsUnreachableSteps()) {
 			if (this.template.getSchritteList().size() == 0) {
 				Helper.setFehlerMeldung("noStepsInWorkflow");

--- a/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
@@ -275,7 +275,7 @@ public class ProzesskopieForm {
 	private String tifHeader_imagedescription = "";
 	private String tifHeader_documentname = "";
 
-	public String Prepare() {
+	public String prepare() {
 	    atstsl = "";
 		Helper.getHibernateSession().refresh(this.prozessVorlage);
 		if (this.prozessVorlage.getContainsUnreachableSteps()) {

--- a/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -419,7 +419,7 @@ public class ProzessverwaltungForm extends BasisForm {
 			Prozess einziger = (Prozess) this.page.getListReload().get(0);
 			ProzesskopieForm pkf = (ProzesskopieForm) Helper.getManagedBeanValue("#{ProzesskopieForm}");
 			pkf.setProzessVorlage(einziger);
-			return pkf.Prepare();
+			return pkf.prepare();
 		} else {
 			return "ProzessverwaltungAlle";
 		}

--- a/Goobi/src/org/goobi/mq/processors/CreateNewProcessProcessor.java
+++ b/Goobi/src/org/goobi/mq/processors/CreateNewProcessProcessor.java
@@ -173,7 +173,7 @@ public class CreateNewProcessProcessor extends ActiveMQProcessor {
 
 		Prozess selectedTemplate = getTemplateByTitle(templateTitle);
 		result.setProzessVorlage(selectedTemplate);
-		result.Prepare();
+		result.prepare();
 		return result;
 	}
 

--- a/Goobi/src/org/goobi/production/cli/helper/CopyProcess.java
+++ b/Goobi/src/org/goobi/production/cli/helper/CopyProcess.java
@@ -121,7 +121,7 @@ public class CopyProcess extends ProzesskopieForm {
 
 	/* =============================================================== */
 
-	public String Prepare(ImportObject io) {
+	public String prepare(ImportObject io) {
 		if (this.prozessVorlage.getContainsUnreachableSteps()) {
 			return "";
 		}
@@ -159,7 +159,7 @@ public class CopyProcess extends ProzesskopieForm {
 	}
 
 	@Override
-	public String Prepare() {
+	public String prepare() {
 		if (this.prozessVorlage.getContainsUnreachableSteps()) {
 			for (Schritt s : this.prozessVorlage.getSchritteList()) {
 				if (s.getBenutzergruppenSize() == 0 && s.getBenutzerSize() == 0) {

--- a/Goobi/src/org/goobi/production/flow/helper/JobCreation.java
+++ b/Goobi/src/org/goobi/production/flow/helper/JobCreation.java
@@ -97,7 +97,7 @@ public class JobCreation {
         CopyProcess cp = new CopyProcess();
         cp.setProzessVorlage(vorlage);
         cp.metadataFile = metsfilename;
-        cp.Prepare(io);
+        cp.prepare(io);
         cp.getProzessKopie().setTitel(processTitle);
         logger.trace("testing title");
         if (cp.testTitle()) {

--- a/Goobi/src/org/goobi/production/flow/jobs/HotfolderJob.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/HotfolderJob.java
@@ -238,7 +238,7 @@ public class HotfolderJob extends AbstractGoobiJob {
 			CopyProcess form = new CopyProcess();
 			form.setProzessVorlage(vorlage);
 			form.metadataFile = dir.getAbsolutePath() + File.separator + processTitle;
-			form.Prepare();
+			form.prepare();
 			form.getProzessKopie().setTitel(processTitle.substring(0, processTitle.length() - 4));
 			if (form.testTitle()) {
 				if (digitalCollection == null) {
@@ -401,7 +401,7 @@ public class HotfolderJob extends AbstractGoobiJob {
 		CopyProcess cp = new CopyProcess();
 		cp.setProzessVorlage(vorlage);
 		cp.metadataFile = metsfilename;
-		cp.Prepare(io);
+		cp.prepare(io);
 		cp.getProzessKopie().setTitel(processTitle);
 		logger.trace("testing title");
 		if (cp.testTitle()) {


### PR DESCRIPTION
Method names should not start with an uppercase letter, so replace
"Prepare" by "prepare" in several classes.

Signed-off-by: Stefan Weil <sw@weilnetz.de>