### PR TITLE
Adds a feature to import delegate records during PICA import

### DIFF
--- a/Goobi/config/goobi_opac.xml
+++ b/Goobi/config/goobi_opac.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <opacCatalogues>
 	<doctypes>
+	<!--
+	 ! <doctypes> section
+	 !
+	 ! Repeatable: No
+	 !
+	 ! In this section, define the different media types that you want to edit
+	 ! with Kitodo.Production.
+	 !
+	 ! Every media type must be declared as a <type> element.
+	 ! -->
 		<type isContainedWork="false" isMultiVolume="false" isPeriodical="false" isNewspaper="false" rulesetType="Monograph" tifHeaderType="Monographie" title="monograph">
 			<label language="de">Monographie</label>
 			<label language="en">Monograph</label>
@@ -39,9 +49,55 @@
 			<searchField label="Barcode" value="8535" />
 			<searchField label="Barcode 8200" value="8200" />
 		</searchFields>
+
+		<!--
+		 ! <resovle> rules
+		 !
+		 ! Repeatable: Yes
+		 ! Allowed children: <map> rules
+		 !
+		 ! Resolve rules allow to retrieve and insert additional data from norm
+		 ! data records referenced by PPN into the title record.
+		 !
+		 ! Attributes "tag" and "subtag" specify the subtag which contains the
+		 ! identifier of the norm data record to fetch. If this field contains
+		 ! additional information, the optional attribute "substring" can be
+		 ! used to define a regular expression which should find only the
+		 ! identifier. Example: The subtag contains "*1952-* @@ 69749487X". To
+		 ! get the identifier, the attribute substring="(?<=@@ )\d{8}[0-9X]"
+		 ! (using lookbehind) or substring="@@\s*(\d{8}[0-9X])" (using a match
+		 ! group) can be used to extract the PPN. A search is then conducted
+		 ! on the field defined as "searchField" (defaults to 12) to get the
+		 ! norm data records.
+		 !
+		 !
+		 ! <map> rules
+		 !
+		 ! Repeatable: Yes
+		 ! Allowed children: No
+		 !
+		 ! Map rules define which entries from the norm data record shall be
+		 ! imported into the tag on that the subtag with the identifier was
+		 ! found. Attributes "tag" and "subtag" specify the subtag in the norm
+		 ! data record to import, attribute "asSubtag" defines the subtag
+		 ! code under which the found value will be stored in the tag of the
+		 ! title record (should be fictious).
+		 !
+		 ! Example:
+		 !
+		 ! <resolve tag="028C" subtag="9">
+		 !     <map tag="003U" subtag="a" asSubtag="g" />
+		 ! </resolve>
+		 !
+		 ! Get the norm data record whose PPN is in field 028C subfield 9 by a
+		 ! catalogue query on search field 12. Get the value from field 003U
+		 ! subfield a of the norm data record, and add it as subfield g to the
+		 ! field 028C of the title record that contained the PPN.
+		 ! -->
 		<resolve tag="028C" subtag="9">
 			<map tag="003U" subtag="a" asSubtag="g" />
 		</resolve>
+
 	</catalogue>
 	<catalogue title="ZDB">
 		<config address="dispatch.opac.d-nb.de" database="1.1" description="Zeitschriftendatenbank (ZDB)" port="80" />

--- a/Goobi/config/goobi_opac.xml
+++ b/Goobi/config/goobi_opac.xml
@@ -39,6 +39,9 @@
 			<searchField label="Barcode" value="8535" />
 			<searchField label="Barcode 8200" value="8200" />
 		</searchFields>
+		<resolve tag="028C" subtag="9">
+			<map tag="003U" subtag="a" asSubtag="g" />
+		</resolve>
 	</catalogue>
 	<catalogue title="ZDB">
 		<config address="dispatch.opac.d-nb.de" database="1.1" description="Zeitschriftendatenbank (ZDB)" port="80" />

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Catalogue.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Catalogue.java
@@ -15,9 +15,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -42,9 +40,10 @@ class Catalogue {
 	private final String ucnf;
 	private final String charset;
 	private final List<Setvalue> beautify;
+	private final Map<String,ResolveRule> resolveRules = new HashMap<>();
 	
 	Catalogue(String title, String description, String address, String database, int port, String charset,
-			String ucnf, List<Setvalue> beautifySetList) {
+			String ucnf, List<Setvalue> beautifySetList, Collection<ResolveRule> resolveRules) {
 
 		this.title = title;
 		this.description = description;
@@ -54,6 +53,9 @@ class Catalogue {
 		this.beautify = beautifySetList;
 		this.charset = charset;
 		this.ucnf = ucnf;
+		for(ResolveRule rule:resolveRules){
+			this.resolveRules.put(rule.getIdentifier(), rule);
+		}
 	}
 
 	String getTitle() {
@@ -279,6 +281,10 @@ class Catalogue {
 
 	String getUncf() {
 		return ucnf;
+	}
+
+	Map<String,ResolveRule> getResolveRules() {
+		return resolveRules;
 	}
 
 }

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Catalogue.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Catalogue.java
@@ -223,10 +223,10 @@ class Catalogue {
 	 * from match results. There are two different mechanisms available for
 	 * replacement.
 	 * 
-	 * If the marked string contains the replacement mark <code>{@}</code>, the
-	 * matcher’s find() operation will be invoked over and over again and all
-	 * match results are concatenated and inserted in place of the replacement
-	 * marks.
+	 * If the marked string contains the replacement mark <code>&#123;@}</code>,
+	 * the matcher’s find() operation will be invoked over and over again and
+	 * all match results are concatenated and inserted in place of the
+	 * replacement marks.
 	 * 
 	 * Otherwise, all replacement marks <code>{1}</code>, <code>{2}</code>,
 	 * <code>{3}</code>, … will be replaced by the capturing groups matched by

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/CatalogueClient.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/CatalogueClient.java
@@ -228,15 +228,12 @@ class CatalogueClient {
 	 */
 	private void applyResolveRules(Map<String, ResolveRule> rules, Element root, CatalogueClient client)
 			throws IOException, SAXException, ParserConfigurationException {
-		for (Node node : new GetChildren(root)) {
-			if (node instanceof Element) {
-				Element field = (Element) node;
+		for (Element field : new GetChildElements(root)) {
 				if (field.getNodeName().equals("field")) {
 					String tag = field.getAttributeNode("tag").getTextContent();
-					for (Node subnoed : new GetChildren(field)) {
-						if (subnoed instanceof Element && subnoed.getNodeName().equals("subfield")) {
-							Element subfield = (Element) subnoed;
-							String subtag = field.getAttributeNode("code").getTextContent();
+					for (Element subfield : new GetChildElements(field)) {
+						if (subfield.getNodeName().equals("subfield")) {
+							String subtag = subfield.getAttributeNode("code").getTextContent();
 							String ruleID = ResolveRule.getIdentifier(tag, subtag);
 							if (rules.containsKey(ruleID)) {
 								rules.get(ruleID).execute(subfield, client, field);
@@ -246,7 +243,6 @@ class CatalogueClient {
 				} else {
 					applyResolveRules(rules, field, client);
 				}
-			}
 		}
 	}
 

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/CatalogueClient.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/CatalogueClient.java
@@ -32,11 +32,11 @@ import org.xml.sax.XMLReader;
 
 /**
  * Connects to OPAC system.
- * 
+ *
  * TODO Talk with the GBV if the URLs are ok this way
- * 
+ *
  * TODO check if correct character encodings are returned
- * 
+ *
  * @author Ludwig
  */
 
@@ -112,10 +112,10 @@ class CatalogueClient {
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * Note that up to now the search item list is always retrieved and parsed.
 	 * TODO check for local availability.
-	 * 
+	 *
 	 * @param serverAddress
 	 *            the serveraddress of the opac
 	 * @param port
@@ -138,7 +138,7 @@ class CatalogueClient {
 	/**
 	 * Gets the number of hits for the query in the specified field from the
 	 * OPAC.
-	 * 
+	 *
 	 * @param query
 	 *            The query string you are looking for.
 	 * @return returns the number of hits.
@@ -155,7 +155,7 @@ class CatalogueClient {
 	/**
 	 * Gets the formatted picaplus data of the specified hits for the query from
 	 * the OPAC.
-	 * 
+	 *
 	 * @param query
 	 *            The query string you are looking for.
 	 * @param fieldKey
@@ -182,7 +182,7 @@ class CatalogueClient {
 	/**
 	 * Gets the formatted picaplus data of the specified hits for the query from
 	 * the OPAC.
-	 * 
+	 *
 	 * @param query
 	 *            The query you are looking for.
 	 * @param start
@@ -210,7 +210,7 @@ class CatalogueClient {
 
 	/**
 	 * Apply resolve rules on a result note set.
-	 * 
+	 *
 	 * @param rules
 	 *            Rules to apply
 	 * @param root
@@ -249,7 +249,7 @@ class CatalogueClient {
 	/**
 	 * Gets the raw picaplus data for the specified hits for the query in the
 	 * specified field from the OPAC.
-	 * 
+	 *
 	 * @param query
 	 *            The query you are looking for.
 	 * @param start
@@ -310,7 +310,7 @@ class CatalogueClient {
 
 	/**
 	 * Retrieves a single hit from the catalogue system.
-	 * 
+	 *
 	 * @param numberOfHits
 	 *            The index of the hit to return
 	 * @param timeout
@@ -327,7 +327,7 @@ class CatalogueClient {
 
 	/**
 	 * Queries the catalogue system.
-	 * 
+	 *
 	 * @param query
 	 *            The query you are looking for.
 	 * @return The search result as xml string.
@@ -426,7 +426,7 @@ class CatalogueClient {
 
 	/**
 	 * Helper method that parses an InputSource and returns a DOM Document.
-	 * 
+	 *
 	 * @param source
 	 *            The InputSource to parse
 	 * @return The resulting document
@@ -450,7 +450,7 @@ class CatalogueClient {
 
 	/**
 	 * Retrieves the content of the specified url from the serverAddress.
-	 * 
+	 *
 	 * @param url
 	 *            The requested url as string. Note that the string needs to be
 	 *            already url encoded.
@@ -514,7 +514,7 @@ class CatalogueClient {
 		return ids;
 	}
 
-	public void setTimeout(long timeout) {
+	void setTimeout(long timeout) {
 		this.timeout = timeout;
 	}
 }

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/CatalogueClient.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/CatalogueClient.java
@@ -166,9 +166,13 @@ class CatalogueClient {
 	 *            return all hits.
 	 * @return returns the root node of the retrieved and formatted xml.
 	 * @throws IOException
-	 *             If connection to catalogue system failed
+	 *             an IO exception from the parser, possibly from a byte stream
+	 *             or character stream supplied by the application.
 	 * @throws ParserConfigurationException
+	 *             if a parser cannot be created which satisfies the requested
+	 *             configuration.
 	 * @throws SAXException
+	 *             if any SAX errors occur during processing
 	 */
 	Node retrievePicaNode(Query query, int numberOfHits)
 			throws IOException, SAXException, ParserConfigurationException {
@@ -188,9 +192,13 @@ class CatalogueClient {
 	 * @param timeout
 	 * @return returns the root node of the retrieved and formatted xml.
 	 * @throws IOException
-	 *             If connection to catalogue system failed
+	 *             an IO exception from the parser, possibly from a byte stream
+	 *             or character stream supplied by the application.
 	 * @throws ParserConfigurationException
+	 *             if a parser cannot be created which satisfies the requested
+	 *             configuration.
 	 * @throws SAXException
+	 *             if any SAX errors occur during processing
 	 */
 	Node retrievePicaNode(Query query, int start, int end, long timeout)
 			throws IOException, SAXException, ParserConfigurationException {
@@ -209,9 +217,14 @@ class CatalogueClient {
 	 *            rot node to examine
 	 * @param client
 	 *            catalogue client to use for queries
-	 * @throws ParserConfigurationException
-	 * @throws SAXException
 	 * @throws IOException
+	 *             an IO exception from the parser, possibly from a byte stream
+	 *             or character stream supplied by the application.
+	 * @throws ParserConfigurationException
+	 *             if a parser cannot be created which satisfies the requested
+	 *             configuration.
+	 * @throws SAXException
+	 *             if any SAX errors occur during processing
 	 */
 	private void applyResolveRules(Map<String, ResolveRule> rules, Element root, CatalogueClient client)
 			throws IOException, SAXException, ParserConfigurationException {
@@ -253,9 +266,13 @@ class CatalogueClient {
 	 *         pretty messy! It is recommended that you use
 	 *         retrieveXMLPicaPlus()
 	 * @throws IOException
-	 *             If connection to catalogue system failed
+	 *             an IO exception from the parser, possibly from a byte stream
+	 *             or character stream supplied by the application.
 	 * @throws ParserConfigurationException
+	 *             if a parser cannot be created which satisfies the requested
+	 *             configuration.
 	 * @throws SAXException
+	 *             if any SAX errors occur during processing
 	 */
 	private String retrievePica(Query query, int start, int end, long timeout)
 			throws IOException, SAXException, ParserConfigurationException {
@@ -319,9 +336,13 @@ class CatalogueClient {
 	 *            The query you are looking for.
 	 * @return The search result as xml string.
 	 * @throws IOException
-	 *             If connection to catalogue system failed.
+	 *             an IO exception from the parser, possibly from a byte stream
+	 *             or character stream supplied by the application.
 	 * @throws ParserConfigurationException
+	 *             if a parser cannot be created which satisfies the requested
+	 *             configuration.
 	 * @throws SAXException
+	 *             if any SAX errors occur during processing
 	 */
 	private Response getResult(Query query) throws IOException, SAXException, ParserConfigurationException {
 		String result = null;
@@ -469,6 +490,16 @@ class CatalogueClient {
 		}
 	}
 
+	/**
+	 * @throws IOException
+	 *             an IO exception from the parser, possibly from a byte stream
+	 *             or character stream supplied by the application.
+	 * @throws ParserConfigurationException
+	 *             if a parser cannot be created which satisfies the requested
+	 *             configuration.
+	 * @throws SAXException
+	 *             if any SAX errors occur during processing
+	 */
 	private Response parseOpacResponse(String opacResponse)
 			throws IOException, SAXException, ParserConfigurationException {
 		opacResponse = opacResponse.replace("&amp;amp;", "&amp;").replace("&amp;quot;", "&quot;")

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/GetChildElements.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/GetChildElements.java
@@ -17,15 +17,16 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /**
- * The class provides the ability to iterate over the children of a DOM element.
+ * The class provides the ability to iterate over the child elements of a DOM
+ * element.
  *
  * @author Matthias Ronge
  */
-class GetChildren implements Iterable<Node>, Iterator<Node> {
+class GetChildElements implements Iterable<Element>, Iterator<Element> {
     /**
      * The next child to offer
      */
-    private Node next;
+    private Element next;
 
     /**
      * Creates a class to iterate over the children of a DOM element.
@@ -33,8 +34,22 @@ class GetChildren implements Iterable<Node>, Iterator<Node> {
      * @param parent
      *            parent over whose children shall be iterated
      */
-    GetChildren(Element parent) {
-        next = parent.getFirstChild();
+    GetChildElements(Element parent) {
+        next = filter(parent.getFirstChild());
+    }
+
+    /**
+     * Returns the next element, if any, or {@code null}.
+     * 
+     * @param node
+     *            node that might be the next candidate
+     * @return the next element, or {@code null}
+     */
+    private Element filter(Node node) {
+        while (node != null && !(node instanceof Element)) {
+            node = node.getNextSibling();
+        }
+        return (Element) node;
     }
 
     /**
@@ -51,7 +66,7 @@ class GetChildren implements Iterable<Node>, Iterator<Node> {
      * Returns an iterator instance, which is this implementation.
      */
     @Override
-    public Iterator<Node> iterator() {
+    public Iterator<Element> iterator() {
         return this;
     }
 
@@ -59,10 +74,12 @@ class GetChildren implements Iterable<Node>, Iterator<Node> {
      * Returns the next element while iterating.
      */
     @Override
-    public Node next() {
-        if (next == null) { throw new NoSuchElementException(); }
-        Node current = next;
-        next = next.getNextSibling();
+    public Element next() {
+        if (next == null) {
+            throw new NoSuchElementException();
+        }
+        Element current = next;
+        next = filter(next.getNextSibling());
         return current;
     }
 

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/GetChildElements.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/GetChildElements.java
@@ -40,7 +40,7 @@ class GetChildElements implements Iterable<Element>, Iterator<Element> {
 
     /**
      * Returns the next element, if any, or {@code null}.
-     * 
+     *
      * @param node
      *            node that might be the next candidate
      * @return the next element, or {@code null}

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/GetChildren.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/GetChildren.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+package org.goobi.production.plugin.CataloguePlugin.PicaPlugin;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * The class provides the ability to iterate over the children of a DOM element.
+ *
+ * @author Matthias Ronge
+ */
+class GetChildren implements Iterable<Node>, Iterator<Node> {
+    /**
+     * The next child to offer
+     */
+    private Node next;
+
+    /**
+     * Creates a class to iterate over the children of a DOM element.
+     *
+     * @param parent
+     *            parent over whose children shall be iterated
+     */
+    GetChildren(Element parent) {
+        next = parent.getFirstChild();
+    }
+
+    /**
+     * Returns whether the iterator can return another element.
+     *
+     * @see java.util.Iterator#hasNext()
+     */
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    /**
+     * Returns an iterator instance, which is this implementation.
+     */
+    @Override
+    public Iterator<Node> iterator() {
+        return this;
+    }
+
+    /**
+     * Returns the next element while iterating.
+     */
+    @Override
+    public Node next() {
+        if (next == null) { throw new NoSuchElementException(); }
+        Node current = next;
+        next = next.getNextSibling();
+        return current;
+    }
+
+    /**
+     * This iterator does not support removal.
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
@@ -1,3 +1,13 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
 package org.goobi.production.plugin.CataloguePlugin.PicaPlugin;
 
 import java.util.*;

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
@@ -10,14 +10,24 @@
  */
 package org.goobi.production.plugin.CataloguePlugin.PicaPlugin;
 
-import java.util.*;
-import java.util.regex.Pattern;
-
 import org.apache.commons.configuration.HierarchicalConfiguration;
 
 /**
- * <resolve tag="028C" subtag="9" searchField="12" substring="@\s*([^@]+)$">
- * <map asSubtag="X" tag="028C" subtag="9" /> </resolve>
+ * Map rules are used to map data from norm data records to a media record. This
+ * is used inside a {@code ResolveRule}. Example usage:
+ * 
+ * <pre>
+ * &lt;catalogue title="…">
+ *     &lt;!-- ... -->
+ *     &lt;resolve tag="028C" subtag="9" searchField="12">
+ *         &lt;map tag="003U" subtag="a" asSubtag="g" />
+ *     &lt;/resolve>
+ * </pre>
+ * 
+ * In this case, the value from PICA field 028C subfield 9 is taken to execute a
+ * catalogue query on search field 12. From the result of this query, the value
+ * from field 003U subfield a is taken and stored in subfield g on the instance
+ * of field 028C of the main record.
  * 
  * @author Matthias Ronge
  */

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
@@ -40,9 +40,17 @@ class MapRule {
 	 *            configuration for the resolve rule from
 	 */
 	public MapRule(HierarchicalConfiguration config) {
-		tag = config.getString("tag");
-		subtag = config.getString("subtag");
-		asSubtag = config.getString("asSubtag");
+		tag = config.getString("[@tag]");
+		assert tag != null : "Missing mandatory attribute tag in element <map> of catalogue configuration";
+		assert tag.length() == 4 : "Attribute tag in element <map> is not 4 characters long";
+		
+		subtag = config.getString("[@subtag]");
+		assert subtag != null : "Missing mandatory attribute subtag in element <map> of catalogue configuration";
+		assert subtag.length() == 1 : "Attribute subtag in element <map> is not 1 character long";		
+		
+		asSubtag = config.getString("[@asSubtag]");
+		assert asSubtag != null : "Missing mandatory attribute asSubtag in element <map> of catalogue configuration";
+		assert asSubtag.length() == 1 : "Attribute asSubtag in element <map> is not 1 character long";
 	}
 
 	/**

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
@@ -17,11 +17,13 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
  * is used inside a {@code ResolveRule}. Example usage:
  *
  * <pre>
- * &lt;catalogue title="…">
- *     &lt;!-- ... -->
- *     &lt;resolve tag="028C" subtag="9" searchField="12">
- *         &lt;map tag="003U" subtag="a" asSubtag="g" />
- *     &lt;/resolve>
+ * {@code
+ * <catalogue title="…">
+ *     <!-- ... -->
+ *     <resolve tag="028C" subtag="9" searchField="12">
+ *         <map tag="003U" subtag="a" asSubtag="g" />
+ *     </resolve>
+ * }
  * </pre>
  *
  * In this case, the value from PICA field 028C subfield 9 is taken to execute a

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
@@ -1,0 +1,50 @@
+package org.goobi.production.plugin.CataloguePlugin.PicaPlugin;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+import org.apache.commons.configuration.HierarchicalConfiguration;
+
+/**
+ * <resolve tag="028C" subtag="9" searchField="12" substring="@\s*([^@]+)$">
+ * <map asSubtag="X" tag="028C" subtag="9" /> </resolve>
+ * 
+ * @author Matthias Ronge
+ */
+class MapRule {
+	/**
+	 * Creates a new resolve rule from the XML configuration. The attributes
+	 * {@code tag}, {@code subtag} and {@code asSubtag} are required.
+	 * 
+	 * @param config
+	 *            configuration for the resolve rule from
+	 */
+	public MapRule(HierarchicalConfiguration config) {
+		tag = config.getString("tag");
+		subtag = config.getString("subtag");
+		asSubtag = config.getString("asSubtag");
+	}
+
+	/**
+	 * PICA field tag of a field that has a subfield that shall be imported from
+	 * the resolved record. Typical values match the pattern
+	 * <code>\d{3}[@-Z]</code>. An example value is "003U" for the field holding
+	 * a subfield with the GND record path.
+	 */
+	String tag;
+
+	/**
+	 * PICA subfield code of the subfield that shall be imported from the
+	 * resolved record. Typical values match the pattern <code>[0-9a-z]</code>.
+	 * An example value is "a" for the subfield with the GND record path.
+	 */
+	String subtag;
+
+	/**
+	 * PICA subfield code of a subfield in the original record that the value
+	 * identified by tag and subtag shall be written to. The subfield code can
+	 * be fictions. Typical values match the pattern <code>[0-9a-z]</code>. An
+	 * example value is "g".
+	 */
+	String asSubtag;
+}

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/MapRule.java
@@ -15,7 +15,7 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 /**
  * Map rules are used to map data from norm data records to a media record. This
  * is used inside a {@code ResolveRule}. Example usage:
- * 
+ *
  * <pre>
  * &lt;catalogue title="…">
  *     &lt;!-- ... -->
@@ -23,19 +23,19 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
  *         &lt;map tag="003U" subtag="a" asSubtag="g" />
  *     &lt;/resolve>
  * </pre>
- * 
+ *
  * In this case, the value from PICA field 028C subfield 9 is taken to execute a
  * catalogue query on search field 12. From the result of this query, the value
  * from field 003U subfield a is taken and stored in subfield g on the instance
  * of field 028C of the main record.
- * 
+ *
  * @author Matthias Ronge
  */
 class MapRule {
 	/**
 	 * Creates a new resolve rule from the XML configuration. The attributes
 	 * {@code tag}, {@code subtag} and {@code asSubtag} are required.
-	 * 
+	 *
 	 * @param config
 	 *            configuration for the resolve rule from
 	 */
@@ -43,11 +43,11 @@ class MapRule {
 		tag = config.getString("[@tag]");
 		assert tag != null : "Missing mandatory attribute tag in element <map> of catalogue configuration";
 		assert tag.length() == 4 : "Attribute tag in element <map> is not 4 characters long";
-		
+
 		subtag = config.getString("[@subtag]");
 		assert subtag != null : "Missing mandatory attribute subtag in element <map> of catalogue configuration";
-		assert subtag.length() == 1 : "Attribute subtag in element <map> is not 1 character long";		
-		
+		assert subtag.length() == 1 : "Attribute subtag in element <map> is not 1 character long";
+
 		asSubtag = config.getString("[@asSubtag]");
 		assert asSubtag != null : "Missing mandatory attribute asSubtag in element <map> of catalogue configuration";
 		assert asSubtag.length() == 1 : "Attribute asSubtag in element <map> is not 1 character long";
@@ -75,4 +75,9 @@ class MapRule {
 	 * example value is "g".
 	 */
 	String asSubtag;
+
+	@Override
+	public String toString() {
+		return tag + '.' + subtag + " as " + asSubtag;
+	}
 }

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
@@ -11,67 +11,50 @@
 
 package org.goobi.production.plugin.CataloguePlugin.PicaPlugin;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
-import javax.activity.InvalidActivityException;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.configuration.SubnodeConfiguration;
+import org.apache.commons.configuration.*;
 import org.apache.commons.configuration.tree.ConfigurationNode;
-import org.apache.commons.configuration.XMLConfiguration;
-import org.jdom.Attribute;
-import org.jdom.Document;
-import org.jdom.Element;
+import org.jdom.*;
 import org.jdom.input.DOMBuilder;
 import org.jdom.output.DOMOutputter;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
+import org.joda.time.*;
 import org.w3c.dom.Node;
 
-import net.xeoh.plugins.base.annotations.PluginImplementation;
 import net.xeoh.plugins.base.Plugin;
-import ugh.dl.DigitalDocument;
-import ugh.dl.DocStruct;
-import ugh.dl.DocStructType;
-import ugh.dl.Fileformat;
-import ugh.dl.Prefs;
-import ugh.exceptions.TypeNotAllowedAsChildException;
-import ugh.exceptions.TypeNotAllowedForParentException;
+import net.xeoh.plugins.base.annotations.PluginImplementation;
+import ugh.dl.*;
+import ugh.exceptions.*;
 import ugh.fileformats.mets.XStream;
 import ugh.fileformats.opac.PicaPlus;
 
 /**
- * The class PicaPlugin is the main class of the Goobi PICA catalogue plugin
- * implementation. It provides the public methods
+ * The class PicaPlugin is the main class of the Kitodo PICA catalogue plug-in
+ * implementation. This plug-in can be used to access OCLC PICA library
+ * catalogue systems. It provides the public methods
+ * 
+ * <pre>
+ * void     configure(Map) [*]
+ * Object   find(String, long)
+ * String   getDescription() [*]
+ * Map      getHit(Object, long, long)
+ * long     getNumberOfHits(Object, long)
+ * String   getTitle() [*]
+ * void     setPreferences(Prefs)
+ * boolean  supportsCatalogue(String)
+ * void     useCatalogue(String)
+ * </pre>
+ * 
+ * as specified by {@code org.goobi.production.plugin.UnspecificPlugin}
+ * {@code [*]} and
+ * {@code org.goobi.production.plugin.CataloguePlugin.CataloguePlugin}.
  *
- *    void    configure(Map) [*]
- *    Object  find(String, long)
- *    String  getDescription() [*]
- *    Map     getHit(Object, long, long)
- *    long    getNumberOfHits(Object, long)
- *    String  getTitle() [*]
- *    void    setPreferences(Prefs)
- *    boolean supportsCatalogue(String)
- *    void    useCatalogue(String)
- *
- * as specified by org.goobi.production.plugin.UnspecificPlugin [*] and
- * org.goobi.production.plugin.CataloguePlugin.CataloguePlugin.
- *
- * Parts of the code of this class have been ported from ancient class
- * <kbd>org.goobi.production.plugin.opac.PicaOpacImport</kbd>.
- *
- * @author Partly based on previous works of other authors who didn’t leave
- *         their names
- * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
+ * @author unascribed
+ * @author Matthias Ronge
+ * 
+ * @see "https://en.wikipedia.org/wiki/OCLC_PICA"
  */
 @PluginImplementation
 public class PicaPlugin implements Plugin {
@@ -134,16 +117,27 @@ public class PicaPlugin implements Plugin {
 	private CatalogueClient client;
 
 	/**
-	 * The method configure() accepts a Map with configuration parameters. Two
-	 * entries, "configDir" and "tempDir", are expected.
+	 * Injects the plug-in’s configuration. The method takes a Map with
+	 * configuration parameters. Two entries, {@code configDir} and
+	 * {@code tempDir}, are expected:
 	 *
-	 * configDir must point to a directory on the local file system where the
-	 * plug-in can read individual configuration files from. The configuration
-	 * file, "goobi_opac.xml" is expected in that directory.
+	 * <ul>
+	 * <li>{@code configDir} must point to a directory on the local file system
+	 * where the plug-in can read individual configuration files from. The
+	 * configuration file {@code goobi_opac.xml} is expected in that
+	 * directory.</li>
+	 * <li>{@code tempDir} is a directory on the local file system where the
+	 * plug-in can write temporary files to. Currently, two files are written
+	 * there to help admins configure opac beautifiers correctly.</li>
+	 * </ul>
+	 * 
+	 * This method is called at runtime after the classloader has created the
+	 * instance, because the plug-in constructor cannot take arguments. Confer
+	 * to {@code UnspecificPlugin.configure(Map)} in package
+	 * {@code org.goobi.production.plugin} of the core application, too.
 	 *
 	 * @param configuration
 	 *            a Map with configuration parameters
-	 * @see org.goobi.production.plugin.UnspecificPlugin#configure(Map)
 	 */
 	public void configure(Map<String, String> configuration) {
 		configDir = configuration.get("configDir");
@@ -151,19 +145,19 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function find() initially queries the library catalogue with the
-	 * given query. If successful, it returns a FindResult with the number of
-	 * hits.
+	 * Initially queries the library catalogue with the given query. If
+	 * successful, it returns a FindResult with the number of hits.
+	 * <p>
+	 * For the semantics of the query, see class {@code QueryBuilder} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application. Confer to {@code UnspecificPlugin.find(String, long)} in
+	 * package {@code org.goobi.production.plugin} of the core application, too.
 	 *
 	 * @param query
-	 *            a query String. See
-	 *            {@link org.goobi.production.plugin.CataloguePlugin.QueryBuilder}
-	 *            for the semantics of the query.
+	 *            the query to the catalogue
 	 * @param timeout
 	 *            timeout in milliseconds after which the operation shall return
 	 * @return a FindResult that may be used for future operations on the query
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#find(String,
-	 *      long)
 	 */
 	public Object find(String query, long timeout) {
 		client.setTimeout(timeout);
@@ -183,8 +177,8 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function getConfigDir() provides a reference to the file system
-	 * directory where configuration files are read from.
+	 * Provides a reference to the file system directory where configuration
+	 * files are read from.
 	 *
 	 * @return the file system directory with the configuration files
 	 */
@@ -193,25 +187,33 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function getDescription() returns a human-readable description of the
-	 * plug-in’s functionality in English. The parameter language is ignored.
+	 * Returns a human-readable description of the plug-in’s functionality in
+	 * English. The parameter language is ignored.
+	 * <p>
+	 * Confer to {@code UnspecificPlugin.getDescription(Locale)} in package
+	 * {@code org.goobi.production.plugin} of the core application, too.
 	 *
 	 * @param language
 	 *            desired language of the human-readable description (support is
 	 *            optional)
 	 * @return a human-readable description of the plug-in’s functionality
-	 * @see org.goobi.production.plugin.UnspecificPlugin#getDescription(Locale)
 	 */
 	public static String getDescription(Locale language) {
 		return "The PICA plugin can be used to access PICA library catalogue systems.";
 	}
 
 	/**
-	 * The function getHit() returns the hit with the given index from the given
-	 * search result as a Map&lt;String, Object&gt;. The map contains the full
-	 * hit as "fileformat", the docType as "type" and some bibliographic
-	 * metadata for Production to be able to show a short hit display as
-	 * supposed in {@link org.goobi.production.plugin.CataloguePlugin.Hit}.
+	 * Returns the hit with the given index from the given search result. The
+	 * object returned is a Map&lt;String, Object>. It contains the full hit as
+	 * {@code fileformat}, the docType as {@code type} and some bibliographic
+	 * meta-data to show a bibliographic hit summary as supposed in class
+	 * {@code Hit} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.getHit(Object, long, long)} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
 	 *
 	 * @param searchResult
 	 *            a FindResult created by {@link #find(String, long)}
@@ -221,8 +223,6 @@ public class PicaPlugin implements Plugin {
 	 *            a timeout in milliseconds after which the operation shall
 	 *            return
 	 * @return a Map with the hit
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#getHit(Object,
-	 *      long, long)
 	 */
 	public Map<String, Object> getHit(Object searchResult, long index, long timeout) {
 		client.setTimeout(timeout);
@@ -236,19 +236,19 @@ public class PicaPlugin implements Plugin {
 		Type type;
 		Fileformat ff;
 		try {
-			/*
-			 * -------------------------------- Opac abfragen und erhaltenes
-			 * Dom-Dokument in JDom-Dokument umwandeln
+			/* 
+			 * --------------------------------
+			 * Query OPAC and convert the DOM document returned to JDOM
 			 * --------------------------------
 			 */
 			Node myHitlist = client.retrievePicaNode(myQuery, (int) index, (int) index + 1, timeout);
 
-			/* Opac-Beautifier aufrufen */
+			// call OPAC beautifier
 			myHitlist = catalogue.executeBeautifier(myHitlist);
 			Document myJdomDoc = new DOMBuilder().build(myHitlist.getOwnerDocument());
 			myFirstHit = myJdomDoc.getRootElement().getChild("record");
 
-			/* von dem Treffer den Dokumententyp ermitteln */
+			// detemine the document type from the first hit
 			typeID = getTypeID(myFirstHit);
 			type = OpacCatalogues.getDoctypeByMapping(typeID.length() > 2 ? typeID.substring(0, 2) : typeID,
 					catalogue.getTitle());
@@ -258,106 +258,108 @@ public class PicaPlugin implements Plugin {
 			}
 
 			/*
-			 * -------------------------------- wenn der Treffer ein Volume
-			 * eines Multivolume-Bandes ist, dann das Sammelwerk überordnen
+			 * --------------------------------
+			 * if the hit is a volume from a multivolume volume, then
+			 * superordinate the compilation
 			 * --------------------------------
 			 */
 			if (type.isMultiVolume()) {
-				/* Sammelband-PPN ermitteln */
+				// determine the PPN of the anthology
 				String multiVolumePpn = getPPNFromParent(myFirstHit, "036D", "9");
 				if (!multiVolumePpn.equals("")) {
-					/* Sammelband aus dem Opac holen */
+					// take the anthology out of the OPAC
 
 					myQuery = new Query(multiVolumePpn, "12");
-					/* wenn ein Treffer des Parents im Opac gefunden wurde */
+					// if a hit of the parent was found in the OPAC
 					if (client.getNumberOfHits(myQuery) == 1) {
 						Node myParentHitlist = client.retrievePicaNode(myQuery, 1);
-						/* Opac-Beautifier aufrufen */
+						// call OPAC beautifier
 						myParentHitlist = catalogue.executeBeautifier(myParentHitlist);
-						/* Konvertierung in jdom-Elemente */
+						// conversion to JDOM elements
 						Document myJdomDocMultivolumeband = new DOMBuilder().build(myParentHitlist.getOwnerDocument());
 
-						/* dem Rootelement den Volume-Treffer hinzufügen */
+						// add the volume-hit to the root element
 						myFirstHit.getParent().removeContent(myFirstHit);
 						myJdomDocMultivolumeband.getRootElement().addContent(myFirstHit);
 
 						myJdomDoc = myJdomDocMultivolumeband;
 						myFirstHit = myJdomDoc.getRootElement().getChild("record");
 
-						/* die Jdom-Element wieder zurück zu Dom konvertieren */
+						// convert the JDOM elements back to DOM
 						DOMOutputter doutputter = new DOMOutputter();
 						myHitlist = doutputter.output(myJdomDocMultivolumeband);
-						/*
-						 * dabei aber nicht das Document, sondern das erste Kind
-						 * nehmen
-						 */
+
+						// nevertheless, do not take the document, but the first
+						// child
+
 						myHitlist = myHitlist.getFirstChild();
 					}
 				}
 			}
 
 			/*
-			 * -------------------------------- wenn der Treffer ein Volume
-			 * eines Periodical-Bandes ist, dann die Serie überordnen
+			 * --------------------------------
+			 * if the hit is a volume from a periodical volume, then
+			 * superordinate the series
 			 * --------------------------------
 			 */
 			if (type.isPeriodical()) {
-				/* Sammelband-PPN ermitteln */
+				// determine the PPN of the anthology
 				String serialPublicationPpn = getPPNFromParent(myFirstHit, "036F", "9");
 				if (!serialPublicationPpn.equals("")) {
-					/* Sammelband aus dem Opac holen */
+					// take the anthology out of the OPAC
 
 					myQuery = new Query(serialPublicationPpn, "12");
-					/* wenn ein Treffer des Parents im Opac gefunden wurde */
+					// if a hit of the parent was found in the OPAC
 					if (client.getNumberOfHits(myQuery) == 1) {
 						Node myParentHitlist = client.retrievePicaNode(myQuery, 1);
-						/* Opac-Beautifier aufrufen */
+						// call OPAC beautifier
 						myParentHitlist = catalogue.executeBeautifier(myParentHitlist);
-						/* Konvertierung in jdom-Elemente */
+						// conversion to JDOM elements
 						Document myJdomDocMultivolumeband = new DOMBuilder().build(myParentHitlist.getOwnerDocument());
 
-						/* dem Rootelement den Volume-Treffer hinzufügen */
+						// add the volume-hit to the root element
 						myFirstHit.getParent().removeContent(myFirstHit);
 						myJdomDocMultivolumeband.getRootElement().addContent(myFirstHit);
 
 						myJdomDoc = myJdomDocMultivolumeband;
 						myFirstHit = myJdomDoc.getRootElement().getChild("record");
 
-						/* die Jdom-Element wieder zurück zu Dom konvertieren */
+						// convert the JDOM elements back to DOM
 						DOMOutputter doutputter = new DOMOutputter();
 						myHitlist = doutputter.output(myJdomDocMultivolumeband);
-						/*
-						 * dabei aber nicht das Document, sondern das erste Kind
-						 * nehmen
-						 */
+
+						// nevertheless, do not take the document, but the first
+						// child
+
 						myHitlist = myHitlist.getFirstChild();
 					}
 				}
 			}
 
 			/*
-			 * -------------------------------- wenn der Treffer ein Contained
-			 * Work ist, dann übergeordnetes Werk
+			 * --------------------------------
+			 * if the hit is a contained work, then superordinated work
 			 * --------------------------------
 			 */
 			if (type.isContainedWork()) {
-				/* PPN des übergeordneten Werkes ermitteln */
+				// determine the PPN of the superordinated work
 				String ueberGeordnetePpn = getPPNFromParent(myFirstHit, "021A", "9");
 				if (!ueberGeordnetePpn.equals("")) {
-					/* Sammelband aus dem Opac holen */
+					// take anthology out of the OPAC
 					myQuery = new Query(ueberGeordnetePpn, "12");
-					/* wenn ein Treffer des Parents im Opac gefunden wurde */
+					// if a hit of the parent was found in the OPAC
 					if (client.getNumberOfHits(myQuery) == 1) {
 						Node myParentHitlist = client.retrievePicaNode(myQuery, 1);
-						/* Opac-Beautifier aufrufen */
+						// call OPAC beautifier
 						myParentHitlist = catalogue.executeBeautifier(myParentHitlist);
-						/* Konvertierung in jdom-Elemente */
+						// conversion to JDOM elements
 						Document myJdomDocParent = new DOMBuilder().build(myParentHitlist.getOwnerDocument());
 						Element myFirstHitParent = myJdomDocParent.getRootElement().getChild("record");
-						/*
-						 * alle Elemente des Parents übernehmen, die noch nicht
-						 * selbst vorhanden sind
-						 */
+
+						// take over all elements of the parent that are not
+						// yet available by themselves
+
 						if (myFirstHitParent.getChildren() != null) {
 							for (@SuppressWarnings("unchecked")
 							Iterator<Element> iter = myFirstHitParent.getChildren().iterator(); iter.hasNext();) {
@@ -374,21 +376,22 @@ public class PicaPlugin implements Plugin {
 			}
 
 			/*
-			 * -------------------------------- aus Opac-Ergebnis RDF-Datei
-			 * erzeugen --------------------------------
+			 * --------------------------------
+			 * create RDF file from the OPAC result
+			 * --------------------------------
 			 */
 
-			/* zugriff auf ugh-Klassen */
+			// access to Ugh classes
 			PicaPlus pp = new PicaPlus(preferences);
 			pp.read(myHitlist);
 			DigitalDocument dd = pp.getDigitalDocument();
 			ff = new XStream(preferences);
 			ff.setDigitalDocument(dd);
-			/* BoundBook hinzufügen */
+			// add BoundBook
 			DocStructType dst = preferences.getDocStrctTypeByName("BoundBook");
 			DocStruct dsBoundBook = dd.createDocStruct(dst);
 			dd.setPhysicalDocStruct(dsBoundBook);
-			/* Inhalt des RDF-Files überprüfen und ergänzen */
+			// check and complement content of the RDF file
 			checkMyOpacResult(ff.getDigitalDocument(), preferences, myFirstHit, type, typeID);
 		} catch (RuntimeException e) {
 			throw e;
@@ -399,10 +402,7 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * DocType (Gattung) ermitteln
-	 *
-	 * @param inHit
-	 * @return
+	 * Determines the document type (genre).
 	 */
 	@SuppressWarnings("unchecked")
 	private static String getTypeID(Element inHit) {
@@ -433,11 +433,8 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * die PPN des übergeordneten Bandes (MultiVolume: 036D-9 und ContainedWork:
-	 * 021A-9) ermitteln
-	 *
-	 * @param inElement
-	 * @return
+	 * Determines the PPN of the superodinated volume. (MultiVolume: 036D-9 and ContainedWork:
+	 * 021A-9)
 	 */
 	@SuppressWarnings("unchecked")
 	private static String getPPNFromParent(Element inHit, String inFeldName, String inSubElement) {
@@ -456,10 +453,10 @@ public class PicaPlugin implements Plugin {
 		for (Iterator<Element> iter2 = inHit.getChildren().iterator(); iter2.hasNext();) {
 			Element myElement = iter2.next();
 			String feldname = myElement.getAttributeValue("tag");
-			/*
-			 * wenn es das gesuchte Feld ist, dann den Wert mit dem passenden
-			 * Attribut zurückgeben
-			 */
+
+			// if it is the desired field, then return the value with the
+			// appropriate attribute
+
 			if (feldname.equals(inTagName)) {
 				return myElement;
 			}
@@ -468,23 +465,22 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * rekursives Kopieren von Elementen, weil das Einfügen eines Elements an
-	 * einen anderen Knoten mit dem Fehler abbricht, dass das einzufügende
-	 * Element bereits einen Parent hat
-	 * ================================================================
+	 * Recursively copies elements. This method exists because inserting an
+	 * element onto an other node fails with an error stating that the element
+	 * to add already has a parent.
 	 */
 	@SuppressWarnings("unchecked")
 	private static Element getCopyFromJdomElement(Element inHit) {
 		Element myElement = new Element(inHit.getName());
 		myElement.setText(inHit.getText());
-		/* jetzt auch alle Attribute übernehmen */
+		// now take over all attributes, too
 		if (inHit.getAttributes() != null) {
 			for (Iterator<Attribute> iter = inHit.getAttributes().iterator(); iter.hasNext();) {
 				Attribute att = iter.next();
 				myElement.getAttributes().add(new Attribute(att.getName(), att.getValue()));
 			}
 		}
-		/* jetzt auch alle Children übernehmen */
+		// now take over all children, too
 		if (inHit.getChildren() != null) {
 
 			for (Iterator<Element> iter = inHit.getChildren().iterator(); iter.hasNext();) {
@@ -496,11 +492,11 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/*
-	 * #####################################################
-	 * ##################################################### ## ## Ergänze das
-	 * Docstruct um zusätzliche Opac-Details ##
-	 * #####################################################
-	 * ####################################################
+	 * #########################################################
+	 * #########################################################
+	 * ## Complement the DocStruct by additional OPAC details ##
+	 * #########################################################
+	 * #########################################################
 	 */
 
 	private static void checkMyOpacResult(DigitalDocument inDigDoc, Prefs inPrefs, Element myFirstHit,
@@ -511,10 +507,10 @@ public class PicaPlugin implements Plugin {
 		Element mySecondHit = null;
 
 		/*
-		 * -------------------------------- bei Multivolumes noch das Child in
-		 * xml und docstruct ermitteln --------------------------------
+		 * --------------------------------
+		 * at multivolumes, still determine the child in XML and DocStruct
+		 * --------------------------------
 		 */
-		// if (isMultivolume()) {
 		if (type.isMultiVolume()) {
 			try {
 				topstructChild = topstruct.getAllChildren().get(0);
@@ -524,8 +520,9 @@ public class PicaPlugin implements Plugin {
 		}
 
 		/*
-		 * -------------------------------- vorhandene PPN als digitale oder
-		 * analoge einsetzen --------------------------------
+		 * --------------------------------
+		 * insert available PPN as digital or analogous
+		 * --------------------------------
 		 */
 		String ppn = getElementFieldValue(myFirstHit, "003@", "0");
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "CatalogIDDigital", "");
@@ -536,8 +533,9 @@ public class PicaPlugin implements Plugin {
 		}
 
 		/*
-		 * -------------------------------- wenn es ein multivolume ist, dann
-		 * auch die PPN prüfen --------------------------------
+		 * --------------------------------
+		 * if it is a multivolume, then check the PPN, too
+		 * --------------------------------
 		 */
 		if ((topstructChild != null) && (mySecondHit != null)) {
 			String secondHitppn = getElementFieldValue(mySecondHit, "003@", "0");
@@ -550,22 +548,24 @@ public class PicaPlugin implements Plugin {
 		}
 
 		/*
-		 * -------------------------------- den Main-Title bereinigen
+		 * --------------------------------
+		 * clean up the main title
 		 * --------------------------------
 		 */
 		String myTitle = getElementFieldValue(myFirstHit, "021A", "a");
-		/*
-		 * wenn der Fulltittle nicht in dem Element stand, dann an anderer
-		 * Stelle nachsehen (vor allem bei Contained-Work)
-		 */
+
+		// if the full title was not written in the element, then have a look
+		// elsewhere (especially at contained work)
+
 		if ((myTitle == null) || (myTitle.length() == 0)) {
 			myTitle = getElementFieldValue(myFirstHit, "021B", "a");
 		}
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "TitleDocMain", myTitle.replaceAll("@", ""));
 
 		/*
-		 * -------------------------------- Sorting-Titel mit
-		 * Umlaut-Konvertierung --------------------------------
+		 * --------------------------------
+		 * sort title with conversion of umlauts
+		 * --------------------------------
 		 */
 		if (myTitle.indexOf("@") != -1) {
 			myTitle = myTitle.substring(myTitle.indexOf("@") + 1);
@@ -573,8 +573,9 @@ public class PicaPlugin implements Plugin {
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "TitleDocMainShort", myTitle);
 
 		/*
-		 * -------------------------------- bei multivolumes den Main-Title
-		 * bereinigen --------------------------------
+		 * --------------------------------
+		 * clean up the main title at multivolumes
+		 * --------------------------------
 		 */
 		if ((topstructChild != null) && (mySecondHit != null)) {
 			String fulltitleMulti = getElementFieldValue(mySecondHit, "021A", "a").replaceAll("@", "");
@@ -582,94 +583,101 @@ public class PicaPlugin implements Plugin {
 		}
 
 		/*
-		 * -------------------------------- bei multivolumes den Sorting-Titel
-		 * mit Umlaut-Konvertierung --------------------------------
+		 * --------------------------------
+		 * at multivolumes, the sort title with conversion of umlauts
+		 * --------------------------------
 		 */
 		if ((topstructChild != null) && (mySecondHit != null)) {
-			String sortingTitleMulti = getElementFieldValue(mySecondHit, "021A", "a");
-			if (sortingTitleMulti.indexOf("@") != -1) {
-				sortingTitleMulti = sortingTitleMulti.substring(sortingTitleMulti.indexOf("@") + 1);
+			String sortTitleMulti = getElementFieldValue(mySecondHit, "021A", "a");
+			if (sortTitleMulti.indexOf("@") != -1) {
+				sortTitleMulti = sortTitleMulti.substring(sortTitleMulti.indexOf("@") + 1);
 			}
-			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "TitleDocMainShort", sortingTitleMulti);
-			// sortingTitle = sortingTitleMulti;
+			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "TitleDocMainShort", sortTitleMulti);
 		}
 
 		/*
-		 * -------------------------------- Sprachen - Konvertierung auf zwei
-		 * Stellen --------------------------------
+		 * --------------------------------
+		 * languages - conversion to two places
+		 * --------------------------------
 		 */
-		Iterable<String> sprachen = getElementFieldValues(myFirstHit, "010@", "a");
-		sprachen = UGHUtils.convertLanguages(sprachen);
-		UGHUtils.replaceMetadatum(topstruct, inPrefs, "DocLanguage", sprachen);
+		Iterable<String> languages = getElementFieldValues(myFirstHit, "010@", "a");
+		languages = UGHUtils.convertLanguages(languages);
+		UGHUtils.replaceMetadatum(topstruct, inPrefs, "DocLanguage", languages);
 
 		/*
-		 * -------------------------------- bei multivolumes die Sprachen -
-		 * Konvertierung auf zwei Stellen --------------------------------
+		 * --------------------------------
+		 * at multivolumes, the languages - conversion to two places
+		 * --------------------------------
 		 */
 		if ((topstructChild != null) && (mySecondHit != null)) {
-			Iterable<String> sprachenMulti = getElementFieldValues(mySecondHit, "010@", "a");
-			sprachenMulti = UGHUtils.convertLanguages(sprachenMulti);
-			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "DocLanguage", sprachenMulti);
+			Iterable<String> languagesMulti = getElementFieldValues(mySecondHit, "010@", "a");
+			languagesMulti = UGHUtils.convertLanguages(languagesMulti);
+			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "DocLanguage", languagesMulti);
 		}
 
 		/*
-		 * -------------------------------- ISSN
+		 * --------------------------------
+		 * ISSN
 		 * --------------------------------
 		 */
 		String issn = getElementFieldValue(myFirstHit, "005A", "0");
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "ISSN", issn);
 
 		/*
-		 * -------------------------------- Copyright
+		 * --------------------------------
+		 * Copyright
 		 * --------------------------------
 		 */
 		String copyright = getElementFieldValue(myFirstHit, "037I", "a");
 		UGHUtils.replaceMetadatum(boundbook, inPrefs, "copyrightimageset", copyright);
 
 		/*
-		 * -------------------------------- Format
+		 * --------------------------------
+		 * Format
 		 * --------------------------------
 		 */
 		String format = getElementFieldValue(myFirstHit, "034I", "a");
 		UGHUtils.replaceMetadatum(boundbook, inPrefs, "FormatSourcePrint", format);
 
 		/*
-		 * -------------------------------- Umfang
+		 * --------------------------------
+		 * Extent
 		 * --------------------------------
 		 */
-		String umfang = getElementFieldValue(myFirstHit, "034D", "a");
-		UGHUtils.replaceMetadatum(topstruct, inPrefs, "SizeSourcePrint", umfang);
+		String extent = getElementFieldValue(myFirstHit, "034D", "a");
+		UGHUtils.replaceMetadatum(topstruct, inPrefs, "SizeSourcePrint", extent);
 
 		/*
-		 * -------------------------------- Signatur
+		 * --------------------------------
+		 * Shelf mark
 		 * --------------------------------
 		 */
-		String sig = getElementFieldValue(myFirstHit, "209A", "c");
-		if (sig.length() > 0) {
-			sig = "<" + sig + ">";
+		String shm = getElementFieldValue(myFirstHit, "209A", "c");
+		if (shm.length() > 0) {
+			shm = "<" + shm + ">";
 		}
-		sig += getElementFieldValue(myFirstHit, "209A", "f") + " ";
-		sig += getElementFieldValue(myFirstHit, "209A", "a");
-		UGHUtils.replaceMetadatum(boundbook, inPrefs, "shelfmarksource", sig.trim());
-		if (sig.trim().length() == 0) {
-			sig = getElementFieldValue(myFirstHit, "209A/01", "c");
-			if (sig.length() > 0) {
-				sig = "<" + sig + ">";
+		shm += getElementFieldValue(myFirstHit, "209A", "f") + " ";
+		shm += getElementFieldValue(myFirstHit, "209A", "a");
+		UGHUtils.replaceMetadatum(boundbook, inPrefs, "shelfmarksource", shm.trim());
+		if (shm.trim().length() == 0) {
+			shm = getElementFieldValue(myFirstHit, "209A/01", "c");
+			if (shm.length() > 0) {
+				shm = "<" + shm + ">";
 			}
-			sig += getElementFieldValue(myFirstHit, "209A/01", "f") + " ";
-			sig += getElementFieldValue(myFirstHit, "209A/01", "a");
+			shm += getElementFieldValue(myFirstHit, "209A/01", "f") + " ";
+			shm += getElementFieldValue(myFirstHit, "209A/01", "a");
 			if (mySecondHit != null) {
-				sig += getElementFieldValue(mySecondHit, "209A", "f") + " ";
-				sig += getElementFieldValue(mySecondHit, "209A", "a");
+				shm += getElementFieldValue(mySecondHit, "209A", "f") + " ";
+				shm += getElementFieldValue(mySecondHit, "209A", "a");
 			}
-			UGHUtils.replaceMetadatum(boundbook, inPrefs, "shelfmarksource", sig.trim());
+			UGHUtils.replaceMetadatum(boundbook, inPrefs, "shelfmarksource", shm.trim());
 		}
 
 		/*
-		 * -------------------------------- bei Zeitschriften noch ein
-		 * PeriodicalVolume als Child einfügen --------------------------------
+		 * --------------------------------
+		 * In case of magazines, insert another PeriodicalVolume as child
+		 * --------------------------------
 		 */
-		// if (isPeriodical()) {
 		if (type.isPeriodical() && (topstruct.getAllChildren() == null)) {
 			try {
 				DocStructType dstV = inPrefs.getDocStrctTypeByName("PeriodicalVolume");
@@ -706,10 +714,10 @@ public class PicaPlugin implements Plugin {
 		for (Iterator<Element> iter2 = myFirstHit.getChildren().iterator(); iter2.hasNext();) {
 			Element myElement = iter2.next();
 			String feldname = myElement.getAttributeValue("tag");
-			/*
-			 * wenn es das gesuchte Feld ist, dann den Wert mit dem passenden
-			 * Attribut zurückgeben
-			 */
+
+			// if it is the desired field, then return the value with the
+			// appropriate attribute
+
 			if (feldname.equals(inFieldName)) {
 				return getFieldValue(myElement, inAttributeName);
 			}
@@ -738,10 +746,10 @@ public class PicaPlugin implements Plugin {
 		for (Iterator<Element> iter2 = myFirstHit.getChildren().iterator(); iter2.hasNext();) {
 			Element myElement = iter2.next();
 			String feldname = myElement.getAttributeValue("tag");
-			/*
-			 * wenn es das gesuchte Feld ist, dann den Wert mit dem passenden
-			 * Attribut zurückgeben
-			 */
+
+			// if it is the desired field, then return the value with the
+			// appropriate attribute
+
 			if (feldname.equals(inFieldName)) {
 				result.addAll(getFieldValues(myElement, inAttributeName));
 			}
@@ -923,23 +931,24 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function getNumberOfHits() returns the number of hits from a given
-	 * search result.
-	 *
+	 * Returns the number of hits from a given search result.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.getNumberOfHits(Object, long)} in
+	 * package {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
+	 * 
 	 * @param searchResult
 	 *            the reference to the search whose number of hits shall be
 	 *            looked up
 	 * @param timeout
 	 *            ignored because there is no network acceess in this step
 	 * @return the number of hits
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#getNumberOfHits(Object,
-	 *      long)
 	 */
 	public static long getNumberOfHits(Object searchResult, long timeout) {
 		if (searchResult instanceof FindResult) {
 			return ((FindResult) searchResult).getHits();
 		} else {
-			throw new ClassCastException();
+			throw new ClassCastException("Search result of class "+searchResult.getClass().getName()+" not supported.");
 		}
 	}
 
@@ -954,62 +963,74 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function getDescription() returns a human-readable name for the
-	 * plug-in in English. The parameter language is ignored.
+	 * Returns a human-readable name for the plug-in in English. The parameter
+	 * language is ignored.
+	 * <p>
+	 * Confer to {@code UnspecificPlugin.getTitle(Locale)} in package
+	 * {@code org.goobi.production.plugin} of the core application, too.
 	 *
 	 * @param language
 	 *            desired language of the human-readable name (support is
 	 *            optional)
 	 * @return a human-readable name for the plug-in
-	 * @see org.goobi.production.plugin.UnspecificPlugin#getTitle(Locale)
 	 */
 	public static String getTitle(Locale language) {
 		return "PICA Catalogue Plugin";
 	}
 
 	/**
-	 * The function setPreferences is called by Production to set the UGH
-	 * preferences to be used.
-	 *
+	 * Sets the Ugh preferences to be used to create the main result.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.setPreferences(Prefs)} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
+	 * 
 	 * @param preferences
-	 *            the UGH preferences
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#setPreferences(Prefs)
+	 *            Ugh preferences to use
 	 */
 	public void setPreferences(Prefs preferences) {
 		this.preferences = preferences;
 	}
 
 	/**
-	 * The function supportsCatalogue() investigates whether the plug-in is able
-	 * to acceess a catalogue identified by the given String. (This depends on
-	 * the configuration.)
+	 * Returns whether this plug-in is able to access the catalogue identified
+	 * by the given String. This depends on the configuration.
+	 * <p>
+	 * Confer to {@code CataloguePlugin#supportsCatalogue(String)} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
 	 *
 	 * @param catalogue
-	 *            a String indentifying the catalogue
-	 * @return whether the plug-in is able to acceess that catalogue
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#supportsCatalogue(String)
+	 *            a String identifying the catalogue
+	 * @return whether the plug-in is able to access that catalogue
 	 */
 	public static boolean supportsCatalogue(String catalogue) {
 		return OpacCatalogues.getCatalogueByName(catalogue) != null;
 	}
 
 	/**
-	 * The function getSupportedCatalogues() returns the names of all catalogues supported
-	 * by this plugin. (This depends on the plugin configuration.)
+	 * Returns the names of all catalogues supported by this plug-in. This
+	 * depends on the plug-in’s configuration.
+	 * <p>
+	 * Confer to {@code CataloguePlugin#getSupportedCatalogues()} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
 	 *
 	 * @return list of catalogue names
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#getSupportedCatalogues()
 	 */
 	public static List<String> getSupportedCatalogues() {
 		return OpacCatalogues.getAllCatalogues();
 	}
 
 	/**
-	 * The function getAllConfigDocTypes() returns the names of all docTypes configured
-	 * for this plugin. (This depends on the plugin configuration.)
+	 * Returns the names of all docTypes configured for this plug-in. This
+	 * depends on the plug-in’s configuration.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.getAllConfigDocTypes()} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
 	 *
 	 * @return list of ConfigOapcDocTypes
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#getAllConfigDocTypes()
 	 */
 	public static List<String> getAllConfigDocTypes() {
 		List<String> result = new ArrayList<>();
@@ -1020,14 +1041,17 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function useCatalogue() sets a catalogue to be used
+	 * Sets a catalogue to be used.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.useCatalogue(String)} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
 	 *
 	 * @param catalogueID
-	 *            a String indentifying the catalogue
+	 *            a String identifying the catalogue
 	 * @throws ParserConfigurationException
 	 *             if a DocumentBuilder cannot be created which satisfies the
 	 *             configuration requested
-	 * @see org.goobi.production.plugin.CataloguePlugin.CataloguePlugin#useCatalogue(String)
 	 */
 	public void useCatalogue(String catalogueID) throws ParserConfigurationException {
 		catalogue = OpacCatalogues.getCatalogueByName(catalogueID);
@@ -1035,17 +1059,22 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function getSearchFields(String catalogueName) loads the search fields, configured
-	 * in the configuration file of this plugin, for the catalogue with the given String 'catalogueName',
-	 * and returns them in a HashMap. The map contains the labels of the search fields as keys
-	 * and the corresponding URL parameters as values.
+	 * Returns the search fields for the given catalogue. The search fields are
+	 * read from the configuration file of this plug-in, for the catalogue with
+	 * the given String {@code catalogueName}. They are returned in a HashMap.
+	 * The map contains the labels of the search fields as keys and the
+	 * corresponding URL parameters as values.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.getSearchFields(String)} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
 	 *
 	 * @param catalogueName
-	 *            the name of the catalogue for which the list of search fields will be returned
+	 *            the name of the catalogue for which the list of search fields
+	 *            will be returned
 	 * @return Map containing the search fields of the selected OPAC
-	 * @throws InvalidActivityException
 	 */
-	public HashMap<String, String> getSearchFields(String catalogueName) throws InvalidActivityException {
+	public HashMap<String, String> getSearchFields(String catalogueName) {
 		LinkedHashMap<String, String> searchFields = new LinkedHashMap<>();
 		if(!Objects.equals(OpacCatalogues.getConfig(), null)) {
 			for (Object catalogueObject : OpacCatalogues.getConfig().configurationsAt("catalogue")) {
@@ -1066,15 +1095,21 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function getInstitutions(String catalogueName) loads the institutions usable
-	 * for result filtering, configured in the configuration file of this plugin, for
-	 * the catalogue with the given String 'cagalogueName', and returns them in a
-	 * HashMap. The map contains the labels of the institutions as keys and the
-	 * corresponding ISIL IDs as values.
+	 * Returns the institutions the result can be filtered by for the given
+	 * catalogue. The institutions can be configured in the configuration file
+	 * of this plug-in. Returns a map that contains the labels of the
+	 * institutions as keys and the IDs used to for filtering as values. In PICA
+	 * catalogues, ISIL IDs are used for that purpose.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.getInstitutions(String)} in package
+	 * {@code org.goobi.production.plugin.CataloguePlugin} of the core
+	 * application, too.
 	 *
 	 * @param catalogueName
-	 *            the name of the catalogue for which the list of search fields will be returned
-	 * @return Map containing the filter institutions of the selected OPAC
+	 *            the name of the catalogue for which the list of search fields
+	 *            will be returned
+	 * @return Map containing the institutions for which the selected catalogue
+	 *         supports filtering
 	 */
 	public HashMap<String, String> getInstitutions(String catalogueName) {
 		LinkedHashMap<String, String> institutions = new LinkedHashMap<>();
@@ -1097,13 +1132,17 @@ public class PicaPlugin implements Plugin {
 	}
 
 	/**
-	 * The function getInstitutionFilterParameter(String catalogueName) returns the URL parameter
-	 * used for institution filtering in this plugin.
-	 *
+	 * Returns the URL parameter used for institution filtering in this plug-in.
+	 * <p>
 	 * This function is not yet used in the PicaPlugin.
+	 * <p>
+	 * Confer to {@code CataloguePlugin.getInstitutionFilterParameter(String)}
+	 * in package {@code org.goobi.production.plugin.CataloguePlugin} of the
+	 * core application, too.
 	 *
 	 * @param catalogueName
-	 *            the name of the catalogue for which the institution filter parameter is returned
+	 *            the name of the catalogue for which the institution filter
+	 *            parameter is returned
 	 * @return String the URL parameter used for institution filtering
 	 */
 	public String getInstitutionFilterParameter(String catalogueName) {

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
@@ -236,11 +236,9 @@ public class PicaPlugin implements Plugin {
 		Type type;
 		Fileformat ff;
 		try {
-			/* 
-			 * --------------------------------
-			 * Query OPAC and convert the DOM document returned to JDOM
-			 * --------------------------------
-			 */
+
+			// Query OPAC and convert the DOM document returned to JDOM
+
 			Node myHitlist = client.retrievePicaNode(myQuery, (int) index, (int) index + 1, timeout);
 
 			// call OPAC beautifier
@@ -257,12 +255,9 @@ public class PicaPlugin implements Plugin {
 				typeID = type.getMappings().get(0);
 			}
 
-			/*
-			 * --------------------------------
-			 * if the hit is a volume from a multivolume volume, then
-			 * superordinate the compilation
-			 * --------------------------------
-			 */
+			/* if the hit is a volume from a multivolume volume, then
+			 * superordinate the compilation */
+
 			if (type.isMultiVolume()) {
 				// determine the PPN of the anthology
 				String multiVolumePpn = getPPNFromParent(myFirstHit, "036D", "9");
@@ -289,20 +284,17 @@ public class PicaPlugin implements Plugin {
 						DOMOutputter doutputter = new DOMOutputter();
 						myHitlist = doutputter.output(myJdomDocMultivolumeband);
 
-						// nevertheless, do not take the document, but the first
-						// child
+						/* nevertheless, do not take the document, but the first
+						 * child */
 
 						myHitlist = myHitlist.getFirstChild();
 					}
 				}
 			}
 
-			/*
-			 * --------------------------------
-			 * if the hit is a volume from a periodical volume, then
-			 * superordinate the series
-			 * --------------------------------
-			 */
+			/* if the hit is a volume from a periodical volume, then
+			 * superordinate the series */
+
 			if (type.isPeriodical()) {
 				// determine the PPN of the anthology
 				String serialPublicationPpn = getPPNFromParent(myFirstHit, "036F", "9");
@@ -329,19 +321,16 @@ public class PicaPlugin implements Plugin {
 						DOMOutputter doutputter = new DOMOutputter();
 						myHitlist = doutputter.output(myJdomDocMultivolumeband);
 
-						// nevertheless, do not take the document, but the first
-						// child
+						/* nevertheless, do not take the document, but the first
+						 * child */
 
 						myHitlist = myHitlist.getFirstChild();
 					}
 				}
 			}
 
-			/*
-			 * --------------------------------
-			 * if the hit is a contained work, then superordinated work
-			 * --------------------------------
-			 */
+			// if the hit is a contained work, then superordinated work
+
 			if (type.isContainedWork()) {
 				// determine the PPN of the superordinated work
 				String ueberGeordnetePpn = getPPNFromParent(myFirstHit, "021A", "9");
@@ -357,8 +346,8 @@ public class PicaPlugin implements Plugin {
 						Document myJdomDocParent = new DOMBuilder().build(myParentHitlist.getOwnerDocument());
 						Element myFirstHitParent = myJdomDocParent.getRootElement().getChild("record");
 
-						// take over all elements of the parent that are not
-						// yet available by themselves
+						/* take over all elements of the parent that are not
+						 * yet available by themselves */
 
 						if (myFirstHitParent.getChildren() != null) {
 							for (@SuppressWarnings("unchecked")
@@ -375,11 +364,7 @@ public class PicaPlugin implements Plugin {
 				}
 			}
 
-			/*
-			 * --------------------------------
-			 * create RDF file from the OPAC result
-			 * --------------------------------
-			 */
+			// create RDF file from the OPAC result
 
 			// access to Ugh classes
 			PicaPlus pp = new PicaPlus(preferences);
@@ -454,8 +439,8 @@ public class PicaPlugin implements Plugin {
 			Element myElement = iter2.next();
 			String feldname = myElement.getAttributeValue("tag");
 
-			// if it is the desired field, then return the value with the
-			// appropriate attribute
+			/* if it is the desired field, then return the value with the
+			 * appropriate attribute */
 
 			if (feldname.equals(inTagName)) {
 				return myElement;
@@ -491,14 +476,9 @@ public class PicaPlugin implements Plugin {
 		return myElement;
 	}
 
-	/*
-	 * #########################################################
-	 * #########################################################
-	 * ## Complement the DocStruct by additional OPAC details ##
-	 * #########################################################
-	 * #########################################################
+	/**
+	 * Complements the DigitalDocument by additional OPAC details.
 	 */
-
 	private static void checkMyOpacResult(DigitalDocument inDigDoc, Prefs inPrefs, Element myFirstHit,
 			Type type, String gattung) {
 		DocStruct topstruct = inDigDoc.getLogicalDocStruct();
@@ -506,11 +486,8 @@ public class PicaPlugin implements Plugin {
 		DocStruct topstructChild = null;
 		Element mySecondHit = null;
 
-		/*
-		 * --------------------------------
-		 * at multivolumes, still determine the child in XML and DocStruct
-		 * --------------------------------
-		 */
+		// at multivolumes, still determine the child in XML and DocStruct
+
 		if (type.isMultiVolume()) {
 			try {
 				topstructChild = topstruct.getAllChildren().get(0);
@@ -519,11 +496,8 @@ public class PicaPlugin implements Plugin {
 			mySecondHit = (Element) myFirstHit.getParentElement().getChildren().get(1);
 		}
 
-		/*
-		 * --------------------------------
-		 * insert available PPN as digital or analogous
-		 * --------------------------------
-		 */
+		// insert available PPN as digital or analogous
+
 		String ppn = getElementFieldValue(myFirstHit, "003@", "0");
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "CatalogIDDigital", "");
 		if (gattung.toLowerCase().startsWith("o")) {
@@ -532,11 +506,8 @@ public class PicaPlugin implements Plugin {
 			UGHUtils.replaceMetadatum(topstruct, inPrefs, "CatalogIDSource", ppn);
 		}
 
-		/*
-		 * --------------------------------
-		 * if it is a multivolume, then check the PPN, too
-		 * --------------------------------
-		 */
+		// if it is a multivolume, then check the PPN, too
+
 		if ((topstructChild != null) && (mySecondHit != null)) {
 			String secondHitppn = getElementFieldValue(mySecondHit, "003@", "0");
 			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "CatalogIDDigital", "");
@@ -547,46 +518,34 @@ public class PicaPlugin implements Plugin {
 			}
 		}
 
-		/*
-		 * --------------------------------
-		 * clean up the main title
-		 * --------------------------------
-		 */
+		// clean up the main title
+
 		String myTitle = getElementFieldValue(myFirstHit, "021A", "a");
 
-		// if the full title was not written in the element, then have a look
-		// elsewhere (especially at contained work)
+		/* if the full title was not written in the element, then have a look
+		 * elsewhere (especially at contained work) */
 
 		if ((myTitle == null) || (myTitle.length() == 0)) {
 			myTitle = getElementFieldValue(myFirstHit, "021B", "a");
 		}
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "TitleDocMain", myTitle.replaceAll("@", ""));
 
-		/*
-		 * --------------------------------
-		 * sort title with conversion of umlauts
-		 * --------------------------------
-		 */
+		// sort title with conversion of diacritics
+
 		if (myTitle.indexOf("@") != -1) {
 			myTitle = myTitle.substring(myTitle.indexOf("@") + 1);
 		}
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "TitleDocMainShort", myTitle);
 
-		/*
-		 * --------------------------------
-		 * clean up the main title at multivolumes
-		 * --------------------------------
-		 */
+		// clean up the main title at multivolumes
+
 		if ((topstructChild != null) && (mySecondHit != null)) {
 			String fulltitleMulti = getElementFieldValue(mySecondHit, "021A", "a").replaceAll("@", "");
 			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "TitleDocMain", fulltitleMulti);
 		}
 
-		/*
-		 * --------------------------------
-		 * at multivolumes, the sort title with conversion of umlauts
-		 * --------------------------------
-		 */
+		// at multivolumes, the sort title with conversion of diacritics
+
 		if ((topstructChild != null) && (mySecondHit != null)) {
 			String sortTitleMulti = getElementFieldValue(mySecondHit, "021A", "a");
 			if (sortTitleMulti.indexOf("@") != -1) {
@@ -595,63 +554,42 @@ public class PicaPlugin implements Plugin {
 			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "TitleDocMainShort", sortTitleMulti);
 		}
 
-		/*
-		 * --------------------------------
-		 * languages - conversion to two places
-		 * --------------------------------
-		 */
+		// languages - conversion to two places
+
 		Iterable<String> languages = getElementFieldValues(myFirstHit, "010@", "a");
 		languages = UGHUtils.convertLanguages(languages);
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "DocLanguage", languages);
 
-		/*
-		 * --------------------------------
-		 * at multivolumes, the languages - conversion to two places
-		 * --------------------------------
-		 */
+		// at multivolumes, the languages - conversion to two places
+
 		if ((topstructChild != null) && (mySecondHit != null)) {
 			Iterable<String> languagesMulti = getElementFieldValues(mySecondHit, "010@", "a");
 			languagesMulti = UGHUtils.convertLanguages(languagesMulti);
 			UGHUtils.replaceMetadatum(topstructChild, inPrefs, "DocLanguage", languagesMulti);
 		}
 
-		/*
-		 * --------------------------------
-		 * ISSN
-		 * --------------------------------
-		 */
+		// ISSN
+
 		String issn = getElementFieldValue(myFirstHit, "005A", "0");
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "ISSN", issn);
 
-		/*
-		 * --------------------------------
-		 * Copyright
-		 * --------------------------------
-		 */
+		// Copyright
+
 		String copyright = getElementFieldValue(myFirstHit, "037I", "a");
 		UGHUtils.replaceMetadatum(boundbook, inPrefs, "copyrightimageset", copyright);
 
-		/*
-		 * --------------------------------
-		 * Format
-		 * --------------------------------
-		 */
+		// Format
+
 		String format = getElementFieldValue(myFirstHit, "034I", "a");
 		UGHUtils.replaceMetadatum(boundbook, inPrefs, "FormatSourcePrint", format);
 
-		/*
-		 * --------------------------------
-		 * Extent
-		 * --------------------------------
-		 */
+		// Extent
+
 		String extent = getElementFieldValue(myFirstHit, "034D", "a");
 		UGHUtils.replaceMetadatum(topstruct, inPrefs, "SizeSourcePrint", extent);
 
-		/*
-		 * --------------------------------
-		 * Shelf mark
-		 * --------------------------------
-		 */
+		// Shelf mark
+
 		String shm = getElementFieldValue(myFirstHit, "209A", "c");
 		if (shm.length() > 0) {
 			shm = "<" + shm + ">";
@@ -673,11 +611,8 @@ public class PicaPlugin implements Plugin {
 			UGHUtils.replaceMetadatum(boundbook, inPrefs, "shelfmarksource", shm.trim());
 		}
 
-		/*
-		 * --------------------------------
-		 * In case of magazines, insert another PeriodicalVolume as child
-		 * --------------------------------
-		 */
+		// In case of magazines, insert another PeriodicalVolume as child
+
 		if (type.isPeriodical() && (topstruct.getAllChildren() == null)) {
 			try {
 				DocStructType dstV = inPrefs.getDocStrctTypeByName("PeriodicalVolume");
@@ -715,8 +650,8 @@ public class PicaPlugin implements Plugin {
 			Element myElement = iter2.next();
 			String feldname = myElement.getAttributeValue("tag");
 
-			// if it is the desired field, then return the value with the
-			// appropriate attribute
+			/* if it is the desired field, then return the value with the
+			 * appropriate attribute */
 
 			if (feldname.equals(inFieldName)) {
 				return getFieldValue(myElement, inAttributeName);
@@ -747,8 +682,8 @@ public class PicaPlugin implements Plugin {
 			Element myElement = iter2.next();
 			String feldname = myElement.getAttributeValue("tag");
 
-			// if it is the desired field, then return the value with the
-			// appropriate attribute
+			/* if it is the desired field, then return the value with the
+			 * appropriate attribute */
 
 			if (feldname.equals(inFieldName)) {
 				result.addAll(getFieldValues(myElement, inAttributeName));

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
@@ -166,9 +166,10 @@ public class PicaPlugin implements Plugin {
 	 *      long)
 	 */
 	public Object find(String query, long timeout) {
+		client.setTimeout(timeout);
 		try {
 			Query queryObject = new Query(query);
-			int hits = client.getNumberOfHits(queryObject, timeout);
+			int hits = client.getNumberOfHits(queryObject);
 			if (hits > 0) {
 				return new FindResult(queryObject, hits);
 			} else {
@@ -224,6 +225,7 @@ public class PicaPlugin implements Plugin {
 	 *      long, long)
 	 */
 	public Map<String, Object> getHit(Object searchResult, long index, long timeout) {
+		client.setTimeout(timeout);
 		if (!(searchResult instanceof FindResult)) {
 			throw new ClassCastException();
 		}
@@ -268,8 +270,8 @@ public class PicaPlugin implements Plugin {
 
 					myQuery = new Query(multiVolumePpn, "12");
 					/* wenn ein Treffer des Parents im Opac gefunden wurde */
-					if (client.getNumberOfHits(myQuery, timeout) == 1) {
-						Node myParentHitlist = client.retrievePicaNode(myQuery, 1, timeout);
+					if (client.getNumberOfHits(myQuery) == 1) {
+						Node myParentHitlist = client.retrievePicaNode(myQuery, 1);
 						/* Opac-Beautifier aufrufen */
 						myParentHitlist = catalogue.executeBeautifier(myParentHitlist);
 						/* Konvertierung in jdom-Elemente */
@@ -307,8 +309,8 @@ public class PicaPlugin implements Plugin {
 
 					myQuery = new Query(serialPublicationPpn, "12");
 					/* wenn ein Treffer des Parents im Opac gefunden wurde */
-					if (client.getNumberOfHits(myQuery, timeout) == 1) {
-						Node myParentHitlist = client.retrievePicaNode(myQuery, 1, timeout);
+					if (client.getNumberOfHits(myQuery) == 1) {
+						Node myParentHitlist = client.retrievePicaNode(myQuery, 1);
 						/* Opac-Beautifier aufrufen */
 						myParentHitlist = catalogue.executeBeautifier(myParentHitlist);
 						/* Konvertierung in jdom-Elemente */
@@ -345,8 +347,8 @@ public class PicaPlugin implements Plugin {
 					/* Sammelband aus dem Opac holen */
 					myQuery = new Query(ueberGeordnetePpn, "12");
 					/* wenn ein Treffer des Parents im Opac gefunden wurde */
-					if (client.getNumberOfHits(myQuery, timeout) == 1) {
-						Node myParentHitlist = client.retrievePicaNode(myQuery, 1, timeout);
+					if (client.getNumberOfHits(myQuery) == 1) {
+						Node myParentHitlist = client.retrievePicaNode(myQuery, 1);
 						/* Opac-Beautifier aufrufen */
 						myParentHitlist = catalogue.executeBeautifier(myParentHitlist);
 						/* Konvertierung in jdom-Elemente */

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
@@ -128,8 +128,8 @@ class ResolveRule {
 
 	/**
 	 * PICA subfield code of the subfield that has the ID to resolve. Typical
-	 * values match the pattern <code>[0-9a-z]</code>. An example value is "9"
-	 * for the PPN of the person record for the person.
+	 * values match the pattern {@code [0-9a-z]}. An example value is "9" for
+	 * the PPN of the person record for the person.
 	 */
 	String subtag;
 

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
@@ -32,34 +32,40 @@ import org.xml.sax.SAXException;
  * same field of the main record. Configuration:
  *
  * <pre>
- * &lt;catalogue title="…">
- *     &lt;!-- ... -->
- *     &lt;resolve tag="028C" subtag="9" searchField="12">
- *         &lt;map tag="003U" subtag="a" asSubtag="g" />
- *     &lt;/resolve>
+ * {@code
+ * <catalogue title="…">
+ *     <!-- ... -->
+ *     <resolve tag="028C" subtag="9" searchField="12">
+ *         <map tag="003U" subtag="a" asSubtag="g" />
+ *     </resolve>
+ * }
  * </pre>
  *
  * Example field on a record:
  *
  * <pre>
- * &lt;field tag="028C">
- *     &lt;subfield code="d">Dirk&lt;/subfield>
- *     &lt;subfield code="a">Fahlenkamp&lt;/subfield>
- *     &lt;subfield code="9">69749487X&lt;/subfield>
- *     &lt;subfield code="8">Fahlenkamp, Dirk *1952-*&lt;/subfield>
- * &lt;/field>
+ * {@code
+ * <field tag="028C">
+ *     <subfield code="d">Dirk</subfield>
+ *     <subfield code="a">Fahlenkamp</subfield>
+ *     <subfield code="9">69749487X</subfield>
+ *     <subfield code="8">Fahlenkamp, Dirk *1952-*</subfield>
+ * </field>
+ * }
  * </pre>
  *
  * Example result after successful resolving:
  *
  * <pre>
- * &lt;field tag="028C">
- *     &lt;subfield code="d">Dirk&lt;/subfield>
- *     &lt;subfield code="a">Fahlenkamp&lt;/subfield>
- *     &lt;subfield code="9">69749487X&lt;/subfield>
- *     &lt;subfield code="8">Fahlenkamp, Dirk *1952-*&lt;/subfield>
- *     &lt;subfield code="g">http://d-nb.info/gnd/172559227&lt;/subfield>
- * &lt;/field>
+ * {@code
+ * <field tag="028C">
+ *     <subfield code="d">Dirk</subfield>
+ *     <subfield code="a">Fahlenkamp</subfield>
+ *     <subfield code="9">69749487X</subfield>
+ *     <subfield code="8">Fahlenkamp, Dirk *1952-*</subfield>
+ *     <subfield code="g">http://d-nb.info/gnd/172559227</subfield>
+ * </field>
+ * }
  * </pre>
  *
  * @author Matthias Ronge

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
@@ -209,6 +209,14 @@ class ResolveRule {
 	 *            catalogue client to use for catalogue look-up
 	 * @param out
 	 *            field to write the result to
+	 * @throws IOException
+	 *             an IO exception from the parser, possibly from a byte stream
+	 *             or character stream supplied by the application.
+	 * @throws ParserConfigurationException
+	 *             if a parser cannot be created which satisfies the requested
+	 *             configuration.
+	 * @throws SAXException
+	 *             if any SAX errors occur during processing
 	 */
 	void execute(Element subfield, CatalogueClient client, Element out) throws IOException, SAXException, ParserConfigurationException {
 		assert tag.equals(out.getAttributeNode("tag").getTextContent()) : "Attempt to call the rule on the wrong field.";

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
@@ -1,0 +1,106 @@
+package org.goobi.production.plugin.CataloguePlugin.PicaPlugin;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+import org.apache.commons.configuration.HierarchicalConfiguration;
+
+/**
+ * Resolve rules are used to import data from a related record into a PICA
+ * field.
+ * <p>
+ * Example: If PICA field 028C subfield 9 is present, take the value from that
+ * field and look it up in the catalogue by a request on search field 12. In the
+ * result, select field 003U subfield a and store its value as subfield g in the
+ * same field of the main record. Configuration:
+ * 
+ * <pre>
+ * &lt;catalogue title="…">
+ *     &lt;!-- ... -->
+ *     &lt;resolve tag="028C" subtag="9" searchField="12">
+ *         &lt;map tag="003U" subtag="a" asSubtag="g" />
+ *     &lt;/resolve>
+ * </pre>
+ * 
+ * Example field on a record:
+ * 
+ * <pre>
+ * &lt;field tag="028C">
+ *     &lt;subfield code="d">Dirk&lt;/subfield>
+ *     &lt;subfield code="a">Fahlenkamp&lt;/subfield>
+ *     &lt;subfield code="9">69749487X&lt;/subfield>
+ *     &lt;subfield code="8">Fahlenkamp, Dirk *1952-*&lt;/subfield>
+ * &lt;/field>
+ * </pre>
+ * 
+ * Example result after successful resolving:
+ * 
+ * <pre>
+ * &lt;field tag="028C">
+ *     &lt;subfield code="d">Dirk&lt;/subfield>
+ *     &lt;subfield code="a">Fahlenkamp&lt;/subfield>
+ *     &lt;subfield code="9">69749487X&lt;/subfield>
+ *     &lt;subfield code="8">Fahlenkamp, Dirk *1952-*&lt;/subfield>
+ *     &lt;subfield code="g">http://d-nb.info/gnd/172559227&lt;/subfield>
+ * &lt;/field>
+ * </pre>
+ * 
+ * @author Matthias Ronge
+ */
+class ResolveRule {
+	/**
+	 * Creates a new resolve rule from the XML configuration. The attributes
+	 * {@code tag} and {@code subtag} are required. The attributes
+	 * {@code searchField} is optional, defaults to 12. The attribute
+	 * {@code substring} is optional as well; if it is missing, no substring
+	 * will be created.
+	 * 
+	 * @param config
+	 *            configuration for the resolve rule from
+	 */
+	@SuppressWarnings("unchecked")
+	public ResolveRule(HierarchicalConfiguration config) {
+		tag = config.getString("tag");
+		subtag = config.getString("subtag");
+		searchField = config.getInt("searchField", 12);
+		String substringRegex = config.getString("substring", null);
+		substring = substringRegex != null ? Pattern.compile(substringRegex) : null;
+		mapping = new LinkedList<>();
+		for (HierarchicalConfiguration map : (List<HierarchicalConfiguration>) config.configurationsAt("map")) {
+			mapping.add(new MapRule(map));
+		}
+	}
+
+	/**
+	 * PICA field tag of a field which may have a subfield with an ID to
+	 * resolve. Typical values match the pattern <code>\d{3}[@-Z]</code>. An
+	 * example value is "028C" for an author.
+	 */
+	String tag;
+
+	/**
+	 * PICA subfield code of the subfield that has the ID to resolve. Typical
+	 * values match the pattern <code>[0-9a-z]</code>. An example value is "9"
+	 * for the PPN of the person record for the person.
+	 */
+	String subtag;
+
+	/**
+	 * Catalogue search field to resolve the ID on. Typical values are in range
+	 * 1—9999. An example value is 12 for PPN search.
+	 */
+	int searchField;
+
+	/**
+	 * Allows to look up a substring from the field only. If the pattern
+	 * contains a match group (identified by parentheses) the value from that
+	 * group is used. If not, the region returned by the find() operation is
+	 * used.
+	 */
+	Pattern substring;
+
+	/**
+	 * Import mapping fields and sub-fields to import.
+	 */
+	Collection<MapRule> mapping;
+}

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/ResolveRule.java
@@ -12,11 +12,13 @@ package org.goobi.production.plugin.CataloguePlugin.PicaPlugin;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.regex.*;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.log4j.Logger;
 import org.w3c.dom.*;
 import org.xml.sax.SAXException;
 
@@ -28,7 +30,7 @@ import org.xml.sax.SAXException;
  * field and look it up in the catalogue by a request on search field 12. In the
  * result, select field 003U subfield a and store its value as subfield g in the
  * same field of the main record. Configuration:
- * 
+ *
  * <pre>
  * &lt;catalogue title="…">
  *     &lt;!-- ... -->
@@ -36,9 +38,9 @@ import org.xml.sax.SAXException;
  *         &lt;map tag="003U" subtag="a" asSubtag="g" />
  *     &lt;/resolve>
  * </pre>
- * 
+ *
  * Example field on a record:
- * 
+ *
  * <pre>
  * &lt;field tag="028C">
  *     &lt;subfield code="d">Dirk&lt;/subfield>
@@ -47,9 +49,9 @@ import org.xml.sax.SAXException;
  *     &lt;subfield code="8">Fahlenkamp, Dirk *1952-*&lt;/subfield>
  * &lt;/field>
  * </pre>
- * 
+ *
  * Example result after successful resolving:
- * 
+ *
  * <pre>
  * &lt;field tag="028C">
  *     &lt;subfield code="d">Dirk&lt;/subfield>
@@ -59,13 +61,15 @@ import org.xml.sax.SAXException;
  *     &lt;subfield code="g">http://d-nb.info/gnd/172559227&lt;/subfield>
  * &lt;/field>
  * </pre>
- * 
+ *
  * @author Matthias Ronge
  */
 class ResolveRule {
+	private static final Logger logger = Logger.getLogger(ResolveRule.class);
+
 	/**
 	 * Returns an identifier for a resolve rule.
-	 * 
+	 *
 	 * @param tag
 	 *            PICA field tag
 	 * @param subtag
@@ -82,7 +86,7 @@ class ResolveRule {
 	 * {@code searchField} is optional, defaults to 12. The attribute
 	 * {@code substring} is optional as well; if it is missing, no substring
 	 * will be created.
-	 * 
+	 *
 	 * @param config
 	 *            configuration for the resolve rule from
 	 */
@@ -91,16 +95,16 @@ class ResolveRule {
 		tag = config.getString("[@tag]");
 		assert tag != null : "Missing mandatory attribute tag in element <resolve> of catalogue configuration";
 		assert tag.length() == 4 : "Attribute tag in element <resolve> is not 4 characters long";
-		
+
 		subtag = config.getString("[@subtag]");
 		assert subtag != null : "Missing mandatory attribute subtag in element <resolve> of catalogue configuration";
 		assert subtag.length() == 1 : "Attribute subtag in element <resolve> is not 1 character long";
-		
+
 		searchField = config.getInt("[@searchField]", 12);
-		
+
 		String substringRegex = config.getString("[@substring]", null);
 		substring = substringRegex != null ? Pattern.compile(substringRegex) : null;
-		
+
 		mapping = new HashMap<>();
 		for (HierarchicalConfiguration map : (List<HierarchicalConfiguration>) config.configurationsAt("map")) {
 			MapRule e = new MapRule(map);
@@ -144,7 +148,7 @@ class ResolveRule {
 
 	/**
 	 * Returns an identifier for the resolve rule.
-	 * 
+	 *
 	 * @return an identifier for the resolve rule
 	 */
 	String getIdentifier() {
@@ -154,13 +158,15 @@ class ResolveRule {
 	/**
 	 * Copy data from resolved record to corresponding element, as defined by
 	 * mapping.
-	 * 
+	 *
 	 * @param in
 	 *            input data
 	 * @param resultField
 	 *            element to write to
 	 */
 	private void applyMapping(Element in, Element resultField) {
+		boolean debugEnabledAndNoMappingRuleMatches = logger.isDebugEnabled();
+		Set<String> fieldsInResult = logger.isDebugEnabled() ? new TreeSet<String>() : null;
 		for (Element field : new GetChildElements(in)) {
 			if (field.getNodeName().equals("field")) {
 				String tag = field.getAttributeNode("tag").getTextContent();
@@ -169,10 +175,13 @@ class ResolveRule {
 						String subtag = subfield.getAttributeNode("code").getTextContent();
 						String mappingID = ResolveRule.getIdentifier(tag, subtag);
 						if (mapping.containsKey(mappingID)) {
+							debugEnabledAndNoMappingRuleMatches = false;
 							Element newChild = resultField.getOwnerDocument().createElement("subfield");
 							newChild.setAttribute("code", mapping.get(mappingID).asSubtag);
 							newChild.setTextContent(subfield.getTextContent());
 							resultField.appendChild(newChild);
+						} else if (debugEnabledAndNoMappingRuleMatches) {
+							fieldsInResult.add(mappingID);
 						}
 					}
 				}
@@ -180,11 +189,36 @@ class ResolveRule {
 				applyMapping(field, resultField);
 			}
 		}
+		if (debugEnabledAndNoMappingRuleMatches) {
+			StringBuilder debugLogMessage = new StringBuilder(13 * mapping.size() + 8 * fieldsInResult.size() + 71);
+			debugLogMessage.append("No import mapping for any of the result fields ");
+			boolean addAComma = false;
+			for (String fieldInResult : fieldsInResult) {
+				debugLogMessage.append(fieldInResult);
+				if (addAComma) {
+					debugLogMessage.append(", ");
+				} else {
+					addAComma = true;
+				}
+			}
+			debugLogMessage.append(". Configured mappings: ");
+			addAComma = false;
+			for (Entry<String, MapRule> mappingEntry : mapping.entrySet()) {
+				debugLogMessage.append(mappingEntry.getValue());
+				if (addAComma) {
+					debugLogMessage.append(", ");
+				} else {
+					addAComma = true;
+				}
+			}
+			debugLogMessage.append('.');
+			logger.debug(debugLogMessage);
+		}
 	}
 
 	/**
 	 * Applies the substring on the input, if any.
-	 * 
+	 *
 	 * @param input
 	 *            String to apply the substring on
 	 * @return substring if found, or input otherwise
@@ -194,20 +228,28 @@ class ResolveRule {
 			return input;
 		Matcher matcher = substring.matcher(input);
 		if (!matcher.find()) {
+			logger.warn("Pattern /" + substring.pattern() + "/ was not found on input string \"" + input + '"');
 			return input;
 		} else {
 			String matchGroup1 = matcher.group(1);
 			if (matchGroup1 != null) {
+				if(logger.isDebugEnabled()) {
+					logger.debug("Using substring from match group 1: " + matchGroup1);
+				}
 				return matchGroup1;
 			} else {
-				return matcher.group();
+				String found = matcher.group();
+				if(logger.isDebugEnabled()) {
+					logger.debug("Using found substring: " + found);
+				}
+				return found;
 			}
 		}
 	}
 
 	/**
 	 * Execute the resolve rule.
-	 * 
+	 *
 	 * @param subfield
 	 *            subfield to take the ID to resolve from
 	 * @param client
@@ -235,6 +277,26 @@ class ResolveRule {
 			if (result instanceof Element) {
 				applyMapping((Element) result, out);
 			}
+		} else {
+			logger.warn("Could not apply resolve rule " + this.toString() + " for query string \"" + queryString
+					+ "\": Number of hits is " + numberOfHits);
 		}
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder result = new StringBuilder(80);
+		result.append("<resolve tag=\"");
+		result.append(tag);
+		result.append("\" subtag=\"");
+		result.append(subtag);
+		if (substring != null) {
+			result.append("\" substring=\"");
+			result.append(substring.pattern());
+		}
+		result.append("\" searchField=\"");
+		result.append(searchField);
+		result.append("\">");
+		return result.toString();
 	}
 }

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Response.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Response.java
@@ -42,6 +42,7 @@ class Response extends DefaultHandler {
 	 * SAX parser callback method.
 	 * 
 	 * @throws SAXException
+	 *             if an illegal error was found
 	 */
 	@Override
 	public void startElement(String namespaceURI, String localName, String qName, Attributes atts) throws SAXException {


### PR DESCRIPTION
By an additional entry in opac.xml, a “resolve rule” can be defined. If a field in the imported PICA hit matches the rule’s `tag` and `subtag`, the value from that subtag is used to query the catalogue again. In a mapping, values from the result of that second query can be added as (fictious) subfields to the title field that the query was started from.

Example mapping:

    <catalogue title="…">
        <!-- ... -->
        <resolve tag="028C" subtag="9" searchField="12">
            <map tag="003U" subtag="a" asSubtag="g" />
        </resolve>
    
Example field on a title record:
    
    <field tag="028C">
        <subfield code="d">Dirk</subfield>
        <subfield code="a">Fahlenkamp</subfield>
        <subfield code="9">69749487X</subfield>
        <subfield code="8">Fahlenkamp, Dirk *1952-*</subfield>
    </field>
    
Example result after successful resolving:
    
    <field tag="028C">
        <subfield code="d">Dirk</subfield>
        <subfield code="a">Fahlenkamp</subfield>
        <subfield code="9">69749487X</subfield>
        <subfield code="8">Fahlenkamp, Dirk *1952-*</subfield>
        <subfield code="g">http://d-nb.info/gnd/172559227</subfield>
    </field>

This is part of issue #619.

**Additional edit:** German javadoc comments in `PicaPlugin.java` have been translated into English.