### PR TITLE
use maven-eu repository instead of Jiha to provide quartz-all:1.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
             </snapshots>
         </repository>
         <repository>
-            <id>Jahia</id>
-            <name>Jahia Repository</name>
-            <url>http://maven.jahia.org/maven2/</url>
+            <id>maven-eu</id>
+            <name>maven-eu Repository</name>
+            <url>https://maven-eu.nuxeo.org/nexus/content/repositories/public/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
fixes #651 