### PR TITLE
flow/statistics: Remove unnecessary Double constructor invocations

### DIFF
--- a/Goobi/src/org/goobi/production/flow/statistics/StepInformation.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/StepInformation.java
@@ -30,7 +30,7 @@ public class StepInformation {
 
 	// step identifier in workflow
 	private String title = "";
-	private Double averageStepOrder = new Double(0);
+	private Double averageStepOrder = 0.0;
 	
 	// information about all steps of these type
 	private int numberOfTotalSteps = 0;

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestCorrections.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestCorrections.java
@@ -147,7 +147,7 @@ public class StatQuestCorrections implements
 						(new Converter(objArr[0]).getDouble()));
 
 			} catch (Exception e) {
-				dataRow.addValue(e.getMessage(), new Double(0));
+				dataRow.addValue(e.getMessage(), 0.0);
 			}
 
 			//finally adding dataRow to DataTable and fetching next row

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProduction.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProduction.java
@@ -199,8 +199,8 @@ public class StatQuestProduction implements IStatisticalQuestionLimitedTimeframe
 
 				// fall back, if conversion triggers an exception
 			} catch (Exception e) {
-				dataRowChart.addValue(e.getMessage(), new Double(0));
-				dataRow.addValue(e.getMessage(), new Double(0));
+				dataRowChart.addValue(e.getMessage(), 0.0);
+				dataRow.addValue(e.getMessage(), 0.0);
 			}
 
 			// finally adding dataRow to DataTable and fetching next row

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
@@ -423,7 +423,7 @@ public class StatQuestProjectProgressData implements IStatisticalQuestionLimited
 
 				} catch (Exception e) {
 					if (dataRow != null) {
-						dataRow.addValue(e.getMessage(), new Double(0));
+						dataRow.addValue(e.getMessage(), 0.0);
 					}
 				}
 			}

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestStorage.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestStorage.java
@@ -137,7 +137,7 @@ public class StatQuestStorage implements IStatisticalQuestionLimitedTimeframe {
 						(new Converter(objArr[0]).getGB()));
 
 			} catch (Exception e) {
-				dataRow.addValue(e.getMessage(), new Double(0));
+				dataRow.addValue(e.getMessage(), 0.0);
 			}
 
 			//finally adding dataRow to DataTable and fetching next row

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
@@ -377,7 +377,7 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 							+ ")", (new Converter(objArr[0]).getDouble()));
 
 				} catch (Exception e) {
-					headerRow.addValue(e.getMessage(), new Double(0));
+					headerRow.addValue(e.getMessage(), 0.0);
 				}
 			}
 
@@ -439,7 +439,7 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 						(new Converter(objArr[0]).getDouble()));
 
 			} catch (Exception e) {
-				dataRow.addValue(e.getMessage(), new Double(0));
+				dataRow.addValue(e.getMessage(), 0.0);
 			}
 		}
 		// to add the last row


### PR DESCRIPTION
This fixes a FindBugs warning:

 Method invokes inefficient floating-point Number constructor;
 use static valueOf instead

Signed-off-by: Stefan Weil <sw@weilnetz.de>