### PR TITLE
Fix FindBugs warnings caused by redundant interface declaration

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/ScriptThreadWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/helper/ScriptThreadWithoutHibernate.java
@@ -42,7 +42,7 @@ import de.sub.goobi.persistence.apache.MySQLHelper;
 import de.sub.goobi.persistence.apache.StepManager;
 import de.sub.goobi.persistence.apache.StepObject;
 
-public class ScriptThreadWithoutHibernate extends EmptyTask implements INameableTask {
+public class ScriptThreadWithoutHibernate extends EmptyTask {
 	HelperSchritteWithoutHibernate hs = new HelperSchritteWithoutHibernate();
 	private final StepObject step;
 	private static final Logger logger = Logger.getLogger(ScriptThreadWithoutHibernate.class);

--- a/Goobi/src/de/sub/goobi/helper/tasks/CreateNewspaperProcessesTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/CreateNewspaperProcessesTask.java
@@ -75,7 +75,7 @@ import de.sub.goobi.persistence.BatchDAO;
  * 
  * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
  */
-public class CreateNewspaperProcessesTask extends EmptyTask implements INameableTask {
+public class CreateNewspaperProcessesTask extends EmptyTask {
 
 	/**
 	 * The field batchLabel is set in addToBatches() on the first function call

--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportDmsTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportDmsTask.java
@@ -49,7 +49,7 @@ import de.sub.goobi.helper.Helper;
  * 
  * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
  */
-public class ExportDmsTask extends EmptyTask implements INameableTask {
+public class ExportDmsTask extends EmptyTask {
 
 	private final ExportDms exportDms;
 	private final Prozess process;

--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
@@ -76,7 +76,7 @@ import de.sub.goobi.helper.exceptions.DAOException;
 import de.sub.goobi.helper.exceptions.SwapException;
 import de.sub.goobi.persistence.BatchDAO;
 
-public class ExportNewspaperBatchTask extends EmptyTask implements INameableTask {
+public class ExportNewspaperBatchTask extends EmptyTask {
 	private static final Logger logger = Logger.getLogger(ExportNewspaperBatchTask.class);
 
 	private static final double GAUGE_INCREMENT_PER_ACTION = 100 / 3d;

--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportSerialBatchTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportSerialBatchTask.java
@@ -73,7 +73,7 @@ import de.sub.goobi.helper.exceptions.SwapException;
  * 
  * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
  */
-public class ExportSerialBatchTask extends EmptyTask implements INameableTask {
+public class ExportSerialBatchTask extends EmptyTask {
 
 	/**
 	 * The batch to export

--- a/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
@@ -37,7 +37,7 @@ import de.sub.goobi.helper.Helper;
  * @deprecated New task implementations should directly implement EmptyTask.
  */
 @Deprecated
-public abstract class LongRunningTask extends EmptyTask implements INameableTask {
+public abstract class LongRunningTask extends EmptyTask {
 	/**
 	 * No-argument constructor. Creates an empty long running task. Must be made
 	 * explicit because a constructor taking an argument is present.


### PR DESCRIPTION
FindBugs reports "Class implements same interface as superclass".

Class EmptyTask also implements INameableTask, so it is not necessary
to repeat that declaration for child classes.

Signed-off-by: Stefan Weil <sw@weilnetz.de>