### PR TITLE
Remove unused private methods

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/enums/PropertyType.java
+++ b/Goobi/src/de/sub/goobi/helper/enums/PropertyType.java
@@ -88,11 +88,6 @@ public enum PropertyType {
 		return this.name.toLowerCase();
 	}
 
-	@SuppressWarnings("unused")
-	//here for jsf compatibility
-	private void setName(String name) {
-	}
-
 	@Override
 	public java.lang.String toString() {
 		return this.name(); 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilter.java
@@ -325,11 +325,6 @@ public class UserDefinedFilter implements IEvaluableFilter, Cloneable {
 			this.exactStepDone = exactStepDone;
 		}
 
-		@SuppressWarnings("unused")
-		private Boolean getCriticalQuery() {
-			return flagCriticalQuery;
-		}
-
 		private Integer getExactStepDone() {
 			return exactStepDone;
 		}


### PR DESCRIPTION
This is an extract of an earlier patch which wrongly also removed methods needed for hibernate.

Signed-off-by: Stefan Weil <sw@weilnetz.de>
