### PR TITLE
Change log level to info on test runs

### DIFF
--- a/Kitodo-DataManagement/src/test/resources/log4j2.properties
+++ b/Kitodo-DataManagement/src/test/resources/log4j2.properties
@@ -15,7 +15,7 @@ name = PropertiesConfig
 filters = threshold
 
 filter.threshold.type = ThresholdFilter
-filter.threshold.level = debug
+filter.threshold.level = info
 
 appenders = console
 
@@ -24,6 +24,6 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = debug
+rootLogger.level = info
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.stdout.ref = STDOUT

--- a/Kitodo/src/test/resources/log4j2.properties
+++ b/Kitodo/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@ name = PropertiesConfig
 filters = threshold
 
 filter.threshold.type = ThresholdFilter
-filter.threshold.level = debug
+filter.threshold.level = info
 
 appenders = console
 
@@ -25,6 +25,6 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = debug
+rootLogger.level = info
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
Running all tests it creates a lot of debug messages on default. This causes troubles on Travis systems as there only 4 MB of log files are stored. If a test is failing at the end of tests then this test error messages are not visible. Changing log level to info solves this.