### PR TITLE
HelperForm: Remove unused method getApplicationVersionLogo

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/HelperForm.java
+++ b/Goobi/src/de/sub/goobi/forms/HelperForm.java
@@ -71,16 +71,6 @@ public class HelperForm {
 		return GoobiVersion.getBuildversion();
 	}
 
-	/**
-	 * @return returns dynamically resolved path for Version Logo
-	 */
-	public String getApplicationVersionLogo() {
-		String logo = getServletPathWithHostAsUrl() + IMAGE_PATH + "/template/";
-		logo += ConfigMain.getParameter("ApplicationVersionLogo", "Goobi151Logo.jpg");
-		return logo;
-
-	}
-
 	public String getApplicationLogo() {
 		String logo = getServletPathWithHostAsUrl() + IMAGE_PATH + "/template/";
 		logo += ConfigMain.getParameter("ApplicationLogo", "kitodo-header-logo.svg");


### PR DESCRIPTION
The current code neither calls getApplicationVersionLogo nor uses
applicationVersionLogo or Goobi151Logo.jpg.

Signed-off-by: Stefan Weil <sw@weilnetz.de>