### PR TITLE
Change long to int in count methods

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
@@ -231,10 +231,10 @@ public abstract class BaseDAO implements Serializable {
      * @throws DAOException
      *             add description
      */
-    protected Long retrieveAmount(String query) throws DAOException {
+    protected Integer retrieveAmount(String query) throws DAOException {
         try {
             Session session = Helper.getHibernateSession();
-            return (Long) session.createQuery("select count(*) " + query).uniqueResult();
+            return (Integer) session.createQuery("select count(*) " + query).uniqueResult();
         } catch (HibernateException he) {
             throw new DAOException(he);
         }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DocketDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DocketDAO.java
@@ -77,7 +77,7 @@ public class DocketDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/HistoryDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/HistoryDAO.java
@@ -91,7 +91,7 @@ public class HistoryDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProcessDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProcessDAO.java
@@ -104,7 +104,7 @@ public class ProcessDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProjectDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProjectDAO.java
@@ -84,7 +84,7 @@ public class ProjectDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProjectFileGroupDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProjectFileGroupDAO.java
@@ -88,7 +88,7 @@ public class ProjectFileGroupDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/PropertyDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/PropertyDAO.java
@@ -98,7 +98,7 @@ public class PropertyDAO extends BaseDAO {
      *            as String
      * @return amount of objects as Long
      */
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RulesetDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RulesetDAO.java
@@ -75,7 +75,7 @@ public class RulesetDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TaskDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TaskDAO.java
@@ -88,7 +88,7 @@ public class TaskDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TemplateDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TemplateDAO.java
@@ -87,7 +87,7 @@ public class TemplateDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserDAO.java
@@ -114,7 +114,7 @@ public class UserDAO extends BaseDAO {
         return retrieveObjects(query, namedParameter, parameter);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserGroupDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserGroupDAO.java
@@ -77,7 +77,7 @@ public class UserGroupDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkpieceDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkpieceDAO.java
@@ -87,7 +87,7 @@ public class WorkpieceDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return retrieveAmount(query);
     }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/StatistikForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/StatistikForm.java
@@ -59,7 +59,7 @@ public class StatistikForm {
      *             thrown while performing the rollback.
      */
 
-    public Long getAnzahlBenutzer() {
+    public Integer getAnzahlBenutzer() {
         try {
             return serviceManager.getUserService().count("from User where visible is null");
         } catch (DAOException e) {
@@ -73,7 +73,7 @@ public class StatistikForm {
      *
      * @return Anzahl der Benutzer
      */
-    public Long getAnzahlBenutzergruppen() {
+    public Integer getAnzahlBenutzergruppen() {
         try {
             return serviceManager.getUserService().count("from UserGroup");
         } catch (DAOException e) {
@@ -87,7 +87,7 @@ public class StatistikForm {
      *
      * @return amount of processes
      */
-    public Long getAnzahlProzesse() {
+    public Integer getAnzahlProzesse() {
         try {
             return serviceManager.getProcessService().count("from Process");
         } catch (DAOException e) {
@@ -101,13 +101,13 @@ public class StatistikForm {
      *
      * @return amount of tasks
      */
-    public Long getAnzahlSchritte() {
+    public Integer getAnzahlSchritte() {
         try {
             return serviceManager.getTaskService().count("from Task");
         } catch (DAOException e) {
             logger.error("Hibernate error", e);
             Helper.setFehlerMeldung("fehlerBeimEinlesen", e);
-            return Long.valueOf(-1);
+            return -1;
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/DocketService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/DocketService.java
@@ -110,7 +110,7 @@ public class DocketService extends TitleSearchService<Docket> {
         return docketDAO.search(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return docketDAO.count(query);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
@@ -220,7 +220,7 @@ public class ProcessService extends TitleSearchService<Process> {
         return processDAO.search(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return processDAO.count(query);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/TaskService.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.Session;
-import org.kitodo.data.database.beans.Property;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.helper.enums.TaskStatus;
@@ -112,7 +111,7 @@ public class TaskService extends TitleSearchService<Task> {
         return taskDAO.search(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return taskDAO.count(query);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/UserGroupService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/UserGroupService.java
@@ -128,7 +128,7 @@ public class UserGroupService extends TitleSearchService<UserGroup> {
         return userGroupDAO.search(query);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return userGroupDAO.count(query);
     }
 
@@ -139,7 +139,8 @@ public class UserGroupService extends TitleSearchService<UserGroup> {
      *            of the searched user group
      * @return list of search results
      */
-    public List<SearchResult> findByPermission(Integer permission) throws CustomResponseException, IOException, ParseException {
+    public List<SearchResult> findByPermission(Integer permission)
+            throws CustomResponseException, IOException, ParseException {
         QueryBuilder query = createSimpleQuery("permission", permission, true);
         return searcher.findDocuments(query.toString());
     }

--- a/Kitodo/src/main/java/org/kitodo/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/UserService.java
@@ -20,9 +20,7 @@ import de.sub.goobi.helper.ldap.Ldap;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -174,7 +172,7 @@ public class UserService extends SearchService<User> {
         return userDAO.search(query, namedParameter, parameter);
     }
 
-    public Long count(String query) throws DAOException {
+    public Integer count(String query) throws DAOException {
         return userDAO.count(query);
     }
 
@@ -561,7 +559,8 @@ public class UserService extends SearchService<User> {
     /**
      * Adds a new filter to list.
      *
-     * @param user object
+     * @param user
+     *            object
      * @param filter
      *            the filter to add
      */
@@ -579,7 +578,8 @@ public class UserService extends SearchService<User> {
     /**
      * Removes filter from list.
      *
-     * @param user objec
+     * @param user
+     *            objec
      * @param filter
      *            the filter to remove
      */
@@ -620,8 +620,7 @@ public class UserService extends SearchService<User> {
      * @param filter
      *            String
      */
-    private void addFilterToUser(User user, String filter)
-            throws CustomResponseException, DAOException, IOException {
+    private void addFilterToUser(User user, String filter) throws CustomResponseException, DAOException, IOException {
         LocalDateTime localDateTime = new LocalDateTime();
         Property property = new Property();
         property.setTitle("_filter");


### PR DESCRIPTION
A count method should always return int, because the amount of entries in a database is always an integer.