### PR TITLE
Fix #617: Add image path to swapped files

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -2719,8 +2719,14 @@ public class Metadaten {
         String firstFile = firstpage.getImageName();
         String otherFile = secondpage.getImageName();
 
-        firstpage.setImageName(otherFile);
-        secondpage.setImageName(firstFile);
+        try {
+            File first = new File(myProzess.getImagesTifDirectory(true), otherFile);
+            File other = new File(myProzess.getImagesTifDirectory(true), firstFile);
+            firstpage.setImageName(first.toURI().toString());
+            secondpage.setImageName(other.toURI().toString());
+        } catch (InterruptedException | SwapException | DAOException | IOException e) {
+            logger.error("Could not determinate image directory!", e);
+        }
     }
 
     public void moveSeltectedPagesUp() {


### PR DESCRIPTION
Swapping files inside meta data editor ignores used image path. See method [switchFileNames](https://github.com/kitodo/kitodo-production/blob/kitodo-production-2.0.0/Goobi/src/de/sub/goobi/metadaten/Metadaten.java#L2753-L2759). Returned values from DocStruct method [getImageName() ](https://github.com/kitodo/kitodo-ugh/blob/kitodo-ugh-2.0.0/ugh/src/ugh/dl/DocStruct.java#L3786-L3799) contain only file name but no path to this files.

Other possible approach to fix that is to extend UGH library on class DocStruct for a method which returns file path.