### PR TITLE
build: Add script files to war file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -308,7 +308,8 @@
         ==================================================-->
 
     <!-- Build of war file. -->
-    <target name="war" depends="compile, copy-config, create-plugin-jar-files">
+    <target name="war"
+            depends="compile, copy-config, copy-scripts, create-plugin-jar-files">
 
         <war destfile="${build.dist.war}" webxml="${src.dir}/WEB-INF/web.xml">
 
@@ -341,6 +342,8 @@
 
         	<zipfileset dir="${build.dist.dir}/plugins" prefix="plugins"/>
 
+            <zipfileset dir="${build.dir}/scripts" prefix="scripts"/>
+
             <manifest>
                 <attribute name="Implementation-Title" value="${ant.project.name}"/>
                 <attribute name="Implementation-Version" value="${build.dist.version}"/>
@@ -370,6 +373,13 @@
     <target name="copy-local-config" if="config.local.available">
         <copy overwrite="true" todir="${build.classes}">
             <fileset dir="${config.local.dir}" includes="*.*"/>
+        </copy>
+    </target>
+
+    <!-- Copy script files to build directory -->
+    <target name="copy-scripts">
+        <copy todir="${build.dir}/scripts">
+            <fileset dir="${src.dir}/scripts" includes="*.*"/>
         </copy>
     </target>
 


### PR DESCRIPTION
They still must be copied to their final destination directory,
and the execute flag must also be fixed manually.

Nevertheless it is no longer necessary to get those files from GitHub
as they are now included in a Kitodo installation.

Signed-off-by: Stefan Weil <sw@weilnetz.de>