### PR TITLE
Add .gitignore paths required to integrate in Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,15 @@
 /config-local
 /deploy.properties
 /dist
+
+# Eclipse development.
+/.settings/
+/.classpath
+/.project
+/Goobi/META-INF/
+/Goobi/src/*.icc
+/Goobi/src/*.jpg
+/Goobi/src/*.properties
+/Goobi/src/*.txt
+/Goobi/src/*.xml
+/Goobi/src/*.xsl


### PR DESCRIPTION
Integrating kitodo-production as an Eclipse project requires some additional files and directories which should be ignored by Git.