### PR TITLE
Prevent wrong JDK usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
       - ant-optional
       - tomcat7-common
 
+sudo: required
+
 cache:
 
 env:


### PR DESCRIPTION
Travis CI trusty environment has currently a [bug](https://github.com/travis-ci/travis-ci/issues/7742) that is preventing usage of JDK7 without using `sudo:required` in Travis configuration.

My Travis runs for issue [356](https://travis-ci.org/henning-gerhardt/kitodo-production/builds/232734857) and [617](https://travis-ci.org/henning-gerhardt/kitodo-production/builds/232735024) are effected by this bug but for a unknown reason not the open pull requests on Kitodo.Production.