### PR TITLE
Add parameter MetsEditorWithAutomaticPagination

### DIFF
--- a/Goobi/config/goobi_config.properties
+++ b/Goobi/config/goobi_config.properties
@@ -261,6 +261,9 @@ catalogue.timeout=1800000
 # use special image folder for METS editor if exists (define suffix here)
 MetsEditorDefaultSuffix=jpeg
 
+# use automatic default pagination
+MetsEditorWithAutomaticPagination=true
+
 # use special pagination type for automatic default pagination (uncounted, roman, arabic)
 MetsEditorDefaultPagination=uncounted
 

--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -695,8 +695,8 @@ public class Metadaten {
 
 		BildErmitteln(0);
 		retrieveAllImages();
-		if (this.mydocument.getPhysicalDocStruct() == null || this.mydocument.getPhysicalDocStruct().getAllChildren() == null
-				|| this.mydocument.getPhysicalDocStruct().getAllChildren().size() == 0) {
+		if (ConfigMain.getBooleanParameter(Parameters.WITH_AUTOMATIC_PAGINATION, true) && (this.mydocument.getPhysicalDocStruct() == null || this.mydocument.getPhysicalDocStruct().getAllChildren() == null
+				|| this.mydocument.getPhysicalDocStruct().getAllChildren().size() == 0)) {
 			try {
 				createPagination();
 			} catch (TypeNotAllowedForParentException e) {
@@ -1630,7 +1630,7 @@ public class Metadaten {
 	        myLogger.trace("dataList");
 	        List<String> dataList = this.imagehelper.getImageFiles(mydocument.getPhysicalDocStruct());
 	        myLogger.trace("dataList 2");
-	        if (dataList == null || dataList.isEmpty()) {
+	        if (ConfigMain.getBooleanParameter(Parameters.WITH_AUTOMATIC_PAGINATION, true) && (dataList == null || dataList.isEmpty())) {
 	            try {
 	                createPagination();
 	                dataList = this.imagehelper.getImageFiles(mydocument.getPhysicalDocStruct());

--- a/Goobi/src/org/goobi/production/constants/Parameters.java
+++ b/Goobi/src/org/goobi/production/constants/Parameters.java
@@ -138,4 +138,11 @@ public class Parameters {
 	 * given they have the same meta data type addable. Defaults to false.
 	 */
 	public static final String USE_METADATA_ENRICHMENT = "useMetadataEnrichment";
+
+	/**
+	 * Boolean. Set to false to disable automatic pagination changes in the
+	 * metadata editor. If false, pagination must be updated manually by
+	 * clicking the link “Read in pagination from images”.
+	 */
+	public static final String WITH_AUTOMATIC_PAGINATION = "MetsEditorWithAutomaticPagination";
 }


### PR DESCRIPTION
Solution for ticket #563

Added parameter name is `MetsEditorWithAutomaticPagination` which is `true` by default. When setting to `false` automatic pagination changes recognition in the metadata editor will be disabled. If false, pagination must be updated manually by clicking the link “Read in pagination from images”.
