### PR TITLE
ProzessverwaltungForm: Fix FindBugs warning (RuntimeException)

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -1737,6 +1737,8 @@ public class ProzessverwaltungForm extends BasisForm {
 				out.flush();
 				facesContext.responseComplete();
 
+			} catch (RuntimeException e) {
+				throw e;
 			} catch (Exception e) {
 			}
 		}


### PR DESCRIPTION
FindBugs report: Exception is caught when Exception is not thrown

Now runtime exceptions will no longer be suppressed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>