### PR TITLE
Switch to JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ language: java
 
 cache:
 
+dist: trusty
+
+jdk:
+  - oraclejdk8
+  - openjdk8
+
 sudo: required
 
 env: DB=mysql

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
         <phase.prop>none</phase.prop>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Use JDK8 (implemented by OpenJDK8 and OracleJDK8) as new base for further development.
