### PR TITLE
ProductionDataImport: Remove redundant null check

### DIFF
--- a/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
+++ b/Goobi/src/org/goobi/production/importer/ProductionDataImport.java
@@ -552,14 +552,13 @@ public class ProductionDataImport {
 		List<Prozesseigenschaft> eig = p.getEigenschaftenList();
 		if (p.getProjekt().getTitel().equals("DigiWunschBuch")) {
 			boolean sponsor = false;
-			if (eig != null) {
 
-				for (Prozesseigenschaft pe : eig) {
-					if (pe.getTitel().contains("Besteller") && (pe.getWert() != null)) {
-						sponsor = true;
-					}
+			for (Prozesseigenschaft pe : eig) {
+				if (pe.getTitel().contains("Besteller") && (pe.getWert() != null)) {
+					sponsor = true;
 				}
 			}
+
 			if (!sponsor) {
 				// SponsorNaming
 				generateProzessProperty(session, p, "Patennennung", String.valueOf(pd.getPatennennung()), PropertyType.Integer, 0, false);


### PR DESCRIPTION
Findbugs report:
    Redundant nullcheck of value known to be non-null

The method getEigenschaftenList never returns null.

Signed-off-by: Stefan Weil <sw@weilnetz.de>