### PR TITLE
Remove obsolete entries from ant clean target.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -101,10 +101,6 @@
         <delete dir="${build.dir}"/>
         <delete dir="${build.dist.dir}"/>
         <delete dir="${doc.javadocs.dir}"/>
-        <delete file="goobi.log"/>
-        <delete file="goobi_xml.log"/>
-        <!-- TODO Determine log configuration and configure build-path for logging -->
-        <delete file="goobicontentserver.log"/>
     </target>
 
     <target name="debug" description="Print diagnosis information">


### PR DESCRIPTION
Three log files (goobi.log, goobi_xml.log and goobicontentserver.log) are deleted on ant clean target but this files dos not exists in a normal environment in this location.