### PR TITLE
Remove the unused parameter "iktlist"

### DIFF
--- a/Goobi/config/goobi_opac.xml
+++ b/Goobi/config/goobi_opac.xml
@@ -30,7 +30,7 @@
 		</type>
 	</doctypes>
 	<catalogue title="GBV">
-		<config address="gso.gbv.de" database="2.1" description="Gemeinsamer Bibliotheksverbund" iktlist="IKTLIST-GBV.xml" port="80" ucnf="UCNF=NFC" />
+		<config address="gso.gbv.de" database="2.1" description="Gemeinsamer Bibliotheksverbund" port="80" ucnf="UCNF=NFC" />
 		<searchFields>
 			<searchField label="Title" value="4" />
 			<searchField label="Identifier" value="12" />
@@ -41,7 +41,7 @@
 		</searchFields>
 	</catalogue>
 	<catalogue title="ZDB">
-		<config address="dispatch.opac.d-nb.de" database="1.1" description="Zeitschriftendatenbank (ZDB)" iktlist="IKTLIST-ZDB.xml" port="80" />
+		<config address="dispatch.opac.d-nb.de" database="1.1" description="Zeitschriftendatenbank (ZDB)" port="80" />
 		<searchFields>
 			<searchField label="Title" value="4" />
 			<searchField label="Identifier" value="12" />

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ConfigOpac.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ConfigOpac.java
@@ -67,7 +67,6 @@ class ConfigOpac {
 				String description = getConfig().getString("catalogue(" + i + ").config[@description]");
 				String address = getConfig().getString("catalogue(" + i + ").config[@address]");
 				String database = getConfig().getString("catalogue(" + i + ").config[@database]");
-				String iktlist = getConfig().getString("catalogue(" + i + ").config[@iktlist]");
 				String cbs = getConfig().getString("catalogue(" + i + ").config[@ucnf]", "");
 				if (!cbs.equals("")) {
 					cbs = "&" + cbs;
@@ -104,7 +103,7 @@ class ConfigOpac {
 					beautyList.add(new ConfigOpacCatalogueBeautifier(oteChange, proofElements));
 				}
 
-				ConfigOpacCatalogue coc = new ConfigOpacCatalogue(title, description, address, database, iktlist, port,
+				ConfigOpacCatalogue coc = new ConfigOpacCatalogue(title, description, address, database, port,
 						charset, cbs, beautyList, opacType);
 				return coc;
 			}

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ConfigOpacCatalogue.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ConfigOpacCatalogue.java
@@ -42,7 +42,7 @@ class ConfigOpacCatalogue {
 	private String cbs;
 	private String charset = "iso-8859-1";
 	private final ArrayList<ConfigOpacCatalogueBeautifier> beautifySetList;
-	private ConfigOpacCatalogue(String title, String desciption, String address, String database, String iktlist,
+	private ConfigOpacCatalogue(String title, String desciption, String address, String database,
 			int port,
 			ArrayList<ConfigOpacCatalogueBeautifier> inBeautifySetList, String opacType) {
 		this.title = title;
@@ -54,11 +54,11 @@ class ConfigOpacCatalogue {
 	}
 
 	// Constructor that also takes a charset, a quick hack for DPD-81
-	ConfigOpacCatalogue(String title, String desciption, String address, String database, String iktlist,
+	ConfigOpacCatalogue(String title, String desciption, String address, String database,
 			int port, String charset,
 			String cbs, ArrayList<ConfigOpacCatalogueBeautifier> inBeautifySetList, String opacType) {
 		// Call the contructor above
-		this(title, desciption, address, database, iktlist, port, inBeautifySetList, opacType);
+		this(title, desciption, address, database, port, inBeautifySetList, opacType);
 		this.charset = charset;
 		this.setCbs(cbs);
 	}


### PR DESCRIPTION
The parameter is passed half way into constructors of the Pica plug-in, but, in the end, it is never assigned to a variable, nor used otherwise.