### PR TITLE
Fix #549: Hide / Remove step done by user search

### DIFF
--- a/Goobi/config/goobi_config.properties
+++ b/Goobi/config/goobi_config.properties
@@ -228,6 +228,8 @@ anonymize=true
 # show statistics box on startpage, default is true
 showStatisticsOnStartPage=true
 
+# enable / disable search for steps done by user
+withUserStepDoneSearch=false
 
 # -----------------------------------
 # Error page

--- a/Goobi/newpages/ProzessverwaltungSuche.jsp
+++ b/Goobi/newpages/ProzessverwaltungSuche.jsp
@@ -164,8 +164,8 @@
 														</h:panelGroup>
 													</h:panelGroup>
 													<%-- user --%>
-													<h:outputText value="#{msgs.stepDoneByUser}: "/>
-													<h:panelGroup>
+													<h:outputText value="#{msgs.stepDoneByUser}: " rendered="#{HelperForm.userStepDoneSearchEnabled}"/>
+													<h:panelGroup rendered="#{HelperForm.userStepDoneSearchEnabled}">
 														<h:selectOneMenu value="#{SearchForm.stepdoneuser}">
 															<si:selectItems value="#{SearchForm.user}"
 																var="user" itemLabel="#{user.nachVorname}" itemValue="#{user.login}" />

--- a/Goobi/src/de/sub/goobi/forms/HelperForm.java
+++ b/Goobi/src/de/sub/goobi/forms/HelperForm.java
@@ -286,4 +286,14 @@ public class HelperForm {
 		
 		return request.getHeader("User-Agent"); 
 	}
+
+	/**
+	 * Returning value of configuration parameter withUserStepDoneSearch.
+	 * Used for enabling/disabling search for done steps by user.
+	 *
+	 * @return boolean
+	 */
+	public boolean getUserStepDoneSearchEnabled() {
+		return ConfigMain.getBooleanParameter("withUserStepDoneSearch");
+	}
 }

--- a/Goobi/src/de/sub/goobi/forms/SearchForm.java
+++ b/Goobi/src/de/sub/goobi/forms/SearchForm.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
 
+import de.sub.goobi.config.ConfigMain;
 import org.apache.log4j.Logger;
 import org.goobi.production.flow.statistics.hibernate.FilterString;
 import org.hibernate.Criteria;
@@ -431,7 +432,10 @@ public class SearchForm {
 		if (!this.stepname.isEmpty() && !this.stepname.equals(Helper.getTranslation("notSelected"))) {
 			search += "\""+ this.stepOperand +  this.status + ":" + this.stepname + "\" ";
 		}
-		if (!this.stepdonetitle.isEmpty() && !this.stepdoneuser.isEmpty() && !this.stepdonetitle.equals(Helper.getTranslation("notSelected"))) {
+		if (!this.stepdonetitle.isEmpty()
+				&& !this.stepdoneuser.isEmpty()
+				&& !this.stepdonetitle.equals(Helper.getTranslation("notSelected"))
+				&& ConfigMain.getBooleanParameter("withUserStepDoneSearch")) {
 			search += "\"" + FilterString.STEPDONEUSER + this.stepdoneuser + "\" \"" + FilterString.STEPDONETITLE + this.stepdonetitle + "\" ";
 		}
 		ProzessverwaltungForm form = (ProzessverwaltungForm) FacesContext.getCurrentInstance().getExternalContext().getSessionMap()

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterHelper.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterHelper.java
@@ -653,8 +653,9 @@ public class FilterHelper {
 				String stepTitel = tok.substring(tok.indexOf(":") + 1);
 				FilterHelper.filterStepName(conjSteps, stepTitel, StepStatus.DONE, false, filterPrefix);
 
-			} else if (tokLowerCase.startsWith(FilterString.STEPDONEUSER)
-					|| tokLowerCase.startsWith(FilterString.ABGESCHLOSSENERSCHRITTBENUTZER)) {
+			} else if ((tokLowerCase.startsWith(FilterString.STEPDONEUSER)
+					|| tokLowerCase.startsWith(FilterString.ABGESCHLOSSENERSCHRITTBENUTZER))
+					&& ConfigMain.getBooleanParameter("withUserStepDoneSearch")) {
 				if (conjUsers == null) {
 					conjUsers = Restrictions.conjunction();
 				}


### PR DESCRIPTION
With new parameter `withUserStepDoneSearch` could this specific search enabled / disabled independent of `anonymize` parameter.
