### PR TITLE
Use TravisCI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 language: java
 
 cache:
+  directories:
+    - $HOME/.m2
 
 dist: trusty
 


### PR DESCRIPTION
With switching to Maven as build tool a lot of data is downloaded every time on every build run. With a cache directory which store downloaded files the build process should go faster and with less lines on build log.

This pull request depends on #768 .