### PR TITLE
Solve TravisCI build warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 
 before_script:
   - cp config/database.yml.travis config/database.yml
+  - cp Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.travis Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
   - mysql -u root -e 'CREATE DATABASE kitodo;'
   - mysql -u root -e "CREATE USER 'kitodo'@'localhost' IDENTIFIED BY 'kitodo';"
   - mysql -u root -e "GRANT ALL ON kitodo.* TO 'kitodo'@'localhost';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ before_script:
   - mysql -u root -e 'CREATE DATABASE kitodo;'
   - mysql -u root -e "CREATE USER 'kitodo'@'localhost' IDENTIFIED BY 'kitodo';"
   - mysql -u root -e "GRANT ALL ON kitodo.* TO 'kitodo'@'localhost';"
+  - mysql -u root kitodo < Kitodo/setup/schema.sql

--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -25,8 +25,6 @@
     <name>Kitodo - API</name>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
         <parent.basedir>${basedir}/../</parent.basedir>
     </properties>
 </project>

--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -27,8 +27,6 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <parent.basedir>${basedir}/../</parent.basedir>
     </properties>
 </project>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -33,8 +33,6 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <parent.basedir>${basedir}/../</parent.basedir>
         <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
         <phase.prop>install</phase.prop>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -31,8 +31,6 @@
     <url>https://github.com/kitodo/kitodo-production</url>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
         <parent.basedir>${basedir}/../</parent.basedir>
         <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
         <phase.prop>install</phase.prop>

--- a/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.travis
+++ b/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.travis
@@ -1,0 +1,4 @@
+flyway.user=kitodo
+flyway.password=kitodo
+flyway.url=jdbc:mysql://localhost/kitodo
+flyway.locations=filesystem:Kitodo-DataManagement/src/main/resources/db/migration

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -28,8 +28,6 @@
     <url>https://github.com/kitodo/kitodo-production</url>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
         <parent.basedir>${basedir}/../</parent.basedir>
         <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
     </properties>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -30,8 +30,6 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <parent.basedir>${basedir}/../</parent.basedir>
         <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
     </properties>

--- a/OpacPica-Plugin/pom.xml
+++ b/OpacPica-Plugin/pom.xml
@@ -28,8 +28,6 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <parent.basedir>${basedir}/../</parent.basedir>
         <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
     </properties>

--- a/OpacPica-Plugin/pom.xml
+++ b/OpacPica-Plugin/pom.xml
@@ -26,8 +26,6 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
         <parent.basedir>${basedir}/../</parent.basedir>
         <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <phase.prop>none</phase.prop>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <checkstyle.config.location>config/checkstyle.xml</checkstyle.config.location>
         <parent.basedir>${basedir}</parent.basedir>
         <phase.prop>none</phase.prop>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Fixing two warnings from TravisCI run:
- `[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent! The file encoding for reports output files should be provided by the POM property ${project.reporting.outputEncoding}.`
- `[WARNING] Unable to resolve location filesystem:../Kitodo-DataManagement/src/main/resources/db/migration`