### PR TITLE
Add OracleJDK and OpenJDK to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: java
 
+jdk:
+  - oraclejdk7
+  - openjdk7
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Without defining a JDK, travis is using his default JDK which could OracleJDK8.