### PR TITLE
StatQuestProjectProgressData: Fix null pointer dereferences

### DIFF
--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
@@ -416,11 +416,15 @@ public class StatQuestProjectProgressData implements IStatisticalQuestionLimited
 						// date/time extraction based on the group
 						dataRow = new DataRow(intervall);
 					}
-					Double count = new Converter(objArr[0]).getDouble();
-					dataRow.addValue(stepName, count);
+					if (dataRow != null) {
+						Double count = new Converter(objArr[0]).getDouble();
+						dataRow.addValue(stepName, count);
+					}
 
 				} catch (Exception e) {
-					dataRow.addValue(e.getMessage(), new Double(0));
+					if (dataRow != null) {
+						dataRow.addValue(e.getMessage(), new Double(0));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
CID 44715 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)

Signed-off-by: Stefan Weil <sw@weilnetz.de>