### PR TITLE
Fix browser check (order of detection)

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/SessionForm.java
+++ b/Goobi/src/de/sub/goobi/forms/SessionForm.java
@@ -103,20 +103,20 @@ public class SessionForm {
 				mybrowser = "-";
 			}
 			map.put("browser", mybrowser);
-			if (mybrowser.indexOf("Gecko") >= 0) {
-				map.put("browserIcon", "mozilla.png");
-			} else if (mybrowser.indexOf("Firefox") >= 0) {
-				map.put("browserIcon", "firefox.png");
-			} else if (mybrowser.indexOf("MSIE") >= 0) {
-				map.put("browserIcon", "ie.png");
-			} else if (mybrowser.indexOf("Opera") >= 0) {
-				map.put("browserIcon", "opera.gif");
-			} else if (mybrowser.indexOf("Safari") >= 0) {
-				map.put("browserIcon", "safari.gif");
+			if (mybrowser.indexOf("Netscape") >= 0) {
+				map.put("browserIcon", "netscape.gif");
 			} else if (mybrowser.indexOf("Konqueror") >= 0) {
 				map.put("browserIcon", "konqueror.gif");
-			} else if (mybrowser.indexOf("Netscape") >= 0) {
-				map.put("browserIcon", "netscape.gif");
+			} else if (mybrowser.indexOf("Safari") >= 0) {
+				map.put("browserIcon", "safari.gif");
+			} else if (mybrowser.indexOf("Opera") >= 0) {
+				map.put("browserIcon", "opera.gif");
+			} else if (mybrowser.indexOf("MSIE") >= 0) {
+				map.put("browserIcon", "ie.png");
+			} else if (mybrowser.indexOf("Firefox") >= 0) {
+				map.put("browserIcon", "firefox.png");
+			} else if (mybrowser.indexOf("Gecko") >= 0) {
+				map.put("browserIcon", "mozilla.png");
 			}
 		}
 		this.alleSessions.add(map);


### PR DESCRIPTION
Commit 07b3e0d5fc93d2c956c90e66dfe9fe17eb9053b7 replaced separated
if statements by a sequence of if / else if statements.

This changed the resulting browser icon when the user agent matched
several strings.

Reversing the order fixes this and restores the old behaviour while
keeping the optimized code.

Signed-off-by: Stefan Weil <sw@weilnetz.de>