### PR TITLE
Checkstyle and findbugs logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>3.0.4</version>
                 <configuration>
+                    <xmlOutput>true</xmlOutput>
                     <xmlOutputDirectory>target/findbugsreports</xmlOutputDirectory>
                     <effort>Max</effort>
                     <failOnError>false</failOnError>
@@ -121,6 +122,7 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
                         <phase>compile</phase>
                         <configuration>
                             <encoding>UTF-8</encoding>
-                            <consoleOutput>true</consoleOutput>
                             <failOnViolation>false</failOnViolation>
                             <failsOnError>false</failsOnError>
                             <maxAllowedViolations>3000</maxAllowedViolations>
@@ -115,10 +114,10 @@
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>3.0.4</version>
                 <configuration>
+                    <xmlOutputDirectory>target/findbugsreports</xmlOutputDirectory>
                     <effort>Max</effort>
                     <failOnError>false</failOnError>
-                    <threshold>Low</threshold>
-                    <xmlOutput>true</xmlOutput>
+                    <threshold>medium</threshold>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.4</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <failOnError>false</failOnError>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -127,31 +145,6 @@
                                 <goals>
                                     <goal>integration-test</goal>
                                     <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>findbugs</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>3.0.4</version>
-                        <configuration>
-                            <effort>Max</effort>
-                            <failOnError>false</failOnError>
-                            <threshold>Low</threshold>
-                            <xmlOutput>true</xmlOutput>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>check</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
remove checkstyle log errors from console. Only show critical errors for findbugs.