### PR TITLE
Disallow null returns from Searcher methods

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
@@ -77,7 +77,7 @@ public class Searcher extends Index {
      */
     public SearchResult findDocument(String query) throws IOException, ParseException {
         SearchRestClient restClient = initiateRestClient();
-        SearchResult searchResult;
+        SearchResult searchResult = new SearchResult();
         JSONParser parser = new JSONParser();
 
         String response = restClient.getDocument(query);
@@ -85,7 +85,9 @@ public class Searcher extends Index {
         if (jsonObject.containsKey("hits")) {
             JSONObject hits = (JSONObject) jsonObject.get("hits");
             JSONArray inHits = (JSONArray) hits.get("hits");
-            searchResult = convertJsonStringToSearchResult((JSONObject) inHits.get(0));
+            if (!inHits.isEmpty()) {
+                searchResult = convertJsonStringToSearchResult((JSONObject) inHits.get(0));
+            }
         } else {
             searchResult = convertJsonStringToSearchResult(jsonObject);
         }
@@ -109,8 +111,10 @@ public class Searcher extends Index {
         if (jsonObject.containsKey("hits")) {
             JSONObject hits = (JSONObject) jsonObject.get("hits");
             JSONArray inHits = (JSONArray) hits.get("hits");
-            for (Object hit : inHits) {
-                searchResults.add(convertJsonStringToSearchResult((JSONObject) hit));
+            if (!inHits.isEmpty()) {
+                for (Object hit : inHits) {
+                    searchResults.add(convertJsonStringToSearchResult((JSONObject) hit));
+                }
             }
         } else {
             searchResults.add(convertJsonStringToSearchResult(jsonObject));

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearcherIT.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearcherIT.java
@@ -43,7 +43,7 @@ public class SearcherIT {
     }
 
     @Test
-    public void shouldGetDocumentById() throws Exception {
+    public void shouldFindDocumentById() throws Exception {
         Searcher searcher = new Searcher("testget");
         SearchResult result = searcher.findDocument(1);
 
@@ -52,7 +52,7 @@ public class SearcherIT {
     }
 
     @Test
-    public void shouldGetDocumentByQuery() throws Exception {
+    public void shouldFindDocumentByQuery() throws Exception {
         Thread.sleep(2000);
         Searcher searcher = new Searcher("testget");
 
@@ -69,10 +69,15 @@ public class SearcherIT {
         assertEquals("Incorrect result - id doesn't match to given plain text!", 1, id.intValue());
         title = result.getProperties().get("title");
         assertEquals("Incorrect result - title doesn't match to given plain text!", "Batch1", title);
+
+        query = "{\n\"query\" : {\n\"match\" : {\n\"title\" : \"Nonexistent\"}\n}\n}";
+        result = searcher.findDocument(query);
+        id = result.getId();
+        assertEquals("Incorrect result - id has another value than null!", null, id);
     }
 
     @Test
-    public void shouldGetDocumentsByQuery() throws Exception {
+    public void shouldFindDocumentsByQuery() throws Exception {
         Thread.sleep(2000);
         Searcher searcher = new Searcher("testget");
 
@@ -88,9 +93,13 @@ public class SearcherIT {
         result = searcher.findDocuments(query);
         id = result.get(0).getId();
         assertEquals("Incorrect result - id doesn't match to given int values!", 1, id.intValue());
-
         size = result.size();
         assertEquals("Incorrect result - size doesn't match to given int value!", 1, size);
+
+        query = "{\n\"query\" : {\n\"match\" : {\n\"title\" : \"Nonexistent\"}\n}\n}";
+        result = searcher.findDocuments(query);
+        size = result.size();
+        assertEquals("Incorrect result - size is bigger than 0!", 0, size);
     }
 
     private static IndexRestClient initializeIndexRestClient() {


### PR DESCRIPTION
Remove possiblity of null returns from findDocument(s) methods and add tests to check it.