### PR TITLE
SQLGenerator: Remove unneeded null check

### DIFF
--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLGenerator.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLGenerator.java
@@ -122,13 +122,9 @@ public abstract class SQLGenerator {
 					+ dateToSqlTimestamp(timeFrom) + "','%Y%m%d%H%i%s')+0";
 		}
 
-		if (timeTo != null) {
-			return " date_format(" + timeLimiter
-					+ ",'%Y%m%d%H%i%s')+0<=date_format('"
-					+ dateToSqlTimestamp(timeTo) + "','%Y%m%d%H%i%s')+0";
-		}
-		return "";
-
+		return " date_format(" + timeLimiter
+				+ ",'%Y%m%d%H%i%s')+0<=date_format('"
+				+ dateToSqlTimestamp(timeTo) + "','%Y%m%d%H%i%s')+0";
 	}
 
 	/*****************************************************************


### PR DESCRIPTION
This fixes a warning from Coverity:

CID 44606 (#1 of 1): Logically dead code (DEADCODE)

Signed-off-by: Stefan Weil <sw@weilnetz.de>