### PR TITLE
Fix #356: Export errors should not close step

### DIFF
--- a/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
@@ -258,7 +258,7 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 
             /* ggf. sollen im Export mets und rdf geschrieben werden */
             if (MetadataFormat.findFileFormatsHelperByName(this.project.getFileFormatDmsExport()) == MetadataFormat.METS_AND_RDF) {
-                writeWasSuccessful = writeMetsFile(process, benutzerHome + File.separator + atsPpnBand + ".mets.xml", gdzfile, false);
+                writeWasSuccessful &= writeMetsFile(process, benutzerHome + File.separator + atsPpnBand + ".mets.xml", gdzfile, false);
             }
 
             if (!writeWasSuccessful) {

--- a/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
@@ -245,21 +245,27 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
             if (task != null) {
                 task.setWorkDetail(atsPpnBand + ".xml");
             }
+
+            boolean writeWasSuccessful;
+
             if (MetadataFormat.findFileFormatsHelperByName(this.project.getFileFormatDmsExport()) == MetadataFormat.METS) {
                 /* Wenn METS, dann per writeMetsFile schreiben... */
-                writeMetsFile(process, benutzerHome + File.separator + atsPpnBand + ".xml", gdzfile, false);
+                writeWasSuccessful = writeMetsFile(process, benutzerHome + File.separator + atsPpnBand + ".xml", gdzfile, false);
             } else {
                 /* ...wenn nicht, nur ein Fileformat schreiben. */
-                gdzfile.write(benutzerHome + File.separator + atsPpnBand + ".xml");
+                writeWasSuccessful = gdzfile.write(benutzerHome + File.separator + atsPpnBand + ".xml");
             }
 
             /* ggf. sollen im Export mets und rdf geschrieben werden */
             if (MetadataFormat.findFileFormatsHelperByName(this.project.getFileFormatDmsExport()) == MetadataFormat.METS_AND_RDF) {
-                writeMetsFile(process, benutzerHome + File.separator + atsPpnBand + ".mets.xml", gdzfile, false);
+                writeWasSuccessful = writeMetsFile(process, benutzerHome + File.separator + atsPpnBand + ".mets.xml", gdzfile, false);
+            }
+
+            if (!writeWasSuccessful) {
+                return false;
             }
 
             Helper.setMeldung(null, process.getTitle() + ": ", "DMS-Export started");
-
 
             if (!ConfigMain.getBooleanParameter("exportWithoutTimeLimit")) {
 

--- a/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
+++ b/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
@@ -359,7 +359,7 @@ public class ExportDms extends ExportMets {
             /* ggf. sollen im Export mets und rdf geschrieben werden */
             if (MetadataFormat.findFileFormatsHelperByName(myProzess
                     .getProjekt().getFileFormatDmsExport()) == MetadataFormat.METS_AND_RDF) {
-                writeWasSuccessful = writeMetsFile(myProzess, benutzerHome + File.separator
+                writeWasSuccessful &= writeMetsFile(myProzess, benutzerHome + File.separator
                         + atsPpnBand + ".mets.xml", gdzfile, false);
             }
 

--- a/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
+++ b/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
@@ -332,6 +332,8 @@ public class ExportDms extends ExportMets {
             return false;
         }
 
+        boolean writeWasSuccessful;
+
         /*
          * -------------------------------- zum Schluss Datei an gewünschten Ort
          * exportieren entweder direkt in den Import-Ordner oder ins
@@ -342,22 +344,27 @@ public class ExportDms extends ExportMets {
             if (exportDmsTask != null) {
                 exportDmsTask.setWorkDetail(atsPpnBand + ".xml");
             }
+
             if (MetadataFormat.findFileFormatsHelperByName(myProzess
                     .getProjekt().getFileFormatDmsExport()) == MetadataFormat.METS) {
                 /* Wenn METS, dann per writeMetsFile schreiben... */
-                writeMetsFile(myProzess, benutzerHome + File.separator
+                writeWasSuccessful = writeMetsFile(myProzess, benutzerHome + File.separator
                         + atsPpnBand + ".xml", gdzfile, false);
             } else {
                 /* ...wenn nicht, nur ein Fileformat schreiben. */
-                gdzfile.write(benutzerHome + File.separator + atsPpnBand
+                writeWasSuccessful = gdzfile.write(benutzerHome + File.separator + atsPpnBand
                         + ".xml");
             }
 
             /* ggf. sollen im Export mets und rdf geschrieben werden */
             if (MetadataFormat.findFileFormatsHelperByName(myProzess
                     .getProjekt().getFileFormatDmsExport()) == MetadataFormat.METS_AND_RDF) {
-                writeMetsFile(myProzess, benutzerHome + File.separator
+                writeWasSuccessful = writeMetsFile(myProzess, benutzerHome + File.separator
                         + atsPpnBand + ".mets.xml", gdzfile, false);
+            }
+
+            if(!writeWasSuccessful) {
+                return false;
             }
 
             Helper.setMeldung(null, myProzess.getTitel() + ": ",
@@ -415,10 +422,14 @@ public class ExportDms extends ExportMets {
             /* ohne Agora-Import die xml-Datei direkt ins Home schreiben */
             if (MetadataFormat.findFileFormatsHelperByName(myProzess
                     .getProjekt().getFileFormatDmsExport()) == MetadataFormat.METS) {
-                writeMetsFile(myProzess, zielVerzeichnis + atsPpnBand + ".xml",
+                writeWasSuccessful = writeMetsFile(myProzess, zielVerzeichnis + atsPpnBand + ".xml",
                         gdzfile, false);
             } else {
-                gdzfile.write(zielVerzeichnis + atsPpnBand + ".xml");
+                writeWasSuccessful = gdzfile.write(zielVerzeichnis + atsPpnBand + ".xml");
+            }
+
+            if (!writeWasSuccessful) {
+                return false;
             }
 
             Helper.setMeldung(null, myProzess.getTitel() + ": ",


### PR DESCRIPTION
On automatic export errors which are not thrown by exception are resulting in successful closed steps. Reasons for this is that return value of file write methods are not evaluated.

This changes should fix #356 .