### PR TITLE
Clean up logger calls

### DIFF
--- a/Goobi/plugins/import/PicaMassImport/de/sub/goobi/helper/UghUtils.java
+++ b/Goobi/plugins/import/PicaMassImport/de/sub/goobi/helper/UghUtils.java
@@ -28,7 +28,7 @@ import org.goobi.production.constants.Parameters;
 import de.sub.goobi.config.ConfigMain;
 
 public class UghUtils {
-	private static final Logger myLogger = Logger.getLogger(UghUtils.class);
+	private static final Logger logger = Logger.getLogger(UghUtils.class);
 
 	/**
 	 * In einem String die Umlaute auf den Grundbuchstaben reduzieren ================================================================
@@ -43,7 +43,7 @@ public class UghUtils {
 				}
 			}
 		} catch (IOException e) {
-			myLogger.error("IOException bei Umlautkonvertierung", e);
+			logger.error("IOException bei Umlautkonvertierung", e);
 		}
 		return line;
 	}

--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
@@ -89,7 +89,7 @@ import ugh.fileformats.mets.XStream;
  */
 @PluginImplementation
 public class ModsPlugin implements Plugin {
-    private static final Logger modsLogger = Logger.getLogger(ModsPlugin.class);
+    private static final Logger logger = Logger.getLogger(ModsPlugin.class);
 
     /**
      * The field configDir holds a reference to the file system directory where
@@ -281,10 +281,10 @@ public class ModsPlugin implements Plugin {
                 return null;
             }
         } catch (RuntimeException e) {
-            modsLogger.error("Error while querying library catalogue: " + e.getMessage());
+            logger.error("Error while querying library catalogue: " + e.getMessage());
             throw e;
         } catch (Exception e) {
-            modsLogger.error("Error while querying library catalogue: " + e.getMessage());
+            logger.error("Error while querying library catalogue: " + e.getMessage());
             throw new RuntimeException(e.getMessage(), e);
         }
     }
@@ -300,7 +300,7 @@ public class ModsPlugin implements Plugin {
             parentIDXPath = XPath.newInstance(getParentElementXPath(configuration.getTitle()));
             identifierXPath = XPath.newInstance(getIdentifierXPath(configuration.getTitle()));
         } catch (JDOMException e) {
-            modsLogger.error("Error while initializing XPath variables: " + e.getMessage());
+            logger.error("Error while initializing XPath variables: " + e.getMessage());
         }
     }
 
@@ -374,19 +374,19 @@ public class ModsPlugin implements Plugin {
 
         if (resultXML == null) {
             String message = "Error: result empty!";
-            modsLogger.error(message);
+            logger.error(message);
             throw new IllegalStateException(message);
         }
 
         else if (!xpathsDefined()) {
             String message = "Error: XPath variables not defined!";
-            modsLogger.error(message);
+            logger.error(message);
             throw new IllegalStateException(message);
         }
 
         else if (!Files.isDirectory(xsltDirPath)) {
             String message = "Error: XSLT directory not found!";
-            modsLogger.error(message);
+            logger.error(message);
             throw new IOException(message);
         }
 
@@ -498,7 +498,7 @@ public class ModsPlugin implements Plugin {
 
             } catch (JDOMException | TypeNotAllowedForParentException | PreferencesException | ReadException
                     | IOException e) {
-                modsLogger.error("Error while retrieving document: " + e.getMessage());
+                logger.error("Error while retrieving document: " + e.getMessage());
             }
         }
         return result;
@@ -557,7 +557,7 @@ public class ModsPlugin implements Plugin {
                 ConfigurationNode titleAttr = (ConfigurationNode) titleAttrObject;
                 if (Objects.equals(opacName, titleAttr.getValue())) {
                     SubnodeConfiguration catalogueConf = (SubnodeConfiguration) catalogueObject;
-                    modsLogger.debug("Setting mapping file for OPAC '" + opacName + "' to '"
+                    logger.debug("Setting mapping file for OPAC '" + opacName + "' to '"
                             + catalogueConf.getString("mappingFile") + "'");
                     MODS2GOOBI_TRANSFORMATION_RULES_FILENAME = catalogueConf.getString("mappingFile");
                     break;
@@ -704,7 +704,7 @@ public class ModsPlugin implements Plugin {
             return resultDoc;
 
         } catch (TransformerException | IOException | JDOMException e) {
-            modsLogger.error("Error while transforming XML document: " + e.getMessage());
+            logger.error("Error while transforming XML document: " + e.getMessage());
         }
         return null;
     }
@@ -729,7 +729,7 @@ public class ModsPlugin implements Plugin {
                     getIdentifierParameter(configuration.getTitle()) + ":" + parentIDElement.getText());
             return client.retrieveModsRecord(parentQuery.getQueryUrl(), timeout);
         } catch (NullPointerException e) {
-            modsLogger.info("Top level element reached. No further parent elements can be retrieved.");
+            logger.info("Top level element reached. No further parent elements can be retrieved.");
             return null;
         }
     }
@@ -874,7 +874,7 @@ public class ModsPlugin implements Plugin {
         try {
             Files.delete(fs.getPath(path));
         } catch (IOException x) {
-            modsLogger.error("Error while deleting file '" + path + "': " + x.getMessage());
+            logger.error("Error while deleting file '" + path + "': " + x.getMessage());
         }
     }
 

--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/UGHUtils.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/UGHUtils.java
@@ -40,7 +40,7 @@ import ugh.exceptions.MetadataTypeNotAllowedException;
  * @author Arved Solth, Christopher Timm
  */
 class UGHUtils {
-    private static final Logger myLogger = Logger.getLogger(UGHUtils.class);
+    private static final Logger logger = Logger.getLogger(UGHUtils.class);
 
     /**
      * The function addMetadatum() adds the meta data element given in terms of
@@ -69,11 +69,11 @@ class UGHUtils {
             md.setValue(inValue);
             inStruct.addMetadata(md);
         } catch (DocStructHasNoTypeException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (MetadataTypeNotAllowedException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (Exception e) {
-            myLogger.error(e);
+            logger.error(e);
         }
     }
 

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Catalogue.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/Catalogue.java
@@ -33,7 +33,7 @@ import org.jdom.output.XMLOutputter;
 import org.w3c.dom.Node;
 
 class Catalogue {
-	private static final Logger myLogger = Logger.getLogger(Catalogue.class);
+	private static final Logger logger = Logger.getLogger(Catalogue.class);
 	private final String title;
 	private final String description;
 	private final String address;
@@ -112,7 +112,7 @@ class Catalogue {
 			myHitlist = doutputter.output(doc);
 			myHitlist = myHitlist.getFirstChild();
 		} catch (JDOMException e) {
-			myLogger.error("JDOMException in executeBeautifier(Node)", e);
+			logger.error("JDOMException in executeBeautifier(Node)", e);
 		}
 
 		/* Ausgabe des überarbeiteten Opac-Ergebnisses */
@@ -270,9 +270,9 @@ class Catalogue {
 			Document tempDoc = new DOMBuilder().build(inNode.getOwnerDocument());
 			outputter.output(tempDoc.getRootElement(), output);
 		} catch (FileNotFoundException e) {
-			myLogger.error("debugMyNode(Node, String)", e);
+			logger.error("debugMyNode(Node, String)", e);
 		} catch (IOException e) {
-			myLogger.error("debugMyNode(Node, String)", e);
+			logger.error("debugMyNode(Node, String)", e);
 		}
 
 	}

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/UGHUtils.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/UGHUtils.java
@@ -40,7 +40,7 @@ import ugh.exceptions.MetadataTypeNotAllowedException;
  * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
  */
 class UGHUtils {
-	private static final Logger myLogger = Logger.getLogger(UGHUtils.class);
+	private static final Logger logger = Logger.getLogger(UGHUtils.class);
 
 	/**
 	 * The function addMetadatum() adds the meta data element given in terms of
@@ -69,11 +69,11 @@ class UGHUtils {
 			md.setValue(inValue);
 			inStruct.addMetadata(md);
 		} catch (DocStructHasNoTypeException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (MetadataTypeNotAllowedException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (Exception e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 	}
 

--- a/Goobi/src/de/sub/goobi/beans/Prozess.java
+++ b/Goobi/src/de/sub/goobi/beans/Prozess.java
@@ -77,7 +77,7 @@ import de.sub.goobi.persistence.ProzessDAO;
 // @XmlElement, but their respective names should be wisely chosen according to
 // the Coding Guidelines (e.g. *english* names).
 public class Prozess implements Serializable {
-	private static final Logger myLogger = Logger.getLogger(Prozess.class);
+	private static final Logger logger = Logger.getLogger(Prozess.class);
 	private static final long serialVersionUID = -6503348094655786275L;
 	private Integer id;
 	private String titel;
@@ -969,8 +969,8 @@ public class Prozess implements Serializable {
 		Hibernate.initialize(getRegelsatz());
 		/* prüfen, welches Format die Metadaten haben (Mets, xstream oder rdf */
 		String type = MetadatenHelper.getMetaFileType(getMetadataFilePath());
-		if (myLogger.isDebugEnabled()) {
-			myLogger.debug("current meta.xml file type for id " + getId() + ": " + type);
+		if (logger.isDebugEnabled()) {
+			logger.debug("current meta.xml file type for id " + getId() + ": " + type);
 		}
 		Fileformat ff = null;
 		if (type.equals("metsmods")) {
@@ -1010,7 +1010,7 @@ public class Prozess implements Serializable {
 			bfr.setProcessDataDirectory(getProcessDataDirectory());
 			bfr.performBackup();
 		} else {
-			myLogger.warn("No backup configured for meta data files.");
+			logger.warn("No backup configured for meta data files.");
 		}
 	}
 
@@ -1102,8 +1102,8 @@ public class Prozess implements Serializable {
 		if (new SafeFile(getTemplateFilePath()).exists()) {
 			Fileformat ff = null;
 			String type = MetadatenHelper.getMetaFileType(getTemplateFilePath());
-			if(myLogger.isDebugEnabled()){
-				myLogger.debug("current template.xml file type: " + type);
+			if(logger.isDebugEnabled()){
+				logger.debug("current template.xml file type: " + type);
 			}
 			if (type.equals("mets")) {
 				ff = new MetsMods(this.regelsatz.getPreferences());
@@ -1193,8 +1193,8 @@ public class Prozess implements Serializable {
 
 	public String downloadDocket() {
 
-		if(myLogger.isDebugEnabled()){
-			myLogger.debug("generate docket for process " + this.id);
+		if(logger.isDebugEnabled()){
+			logger.debug("generate docket for process " + this.id);
 		}
 		String rootpath = ConfigMain.getParameter("xsltFolder");
 		SafeFile xsltfile = new SafeFile(rootpath, "docket.xsl");

--- a/Goobi/src/de/sub/goobi/config/ConfigMain.java
+++ b/Goobi/src/de/sub/goobi/config/ConfigMain.java
@@ -30,7 +30,7 @@ import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 
 public class ConfigMain {
-	private static final Logger myLogger = Logger.getLogger(ConfigMain.class);
+	private static final Logger logger = Logger.getLogger(ConfigMain.class);
 	private static volatile PropertiesConfiguration config;
 	private static String imagesPath = null;
 
@@ -43,8 +43,8 @@ public class ConfigMain {
 					try {
 						initialized = new PropertiesConfiguration(FileNames.CONFIG_FILE);
 					} catch (ConfigurationException e) {
-						if (myLogger.isEnabledFor(Level.WARN)) {
-							myLogger.warn("Loading of " + FileNames.CONFIG_FILE
+						if (logger.isEnabledFor(Level.WARN)) {
+							logger.warn("Loading of " + FileNames.CONFIG_FILE
 									+ " failed. Trying to start with empty configuration.", e);
 						}
 						initialized = new PropertiesConfiguration();
@@ -81,7 +81,7 @@ public class ConfigMain {
 			try {
 				FilesystemHelper.createDirectory(filename);
 			} catch (Exception ioe) {
-				myLogger.error("IO error: " + ioe);
+				logger.error("IO error: " + ioe);
 				Helper.setFehlerMeldung(Helper.getTranslation("couldNotCreateImageFolder"), ioe.getMessage());
 			}
 		}
@@ -101,7 +101,7 @@ public class ConfigMain {
 		try {
 			return getConfig().getString(inParameter);
 		} catch (RuntimeException e) {
-			myLogger.error(e);
+			logger.error(e);
 			return "- keine Konfiguration gefunden -";
 		}
 	}

--- a/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
@@ -52,7 +52,7 @@ import de.sub.goobi.persistence.apache.ProjectManager;
 import de.sub.goobi.persistence.apache.ProjectObject;
 
 public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHibernate {
-	private static final Logger myLogger = Logger.getLogger(AutomaticDmsExportWithoutHibernate.class);
+	private static final Logger logger = Logger.getLogger(AutomaticDmsExportWithoutHibernate.class);
 	ConfigProjects cp;
 	private boolean exportWithImages = true;
 	private boolean exportFulltext = true;
@@ -135,7 +135,7 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 				task.setException(e);
 			}
 			Helper.setFehlerMeldung(Helper.getTranslation("exportError") + process.getTitle(), e);
-			myLogger.error("Export abgebrochen, xml-LeseFehler", e);
+			logger.error("Export abgebrochen, xml-LeseFehler", e);
 			return false;
 		}
 
@@ -374,7 +374,7 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 						task.setException(e);
 					}
 					Helper.setFehlerMeldung("Export canceled, error", "could not create destination directory");
-					myLogger.error("could not create destination directory", e);
+					logger.error("could not create destination directory", e);
 				}
 			}
 

--- a/Goobi/src/de/sub/goobi/export/dms/DmsImportThread.java
+++ b/Goobi/src/de/sub/goobi/export/dms/DmsImportThread.java
@@ -22,7 +22,7 @@ import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
 
 public class DmsImportThread extends Thread {
-	private static final Logger myLogger = Logger.getLogger(DmsImportThread.class);
+	private static final Logger logger = Logger.getLogger(DmsImportThread.class);
 	private SafeFile fileError;
 	private SafeFile fileXml;
 	private SafeFile fileSuccess;
@@ -86,7 +86,7 @@ public class DmsImportThread extends Thread {
 					}
 				}
 			} catch (Throwable t) {
-				myLogger.error("Unexception exception", t);
+				logger.error("Unexception exception", t);
 			}
 		}
 		if (!ConfigMain.getBooleanParameter("exportWithoutTimeLimit")) {

--- a/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
+++ b/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
@@ -51,7 +51,7 @@ import de.sub.goobi.metadaten.copier.CopierData;
 import de.sub.goobi.metadaten.copier.DataCopier;
 
 public class ExportDms extends ExportMets {
-	private static final Logger myLogger = Logger.getLogger(ExportDms.class);
+	private static final Logger logger = Logger.getLogger(ExportDms.class);
 	ConfigProjects cp;
 	private boolean exportWithImages = true;
 	private boolean exportFulltext = true;
@@ -159,7 +159,7 @@ public class ExportDms extends ExportMets {
 				Helper.setFehlerMeldung(Helper.getTranslation("exportError")
 						+ myProzess.getTitel(), e);
 			}
-			myLogger.error("Export abgebrochen, xml-LeseFehler", e);
+			logger.error("Export abgebrochen, xml-LeseFehler", e);
 			return false;
 		}
 	}
@@ -200,7 +200,7 @@ public class ExportDms extends ExportMets {
 				Helper.setFehlerMeldung(Helper.getTranslation("exportError")
 						+ myProzess.getTitel(), e);
 			}
-			myLogger.error("Export abgebrochen, xml-LeseFehler", e);
+			logger.error("Export abgebrochen, xml-LeseFehler", e);
 			return false;
 		}
 
@@ -380,7 +380,7 @@ public class ExportDms extends ExportMets {
 						Helper.setFehlerMeldung(myProzess.getTitel()
 								+ ": error on export - ", e.getMessage());
 					}
-					myLogger.error(myProzess.getTitel() + ": error on export",
+					logger.error(myProzess.getTitel() + ": error on export",
 							e);
 				}
 				if (agoraThread.rueckgabe.length() > 0) {
@@ -551,7 +551,7 @@ public class ExportDms extends ExportMets {
 					} else {
 						Helper.setFehlerMeldung("Export canceled, error", "could not create destination directory");
 					}
-					myLogger.error("could not create destination directory", e);
+					logger.error("could not create destination directory", e);
 					if (e instanceof IOException) {
 						throw (IOException) e;
 					} else if (e instanceof InterruptedException) {

--- a/Goobi/src/de/sub/goobi/export/download/ExportMets.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMets.java
@@ -59,7 +59,7 @@ public class ExportMets {
 	protected Helper help = new Helper();
 	protected Prefs myPrefs;
 
-	protected static final Logger logger = Logger.getLogger(ExportMets.class);
+	private static final Logger logger = Logger.getLogger(ExportMets.class);
 
 	/**
 	 * DMS-Export in das Benutzer-Homeverzeichnis

--- a/Goobi/src/de/sub/goobi/export/download/ExportMets.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMets.java
@@ -59,7 +59,7 @@ public class ExportMets {
 	protected Helper help = new Helper();
 	protected Prefs myPrefs;
 
-	protected static final Logger myLogger = Logger.getLogger(ExportMets.class);
+	protected static final Logger logger = Logger.getLogger(ExportMets.class);
 
 	/**
 	 * DMS-Export in das Benutzer-Homeverzeichnis
@@ -331,10 +331,10 @@ public class ExportMets {
 					}
 				}
 			} catch (IndexOutOfBoundsException e) {
-				myLogger.error(e);
+				logger.error(e);
 				return false;
 			} catch (InvalidImagesException e) {
-				myLogger.error(e);
+				logger.error(e);
 				return false;
 			}
 		} else {

--- a/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
@@ -56,7 +56,7 @@ public class ExportMetsWithoutHibernate {
 	private FolderInformation fi;
 	private ProjectObject project;
 
-	protected static final Logger myLogger = Logger.getLogger(ExportMetsWithoutHibernate.class);
+	protected static final Logger logger = Logger.getLogger(ExportMetsWithoutHibernate.class);
 
 	/**
 	 * DMS-Export in das Benutzer-Homeverzeichnis
@@ -304,9 +304,9 @@ public class ExportMetsWithoutHibernate {
 			}
 		} catch (IndexOutOfBoundsException e) {
 
-			myLogger.error(e);
+			logger.error(e);
 		} catch (InvalidImagesException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 		mm.write(targetFileName);
 		Helper.setMeldung(null, process.getTitle() + ": ", "ExportFinished");

--- a/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
@@ -56,7 +56,7 @@ public class ExportMetsWithoutHibernate {
 	private FolderInformation fi;
 	private ProjectObject project;
 
-	protected static final Logger logger = Logger.getLogger(ExportMetsWithoutHibernate.class);
+	private static final Logger logger = Logger.getLogger(ExportMetsWithoutHibernate.class);
 
 	/**
 	 * DMS-Export in das Benutzer-Homeverzeichnis

--- a/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.log4j.Logger;
 import org.goobi.io.FileListFilter;
 
 import ugh.dl.Fileformat;
@@ -45,6 +46,8 @@ import de.sub.goobi.metadaten.MetadatenHelper;
 import de.sub.goobi.metadaten.MetadatenVerifizierung;
 
 public class ExportPdf extends ExportMets {
+
+	private static final Logger logger = Logger.getLogger(ExportPdf.class);
 
 	private static final String AND_TARGET_FILE_NAME_IS = "&targetFileName=";
 	private static final String PDF_EXTENSION = ".pdf";

--- a/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
@@ -69,8 +69,8 @@ public class ExportPdf extends ExportMets {
 		Helper.setMeldung(null, myProzess.getTitel() + ": ", "mets file created");
 		Helper.setMeldung(null, myProzess.getTitel() + ": ", "start pdf generation now");
 
-		if(myLogger.isDebugEnabled()){
-			myLogger.debug("METS file created: " + metsTempFile);
+		if(logger.isDebugEnabled()){
+			logger.debug("METS file created: " + metsTempFile);
 		}
 
 		FacesContext context = FacesContext.getCurrentInstance();
@@ -87,9 +87,9 @@ public class ExportPdf extends ExportMets {
 			pdf.setMetsURL(metsTempFile.toURI().toURL());
 			pdf.setTargetFolder(new SafeFile(zielVerzeichnis));
 			pdf.setInternalServletPath(myBasisUrl);
-			if(myLogger.isDebugEnabled()){
-				myLogger.debug("Taget directory: " + zielVerzeichnis);
-				myLogger.debug("Using ContentServer2 base URL: " + myBasisUrl);
+			if(logger.isDebugEnabled()){
+				logger.debug("Taget directory: " + zielVerzeichnis);
+				logger.debug("Using ContentServer2 base URL: " + myBasisUrl);
 			}
 			pdf.initialize(myProzess);
 			pdf.start();

--- a/Goobi/src/de/sub/goobi/export/download/Multipage.java
+++ b/Goobi/src/de/sub/goobi/export/download/Multipage.java
@@ -45,7 +45,7 @@ import de.sub.goobi.helper.exceptions.SwapException;
  */
 
 public class Multipage {
-	private static final Logger myLogger = Logger.getLogger(Multipage.class);
+	private static final Logger logger = Logger.getLogger(Multipage.class);
 	Helper help = new Helper();
 
 	private void create(Prozess inProzess) throws IOException, InterruptedException, SwapException, DAOException {
@@ -57,19 +57,19 @@ public class Multipage {
 
 		/* keine Tifs vorhanden, also raus */
 		if (dateien == null) {
-			myLogger.debug("Verzeichnis ist leer");
+			logger.debug("Verzeichnis ist leer");
 			return;
 		}
 
 		/* alle Bilder in ein Array übernehmen */
 		RenderedImage image[] = new PlanarImage[dateien.length];
 		for (int i = 0; i < dateien.length; i++) {
-			if(myLogger.isDebugEnabled()){
-				myLogger.debug(pfad + dateien[i]);
+			if(logger.isDebugEnabled()){
+				logger.debug(pfad + dateien[i]);
 			}
 			image[i] = JAI.create("fileload", pfad + dateien[i]);
 		}
-		myLogger.debug("Bilder durchlaufen");
+		logger.debug("Bilder durchlaufen");
 
 		/*
 		 * -------------------------------- alle Bilder als Multipage erzeugen --------------------------------
@@ -85,7 +85,7 @@ public class Multipage {
 		param.setExtraImages(vector.iterator());
 		encoder.encode(image[0]);
 		out.close();
-		myLogger.debug("fertig");
+		logger.debug("fertig");
 	}
 
 	public void ExportStart(Prozess inProzess) throws IOException, InterruptedException, SwapException, DAOException {

--- a/Goobi/src/de/sub/goobi/forms/AdministrationForm.java
+++ b/Goobi/src/de/sub/goobi/forms/AdministrationForm.java
@@ -64,7 +64,7 @@ import de.sub.goobi.persistence.SchrittDAO;
 
 public class AdministrationForm implements Serializable {
 	private static final long serialVersionUID = 5648439270064158243L;
-	private static final Logger myLogger = Logger.getLogger(AdministrationForm.class);
+	private static final Logger logger = Logger.getLogger(AdministrationForm.class);
 	private String passwort;
 	private boolean istPasswortRichtig = false;
 	private boolean rusFullExport = false;
@@ -152,7 +152,7 @@ public class AdministrationForm implements Serializable {
 				auf.setSortHelperImages(FileUtils.getNumberOfFiles(new SafeFile(auf.getImagesOrigDirectory(true))));
 				dao.save(auf);
 			} catch (RuntimeException e) {
-				myLogger.error("Fehler bei Band: " + auf.getTitel(), e);
+				logger.error("Fehler bei Band: " + auf.getTitel(), e);
 			}
 
 			dao.save(auf);
@@ -186,7 +186,7 @@ public class AdministrationForm implements Serializable {
 			
 			auf.setRegelsatz(mk);
 			dao.save(auf);
-			myLogger.debug(auf.getId() + " - " + i++ + "von" + auftraege.size());
+			logger.debug(auf.getId() + " - " + i++ + "von" + auftraege.size());
 		}
 		Helper.setMeldung(null, "", "Standard-ruleset successful set");
 	}
@@ -244,8 +244,8 @@ public class AdministrationForm implements Serializable {
 			if (p.getBenutzerGesperrt() != null) {
 				Helper.setFehlerMeldung("metadata locked: ", p.getTitel());
 			} else {
-				if(myLogger.isDebugEnabled()){
-					myLogger.debug("Prozess: " + p.getTitel());
+				if(logger.isDebugEnabled()){
+					logger.debug("Prozess: " + p.getTitel());
 				}
 				Prefs myPrefs = p.getRegelsatz().getPreferences();
 				Fileformat gdzfile;
@@ -256,7 +256,7 @@ public class AdministrationForm implements Serializable {
 					List<? extends Metadata> alleMetadaten = gdzfile.getDigitalDocument().getPhysicalDocStruct().getAllMetadataByType(mdt);
 					if (alleMetadaten != null && alleMetadaten.size() > 0) {
 						Metadata md = alleMetadaten.get(0);
-						myLogger.debug(md.getValue());
+						logger.debug(md.getValue());
 
 					
 						if (SystemUtils.IS_OS_WINDOWS) {
@@ -271,22 +271,22 @@ public class AdministrationForm implements Serializable {
 					}
 				} catch (ReadException e) {
 					Helper.setFehlerMeldung("", "ReadException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("ReadException: " + p.getTitel(), e);
+					logger.error("ReadException: " + p.getTitel(), e);
 				} catch (IOException e) {
 					Helper.setFehlerMeldung("", "IOException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("IOException: " + p.getTitel(), e);
+					logger.error("IOException: " + p.getTitel(), e);
 				} catch (InterruptedException e) {
 					Helper.setFehlerMeldung("", "InterruptedException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("InterruptedException: " + p.getTitel(), e);
+					logger.error("InterruptedException: " + p.getTitel(), e);
 				} catch (PreferencesException e) {
 					Helper.setFehlerMeldung("", "PreferencesException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("PreferencesException: " + p.getTitel(), e);
+					logger.error("PreferencesException: " + p.getTitel(), e);
 				} catch (UghHelperException e) {
 					Helper.setFehlerMeldung("", "UghHelperException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("UghHelperException: " + p.getTitel(), e);
+					logger.error("UghHelperException: " + p.getTitel(), e);
 				} catch (Exception e) {
 					Helper.setFehlerMeldung("", "Exception: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("Exception: " + p.getTitel(), e);
+					logger.error("Exception: " + p.getTitel(), e);
 				}
 			}
 		}
@@ -334,7 +334,7 @@ public class AdministrationForm implements Serializable {
 						alleMetadaten = dsFirst.getAllMetadataByType(mdtPpnDigital);
 						if (alleMetadaten != null && alleMetadaten.size() > 0) {
 							Metadata md = alleMetadaten.get(0);
-							myLogger.debug(md.getValue());
+							logger.debug(md.getValue());
 							if (!md.getValue().endsWith(myBandnr)) {
 								md.setValue(md.getValue() + myBandnr);
 								Helper.setMeldung(null, "PPN digital adjusted: ", p.getTitel());
@@ -345,7 +345,7 @@ public class AdministrationForm implements Serializable {
 						alleMetadaten = dsFirst.getAllMetadataByType(mdtPpnAnalog);
 						if (alleMetadaten != null && alleMetadaten.size() > 0) {
 							Metadata md1 = alleMetadaten.get(0);
-							myLogger.debug(md1.getValue());
+							logger.debug(md1.getValue());
 							if (!md1.getValue().endsWith(myBandnr)) {
 								md1.setValue(md1.getValue() + myBandnr);
 								Helper.setMeldung(null, "PPN analog adjusted: ", p.getTitel());
@@ -389,22 +389,22 @@ public class AdministrationForm implements Serializable {
 
 				} catch (ReadException e) {
 					Helper.setFehlerMeldung("", "ReadException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("ReadException: " + p.getTitel(), e);
+					logger.error("ReadException: " + p.getTitel(), e);
 				} catch (IOException e) {
 					Helper.setFehlerMeldung("", "IOException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("IOException: " + p.getTitel(), e);
+					logger.error("IOException: " + p.getTitel(), e);
 				} catch (InterruptedException e) {
 					Helper.setFehlerMeldung("", "InterruptedException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("InterruptedException: " + p.getTitel(), e);
+					logger.error("InterruptedException: " + p.getTitel(), e);
 				} catch (PreferencesException e) {
 					Helper.setFehlerMeldung("", "PreferencesException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("PreferencesException: " + p.getTitel(), e);
+					logger.error("PreferencesException: " + p.getTitel(), e);
 				} catch (UghHelperException e) {
 					Helper.setFehlerMeldung("", "UghHelperException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("UghHelperException: " + p.getTitel(), e);
+					logger.error("UghHelperException: " + p.getTitel(), e);
 				} catch (Exception e) {
 					Helper.setFehlerMeldung("", "Exception: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("Exception: " + p.getTitel(), e);
+					logger.error("Exception: " + p.getTitel(), e);
 				}
 			}
 		}
@@ -449,22 +449,22 @@ public class AdministrationForm implements Serializable {
 					}
 				} catch (ReadException e) {
 					Helper.setFehlerMeldung("", "ReadException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("ReadException: " + p.getTitel(), e);
+					logger.error("ReadException: " + p.getTitel(), e);
 				} catch (IOException e) {
 					Helper.setFehlerMeldung("", "IOException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("IOException: " + p.getTitel(), e);
+					logger.error("IOException: " + p.getTitel(), e);
 				} catch (InterruptedException e) {
 					Helper.setFehlerMeldung("", "InterruptedException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("InterruptedException: " + p.getTitel(), e);
+					logger.error("InterruptedException: " + p.getTitel(), e);
 				} catch (PreferencesException e) {
 					Helper.setFehlerMeldung("", "PreferencesException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("PreferencesException: " + p.getTitel(), e);
+					logger.error("PreferencesException: " + p.getTitel(), e);
 				} catch (UghHelperException e) {
 					Helper.setFehlerMeldung("", "UghHelperException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("UghHelperException: " + p.getTitel(), e);
+					logger.error("UghHelperException: " + p.getTitel(), e);
 				} catch (Exception e) {
 					Helper.setFehlerMeldung("", "Exception: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("Exception: " + p.getTitel(), e);
+					logger.error("Exception: " + p.getTitel(), e);
 				}
 			}
 		}
@@ -548,22 +548,22 @@ public class AdministrationForm implements Serializable {
 
 				} catch (ReadException e) {
 					Helper.setFehlerMeldung("", "ReadException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("ReadException: " + p.getTitel(), e);
+					logger.error("ReadException: " + p.getTitel(), e);
 				} catch (IOException e) {
 					Helper.setFehlerMeldung("", "IOException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("IOException: " + p.getTitel(), e);
+					logger.error("IOException: " + p.getTitel(), e);
 				} catch (InterruptedException e) {
 					Helper.setFehlerMeldung("", "InterruptedException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("InterruptedException: " + p.getTitel(), e);
+					logger.error("InterruptedException: " + p.getTitel(), e);
 				} catch (PreferencesException e) {
 					Helper.setFehlerMeldung("", "PreferencesException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("PreferencesException: " + p.getTitel() + " - " + e.getMessage());
+					logger.error("PreferencesException: " + p.getTitel() + " - " + e.getMessage());
 				} catch (UghHelperException e) {
 					Helper.setFehlerMeldung("", "UghHelperException: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("UghHelperException: " + p.getTitel(), e);
+					logger.error("UghHelperException: " + p.getTitel(), e);
 				} catch (Exception e) {
 					Helper.setFehlerMeldung("", "Exception: " + p.getTitel() + " - " + e.getMessage());
-					myLogger.error("Exception: " + p.getTitel(), e);
+					logger.error("Exception: " + p.getTitel(), e);
 				}
 			}
 		}

--- a/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
+++ b/Goobi/src/de/sub/goobi/forms/AktuelleSchritteForm.java
@@ -82,7 +82,7 @@ import de.unigoettingen.goobi.module.api.exception.GoobiException;
 
 public class AktuelleSchritteForm extends BasisForm {
 	private static final long serialVersionUID = 5841566727939692509L;
-	private static final Logger myLogger = Logger.getLogger(AktuelleSchritteForm.class);
+	private static final Logger logger = Logger.getLogger(AktuelleSchritteForm.class);
 	private Prozess myProzess = new Prozess();
 	private Schritt mySchritt = new Schritt();
 	private Integer myProblemID;
@@ -259,7 +259,7 @@ public class AktuelleSchritteForm extends BasisForm {
 						this.pdao.save(this.mySchritt.getProzess());
 					} catch (DAOException e) {
 						Helper.setFehlerMeldung(Helper.getTranslation("stepSaveError"), e);
-						myLogger.error("step couldn't get saved", e);
+						logger.error("step couldn't get saved", e);
 					} finally {
 						this.flagWait = false;
 					}
@@ -366,7 +366,7 @@ public class AktuelleSchritteForm extends BasisForm {
 
 			} catch (DAOException e) {
 				Helper.setFehlerMeldung(Helper.getTranslation("stepSaveError"), e);
-				myLogger.error("step couldn't get saved", e);
+				logger.error("step couldn't get saved", e);
 			}
 		}
 
@@ -548,9 +548,9 @@ public class AktuelleSchritteForm extends BasisForm {
 			Helper.setFehlerMeldung("userNotFound");
 			return "";
 		}
-		if(myLogger.isDebugEnabled()){
-			myLogger.debug("mySchritt.ID: " + this.mySchritt.getId().intValue());
-			myLogger.debug("Korrekturschritt.ID: " + this.myProblemID.intValue());
+		if(logger.isDebugEnabled()){
+			logger.debug("mySchritt.ID: " + this.mySchritt.getId().intValue());
+			logger.debug("Korrekturschritt.ID: " + this.myProblemID.intValue());
 		}
 		this.myDav.UploadFromHome(this.mySchritt.getProzess());
 		Date myDate = new Date();
@@ -891,7 +891,7 @@ public class AktuelleSchritteForm extends BasisForm {
 						this.gesamtAnzahlImages += FileUtils.getNumberOfFiles(step.getProzess().getImagesOrigDirectory(false));
 					}
 				} catch (Exception e) {
-					myLogger.error(e);
+					logger.error(e);
 				}
 			}
 		}
@@ -913,9 +913,9 @@ public class AktuelleSchritteForm extends BasisForm {
 		try {
 			schrittPerParameterLaden();
 		} catch (NumberFormatException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (DAOException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 		return this.mySchritt;
 	}
@@ -1037,7 +1037,7 @@ public class AktuelleSchritteForm extends BasisForm {
 			export.startExport(this.mySchritt.getProzess());
 		} catch (Exception e) {
 			Helper.setFehlerMeldung("Error on export", e.getMessage());
-			myLogger.error(e);
+			logger.error(e);
 		}
 	}
 
@@ -1098,7 +1098,7 @@ public class AktuelleSchritteForm extends BasisForm {
 			try {
 				this.pdao.save(this.mySchritt.getProzess());
 			} catch (DAOException e) {
-				myLogger.error(e);
+				logger.error(e);
 			}
 		}
 	}
@@ -1178,7 +1178,7 @@ public class AktuelleSchritteForm extends BasisForm {
 				this.pdao.save(p);
 				Helper.setMeldung("propertiesSaved");
 			} catch (DAOException e) {
-				myLogger.error(e);
+				logger.error(e);
 				Helper.setFehlerMeldung("propertiesNotSaved");
 			}
 		}
@@ -1218,7 +1218,7 @@ public class AktuelleSchritteForm extends BasisForm {
 				this.pdao.save(this.mySchritt.getProzess());
 				Helper.setMeldung("propertySaved");
 			} catch (DAOException e) {
-				myLogger.error(e);
+				logger.error(e);
 				Helper.setFehlerMeldung("propertyNotSaved");
 			}
 		}
@@ -1262,7 +1262,7 @@ public class AktuelleSchritteForm extends BasisForm {
 		try {
 			this.pdao.save(this.mySchritt.getProzess());
 		} catch (DAOException e) {
-			myLogger.error(e);
+			logger.error(e);
 			Helper.setFehlerMeldung("propertiesNotDeleted");
 		}
 		// saveWithoutValidation();
@@ -1363,7 +1363,7 @@ public class AktuelleSchritteForm extends BasisForm {
 			this.pdao.save(this.mySchritt.getProzess());
 			Helper.setMeldung("propertySaved");
 		} catch (DAOException e) {
-			myLogger.error(e);
+			logger.error(e);
 			Helper.setFehlerMeldung("propertiesNotSaved");
 		}
 		loadProcessProperties();

--- a/Goobi/src/de/sub/goobi/forms/ProjekteForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProjekteForm.java
@@ -64,7 +64,7 @@ import de.sub.goobi.persistence.ProjektDAO;
 
 public class ProjekteForm extends BasisForm {
 	private static final long serialVersionUID = 6735912903249358786L;
-	private static final Logger myLogger = Logger.getLogger(ProjekteForm.class);
+	private static final Logger logger = Logger.getLogger(ProjekteForm.class);
 
 	private Projekt myProjekt = new Projekt();
 	private ProjectFileGroup myFilegroup;
@@ -154,21 +154,21 @@ public class ProjekteForm extends BasisForm {
 			return "ProjekteAlle";
 		} catch (DAOException e) {
 			Helper.setFehlerMeldung("could not save", e.getMessage());
-			myLogger.error(e);
+			logger.error(e);
 			return "";
 		}
 	}
 
 	public String Apply() {
 		// call this to make saving and deleting permanent
-		myLogger.trace("Apply wird aufgerufen...");
+		logger.trace("Apply wird aufgerufen...");
 		this.commitFileGroups();
 		try {
 			this.dao.save(this.myProjekt);
 			return "";
 		} catch (DAOException e) {
 			Helper.setFehlerMeldung("could not save", e.getMessage());
-			myLogger.error(e.getMessage());
+			logger.error(e.getMessage());
 			return "";
 		}
 	}
@@ -182,7 +182,7 @@ public class ProjekteForm extends BasisForm {
 			this.dao.remove(this.myProjekt);
 		} catch (DAOException e) {
 			Helper.setFehlerMeldung("could not delete", e.getMessage());
-			myLogger.error(e.getMessage());
+			logger.error(e.getMessage());
 			return "";
 		}
 		}
@@ -198,7 +198,7 @@ public class ProjekteForm extends BasisForm {
 			this.page = new Page(crit, 0);
 		} catch (HibernateException he) {
 			Helper.setFehlerMeldung("could not read", he.getMessage());
-			myLogger.error(he.getMessage());
+			logger.error(he.getMessage());
 			return "";
 		}
 		return "ProjekteAlle";
@@ -462,7 +462,7 @@ public class ProjekteForm extends BasisForm {
 		DateTime start = new DateTime(this.myProjekt.getStartDate().getTime());
 		DateTime end = new DateTime(this.myProjekt.getEndDate().getTime());
 		Weeks weeks = Weeks.weeksBetween(start, end);
-		myLogger.trace(weeks.getWeeks());
+		logger.trace(weeks.getWeeks());
 		int days = (weeks.getWeeks() * 5);
 
 		if (days < 1) {
@@ -575,7 +575,7 @@ public class ProjekteForm extends BasisForm {
 			try {
 				ImageIO.write(bi, "png", outputfile);
 			} catch (IOException e) {
-				myLogger.debug("couldn't write project progress chart to file", e);
+				logger.debug("couldn't write project progress chart to file", e);
 			}
 		}
 	}

--- a/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
@@ -105,7 +105,7 @@ import ugh.exceptions.WriteException;
 import ugh.fileformats.mets.XStream;
 
 public class ProzesskopieForm {
-	private static final Logger myLogger = Logger.getLogger(ProzesskopieForm.class);
+	private static final Logger logger = Logger.getLogger(ProzesskopieForm.class);
 
 	/**
 	 * The class SelectableHit represents a hit on the hit list that shows up if
@@ -399,7 +399,7 @@ public class ProzesskopieForm {
 		try {
 			aktuellerNutzer = new BenutzerDAO().get(loginForm.getMyBenutzer().getId());
 		} catch (DAOException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 		if (aktuellerNutzer != null) {
 			/*
@@ -600,7 +600,7 @@ public class ProzesskopieForm {
 							}
 						}
 					} catch (UghHelperException e) {
-						myLogger.error(e);
+						logger.error(e);
 						Helper.setFehlerMeldung(e.getMessage(), "");
 					}
 					if (field.getWert() != null && !field.getWert().equals("")) {
@@ -669,7 +669,7 @@ public class ProzesskopieForm {
 			removeCollections(colStruct);
 		} catch (PreferencesException e) {
 			Helper.setFehlerMeldung("Error on creating process", e);
-			myLogger.error("Error on creating process", e);
+			logger.error("Error on creating process", e);
 		} catch (RuntimeException e) {
 			/*
 			 * das Firstchild unterhalb des Topstructs konnte nicht ermittelt werden
@@ -814,8 +814,8 @@ public class ProzesskopieForm {
 			dao.save(this.prozessKopie);
 			dao.refresh(this.prozessKopie);
 		} catch (DAOException e) {
-			myLogger.error(e);
-			myLogger.error("error on save: ", e);
+			logger.error(e);
+			logger.error("error on save: ", e);
 			return "";
 		}
 
@@ -967,7 +967,7 @@ public class ProzesskopieForm {
 								try {
 									enricher.addMetadata(higherElement.getValue());
 								} catch (UGHException didNotWork) {
-									myLogger.info(didNotWork);
+									logger.info(didNotWork);
 								}
 							}
 						}
@@ -1021,13 +1021,13 @@ public class ProzesskopieForm {
 
 			} catch (ugh.exceptions.DocStructHasNoTypeException e) {
 				Helper.setFehlerMeldung("DocStructHasNoTypeException", e.getMessage());
-				myLogger.error("creation of new process throws an error: ", e);
+				logger.error("creation of new process throws an error: ", e);
 			} catch (UghHelperException e) {
 				Helper.setFehlerMeldung("UghHelperException", e.getMessage());
-				myLogger.error("creation of new process throws an error: ", e);
+				logger.error("creation of new process throws an error: ", e);
 			} catch (MetadataTypeNotAllowedException e) {
 				Helper.setFehlerMeldung("MetadataTypeNotAllowedException", e.getMessage());
-				myLogger.error("creation of new process throws an error: ", e);
+				logger.error("creation of new process throws an error: ", e);
 			}
 
 		}
@@ -1045,8 +1045,8 @@ public class ProzesskopieForm {
 			try {
 				new ProzessDAO().save(this.prozessKopie);
 			} catch (DAOException e) {
-				myLogger.error(e);
-				myLogger.error("error on save: ", e);
+				logger.error(e);
+				logger.error("error on save: ", e);
 				return "";
 			}
 		}
@@ -1105,10 +1105,10 @@ public class ProzesskopieForm {
 			}
 		} catch (UghHelperException e) {
 			Helper.setFehlerMeldung(e.getMessage(), "");
-			myLogger.error(e);
+			logger.error(e);
 		} catch (DocStructHasNoTypeException e) {
 			Helper.setFehlerMeldung(e.getMessage(), "");
-			myLogger.error(e);
+			logger.error(e);
 		}
 	}
 
@@ -1170,13 +1170,13 @@ public class ProzesskopieForm {
 			}
 
 		} catch (TypeNotAllowedForParentException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (TypeNotAllowedAsChildException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (PreferencesException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (FileNotFoundException e) {
-			myLogger.error("Error while reading von opac-config", e);
+			logger.error("Error while reading von opac-config", e);
 			Helper.setFehlerMeldung("Error while reading von opac-config", e.getMessage());
 		}
 	}
@@ -1278,12 +1278,12 @@ public class ProzesskopieForm {
                         }
                     }
                 } catch (PreferencesException e) {
-                    myLogger.error(e);
+                    logger.error(e);
                 }
                 try {
                     fillFieldsFromMetadataFile();
                 } catch (PreferencesException e) {
-                    myLogger.error(e);
+                    logger.error(e);
                 }
             }
         }
@@ -1458,10 +1458,10 @@ public class ProzesskopieForm {
 				}
 			}
 		} catch (JDOMException e1) {
-			myLogger.error("error while parsing digital collections", e1);
+			logger.error("error while parsing digital collections", e1);
 			Helper.setFehlerMeldung("Error while parsing digital collections", e1);
 		} catch (IOException e1) {
-			myLogger.error("error while parsing digital collections", e1);
+			logger.error("error while parsing digital collections", e1);
 			Helper.setFehlerMeldung("Error while parsing digital collections", e1);
 		}
 
@@ -1496,7 +1496,7 @@ public class ProzesskopieForm {
 			}
 			return allCatalogueTitles;
 		} catch (Throwable t) {
-			myLogger.error("Error while reading von opac-config", t);
+			logger.error("Error while reading von opac-config", t);
 			Helper.setFehlerMeldung("Error while reading von opac-config", t.getMessage());
 			return new LinkedList<String>();
 		}
@@ -1576,7 +1576,7 @@ public class ProzesskopieForm {
 			ConfigOpac.setConfiguration(originalConfiguration);
 			return allDocTypes;
 		} catch (Throwable t) {
-			myLogger.error("Error while reading von opac-config", t);
+			logger.error("Error while reading von opac-config", t);
 			Helper.setFehlerMeldung("Error while reading von opac-config", t.getMessage());
 			return new ArrayList<ConfigOpacDoctype>();
 		}
@@ -1872,7 +1872,7 @@ public class ProzesskopieForm {
 				try {
 					this.tifHeader_imagedescription += ConfigOpac.getDoctypeByName(this.docType).getTifHeaderType();
 				} catch (Throwable t) {
-					myLogger.error("Error while reading von opac-config", t);
+					logger.error("Error while reading von opac-config", t);
 					Helper.setFehlerMeldung("Error while reading von opac-config", t.getMessage());
 				}
 			} else {
@@ -2079,7 +2079,7 @@ public class ProzesskopieForm {
 		} catch (NullPointerException e) { // may occur if user continues to interact with the page across a restart of the servlet container
 			return false;
 		} catch (FileNotFoundException e) {
-			myLogger.error("Error while reading von opac-config", e);
+			logger.error("Error while reading von opac-config", e);
 			Helper.setFehlerMeldung("Error while reading von opac-config", e.getMessage());
 			return false;
 		}

--- a/Goobi/src/de/sub/goobi/forms/StatistikForm.java
+++ b/Goobi/src/de/sub/goobi/forms/StatistikForm.java
@@ -33,7 +33,7 @@ import de.sub.goobi.persistence.ProzessDAO;
 import de.sub.goobi.persistence.SchrittDAO;
 
 public class StatistikForm {
-	private static final Logger myLogger = Logger.getLogger(StatistikForm.class);
+	private static final Logger logger = Logger.getLogger(StatistikForm.class);
 	Calendar cal = new GregorianCalendar();
 	int n = 200;
 
@@ -98,7 +98,7 @@ public class StatistikForm {
 		try {
 			return new SchrittDAO().count("from Schritt");
 		} catch (DAOException e) {
-			myLogger.error("Hibernate error", e);
+			logger.error("Hibernate error", e);
 			Helper.setFehlerMeldung("fehlerBeimEinlesen", e);
 			return Long.valueOf(-1);
 		}

--- a/Goobi/src/de/sub/goobi/helper/Helper.java
+++ b/Goobi/src/de/sub/goobi/helper/Helper.java
@@ -71,7 +71,7 @@ public class Helper implements Serializable, Observer {
 
 	}
 
-	private static final Logger myLogger = Logger.getLogger(Helper.class);
+	private static final Logger logger = Logger.getLogger(Helper.class);
 	private static final long serialVersionUID = -7449236652821237059L;
 
 	private String myMetadatenVerzeichnis;
@@ -205,7 +205,7 @@ public class Helper implements Serializable, Observer {
 			context.addMessage(control, new FacesMessage(nurInfo ? FacesMessage.SEVERITY_INFO : FacesMessage.SEVERITY_ERROR, msg, beschr));
 		} else {
 			// wenn kein Kontext da ist, dann die Meldungen in Log
-			myLogger.log(nurInfo ? Level.INFO : Level.ERROR, compoundMessage);
+			logger.log(nurInfo ? Level.INFO : Level.ERROR, compoundMessage);
 
 		}
 	}
@@ -273,9 +273,9 @@ public class Helper implements Serializable, Observer {
 					try {
 					value = vb.getValue(context);
 					} catch (PropertyNotFoundException e) {
-						myLogger.error(e);
+						logger.error(e);
 					} catch (EvaluationException e) {
-						myLogger.error(e);
+						logger.error(e);
 					}
 				}
 			}

--- a/Goobi/src/de/sub/goobi/helper/UghHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/UghHelper.java
@@ -24,7 +24,7 @@ import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.helper.exceptions.UghHelperException;
 
 public class UghHelper {
-	private static final Logger myLogger = Logger.getLogger(UghHelper.class);
+	private static final Logger logger = Logger.getLogger(UghHelper.class);
 
 	/**
 	 * MetadataType aus Preferences eines Prozesses ermitteln
@@ -73,7 +73,7 @@ public class UghHelper {
 
 					return md;
 				} catch (MetadataTypeNotAllowedException e) {
-					myLogger.debug(e.getMessage());
+					logger.debug(e.getMessage());
 					return null;
 				}
 			}

--- a/Goobi/src/de/sub/goobi/helper/WebDav.java
+++ b/Goobi/src/de/sub/goobi/helper/WebDav.java
@@ -34,7 +34,7 @@ import de.sub.goobi.export.download.TiffHeader;
 public class WebDav implements Serializable {
 
 	private static final long serialVersionUID = -1929234096626965538L;
-	private static final Logger myLogger = Logger.getLogger(WebDav.class);
+	private static final Logger logger = Logger.getLogger(WebDav.class);
 
 	/*
 	 * Kopieren bzw. symbolische Links für einen Prozess in das Benutzerhome
@@ -59,7 +59,7 @@ public class WebDav implements Serializable {
 		try {
 			VerzeichnisAlle = aktuellerBenutzer.getHomeDir() + inVerzeichnis;
 		} catch (Exception ioe) {
-			myLogger.error("Exception UploadFromHomeAlle()", ioe);
+			logger.error("Exception UploadFromHomeAlle()", ioe);
 			Helper.setFehlerMeldung("UploadFromHomeAlle abgebrochen, Fehler", ioe.getMessage());
 			return rueckgabe;
 		}
@@ -100,7 +100,7 @@ public class WebDav implements Serializable {
 		try {
 			VerzeichnisAlle = aktuellerBenutzer.getHomeDir() + inVerzeichnis;
 		} catch (Exception ioe) {
-			myLogger.error("Exception RemoveFromHomeAlle()", ioe);
+			logger.error("Exception RemoveFromHomeAlle()", ioe);
 			Helper.setFehlerMeldung("Upload stoped, error", ioe.getMessage());
 			return;
 		}
@@ -124,7 +124,7 @@ public class WebDav implements Serializable {
 		try {
 			nach = inBenutzer.getHomeDir();
 		} catch (Exception ioe) {
-			myLogger.error("Exception UploadFromHome(...)", ioe);
+			logger.error("Exception UploadFromHome(...)", ioe);
 			Helper.setFehlerMeldung("Aborted upload from home, error", ioe.getMessage());
 			return;
 		}
@@ -137,7 +137,7 @@ public class WebDav implements Serializable {
 				List<String> param = new ArrayList<String>();
 				param.add(String.valueOf(nach.replaceAll(" ", "__")));
 				Helper.setFehlerMeldung(Helper.getTranslation("MassDownloadProjectCreationError", param));
-				myLogger.error("Cannot create project directory " + nach.replaceAll(" ", "__"));
+				logger.error("Cannot create project directory " + nach.replaceAll(" ", "__"));
 				return;
 			}
 		}
@@ -174,7 +174,7 @@ public class WebDav implements Serializable {
 			}
 
 		} catch (Exception ioe) {
-			myLogger.error("Exception DownloadToHome()", ioe);
+			logger.error("Exception DownloadToHome()", ioe);
 			Helper.setFehlerMeldung("Aborted download to home, error", ioe.getMessage());
 			return;
 		}
@@ -194,9 +194,9 @@ public class WebDav implements Serializable {
 		/* Leerzeichen maskieren */
 		nach = nach.replaceAll(" ", "__");
 
-		if(myLogger.isInfoEnabled()){
-			myLogger.info("von: " + von);
-			myLogger.info("nach: " + nach);
+		if(logger.isInfoEnabled()){
+			logger.info("von: " + von);
+			logger.info("nach: " + nach);
 		}
 
 		SafeFile imagePfad = new SafeFile(von);
@@ -217,12 +217,12 @@ public class WebDav implements Serializable {
 		try {
             	ShellScript.legacyCallShell2(command);
             } catch (java.io.IOException ioe) {
-			myLogger.error("IOException DownloadToHome()", ioe);
+			logger.error("IOException DownloadToHome()", ioe);
 			Helper.setFehlerMeldung("Download aborted, IOException", ioe.getMessage());
 		} catch (InterruptedException e) {
-			myLogger.error("InterruptedException DownloadToHome()", e);
+			logger.error("InterruptedException DownloadToHome()", e);
 			Helper.setFehlerMeldung("Download aborted, InterruptedException", e.getMessage());
-			myLogger.error(e);
+			logger.error(e);
 		}
 	}
 
@@ -242,7 +242,7 @@ public class WebDav implements Serializable {
 			}
 		} catch (Exception e) {
 			Helper.setFehlerMeldung("Download aborted", e);
-			myLogger.error(e);
+			logger.error(e);
 		}
 	}
 
@@ -259,7 +259,7 @@ public class WebDav implements Serializable {
 			};
 			return benutzerHome.list(filter).length;
 		} catch (Exception e) {
-			myLogger.error(e);
+			logger.error(e);
 			return 0;
 		}
 	}

--- a/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
+++ b/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
@@ -51,7 +51,7 @@ import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 
 public class Ldap {
-	private static final Logger myLogger = Logger.getLogger(Ldap.class);
+	private static final Logger logger = Logger.getLogger(Ldap.class);
 
 	public Ldap() {
 
@@ -96,14 +96,14 @@ public class Ldap {
 			/*
 			 * -------------------------------- check if HomeDir exists, else create it --------------------------------
 			 */
-			myLogger.debug("HomeVerzeichnis pruefen");
+			logger.debug("HomeVerzeichnis pruefen");
 			String homePath = getUserHomeDirectory(inBenutzer);
 			if (!new File(homePath).exists()) {
-				myLogger.debug("HomeVerzeichnis existiert noch nicht");
+				logger.debug("HomeVerzeichnis existiert noch nicht");
                 FilesystemHelper.createDirectoryForUser(homePath, inBenutzer.getLogin());
-                myLogger.debug("HomeVerzeichnis angelegt");
+                logger.debug("HomeVerzeichnis angelegt");
 			} else {
-				myLogger.debug("HomeVerzeichnis existiert schon");
+				logger.debug("HomeVerzeichnis existiert schon");
 			}
 		} else {
 			Helper.setMeldung(Helper.getTranslation("ldapIsReadOnly"));
@@ -118,12 +118,12 @@ public class Ldap {
 	 * @return Login correct or not
 	 */
 	public boolean isUserPasswordCorrect(Benutzer inBenutzer, String inPasswort) {
-		myLogger.debug("start login session with ldap");
+		logger.debug("start login session with ldap");
 		Hashtable<String, String> env = LdapConnectionSettings();
 
 		// Start TLS
 		if (ConfigMain.getBooleanParameter("ldap_useTLS", false)) {
-			myLogger.debug("use TLS for auth");
+			logger.debug("use TLS for auth");
 			env = new Hashtable<String, String>();
 			env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
 			env.put(Context.PROVIDER_URL, ConfigMain.getParameter("ldap_url"));
@@ -147,10 +147,10 @@ public class Ldap {
 				// Perform search for privileged attributes under authenticated context
 
 			} catch (IOException e) {
-				myLogger.error("TLS negotiation error:", e);
+				logger.error("TLS negotiation error:", e);
 				return false;
 			} catch (NamingException e) {
-				myLogger.error("JNDI error:", e);
+				logger.error("JNDI error:", e);
 				return false;
 			} finally {
 				if (tls != null) {
@@ -169,7 +169,7 @@ public class Ldap {
 				}
 			}
 		} else {
-			myLogger.debug("don't use TLS for auth");
+			logger.debug("don't use TLS for auth");
 			if (ConfigMain.getBooleanParameter("useSimpleAuthentification", false)) {
 				env.put(Context.SECURITY_AUTHENTICATION, "none");
 				// TODO auf passwort testen
@@ -177,40 +177,40 @@ public class Ldap {
 				env.put(Context.SECURITY_PRINCIPAL, getUserDN(inBenutzer));
 				env.put(Context.SECURITY_CREDENTIALS, inPasswort);
 			}
-			myLogger.debug("ldap environment set");
+			logger.debug("ldap environment set");
 
 			try {
-				if(myLogger.isDebugEnabled()){
-					myLogger.debug("start classic ldap authentification");
-					myLogger.debug("user DN is " + getUserDN(inBenutzer));
+				if(logger.isDebugEnabled()){
+					logger.debug("start classic ldap authentification");
+					logger.debug("user DN is " + getUserDN(inBenutzer));
 				}
 
 				if (ConfigMain.getParameter("ldap_AttributeToTest") == null) {
-					myLogger.debug("ldap attribute to test is null");
+					logger.debug("ldap attribute to test is null");
 					DirContext ctx = new InitialDirContext(env);
 					ctx.close();
 					return true;
 				} else {
-					myLogger.debug("ldap attribute to test is not null");
+					logger.debug("ldap attribute to test is not null");
 					DirContext ctx = new InitialDirContext(env);
 
 					Attributes attrs = ctx.getAttributes(getUserDN(inBenutzer));
 					Attribute la = attrs.get(ConfigMain.getParameter("ldap_AttributeToTest"));
-					myLogger.debug("ldap attributes set");
+					logger.debug("ldap attributes set");
 					String test = (String) la.get(0);
 					if (test.equals(ConfigMain.getParameter("ldap_ValueOfAttribute"))) {
-						myLogger.debug("ldap ok");
+						logger.debug("ldap ok");
 						ctx.close();
 						return true;
 					} else {
-						myLogger.debug("ldap not ok");
+						logger.debug("ldap not ok");
 						ctx.close();
 						return false;
 					}
 				}
 			} catch (NamingException e) {
-				if(myLogger.isDebugEnabled()){
-					myLogger.debug("login not allowed for " + inBenutzer.getLogin(), e);
+				if(logger.isDebugEnabled()){
+					logger.debug("login not allowed for " + inBenutzer.getLogin(), e);
 				}
 				return false;
 			}
@@ -258,12 +258,12 @@ public class Ldap {
 				// Perform search for privileged attributes under authenticated context
 
 			} catch (IOException e) {
-				myLogger.error("TLS negotiation error:", e);
+				logger.error("TLS negotiation error:", e);
 
 				return ConfigMain.getParameter("dir_Users") + inBenutzer.getLogin();
 			} catch (NamingException e) {
 
-				myLogger.error("JNDI error:", e);
+				logger.error("JNDI error:", e);
 
 				return ConfigMain.getParameter("dir_Users") + inBenutzer.getLogin();
 			} finally {
@@ -298,7 +298,7 @@ public class Ldap {
 			rueckgabe = (String) la.get(0);
 			ctx.close();
 		} catch (NamingException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 		return rueckgabe;
 	}
@@ -323,8 +323,8 @@ public class Ldap {
 
 			while (answer.hasMore()) {
 				SearchResult sr = answer.next();
-				if(myLogger.isDebugEnabled()){
-					myLogger.debug(">>>" + sr.getName());
+				if(logger.isDebugEnabled()){
+					logger.debug(">>>" + sr.getName());
 				}
 				Attributes attrs = sr.getAttributes();
 				String givenName = " ";
@@ -357,17 +357,17 @@ public class Ldap {
 				} catch (Exception e4) {
 					hd = " ";
 				}
-				myLogger.debug(givenName);
-				myLogger.debug(surName);
-				myLogger.debug(mail);
-				myLogger.debug(cn);
-				myLogger.debug(hd);
+				logger.debug(givenName);
+				logger.debug(surName);
+				logger.debug(mail);
+				logger.debug(cn);
+				logger.debug(hd);
 
 			}
 
 			ctx.close();
 		} catch (NamingException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 		return rueckgabe;
 	}
@@ -391,7 +391,7 @@ public class Ldap {
 			rueckgabe = (String) la.get(0);
 			ctx.close();
 		} catch (NamingException e) {
-			myLogger.error(e);
+			logger.error(e);
 			Helper.setFehlerMeldung(e.getMessage());
 		}
 		return rueckgabe;
@@ -422,7 +422,7 @@ public class Ldap {
 
 			ctx.close();
 		} catch (NamingException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 
 	}
@@ -468,7 +468,7 @@ public class Ldap {
 					lanmgrpassword = new BasicAttribute("sambaLMPassword", LdapUser.toHexString(LdapUser.lmHash(inNewPassword)));
 					// TODO: Don't catch super class exception, make sure that the password isn't logged here
 				} catch (Exception e) {
-					myLogger.error(e);
+					logger.error(e);
 				}
 
 				/*
@@ -480,7 +480,7 @@ public class Ldap {
 					ntlmpassword = new BasicAttribute("sambaNTPassword", LdapUser.toHexString(hmm));
 				} catch (UnsupportedEncodingException e) {
 					// TODO: Make sure that the password isn't logged here
-					myLogger.error(e);
+					logger.error(e);
 				}
 
 				BasicAttribute sambaPwdLastSet = new BasicAttribute("sambaPwdLastSet", String.valueOf(System.currentTimeMillis() / 1000l));
@@ -495,7 +495,7 @@ public class Ldap {
 				ctx.close();
 				return true;
 			} catch (NamingException e) {
-				myLogger.debug("Benutzeranmeldung nicht korrekt oder Passwortänderung nicht möglich", e);
+				logger.debug("Benutzeranmeldung nicht korrekt oder Passwortänderung nicht möglich", e);
 				return false;
 			}
 		}
@@ -551,7 +551,7 @@ public class Ldap {
 				ks.setCertificateEntry("PDC", servercert);
 				ks.store(ksos, password);
 			} catch (Exception e) {
-				myLogger.error(e);
+				logger.error(e);
 			}
 
 		}

--- a/Goobi/src/de/sub/goobi/helper/ldap/LdapUser.java
+++ b/Goobi/src/de/sub/goobi/helper/ldap/LdapUser.java
@@ -53,7 +53,7 @@ import de.sub.goobi.config.ConfigMain;
  * This class is used by the DirObj example. It is a DirContext class that can be stored by service providers like the LDAP system providers.
  */
 public class LdapUser implements DirContext {
-	private static final Logger myLogger = Logger.getLogger(LdapUser.class);
+	private static final Logger logger = Logger.getLogger(LdapUser.class);
 	String type;
 	Attributes myAttrs;
 
@@ -122,14 +122,14 @@ public class LdapUser implements DirContext {
 			try {
 				this.myAttrs.put("sambaLMPassword", toHexString(lmHash(inPassword)));
 			} catch (Exception e) {
-				myLogger.error(e);
+				logger.error(e);
 			}
 			/* NTLM */
 			try {
 				byte hmm[] = MD4.mdfour(inPassword.getBytes("UnicodeLittleUnmarked"));
 				this.myAttrs.put("sambaNTPassword", toHexString(hmm));
 			} catch (UnsupportedEncodingException e) {
-				myLogger.error(e);
+				logger.error(e);
 			}
 
 			/*
@@ -161,9 +161,9 @@ public class LdapUser implements DirContext {
 		rueckgabe = rueckgabe.replaceAll("\\{user full name\\}", inUser.getVorname() + " " + inUser.getNachname());
 		rueckgabe = rueckgabe.replaceAll("\\{uidnumber\\*2\\+1000\\}", String.valueOf(Integer.parseInt(inUidNumber) * 2 + 1000));
 		rueckgabe = rueckgabe.replaceAll("\\{uidnumber\\*2\\+1001\\}", String.valueOf(Integer.parseInt(inUidNumber) * 2 + 1001));
-		if(myLogger.isDebugEnabled()){
-			myLogger.debug("Replace instring: " + inString + " - " + inUser + " - " + inUidNumber);
-			myLogger.debug("Replace outstring: " + rueckgabe);
+		if(logger.isDebugEnabled()){
+			logger.debug("Replace instring: " + inString + " - " + inUser + " - " + inUidNumber);
+			logger.debug("Replace outstring: " + rueckgabe);
 		}
 		return rueckgabe;
 	}

--- a/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
@@ -47,7 +47,7 @@ public abstract class LongRunningTask extends EmptyTask {
 		initialize(master.prozess);
 	}
 
-	protected static final Logger logger = Logger.getLogger(LongRunningTask.class);
+	private static final Logger logger = Logger.getLogger(LongRunningTask.class);
 
 	private Prozess prozess;
 	private boolean isSingleThread = true;

--- a/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapInTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapInTask.java
@@ -11,6 +11,7 @@
 
 package de.sub.goobi.helper.tasks;
 
+import org.apache.log4j.Logger;
 import org.goobi.io.SafeFile;
 
 import java.io.File;
@@ -24,11 +25,14 @@ import org.jdom.input.SAXBuilder;
 
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.export.download.ExportMets;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.exceptions.DAOException;
 import de.sub.goobi.persistence.ProzessDAO;
 
 public class ProcessSwapInTask extends LongRunningTask {
+
+	private static final Logger logger = Logger.getLogger(ProcessSwapInTask.class);
 
 	/**
 	 * No-argument constructor. Creates an empty ProcessSwapInTask. Must be made

--- a/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
@@ -16,6 +16,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Date;
 
+import org.apache.log4j.Logger;
 import org.goobi.io.SafeFile;
 import org.jdom.Document;
 import org.jdom.Element;
@@ -24,6 +25,7 @@ import org.jdom.output.XMLOutputter;
 
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.export.download.ExportMets;
 import de.sub.goobi.helper.CopyFile;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.exceptions.DAOException;
@@ -31,6 +33,7 @@ import de.sub.goobi.persistence.ProzessDAO;
 
 public class ProcessSwapOutTask extends LongRunningTask {
 
+	private static final Logger logger = Logger.getLogger(ProcessSwapOutTask.class);
 
 	/**
 	 * Copies all files under srcDir to dstDir. If dstDir does not exist, it will be created.

--- a/Goobi/src/de/sub/goobi/importer/Import.java
+++ b/Goobi/src/de/sub/goobi/importer/Import.java
@@ -37,7 +37,7 @@ import de.sub.goobi.helper.exceptions.WrongImportFileException;
  * @version 1.00 - 25.06.2005
  */
 public class Import {
-	private static final Logger myLogger = Logger.getLogger(Import.class);
+	private static final Logger logger = Logger.getLogger(Import.class);
 	private String importFehler = "";
 	private String importMeldung = "";
 	private Schritt mySchritt;
@@ -50,7 +50,7 @@ public class Import {
 	}
 
 	public String Start() {
-		myLogger.info("Import Start - start");
+		logger.info("Import Start - start");
 		this.importFehler = "";
 		this.importMeldung = "";
 		try {
@@ -58,15 +58,15 @@ public class Import {
 			Einlesen();
 		} catch (Exception e) {
 			this.importFehler = "An error occurred: " + e.getMessage();
-			myLogger.error(e);
+			logger.error(e);
 		}
-		myLogger.info("Import Start - ende");
+		logger.info("Import Start - ende");
 		return "";
 	}
 
 	private void Einlesen() throws IOException, WrongImportFileException, TypeNotAllowedForParentException, TypeNotAllowedAsChildException,
 			MetadataTypeNotAllowedException, ReadException, InterruptedException, PreferencesException, SwapException, DAOException, WriteException {
-		myLogger.debug("Einlesen() - Start");
+		logger.debug("Einlesen() - Start");
 		BufferedReader reader = null;
 		try {
 
@@ -98,12 +98,12 @@ public class Import {
 				try {
 					reader.close();
 				} catch (IOException e) {
-					myLogger.error("Die Datei kann nicht geschlossen werden", e);
+					logger.error("Die Datei kann nicht geschlossen werden", e);
 				}
 			}
 		}
 		/* wenn alles ok ist, 0 zurückgeben */
-		myLogger.debug("Einlesen() - Ende");
+		logger.debug("Einlesen() - Ende");
 	}
 
 	/*

--- a/Goobi/src/de/sub/goobi/importer/ImportRussland.java
+++ b/Goobi/src/de/sub/goobi/importer/ImportRussland.java
@@ -46,7 +46,7 @@ import de.sub.goobi.helper.exceptions.WrongImportFileException;
  * @version 1.00 - 10.01.2005
  */
 public class ImportRussland {
-   private static final Logger myLogger = Logger.getLogger(ImportRussland.class);
+   private static final Logger logger = Logger.getLogger(ImportRussland.class);
    private DocStruct logicalTopstruct;
    private Prozess prozess;
 
@@ -87,7 +87,7 @@ public class ImportRussland {
       String line = reader.readLine();
       line = reader.readLine();
       line = reader.readLine();
-      //      myLogger.info(line + " : " + myProzesseID);
+      //      logger.info(line + " : " + myProzesseID);
       if (line == null) {
 		throw new WrongImportFileException("Importfehler: ungültige Importdatei oder falsche Kodierung");
 	}
@@ -115,7 +115,7 @@ public class ImportRussland {
        * --------------------------------*/
       List<String> listeDaten = new ArrayList<String>();
       while ((line = reader.readLine()) != null) {
-         //         myLogger.info(line);
+         //         logger.info(line);
          if (line.length() == 0) {
 
             /* immer wenn die Zeile leer ist, können die gesammelten
@@ -136,7 +136,7 @@ public class ImportRussland {
        * Datei abschliessend wieder speichern
        * --------------------------------*/
       inProzess.writeMetadataFile(gdzfile);
-      myLogger.debug("ParsenRussland() - Ende");
+      logger.debug("ParsenRussland() - Ende");
    }
 
 
@@ -169,7 +169,7 @@ public class ImportRussland {
       for (Iterator<String> iter = inListe.iterator(); iter.hasNext();) {
          String meinDetail = iter.next();
          String meineDetailNr = meinDetail.substring(0, 3);
-         //			myLogger.debug("---- " + meinDetail);
+         //			logger.debug("---- " + meinDetail);
 
          /* Zeitschrift Titel russisch */
          if (meineDetailNr.equals("020")) {
@@ -198,7 +198,7 @@ public class ImportRussland {
 
    private void BandDetails(List<String> inListe) throws MetadataTypeNotAllowedException {
       DocStruct ds = this.logicalTopstruct.getAllChildren().get(0);
-      //      myLogger.info(ds.getType().getName());
+      //      logger.info(ds.getType().getName());
       /* zunächst alle Details durchlaufen und dem Band hinzufügenl  */
       for (Iterator<String> iter = inListe.iterator(); iter.hasNext();) {
          String meinDetail = iter.next();
@@ -230,7 +230,7 @@ public class ImportRussland {
       for (Iterator<String> iter = inListe.iterator(); iter.hasNext();) {
          String meinDetail = iter.next();
          if (meinDetail.substring(0, 3).equals("090")) {
-//            myLogger.info("ZBL-Identifier ist " + meinDetail.substring(4).trim());
+//            logger.info("ZBL-Identifier ist " + meinDetail.substring(4).trim());
             zblID = meinDetail.substring(4).trim();
             break;
          }
@@ -238,7 +238,7 @@ public class ImportRussland {
 
       /* für das Debugging bei Problemen */
 //      if (zblID.equals("0843.11050"))
-//         myLogger.warn("gesuchte ID");
+//         logger.warn("gesuchte ID");
 
       /* --------------------------------
        * alle Hefte und Artikel durchlaufen und den richtigen Artikel mit der selben ZBL-ID finden
@@ -246,7 +246,7 @@ public class ImportRussland {
       MetadataType mdt_id = this.prozess.getRegelsatz().getPreferences().getMetadataTypeByName("ZBLIdentifier");
       MetadataType mdt_tempId = this.prozess.getRegelsatz().getPreferences().getMetadataTypeByName("ZBLTempID");
            DocStruct band = this.logicalTopstruct.getAllChildren().get(0);
-      //		myLogger.info(band.getType().getName());
+      //		logger.info(band.getType().getName());
       List<DocStruct> listHefte = band.getAllChildren();
       if (listHefte != null) {
          for (Iterator<DocStruct> iter = listHefte.iterator(); iter.hasNext();) {
@@ -257,7 +257,7 @@ public class ImportRussland {
                /* jetzt alle Artikel durchlaufen, bis der richtige Artikel gefunden wurde */
                for (Iterator<DocStruct> iter1 = listArtikel.iterator(); iter1.hasNext();) {
                   DocStruct artikel = iter1.next();
-//                  myLogger.info(artikel.getType().getName());
+//                  logger.info(artikel.getType().getName());
                   if (artikel.getAllMetadataByType(mdt_id).size() > 0 || artikel.getAllMetadataByType(mdt_tempId).size() > 0) {
                      Metadata md;
                      if (artikel.getAllMetadataByType(mdt_id).size() > 0) {
@@ -265,9 +265,9 @@ public class ImportRussland {
 					} else {
 						md = artikel.getAllMetadataByType(mdt_tempId).get(0);
 					}
-                     //                  myLogger.debug(md.getValue());
+                     //                  logger.debug(md.getValue());
                      if (md.getValue().equals(zblID)) {
-                        //                     myLogger.info("------------ Artikel gefunden -------------");
+                        //                     logger.info("------------ Artikel gefunden -------------");
                         artikelGefunden = true;
                         /* jetzt alle Details durchlaufen und dem Artikel hinzufügenl  */
                         for (Iterator<String> iter2 = inListe.iterator(); iter2.hasNext();) {
@@ -394,13 +394,13 @@ public class ImportRussland {
          //            for (Iterator iter1 = listArtikel.iterator(); iter1.hasNext();) {
          //               DocStruct artikel = (DocStruct) iter1.next();
          //               Metadata md = (Metadata) artikel.getAllMetadataByType(mdt).getFirst();
-         //               myLogger.debug(md.getValue());
+         //               logger.debug(md.getValue());
          //               if (md.getValue().equals(zblID)) {
-         //                  myLogger.info("------------ Artikel gefunden -------------");
+         //                  logger.info("------------ Artikel gefunden -------------");
          //
          inStruct.addMetadata(md);
       } catch (Exception e) {
-         myLogger.error("Import fehlgeschlagen: " + inDetail, e);
+         logger.error("Import fehlgeschlagen: " + inDetail, e);
       }
    }
 

--- a/Goobi/src/de/sub/goobi/importer/ImportZentralblatt.java
+++ b/Goobi/src/de/sub/goobi/importer/ImportZentralblatt.java
@@ -45,7 +45,7 @@ import de.sub.goobi.helper.exceptions.WrongImportFileException;
  * @version 1.00 - 10.01.2005
  */
 public class ImportZentralblatt {
-	private static final Logger myLogger = Logger.getLogger(ImportZentralblatt.class);
+	private static final Logger logger = Logger.getLogger(ImportZentralblatt.class);
 	String Trennzeichen;
 	private final Helper help;
 	private Prefs myPrefs;
@@ -67,7 +67,7 @@ public class ImportZentralblatt {
 	 */
 	protected void Parsen(BufferedReader reader, Prozess inProzess) throws IOException, WrongImportFileException, TypeNotAllowedForParentException,
 			TypeNotAllowedAsChildException, MetadataTypeNotAllowedException, WriteException {
-		myLogger.debug("ParsenZentralblatt() - Start");
+		logger.debug("ParsenZentralblatt() - Start");
 		this.myPrefs = inProzess.getRegelsatz().getPreferences();
 		String prozessID = String.valueOf(inProzess.getId().intValue());
 		String line;
@@ -90,7 +90,7 @@ public class ImportZentralblatt {
 		 * -------------------------------- alle Zeilen durchlaufen --------------------------------
 		 */
 		while ((line = reader.readLine()) != null) {
-			// myLogger.debug(line);
+			// logger.debug(line);
 
 			/*
 			 * -------------------------------- wenn die Zeile leer ist, ist es das Ende eines Absatzes --------------------------------
@@ -111,7 +111,7 @@ public class ImportZentralblatt {
 					DocStructType dstLocal = this.myPrefs.getDocStrctTypeByName("Article");
 					DocStruct ds = dd.createDocStruct(dstLocal);
 					listArtikel.add(ds);
-					// myLogger.debug("---------------          neuer Artikel          ----------------");
+					// logger.debug("---------------          neuer Artikel          ----------------");
 					istAbsatz = true;
 					istErsterTitel = true;
 				}
@@ -120,7 +120,7 @@ public class ImportZentralblatt {
 				int posTrennzeichen = line.indexOf(this.Trennzeichen);
 				/* wenn kein Trennzeichen vorhanden, Parsingfehler */
 				if (posTrennzeichen == -1) {
-					myLogger.error("Import() - Parsingfehler (kein Doppelpunkt) der Importdatei in der Zeile <br/>" + HtmlTagsMaskieren(line));
+					logger.error("Import() - Parsingfehler (kein Doppelpunkt) der Importdatei in der Zeile <br/>" + HtmlTagsMaskieren(line));
 					throw new WrongImportFileException("Parsingfehler (kein Doppelpunkt) der Importdatei in der Zeile <br/>"
 							+ HtmlTagsMaskieren(line));
 				} else {
@@ -181,9 +181,9 @@ public class ImportZentralblatt {
 			gdzfile.write(this.help.getGoobiDataDirectory() + prozessID + File.separator + "meta.xml");
 		} catch (PreferencesException e) {
 			Helper.setFehlerMeldung("Import aborted: ", e.getMessage());
-			myLogger.error(e);
+			logger.error(e);
 		}
-		myLogger.debug("ParsenZentralblatt() - Ende");
+		logger.debug("ParsenZentralblatt() - Ende");
 	}
 
 	private String xmlTauglichkeitPruefen(String text) {
@@ -238,9 +238,9 @@ public class ImportZentralblatt {
 		List<DocStruct> myList = dsPeriodicalVolume.getAllChildrenByTypeAndMetadataType("PeriodicalIssue", "CurrentNo");
 		if (myList != null && myList.size() != 0) {
 			for (DocStruct dsIntern : myList) {
-				// myLogger.debug(dsIntern.getAllMetadataByType(mdt).getFirst());
+				// logger.debug(dsIntern.getAllMetadataByType(mdt).getFirst());
 				Metadata myMD1 = dsIntern.getAllMetadataByType(mdt).get(0);
-				// myLogger.debug("und der Wert ist: " + myMD1.getValue());
+				// logger.debug("und der Wert ist: " + myMD1.getValue());
 				if (myMD1.getValue().equals(myRight)) {
 					dsPeriodicalIssue = dsIntern;
 				}
@@ -270,9 +270,9 @@ public class ImportZentralblatt {
 	private void ParsenAllgemein(DocStruct inStruct, String myLeft, String myRight) throws WrongImportFileException,
 			TypeNotAllowedForParentException, MetadataTypeNotAllowedException {
 
-		// myLogger.debug(myLeft);
-		// myLogger.debug(myRight);
-		// myLogger.debug("---");
+		// logger.debug(myLeft);
+		// logger.debug(myRight);
+		// logger.debug("---");
 		Metadata md;
 		MetadataType mdt;
 
@@ -365,9 +365,9 @@ public class ImportZentralblatt {
 	 */
 	private void ParsenArtikel(DocStruct inStruct, String myLeft, String myRight, boolean istErsterTitel) throws MetadataTypeNotAllowedException,
 			WrongImportFileException {
-		// myLogger.debug(myLeft);
-		// myLogger.debug(myRight);
-		// myLogger.debug("---");
+		// logger.debug(myLeft);
+		// logger.debug(myRight);
+		// logger.debug("---");
 		Metadata md;
 		MetadataType mdt;
 

--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -78,7 +78,7 @@ import de.sub.goobi.persistence.ProzessDAO;
  * @version 1.00 - 17.01.2005
  */
 public class Metadaten {
-	private static final Logger myLogger = Logger.getLogger(Metadaten.class);
+	private static final Logger logger = Logger.getLogger(Metadaten.class);
 	MetadatenImagesHelper imagehelper;
 	MetadatenHelper metahelper;
 	private boolean treeReloaden = false;
@@ -240,7 +240,7 @@ public class Metadaten {
 			md.setValue(this.curMetadatum.getMd().getValue());
 			this.myDocStruct.addMetadata(md);
 		} catch (MetadataTypeNotAllowedException e) {
-			myLogger.error("Fehler beim Kopieren von Metadaten (MetadataTypeNotAllowedException): " + e.getMessage());
+			logger.error("Fehler beim Kopieren von Metadaten (MetadataTypeNotAllowedException): " + e.getMessage());
 		}
 		MetadatenalsBeanSpeichern(this.myDocStruct);
 		if (!SperrungAktualisieren()) {
@@ -259,9 +259,9 @@ public class Metadaten {
 
 			this.myDocStruct.addPerson(per);
 		} catch (IncompletePersonObjectException e) {
-			myLogger.error("Fehler beim Kopieren von Personen (IncompletePersonObjectException): " + e.getMessage());
+			logger.error("Fehler beim Kopieren von Personen (IncompletePersonObjectException): " + e.getMessage());
 		} catch (MetadataTypeNotAllowedException e) {
-			myLogger.error("Fehler beim Kopieren von Personen (MetadataTypeNotAllowedException): " + e.getMessage());
+			logger.error("Fehler beim Kopieren von Personen (MetadataTypeNotAllowedException): " + e.getMessage());
 		}
 		MetadatenalsBeanSpeichern(this.myDocStruct);
 		if (!SperrungAktualisieren()) {
@@ -279,16 +279,16 @@ public class Metadaten {
 				MetadatenalsTree3Einlesen1();
 			} catch (DocStructHasNoTypeException e) {
 				Helper.setFehlerMeldung("Error while changing DocStructTypes (DocStructHasNoTypeException): ", e.getMessage());
-				myLogger.error("Error while changing DocStructTypes (DocStructHasNoTypeException): " + e.getMessage());
+				logger.error("Error while changing DocStructTypes (DocStructHasNoTypeException): " + e.getMessage());
 			} catch (MetadataTypeNotAllowedException e) {
 				Helper.setFehlerMeldung("Error while changing DocStructTypes (MetadataTypeNotAllowedException): ", e.getMessage());
-				myLogger.error("Error while changing DocStructTypes (MetadataTypeNotAllowedException): " + e.getMessage());
+				logger.error("Error while changing DocStructTypes (MetadataTypeNotAllowedException): " + e.getMessage());
 			} catch (TypeNotAllowedAsChildException e) {
 				Helper.setFehlerMeldung("Error while changing DocStructTypes (TypeNotAllowedAsChildException): ", e.getMessage());
-				myLogger.error("Error while changing DocStructTypes (TypeNotAllowedAsChildException): " + e.getMessage());
+				logger.error("Error while changing DocStructTypes (TypeNotAllowedAsChildException): " + e.getMessage());
 			} catch (TypeNotAllowedForParentException e) {
 				Helper.setFehlerMeldung("Error while changing DocStructTypes (TypeNotAllowedForParentException): ", e.getMessage());
-				myLogger.error("Error while changing DocStructTypes (TypeNotAllowedForParentException): " + e.getMessage());
+				logger.error("Error while changing DocStructTypes (TypeNotAllowedForParentException): " + e.getMessage());
 			}
 		}
 		return "Metadaten3links";
@@ -301,7 +301,7 @@ public class Metadaten {
 
 			this.myDocStruct.addMetadata(md);
 		} catch (MetadataTypeNotAllowedException e) {
-			myLogger.error("Error while adding metadata (MetadataTypeNotAllowedException): " + e.getMessage());
+			logger.error("Error while adding metadata (MetadataTypeNotAllowedException): " + e.getMessage());
 		}
 
 		/*
@@ -313,7 +313,7 @@ public class Metadaten {
 				md2.setValue(this.selectedMetadatum.getValue());
 				this.myDocStruct.addMetadata(md2);
 			} catch (MetadataTypeNotAllowedException e) {
-				myLogger.error("Error while adding title (MetadataTypeNotAllowedException): " + e.getMessage());
+				logger.error("Error while adding title (MetadataTypeNotAllowedException): " + e.getMessage());
 			}
 		}
 
@@ -483,7 +483,7 @@ public class Metadaten {
 				this.tempMetadatumList.add(mdum);
 
 			} catch (MetadataTypeNotAllowedException e) {
-				myLogger.error("Fehler beim sortieren der Metadaten: " + e.getMessage());
+				logger.error("Fehler beim sortieren der Metadaten: " + e.getMessage());
 			}
 		}
 		return myList;
@@ -602,7 +602,7 @@ public class Metadaten {
 			XMLlesenStart();
 		} catch (DAOException | IOException | InterruptedException | PreferencesException | ReadException |
 				 SwapException | WriteException e) {
-			myLogger.error(e);
+			logger.error(e);
 			Helper.setFehlerMeldung("metadataCorrupt", e);
 			return Helper.getRequestParameter("zurueck");
 		}
@@ -723,10 +723,10 @@ public class Metadaten {
 			new ProzessDAO().save(this.myProzess);
 		} catch (DAOException e) {
 			Helper.setFehlerMeldung("fehlerNichtSpeicherbar", e);
-			myLogger.error(e);
+			logger.error(e);
 		} catch (Exception e) {
 			Helper.setFehlerMeldung("error while counting current images", e);
-			myLogger.error(e);
+			logger.error(e);
 		}
 	}
 	
@@ -770,7 +770,7 @@ public class Metadaten {
 			this.myProzess.writeMetadataFile(this.gdzfile);
 		} catch (Exception e) {
 			Helper.setFehlerMeldung("fehlerNichtSpeicherbar", e);
-			myLogger.error(e);
+			logger.error(e);
 			result = false;
 
 		}
@@ -1009,8 +1009,8 @@ public class Metadaten {
 		try {
 			this.metahelper.KnotenUp(this.myDocStruct);
 		} catch (TypeNotAllowedAsChildException e) {
-			if(myLogger.isDebugEnabled()){
-				myLogger.debug("Fehler beim Verschieben des Knotens: " + e.getMessage());
+			if(logger.isDebugEnabled()){
+				logger.debug("Fehler beim Verschieben des Knotens: " + e.getMessage());
 			}
 		}
 		return MetadatenalsTree3Einlesen1();
@@ -1023,8 +1023,8 @@ public class Metadaten {
 		try {
 			this.metahelper.KnotenDown(this.myDocStruct);
 		} catch (TypeNotAllowedAsChildException e) {
-			if(myLogger.isDebugEnabled()){
-				myLogger.debug("Fehler beim Verschieben des Knotens: " + e.getMessage());
+			if(logger.isDebugEnabled()){
+				logger.debug("Fehler beim Verschieben des Knotens: " + e.getMessage());
 			}
 		}
 		return MetadatenalsTree3Einlesen1();
@@ -1039,7 +1039,7 @@ public class Metadaten {
 		this.myDocStruct.getParent().removeChild(this.myDocStruct);
 		this.tempStrukturelement.addChild(this.myDocStruct);
 		MetadatenalsTree3Einlesen1();
-		myLogger.debug(this.modusStrukturelementVerschieben);
+		logger.debug(this.modusStrukturelementVerschieben);
 		this.neuesElementWohin = "1";
 		return "Metadaten3links";
 	}
@@ -1090,7 +1090,7 @@ public class Metadaten {
 			}
 			DocStruct parent = this.myDocStruct.getParent();
 			if (parent == null) {
-				myLogger.debug("das gewählte Element kann den Vater nicht ermitteln");
+				logger.debug("das gewählte Element kann den Vater nicht ermitteln");
 				return "Metadaten3links";
 			}
 			List<DocStruct> alleDS = new ArrayList<DocStruct>();
@@ -1125,7 +1125,7 @@ public class Metadaten {
 			ds = this.mydocument.createDocStruct(dst);
 			DocStruct parent = this.myDocStruct.getParent();
 			if (parent == null) {
-				myLogger.debug("das gewählte Element kann den Vater nicht ermitteln");
+				logger.debug("das gewählte Element kann den Vater nicht ermitteln");
 				return "Metadaten3links";
 			}
 			List<DocStruct> alleDS = new ArrayList<DocStruct>();
@@ -1159,7 +1159,7 @@ public class Metadaten {
 			ds = this.mydocument.createDocStruct(dst);
 			DocStruct parent = this.myDocStruct;
 			if (parent == null) {
-				myLogger.debug("das gewählte Element kann den Vater nicht ermitteln");
+				logger.debug("das gewählte Element kann den Vater nicht ermitteln");
 				return "Metadaten3links";
 			}
 			List<DocStruct> alleDS = new ArrayList<DocStruct>();
@@ -1587,61 +1587,61 @@ public class Metadaten {
 	        /*
 	         * wenn die Bilder nicht angezeigt werden, brauchen wir auch das Bild nicht neu umrechnen
 	         */
-	        myLogger.trace("start BildErmitteln 1");
+	        logger.trace("start BildErmitteln 1");
 	        if (!this.bildAnzeigen) {
-	            myLogger.trace("end BildErmitteln 1");
+	            logger.trace("end BildErmitteln 1");
 	            return;
 	        }
-	        myLogger.trace("ocr BildErmitteln");
+	        logger.trace("ocr BildErmitteln");
 	        this.ocrResult = "";
 
-	        myLogger.trace("dataList");
+	        logger.trace("dataList");
 	        List<String> dataList = this.imagehelper.getImageFiles(mydocument.getPhysicalDocStruct());
-	        myLogger.trace("dataList 2");
+	        logger.trace("dataList 2");
 	        if (ConfigMain.getBooleanParameter(Parameters.WITH_AUTOMATIC_PAGINATION, true) && (dataList == null || dataList.isEmpty())) {
 	            try {
 	                createPagination();
 	                dataList = this.imagehelper.getImageFiles(mydocument.getPhysicalDocStruct());
 	            } catch (TypeNotAllowedForParentException e) {
-	                myLogger.error(e);
+	                logger.error(e);
 	            } catch (SwapException e) {
-	                myLogger.error(e);
+	                logger.error(e);
 	            } catch (DAOException e) {
-	                myLogger.error(e);
+	                logger.error(e);
 	            } catch (IOException e) {
-	                myLogger.error(e);
+	                logger.error(e);
 	            } catch (InterruptedException e) {
-	                myLogger.error(e);
+	                logger.error(e);
 	            }
 	        }
 	        if (dataList != null && dataList.size() > 0) {
-	            myLogger.trace("dataList not null");
+	            logger.trace("dataList not null");
 	            this.myBildLetztes = dataList.size();
-	            myLogger.trace("myBildLetztes");
+	            logger.trace("myBildLetztes");
 	            for (int i = 0; i < dataList.size(); i++) {
-	            	if(myLogger.isTraceEnabled()){
-	            		myLogger.trace("file: " + i);
+	            	if(logger.isTraceEnabled()){
+	            		logger.trace("file: " + i);
 	            	}
 	                if (this.myBild == null) {
 	                    this.myBild = dataList.get(0);
 	                }
-	                if(myLogger.isTraceEnabled()){
-	                	myLogger.trace("myBild: " + this.myBild);
+	                if(logger.isTraceEnabled()){
+	                	logger.trace("myBild: " + this.myBild);
 	                }
 	                String index = dataList.get(i).substring(0, dataList.get(i).lastIndexOf("."));
-	                if(myLogger.isTraceEnabled()){
-	                	myLogger.trace("index: " + index);
+	                if(logger.isTraceEnabled()){
+	                	logger.trace("index: " + index);
 	                }
 	                String myPicture = this.myBild.substring(0, this.myBild.lastIndexOf("."));
-	                if(myLogger.isTraceEnabled()){
-	                	myLogger.trace("myPicture: " + myPicture);
+	                if(logger.isTraceEnabled()){
+	                	logger.trace("myPicture: " + myPicture);
 	                }
 	                /* wenn das aktuelle Bild gefunden ist, das neue ermitteln */
 	                if (index.equals(myPicture)) {
-	                    myLogger.trace("index == myPicture");
+	                    logger.trace("index == myPicture");
 	                    int pos = i + welches;
-	                    if(myLogger.isTraceEnabled()){
-	                    	myLogger.trace("pos: " + pos);
+	                    if(logger.isTraceEnabled()){
+	                    	logger.trace("pos: " + pos);
 	                    }
 	                    /* aber keine Indexes ausserhalb des Array erlauben */
 	                    if (pos < 0) {
@@ -1651,8 +1651,8 @@ public class Metadaten {
 	                        pos = dataList.size() - 1;
 	                    }
 	                    if (this.currentTifFolder != null) {
-	                    	if(myLogger.isTraceEnabled()){
-	                    		myLogger.trace("currentTifFolder: " + this.currentTifFolder);
+	                    	if(logger.isTraceEnabled()){
+	                    		logger.trace("currentTifFolder: " + this.currentTifFolder);
 	                    	}
 	                        try {
 	                            dataList = this.imagehelper.getImageFiles(this.myProzess, this.currentTifFolder);
@@ -1660,8 +1660,8 @@ public class Metadaten {
 	                                return;
 	                            }
 	                        } catch (InvalidImagesException e1) {
-	                            myLogger.trace("dataList error");
-	                            myLogger.error("Images could not be read", e1);
+	                            logger.trace("dataList error");
+	                            logger.error("Images could not be read", e1);
 	                            Helper.setFehlerMeldung("images could not be read", e1);
 	                        }
 	                    }
@@ -1671,36 +1671,36 @@ public class Metadaten {
 	                    } else {
 	                        this.myBild = dataList.get(dataList.size() - 1);
 	                    }
-	                    myLogger.trace("found myBild");
+	                    logger.trace("found myBild");
 	                    /* die korrekte Seitenzahl anzeigen */
 	                    this.myBildNummer = pos + 1;
-	                    if(myLogger.isTraceEnabled()){
-	                    	myLogger.trace("myBildNummer: " + this.myBildNummer);
+	                    if(logger.isTraceEnabled()){
+	                    	logger.trace("myBildNummer: " + this.myBildNummer);
 	                    }
 	                    /* Pages-Verzeichnis ermitteln */
 	                    String myPfad = ConfigMain.getTempImagesPathAsCompleteDirectory();
-	                    if(myLogger.isTraceEnabled()){
-	                    	myLogger.trace("myPfad: " + myPfad);
+	                    if(logger.isTraceEnabled()){
+	                    	logger.trace("myPfad: " + myPfad);
 	                    }
 	                    /*
 	                     * den Counter für die Bild-ID auf einen neuen Wert setzen, damit nichts gecacht wird
 	                     */
 	                    this.myBildCounter++;
-	                    if(myLogger.isTraceEnabled()){
-	                    	myLogger.trace("myBildCounter: " + this.myBildCounter);
+	                    if(logger.isTraceEnabled()){
+	                    	logger.trace("myBildCounter: " + this.myBildCounter);
 	                    }
 
 	                    /* Session ermitteln */
 	                    FacesContext context = FacesContext.getCurrentInstance();
 	                    HttpSession session = (HttpSession) context.getExternalContext().getSession(false);
 	                    String mySession = session.getId() + "_" + this.myBildCounter + ".png";
-	                    myLogger.trace("facescontext");
+	                    logger.trace("facescontext");
 
 	                    /* das neue Bild zuweisen */
 	                    try {
 	                        String tiffconverterpfad = this.myProzess.getImagesDirectory() + this.currentTifFolder + File.separator + this.myBild;
-	                        if(myLogger.isTraceEnabled()){
-	                        	myLogger.trace("tiffconverterpfad: " + tiffconverterpfad);
+	                        if(logger.isTraceEnabled()){
+	                        	logger.trace("tiffconverterpfad: " + tiffconverterpfad);
 	                        }
 	                        if (!new SafeFile(tiffconverterpfad).exists()) {
 	                            tiffconverterpfad = this.myProzess.getImagesTifDirectory(true) + this.myBild;
@@ -1708,10 +1708,10 @@ public class Metadaten {
 	                                    + this.currentTifFolder + ", using image from " + new SafeFile(this.myProzess.getImagesTifDirectory(true)).getName());
 	                        }
 	                        this.imagehelper.scaleFile(tiffconverterpfad, myPfad + mySession, this.myBildGroesse, this.myImageRotation);
-	                        myLogger.trace("scaleFile");
+	                        logger.trace("scaleFile");
 	                    } catch (Exception e) {
 	                        Helper.setFehlerMeldung("could not find image folder", e);
-	                        myLogger.error(e);
+	                        logger.error(e);
 	                    }
 	                    break;
 	                }
@@ -1729,7 +1729,7 @@ public class Metadaten {
 			} 
 		} catch (Exception e) {
 			this.myBildNummer = -1;
-			myLogger.error(e);
+			logger.error(e);
 		}
 		/* wenn das Bild nicht existiert, den Status ändern */
 		if (!exists) {
@@ -1818,7 +1818,7 @@ public class Metadaten {
 				this.myDocStruct.addMetadata(mdDin);
 				this.myDocStruct.addMetadata(mdIso);
 			} catch (MetadataTypeNotAllowedException e) {
-				myLogger.error("Fehler beim Hinzufügen der Transliterationen (MetadataTypeNotAllowedException): " + e.getMessage());
+				logger.error("Fehler beim Hinzufügen der Transliterationen (MetadataTypeNotAllowedException): " + e.getMessage());
 			}
 		}
 		MetadatenalsBeanSpeichern(this.myDocStruct);
@@ -1854,7 +1854,7 @@ public class Metadaten {
 				this.myDocStruct.addPerson(mdDin);
 				this.myDocStruct.addPerson(mdIso);
 			} catch (MetadataTypeNotAllowedException e) {
-				myLogger.error("Fehler beim Hinzufügen der Transliterationen (MetadataTypeNotAllowedException): " + e.getMessage());
+				logger.error("Fehler beim Hinzufügen der Transliterationen (MetadataTypeNotAllowedException): " + e.getMessage());
 			}
 		}
 		MetadatenalsBeanSpeichern(this.myDocStruct);
@@ -2026,7 +2026,7 @@ public class Metadaten {
 	}
 
 	public List<String> getAjaxAlleSeiten(String prefix) {
-		myLogger.debug("Ajax-Liste abgefragt");
+		logger.debug("Ajax-Liste abgefragt");
 		List<String> li = new ArrayList<String>();
 		if (this.alleSeiten != null && this.alleSeiten.length > 0) {
 			for (int i = 0; i < this.alleSeiten.length; i++) {
@@ -2316,7 +2316,7 @@ public class Metadaten {
 			Metadata md = new Metadata(mdt);
 			this.selectedMetadatum = new MetadatumImpl(md, this.myMetadaten.size() + 1, this.myPrefs, this.myProzess);
 		} catch (MetadataTypeNotAllowedException e) {
-			myLogger.error(e.getMessage());
+			logger.error(e.getMessage());
 		}
 		this.tempTyp = tempTyp;
 	}
@@ -2469,7 +2469,7 @@ public class Metadaten {
 				BildErmitteln(0);
 			} catch (Exception e) {
 				Helper.setFehlerMeldung("Error while generating image", e.getMessage());
-				myLogger.error(e);
+				logger.error(e);
 			}
 		}
 	}
@@ -2871,13 +2871,13 @@ public class Metadaten {
         try {
             imageDirectory = myProzess.getImagesDirectory();
         } catch (SwapException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (DAOException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (IOException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (InterruptedException e) {
-            myLogger.error(e);
+            logger.error(e);
 
         }
         if (imageDirectory.equals("")) {
@@ -2908,13 +2908,13 @@ public class Metadaten {
                     }
                 }
             } catch (SwapException e) {
-                myLogger.error(e);
+                logger.error(e);
             } catch (DAOException e) {
-                myLogger.error(e);
+                logger.error(e);
             } catch (IOException e) {
-                myLogger.error(e);
+                logger.error(e);
             } catch (InterruptedException e) {
-                myLogger.error(e);
+                logger.error(e);
             }
 
         }
@@ -2942,13 +2942,13 @@ public class Metadaten {
                     }
                 }
             } catch (SwapException e) {
-                myLogger.error(e);
+                logger.error(e);
             } catch (DAOException e) {
-                myLogger.error(e);
+                logger.error(e);
             } catch (IOException e) {
-                myLogger.error(e);
+                logger.error(e);
             } catch (InterruptedException e) {
-                myLogger.error(e);
+                logger.error(e);
             }
             counter++;
         }
@@ -2989,13 +2989,13 @@ public class Metadaten {
                 }
             }
         } catch (SwapException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (DAOException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (IOException e) {
-            myLogger.error(e);
+            logger.error(e);
         } catch (InterruptedException e) {
-            myLogger.error(e);
+            logger.error(e);
         }
 
     }
@@ -3069,7 +3069,7 @@ public class Metadaten {
 		try {
 			myDocStruct.addMetadataGroup(newMetadataGroup.toMetadataGroup());
 		} catch (MetadataTypeNotAllowedException e) {
-			myLogger.error("Error while adding metadata (MetadataTypeNotAllowedException): " + e.getMessage());
+			logger.error("Error while adding metadata (MetadataTypeNotAllowedException): " + e.getMessage());
 		}
 		return showMetadata();
 	}
@@ -3186,7 +3186,7 @@ public class Metadaten {
 					.getProjekt().getTitel());
 		} catch (ConfigurationException e) {
 			Helper.setFehlerMeldung("Form_configuration_mismatch", e.getMessage());
-			myLogger.error(e.getMessage());
+			logger.error(e.getMessage());
 			return "";
 		}
 		modusHinzufuegen = false;

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenHelper.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenHelper.java
@@ -47,7 +47,7 @@ import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.HelperComparator;
 
 public class MetadatenHelper implements Comparator<Object> {
-	private static final Logger myLogger = Logger.getLogger(MetadatenHelper.class);
+	private static final Logger logger = Logger.getLogger(MetadatenHelper.class);
 	public static final int PAGENUMBER_FIRST = 0;
 	public static final int PAGENUMBER_LAST = 1;
 
@@ -298,7 +298,7 @@ public class MetadatenHelper implements Comparator<Object> {
 				newTypes.add(dst);
 			} else {
 				Helper.setMeldung(null, "Regelsatz-Fehler: ", " DocstructType " + tempTitel + " nicht definiert");
-				myLogger.error("getAddableDocStructTypen() - Regelsatz-Fehler: DocstructType " + tempTitel + " nicht definiert");
+				logger.error("getAddableDocStructTypen() - Regelsatz-Fehler: DocstructType " + tempTitel + " nicht definiert");
 			}
 		}
 
@@ -558,8 +558,8 @@ public class MetadatenHelper implements Comparator<Object> {
 				name1 = mdt1.getNameByLanguage(this.language);
 				name2 = mdt2.getNameByLanguage(this.language);
 			} catch (java.lang.NullPointerException e) {
-				if(myLogger.isDebugEnabled()){
-					myLogger.debug("Language " + language + " for metadata " + s1.getType() + " or " + s2.getType() + " is missing in ruleset");
+				if(logger.isDebugEnabled()){
+					logger.debug("Language " + language + " for metadata " + s1.getType() + " or " + s2.getType() + " is missing in ruleset");
 				}
 				return 0;
 			}

--- a/Goobi/src/de/sub/goobi/modul/ModulListener.java
+++ b/Goobi/src/de/sub/goobi/modul/ModulListener.java
@@ -19,19 +19,19 @@ import org.apache.log4j.Logger;
 import de.sub.goobi.forms.ModuleServerForm;
 
 public class ModulListener implements ServletContextListener {
-   private static final Logger myLogger = Logger.getLogger(ModulListener.class);
+   private static final Logger logger = Logger.getLogger(ModulListener.class);
 
    @Override
    public void contextInitialized(ServletContextEvent event) {
-      myLogger.debug("Starte Modularisierung-Server", null);
+      logger.debug("Starte Modularisierung-Server", null);
       new ModuleServerForm().startAllModules();
-      myLogger.debug("Gestartet: Modularisierung-Server", null);
+      logger.debug("Gestartet: Modularisierung-Server", null);
    }
 
    @Override
    public void contextDestroyed(ServletContextEvent event) {
-      myLogger.debug("Stoppe Modularisierung-Server", null);
+      logger.debug("Stoppe Modularisierung-Server", null);
       new ModuleServerForm().stopAllModules();
-      myLogger.debug("Gestoppt: Modularisierung-Server", null);
+      logger.debug("Gestoppt: Modularisierung-Server", null);
    }
 }

--- a/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpac.java
+++ b/Goobi/src/de/unigoettingen/sub/search/opac/ConfigOpac.java
@@ -36,7 +36,7 @@ import de.sub.goobi.helper.Helper;
 
 @XmlRootElement(name = "catalogueConfiguration")
 public class ConfigOpac {
-	private static final Logger myLogger = Logger.getLogger(ConfigOpac.class);
+	private static final Logger logger = Logger.getLogger(ConfigOpac.class);
 
 	private static XMLConfiguration config;
 
@@ -93,7 +93,7 @@ public class ConfigOpac {
 			myList.add(title);
 		}
 		} catch (Throwable t) {
-			myLogger.error("Error while reading von opac-config", t);
+			logger.error("Error while reading von opac-config", t);
 			Helper.setFehlerMeldung("Error while reading von opac-config", t.getMessage());
 		}
 		return myList;
@@ -112,7 +112,7 @@ public class ConfigOpac {
 			myList.add(title);
 		}
 		} catch (Throwable t) {
-			myLogger.error("Error while reading von opac-config", t);
+			logger.error("Error while reading von opac-config", t);
 			Helper.setFehlerMeldung("Error while reading von opac-config", t.getMessage());
 		}
 		return myList;
@@ -130,7 +130,7 @@ public class ConfigOpac {
 			myList.add(getDoctypeByName(title));
 		}
 		} catch (Throwable t) {
-			myLogger.error("Error while reading von opac-config", t);
+			logger.error("Error while reading von opac-config", t);
 			Helper.setFehlerMeldung("Error while reading von opac-config", t.getMessage());
 		}
 		return myList;

--- a/Goobi/src/org/goobi/io/BackupFileRotation.java
+++ b/Goobi/src/org/goobi/io/BackupFileRotation.java
@@ -36,7 +36,7 @@ import de.sub.goobi.helper.FilesystemHelper;
  */
 public class BackupFileRotation {
 
-	private static final Logger myLogger = Logger.getLogger(BackupFileRotation.class);
+	private static final Logger logger = Logger.getLogger(BackupFileRotation.class);
 
 	private int numberOfBackups;
 	private String format;
@@ -60,8 +60,8 @@ public class BackupFileRotation {
 		metaFiles = generateBackupBaseNameFileList(format, processDataDirectory);
 
 		if (metaFiles.length < 1) {
-			if(myLogger.isInfoEnabled()){
-				myLogger.info("No files matching format '" + format + "' in directory " + processDataDirectory + " found.");
+			if(logger.isInfoEnabled()){
+				logger.info("No files matching format '" + format + "' in directory " + processDataDirectory + " found.");
 			}
 			return;
 		}
@@ -112,7 +112,7 @@ public class BackupFileRotation {
 		File oldest = new File(fileName + "." + numberOfBackups);
 		if (oldest.exists() && !oldest.delete()) {
 			String message = "Could not delete " + oldest.getAbsolutePath();
-			myLogger.error(message);
+			logger.error(message);
 			throw new IOException(message);
 		}
 
@@ -122,8 +122,8 @@ public class BackupFileRotation {
 			try {
 				FilesystemHelper.renameFile(oldName, newName);
 			} catch (FileNotFoundException oldNameNotYetPresent) {
-				if(myLogger.isDebugEnabled()){
-					myLogger.debug(oldName + " does not yet exist >>> nothing to do");
+				if(logger.isDebugEnabled()){
+					logger.debug(oldName + " does not yet exist >>> nothing to do");
 				}
 				continue;
 			}

--- a/Goobi/src/org/goobi/io/SafeFile.java
+++ b/Goobi/src/org/goobi/io/SafeFile.java
@@ -40,7 +40,7 @@ import org.apache.log4j.Logger;
  */
 public class SafeFile implements Comparable<SafeFile> {
 
-	private static final Logger LOGGER = Logger.getLogger(SafeFile.class);
+	private static final Logger logger = Logger.getLogger(SafeFile.class);
 
 	private static final SafeFile[] NO_FILE = new SafeFile[0];
 
@@ -116,8 +116,8 @@ public class SafeFile implements Comparable<SafeFile> {
 	 * created.
 	 */
 	public void copyFile(SafeFile destFile, boolean preserveFileDate) throws IOException {
-		if (LOGGER.isDebugEnabled()) {
-			LOGGER.debug("copy " + delegate.getCanonicalPath() + " to " + destFile.delegate.getCanonicalPath());
+		if (logger.isDebugEnabled()) {
+			logger.debug("copy " + delegate.getCanonicalPath() + " to " + destFile.delegate.getCanonicalPath());
 		}
 		FileUtils.copyFile(delegate, destFile.delegate, preserveFileDate);
 	}

--- a/Goobi/src/org/goobi/production/chart/ProjectStatusDraw.java
+++ b/Goobi/src/org/goobi/production/chart/ProjectStatusDraw.java
@@ -39,7 +39,7 @@ import de.intranda.commons.chart.results.DataTable;
  * *************************************************************************************/
 
 public class ProjectStatusDraw {
-	private static final Logger myLogger = Logger.getLogger(ProjectStatusDraw.class);
+	private static final Logger logger = Logger.getLogger(ProjectStatusDraw.class);
 	private static final long MILLICSECS_PER_DAY = 1000 * 60 * 60 * 24;
 	private static final int BORDERTOP = 50;
 	private static int BORDERRIGHT = 50;
@@ -175,8 +175,8 @@ public class ProjectStatusDraw {
 		if (duration==0) {
 			duration=1;
 		}
-		if(myLogger.isDebugEnabled()){
-			myLogger.debug(datePosition + " / " + duration);
+		if(logger.isDebugEnabled()){
+			logger.debug(datePosition + " / " + duration);
 		}
 		float dash1[] = { 2.0f };
 		BasicStroke dashed = new BasicStroke(1.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND, 1.0f, dash1, 0.0f);

--- a/Goobi/src/org/goobi/production/cli/helper/CopyProcess.java
+++ b/Goobi/src/org/goobi/production/cli/helper/CopyProcess.java
@@ -72,7 +72,7 @@ import de.unigoettingen.sub.search.opac.ConfigOpacDoctype;
 
 public class CopyProcess extends ProzesskopieForm {
 
-	private static final Logger myLogger = Logger.getLogger(ProzesskopieForm.class);
+	private static final Logger logger = Logger.getLogger(ProzesskopieForm.class);
 	private Fileformat myRdf;
 	private String opacSuchfeld = "12";
 	private String opacSuchbegriff;
@@ -112,9 +112,9 @@ public class CopyProcess extends ProzesskopieForm {
 			this.myRdf = new MetsMods(myPrefs);
 			this.myRdf.read(this.metadataFile);
 		} catch (PreferencesException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (ReadException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 		;
 		this.prozessKopie = new Prozess();
@@ -155,9 +155,9 @@ public class CopyProcess extends ProzesskopieForm {
 			this.myRdf = new MetsMods(myPrefs);
 			this.myRdf.read(this.metadataFile);
 		} catch (PreferencesException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (ReadException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 		;
 		this.prozessKopie = new Prozess();
@@ -441,7 +441,7 @@ public class CopyProcess extends ProzesskopieForm {
 			removeCollections(colStruct);
 		} catch (PreferencesException e) {
 			Helper.setFehlerMeldung("Fehler beim Anlegen des Vorgangs", e);
-			myLogger.error("Fehler beim Anlegen des Vorgangs", e);
+			logger.error("Fehler beim Anlegen des Vorgangs", e);
 		} catch (RuntimeException e) {
 			/*
 			 * das Firstchild unterhalb des Topstructs konnte nicht ermittelt werden
@@ -617,7 +617,7 @@ public class CopyProcess extends ProzesskopieForm {
 			dao.refresh(this.prozessKopie);
 		} catch (DAOException e) {
 			e.printStackTrace();
-			myLogger.error("error on save: ", e);
+			logger.error("error on save: ", e);
 			return this.prozessKopie;
 		}
 
@@ -638,7 +638,7 @@ public class CopyProcess extends ProzesskopieForm {
 				new ProzessDAO().save(this.prozessKopie);
 			} catch (DAOException e) {
 				e.printStackTrace();
-				myLogger.error("error on save: ", e);
+				logger.error("error on save: ", e);
 				return this.prozessKopie;
 			}
 		}
@@ -694,7 +694,7 @@ public class CopyProcess extends ProzesskopieForm {
 			dao.refresh(this.prozessKopie);
 		} catch (DAOException e) {
 			e.printStackTrace();
-			myLogger.error("error on save: ", e);
+			logger.error("error on save: ", e);
 			return this.prozessKopie;
 		}
 
@@ -708,7 +708,7 @@ public class CopyProcess extends ProzesskopieForm {
 		File f = new File(this.prozessKopie.getProcessDataDirectoryIgnoreSwapping());
 		if (!f.exists() && !f.mkdir()) {
 			Helper.setFehlerMeldung("Could not create process directory");
-			myLogger.error("Could not create process directory");
+			logger.error("Could not create process directory");
 			return this.prozessKopie;
 		}
 		
@@ -724,7 +724,7 @@ public class CopyProcess extends ProzesskopieForm {
 				new ProzessDAO().save(this.prozessKopie);
 			} catch (DAOException e) {
 				e.printStackTrace();
-				myLogger.error("error on save: ", e);
+				logger.error("error on save: ", e);
 				return this.prozessKopie;
 			}
 		}
@@ -771,9 +771,9 @@ public class CopyProcess extends ProzesskopieForm {
 			ff = new MetsMods(myPrefs);
 			ff.read(this.metadataFile);
 		} catch (PreferencesException e) {
-			myLogger.error(e);
+			logger.error(e);
 		} catch (ReadException e) {
-			myLogger.error(e);
+			logger.error(e);
 		}
 
 	}
@@ -972,10 +972,10 @@ public class CopyProcess extends ProzesskopieForm {
 				}
 			}
 		} catch (JDOMException e1) {
-			myLogger.error("error while parsing digital collections", e1);
+			logger.error("error while parsing digital collections", e1);
 			Helper.setFehlerMeldung("Error while parsing digital collections", e1);
 		} catch (IOException e1) {
-			myLogger.error("error while parsing digital collections", e1);
+			logger.error("error while parsing digital collections", e1);
 			Helper.setFehlerMeldung("Error while parsing digital collections", e1);
 		}
 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
@@ -298,8 +298,8 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 		String headerFromSQL = new SQLStepRequestsImprovedDiscrimination(this.timeFilterFrom, this.timeFilterTo, null, this.myIDlist).getSQL(requestedType, null,
 				true, true);
 
-		this.logger.trace(natSQL);
-		this.logger.trace(headerFromSQL);
+		logger.trace(natSQL);
+		logger.trace(headerFromSQL);
 
 		return buildDataTableFromSQL(natSQL, headerFromSQL);
 	}
@@ -317,7 +317,7 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 		// adding time restrictions
 		String natSQL = new SQLStepRequests(this.timeFilterFrom, this.timeFilterTo, this.timeGrouping, this.myIDlist).getSQL(requestedType, step, true, this.flagIncludeLoops);
 
-		this.logger.trace(natSQL);
+		logger.trace(natSQL);
 
 		return buildDataTableFromSQL(natSQL, null);
 	}

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
@@ -71,7 +71,7 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 		this.flagIncludeLoops = includeLoops;
 	}
 
-	final private Logger myLogger = Logger.getLogger(StatQuestThroughput.class);
+	final private Logger logger = Logger.getLogger(StatQuestThroughput.class);
 
 	/*
 	 * (non-Javadoc)
@@ -298,8 +298,8 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 		String headerFromSQL = new SQLStepRequestsImprovedDiscrimination(this.timeFilterFrom, this.timeFilterTo, null, this.myIDlist).getSQL(requestedType, null,
 				true, true);
 
-		this.myLogger.trace(natSQL);
-		this.myLogger.trace(headerFromSQL);
+		this.logger.trace(natSQL);
+		this.logger.trace(headerFromSQL);
 
 		return buildDataTableFromSQL(natSQL, headerFromSQL);
 	}
@@ -317,7 +317,7 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 		// adding time restrictions
 		String natSQL = new SQLStepRequests(this.timeFilterFrom, this.timeFilterTo, this.timeGrouping, this.myIDlist).getSQL(requestedType, step, true, this.flagIncludeLoops);
 
-		this.myLogger.trace(natSQL);
+		this.logger.trace(natSQL);
 
 		return buildDataTableFromSQL(natSQL, null);
 	}

--- a/Goobi/src/org/goobi/webapi/dao/GoobiProcessDAO.java
+++ b/Goobi/src/org/goobi/webapi/dao/GoobiProcessDAO.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class GoobiProcessDAO {
 
-    private static final Logger myLogger = Logger.getLogger(GoobiProcessDAO.class);
+    private static final Logger logger = Logger.getLogger(GoobiProcessDAO.class);
 
     public static GoobiProcess getProcessByPPN(IdentifierPPN PPN) {
         Session session;
@@ -60,7 +60,7 @@ public class GoobiProcessDAO {
             result = (GoobiProcess) criteria.uniqueResult();
 
         } catch (HibernateException he) {
-            myLogger.error("Catched Hibernate exception: " + he.getMessage());
+            logger.error("Catched Hibernate exception: " + he.getMessage());
         }
 
         return result;
@@ -97,7 +97,7 @@ public class GoobiProcessDAO {
                 result.addAll(list);
             }
         } catch (HibernateException he) {
-            myLogger.error("Catched Hibernate exception: " + he.getMessage());
+            logger.error("Catched Hibernate exception: " + he.getMessage());
         }
 
         return result;
@@ -134,7 +134,7 @@ public class GoobiProcessDAO {
                 result.addAll(list);
             }
         } catch (HibernateException he) {
-            myLogger.error("Catched Hibernate exception: " + he.getMessage());
+            logger.error("Catched Hibernate exception: " + he.getMessage());
         }
 
         return result;


### PR DESCRIPTION
**The mess before:** Logger variable is 72× spelled `logger` ([preferable spelling](http://stackoverflow.com/q/1417190/1503237)), 35× `myLogger`, 1× `LOGGER`, 1× `modsLogger`. 3× loggers are declared `protected`, 3× subclasses use the logger of the parent class (logging the wrong class name, cannot be configured separately). 1× logger calls were qualified with `this.` prefix.

**After clean-up:** 112× `private static Logger logger`