### PR TITLE
Remove unneeded calls of method setCreationDate

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
+++ b/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
@@ -587,7 +587,6 @@ public class AktuelleSchritteForm extends BasisForm {
 			pe.setTitel(Helper.getTranslation("Korrektur notwendig"));
 			pe.setWert("[" + this.formatter.format(new Date()) + ", " + ben.getNachVorname() + "] " + this.problemMessage);
 			pe.setType(PropertyType.messageError);
-			pe.setCreationDate(myDate);
 			pe.setProzess(this.mySchritt.getProzess());
 			this.mySchritt.getProzess().getEigenschaften().add(pe);
 
@@ -696,7 +695,6 @@ public class AktuelleSchritteForm extends BasisForm {
 			pe.setWert("[" + this.formatter.format(new Date()) + ", " + ben.getNachVorname() + "] "
 					+ Helper.getTranslation("KorrekturloesungFuer") + " " + temp.getTitel() + ": " + this.solutionMessage);
 			pe.setType(PropertyType.messageImportant);
-			pe.setCreationDate(new Date());
 			pe.setProzess(this.mySchritt.getProzess());
 			this.mySchritt.getProzess().getEigenschaften().add(pe);
 

--- a/Goobi/src/de/sub/goobi/helper/BatchStepHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/BatchStepHelper.java
@@ -504,7 +504,6 @@ public class BatchStepHelper {
 				pe.setTitel(Helper.getTranslation("Korrektur notwendig"));
 				pe.setWert("[" + this.formatter.format(new Date()) + ", " + ben.getNachVorname() + "] " + this.problemMessage);
 				pe.setType(PropertyType.messageError);
-				pe.setCreationDate(myDate);
 				pe.setProzess(this.currentStep.getProzess());
 				this.currentStep.getProzess().getEigenschaften().add(pe);
 
@@ -650,7 +649,6 @@ public class BatchStepHelper {
 						+ this.solutionMessage);
 				pe.setProzess(this.currentStep.getProzess());
 				pe.setType(PropertyType.messageImportant);
-				pe.setCreationDate(new Date());
 				this.currentStep.getProzess().getEigenschaften().add(pe);
 
 				String message = Helper.getTranslation("KorrekturloesungFuer") + " " + temp.getTitel() + ": "

--- a/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
+++ b/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
@@ -287,7 +287,6 @@ public class ProductionDataImport {
 	private void generateWerkProperty(Session session, Werkstueck w, String name, String value, PropertyType type, Integer position, boolean required) {
 		if (value != null) {
 			Werkstueckeigenschaft property = new Werkstueckeigenschaft();
-			property.setCreationDate(new Date());
 			property.setIstObligatorisch(required);
 			property.setTitel(name);
 			property.setWerkstueck(w);
@@ -302,7 +301,6 @@ public class ProductionDataImport {
 	private void generateVorlageProperty(Session session, Vorlage s, String name, String value, PropertyType type, Integer position, boolean required) {
 		if (value != null) {
 			Vorlageeigenschaft property = new Vorlageeigenschaft();
-			property.setCreationDate(new Date());
 			property.setIstObligatorisch(required);
 			property.setTitel(name);
 			property.setVorlage(s);
@@ -317,7 +315,6 @@ public class ProductionDataImport {
 	private void generateProzessProperty(Session session, Prozess s, String name, String value, PropertyType type, Integer position, boolean required) {
 		if (value != null) {
 			Prozesseigenschaft property = new Prozesseigenschaft();
-			property.setCreationDate(new Date());
 			property.setIstObligatorisch(required);
 			property.setTitel(name);
 			property.setProzess(s);


### PR DESCRIPTION
They all pass the current date which is already set in the constructors.

Signed-off-by: Stefan Weil <sw@weilnetz.de>