### PR TITLE
Use standard charset UTF_8

### DIFF
--- a/Goobi/plugins/import/PicaMassImport/com/googlecode/fascinator/redbox/sru/SRUClient.java
+++ b/Goobi/plugins/import/PicaMassImport/com/googlecode/fascinator/redbox/sru/SRUClient.java
@@ -25,6 +25,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -230,12 +231,9 @@ public class SRUClient {
      */
     public Document parseXml(String xmlData) {
         try {
-            byte[] bytes = xmlData.getBytes("utf-8");
+            byte[] bytes = xmlData.getBytes(StandardCharsets.UTF_8);
             ByteArrayInputStream in = new ByteArrayInputStream(bytes);
             return saxReader.read(in);
-        } catch (UnsupportedEncodingException ex) {
-            log.error("Input is not UTF-8", ex);
-            return null;
         } catch (DocumentException ex) {
             log.error("Failed to parse XML", ex);
             return null;
@@ -481,7 +479,7 @@ public class SRUClient {
         String response = null;
         try {
             byte[] bla = get.getResponseBody();
-			response = new String(bla, "utf-8");
+			response = new String(bla, StandardCharsets.UTF_8);
         } catch (IOException ex) {
             log.error("Error accessing response body: ", ex);
             return null;

--- a/Goobi/plugins/import/PicaMassImport/de/sub/goobi/helper/UghUtils.java
+++ b/Goobi/plugins/import/PicaMassImport/de/sub/goobi/helper/UghUtils.java
@@ -33,11 +33,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import javax.faces.context.FacesContext;
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.CharEncoding;
 import org.apache.log4j.Logger;
 import org.goobi.production.constants.Parameters;
 
@@ -91,7 +91,7 @@ public class UghUtils {
 			path = FilenameUtils.concat(session.getServletContext().getRealPath("/WEB-INF"), "classes");
 		}
 		String file = FilenameUtils.concat(path, fileName);
-		return new BufferedReader(new InputStreamReader(new FileInputStream(file), CharEncoding.UTF_8));
+		return new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 	}
 
 }

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/UGHUtils.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/UGHUtils.java
@@ -33,6 +33,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.LinkedList;
 
@@ -40,7 +41,6 @@ import javax.faces.context.FacesContext;
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.CharEncoding;
 import org.apache.log4j.Logger;
 
 import ugh.dl.DocStruct;
@@ -257,7 +257,7 @@ class UGHUtils {
 			path = FilenameUtils.concat(session.getServletContext().getRealPath("/WEB-INF"), "classes");
 		}
 		String file = FilenameUtils.concat(path, fileName);
-		return new BufferedReader(new InputStreamReader(new FileInputStream(file), CharEncoding.UTF_8));
+		return new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 	}
 
 }

--- a/Goobi/src/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -187,7 +188,7 @@ public class BenutzerverwaltungForm extends BasisForm {
 		/* Datei zeilenweise durchlaufen und die auf ungültige Zeichen vergleichen */
 		try (
 			FileInputStream fis = new FileInputStream(filename);
-			InputStreamReader isr = new InputStreamReader(fis, "UTF-8");
+			InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
 			BufferedReader in = new BufferedReader(isr);
 		) {
 			String str;

--- a/Goobi/src/de/sub/goobi/helper/WebDav.java
+++ b/Goobi/src/de/sub/goobi/helper/WebDav.java
@@ -27,14 +27,15 @@ package de.sub.goobi.helper;
  * library, you may extend this exception to your version of the library, but you are not obliged to do so. If you do not wish to do so, delete this
  * exception statement from your version.
  */
-import java.io.BufferedWriter;
-import java.io.File;
 
 import org.goobi.io.SafeFile;
+import java.io.BufferedWriter;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.OutputStreamWriter;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -252,7 +253,7 @@ public class WebDav implements Serializable {
 			try (
 				BufferedWriter outfile =
 					new BufferedWriter(new OutputStreamWriter(new FileOutputStream(inProzess.getImagesDirectory()
-						+ "tiffwriter.conf"), "utf-8"));
+						+ "tiffwriter.conf"), StandardCharsets.UTF_8));
 			) {
 				outfile.write(tif.getTiffAlles());
 			}

--- a/Goobi/src/de/sub/goobi/importer/Import.java
+++ b/Goobi/src/de/sub/goobi/importer/Import.java
@@ -29,6 +29,7 @@ package de.sub.goobi.importer;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.log4j.Logger;
 import org.apache.myfaces.custom.fileupload.UploadedFile;
@@ -91,7 +92,7 @@ public class Import {
 
 			/* russischer Import */
 			if (this.mySchritt.isTypImportFileUpload() && this.mySchritt.isTypExportRus() == true) {
-				String gesamteDatei = new String(this.upDatei.getBytes(), "UTF-16LE");
+				String gesamteDatei = new String(this.upDatei.getBytes(), StandardCharsets.UTF_16LE);
 				reader = new BufferedReader(new StringReader(gesamteDatei));
 				ImportRussland myImport = new ImportRussland();
 				myImport.Parsen(reader, this.mySchritt.getProzess());
@@ -100,7 +101,7 @@ public class Import {
 
 			/* Zentralblatt-Import */
 			if (this.mySchritt.isTypImportFileUpload() && this.mySchritt.isTypExportRus() == false) {
-				String gesamteDatei = new String(this.upDatei.getBytes(), "ISO8859_1"); // ISO8859_1 UTF-8
+				String gesamteDatei = new String(this.upDatei.getBytes(), StandardCharsets.ISO_8859_1);
 				reader = new BufferedReader(new StringReader(gesamteDatei));
 				ImportZentralblatt myImport = new ImportZentralblatt();
 				myImport.Parsen(reader, this.mySchritt.getProzess());

--- a/Goobi/src/de/sub/goobi/metadaten/Separator.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Separator.java
@@ -38,13 +38,11 @@
 package de.sub.goobi.metadaten;
 
 import java.math.BigInteger;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.commons.compress.utils.Charsets;
 
 /**
  * Object representing a separator.
@@ -112,7 +110,7 @@ public class Separator implements Selectable {
 	 */
 	@Override
 	public String getId() {
-		return new BigInteger(separator.getBytes(Charsets.UTF_8)).toString(Character.MAX_RADIX);
+		return new BigInteger(separator.getBytes(StandardCharsets.UTF_8)).toString(Character.MAX_RADIX);
 	}
 
 	/**

--- a/Goobi/src/org/goobi/production/export/ExportXmlLog.java
+++ b/Goobi/src/org/goobi/production/export/ExportXmlLog.java
@@ -434,7 +434,7 @@ public class ExportXmlLog implements IProcessDataExport {
 			docTrans = doc;
 		}
 		Format format = Format.getPrettyFormat();
-		format.setEncoding("utf-8");
+		format.setEncoding("UTF-8");
 		XMLOutputter xmlOut = new XMLOutputter(format);
 
 		xmlOut.output(docTrans, out);

--- a/Goobi/src/org/goobi/production/importer/FireburnDataImport.java
+++ b/Goobi/src/org/goobi/production/importer/FireburnDataImport.java
@@ -32,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -229,7 +230,7 @@ public class FireburnDataImport {
 		xstream.setMode(XStream.NO_REFERENCES);
 		xstream.processAnnotations(FireburnDataImport.class);
 		xstream.processAnnotations(FireburnProperty.class);
-		OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(new File(notfoundFilename)), "UTF-8");
+		OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(new File(notfoundFilename)), StandardCharsets.UTF_8);
 		xstream.toXML(fdi.pNotFoundList, fw);
 		// DEBUG
 		long time2 = System.currentTimeMillis();

--- a/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
+++ b/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
@@ -35,7 +35,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -109,17 +109,16 @@ public class ProductionDataImport {
 	 * @throws ConfigurationException
 	 * @throws DAOException
 	 * @throws FileNotFoundException
-	 * @throws UnsupportedEncodingException
 	 */
 
 	public static void main(String[] args) throws HibernateException, SQLException, ConfigurationException, DAOException,
-			UnsupportedEncodingException, FileNotFoundException {
+			FileNotFoundException {
 		new ProductionDataImport().importData();
 
 	}
 
 	@SuppressWarnings("unchecked")
-	private void importData() throws DAOException, HibernateException, ConfigurationException, SQLException, UnsupportedEncodingException,
+	private void importData() throws DAOException, HibernateException, ConfigurationException, SQLException,
 			FileNotFoundException {
 		filename = ConfigMain.getParameter("tempfolder") + "produktionsDb.xml";
 		// load data from xml
@@ -207,7 +206,7 @@ public class ProductionDataImport {
 			XStream xstream = new XStream();
 			xstream.setMode(XStream.NO_REFERENCES);
 			OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(new File(ConfigMain.getParameter("tempfolder") + conflictFilename)),
-					"UTF-8");
+					StandardCharsets.UTF_8);
 			xstream.toXML(conflicts, fw);
 		}
 		if(logger.isDebugEnabled()){

--- a/Goobi/src/org/kitodo/encryption/DesEncrypter.java
+++ b/Goobi/src/org/kitodo/encryption/DesEncrypter.java
@@ -34,7 +34,7 @@ import org.apache.log4j.Logger;
 import javax.crypto.*;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -104,11 +104,9 @@ public class DesEncrypter {
 		}
 
 		try {
-			byte[] utf8 = messageToEncrypt.getBytes("UTF-8");
+			byte[] utf8 = messageToEncrypt.getBytes(StandardCharsets.UTF_8);
 			byte[] enc = encryptionCipher.doFinal(utf8);
-			return new String(Base64.encodeBase64(enc), "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			logger.warn("Catched UnsupportedEncodingException with message: " + e.getMessage());
+			return new String(Base64.encodeBase64(enc), StandardCharsets.UTF_8);
 		} catch (BadPaddingException e) {
 			logger.warn("Catched BadPaddingException with message: " + e.getMessage());
 		} catch (IllegalBlockSizeException e) {
@@ -127,11 +125,9 @@ public class DesEncrypter {
 	public String decrypt(String messageToDecrypt) {
 
 		try {
-			byte[] dec = Base64.decodeBase64(messageToDecrypt.getBytes("UTF-8"));
+			byte[] dec = Base64.decodeBase64(messageToDecrypt.getBytes(StandardCharsets.UTF_8));
 			byte[] utf8 = decryptionCipher.doFinal(dec);
-			return new String(utf8, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			logger.warn("Catched UnsupportedEncodingException with message: " + e.getMessage());
+			return new String(utf8, StandardCharsets.UTF_8);
 		} catch (IllegalBlockSizeException e) {
 			logger.warn("Catched IllegalBlockSizeException with message: " + e.getMessage());
 		} catch (BadPaddingException e) {


### PR DESCRIPTION
This implies that the UnsupportedEncodingException can no longer occur,
so the exception handling must be removed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>