### PR TITLE
Add missing alt attribute to images

### DIFF
--- a/Kitodo/src/main/webapp/newpages/BatchProperties.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BatchProperties.xhtml
@@ -138,7 +138,7 @@
 
                                                                                 <h:commandLink action="BatchProperties"
                                                                                                title="#{msgs.bearbeiten}">
-                                                                                    <h:graphicImage
+                                                                                    <h:graphicImage alt="edit"
                                                                                             value="/newpages/images/buttons/edit.gif"/>
                                                                                     <t:updateActionListener
                                                                                             property="#{BatchForm.batchHelper.processProperty}"
@@ -183,7 +183,7 @@
                                                                                     <h:panelGroup>
                                                                                         <h:commandLink action="BatchProperties"
                                                                                                        title="#{msgs.bearbeiten}">
-                                                                                            <h:graphicImage
+                                                                                            <h:graphicImage alt="edit"
                                                                                                     value="/newpages/images/buttons/edit.gif"/>
                                                                                             <t:updateActionListener
                                                                                                     property="#{BatchForm.batchHelper.container}"

--- a/Kitodo/src/main/webapp/newpages/BatchesAll.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BatchesAll.xhtml
@@ -199,21 +199,21 @@
                                                     </h:commandLink>
 
                                                     <h:commandLink action="#{BatchForm.downloadDocket}">
-                                                        <h:graphicImage alt="/newpages/images/buttons/laufzettel_wide.png"
+                                                        <h:graphicImage alt="download docket"
                                                                         value="/newpages/images/buttons/laufzettel_wide.png"
                                                                         style="vertical-align:middle"/>
                                                         <h:outputText value="#{msgs.laufzettelDrucken}"/>
                                                     </h:commandLink>
 
                                                     <h:commandLink action="#{BatchForm.editProperties}">
-                                                        <h:graphicImage alt="edit" value="/newpages/images/buttons/edit.gif"
+                                                        <h:graphicImage alt="edit batch properties" value="/newpages/images/buttons/edit.gif"
                                                                         style="vertical-align:middle"/>
                                                         <h:outputText value="#{msgs.eigenschaftBearbeiten}"/>
                                                     </h:commandLink>
 
                                                     <h:commandLink action="#{BatchForm.deleteBatch}"
                                                                    style="margin-left:7px;">
-                                                        <h:graphicImage alt="deleteBatch"
+                                                        <h:graphicImage alt="delete batch"
                                                                         value="/newpages/images/buttons/waste1a_20px.gif"
                                                                         style="vertical-align:middle;margin-right:7px"/>
                                                         <h:outputText value="#{msgs.deleteBatch}"/>
@@ -243,20 +243,21 @@
 
                                                 <h:panelGrid columns="1" cellpadding="2px">
                                                     <h:commandLink action="#{BatchForm.loadBatchData}">
-                                                        <h:graphicImage alt="reload"
+                                                        <h:graphicImage alt="reload batch data"
                                                                         value="/newpages/images/buttons/reload_doc.gif"
                                                                         style="vertical-align:middle"/>
                                                         <h:outputText value="#{msgs.loadAssociatedBatchOfProcess}"/>
                                                     </h:commandLink>
 
                                                     <h:commandLink action="#{BatchForm.addProcessesToBatch}">
-                                                        <h:graphicImage alt="add" value="/newpages/images/buttons/ok.gif"
+                                                        <h:graphicImage alt="add processes to batch"
+                                                                        value="/newpages/images/buttons/ok.gif"
                                                                         style="vertical-align:middle"/>
                                                         <h:outputText value="#{msgs.addToSelectedBatch}"/>
                                                     </h:commandLink>
 
                                                     <h:commandLink action="#{BatchForm.removeProcessesFromBatch}">
-                                                        <h:graphicImage alt="remove"
+                                                        <h:graphicImage alt="remove processes from batch"
                                                                         value="/newpages/images/buttons/cancel1.gif"
                                                                         style="vertical-align:middle"/>
                                                         <h:outputText value="#{msgs.removeFromAssociatedBatch}"/>

--- a/Kitodo/src/main/webapp/newpages/BenutzerAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerAlle.xhtml
@@ -101,7 +101,7 @@
                                                 <h:commandLink
                                                         action="#{BenutzerverwaltungForm.filterAlleStart}"
                                                         title="#{msgs.filterAnwenden}" style="margin-left:5px">
-                                                    <h:graphicImage id="id13"
+                                                    <h:graphicImage id="id13" alt="reload"
                                                                     value="/newpages/images/buttons/reload.gif"/>
                                                 </h:commandLink>
 
@@ -175,7 +175,7 @@
                                                 <!-- Bearbeiten-Schaltknopf -->
                                                 <h:commandLink id="id32" action="BenutzerBearbeiten"
                                                                title="#{msgs.benutzerBearbeiten}">
-                                                    <h:graphicImage id="id33"
+                                                    <h:graphicImage id="id33" alt="edit"
                                                                     value="/newpages/images/buttons/edit.gif"/>
                                                     <t:updateActionListener
                                                             property="#{BenutzerverwaltungForm.myClass}"
@@ -193,7 +193,7 @@
                                                 <!-- Benutzerprofil laden-Schaltknopf -->
                                                 <h:commandLink id="id36" title="#{msgs.benutzerprofilLaden}"
                                                                action="#{LoginForm.EinloggenAls}" style="margin-left:15px">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="load user profile"
                                                             value="/newpages/images/buttons/change_user3_20px.gif"/>
                                                     <f:param id="id37" name="ID" value="#{item.id}"/>
                                                 </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/BenutzerBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerBearbeiten.xhtml
@@ -77,7 +77,8 @@
                                                 </td>
                                                 <td class="eingabeBoxen_row1" align="right">
                                                     <h:commandLink id="id10" action="#{NavigationForm.Reload}">
-                                                        <h:graphicImage id="id11" value="/newpages/images/reload.gif"/>
+                                                        <h:graphicImage alt="reload" id="id11"
+                                                                        value="/newpages/images/reload.gif"/>
                                                     </h:commandLink>
                                                 </td>
                                             </tr>
@@ -170,7 +171,7 @@
                                                             <h:commandLink id="id32" title="#{msgs.ldapKonfigurationSchreiben}"
                                                                            action="#{BenutzerverwaltungForm.ldapKonfigurationSchreiben}"
                                                                            rendered="#{BenutzerverwaltungForm.myClass.id != null}">
-                                                                <h:graphicImage id="id33"
+                                                                <h:graphicImage alt="save configuration" id="id33"
                                                                                 value="/newpages/images/buttons/key3.gif"/>
                                                                 <t:updateActionListener
                                                                         property="#{BenutzerverwaltungForm.myClass}"
@@ -242,7 +243,7 @@
                                                                 <h:commandLink
                                                                         action="#{BenutzerverwaltungForm.deleteFromGroup}"
                                                                         title="#{msgs.ausGruppeLoeschen}">
-                                                                    <h:graphicImage id="id49"
+                                                                    <h:graphicImage alt="delete from group" id="id49"
                                                                                     value="images/buttons/waste1a_20px.gif"/>
                                                                     <f:param id="id50" name="ID" value="#{item.id}"/>
                                                                 </h:commandLink>
@@ -280,7 +281,7 @@
                                                                 <h:commandLink
                                                                         action="#{BenutzerverwaltungForm.ausProjektLoeschen}"
                                                                         title="#{msgs.ausProjektLoeschen}">
-                                                                    <h:graphicImage id="id56"
+                                                                    <h:graphicImage alt="delete from project" id="id56"
                                                                                     value="images/buttons/waste1a_20px.gif"/>
                                                                     <f:param id="id57" name="ID" value="#{item.id}"/>
                                                                 </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/BenutzerBearbeitenPopup.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerBearbeitenPopup.xhtml
@@ -81,7 +81,7 @@
                                     <h:commandLink
                                             action="#{BenutzerverwaltungForm.addToGroup}"
                                             title="#{msgs.uebernehmen}">
-                                        <h:graphicImage id="id14" value="/newpages/images/buttons/addUser.gif"/>
+                                        <h:graphicImage id="id14" alt="add user" value="/newpages/images/buttons/addUser.gif"/>
                                         <f:param id="id15" name="ID" value="#{item.id}"/>
                                     </h:commandLink>
 

--- a/Kitodo/src/main/webapp/newpages/BenutzerBearbeitenPopupProjekte.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerBearbeitenPopupProjekte.xhtml
@@ -81,7 +81,8 @@
                                     <h:commandLink
                                             action="#{BenutzerverwaltungForm.zuProjektHinzufuegen}"
                                             title="#{msgs.uebernehmen}">
-                                        <h:graphicImage id="id14" value="/newpages/images/buttons/addUser.gif"/>
+                                        <h:graphicImage id="id14" alt="add user"
+                                                        value="/newpages/images/buttons/addUser.gif"/>
                                         <f:param id="id15" name="ID" value="#{item.id}"/>
                                     </h:commandLink>
 

--- a/Kitodo/src/main/webapp/newpages/BenutzergruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzergruppenAlle.xhtml
@@ -114,7 +114,7 @@
                                                 <!-- Bearbeiten-Schaltknopf -->
                                                 <h:commandLink id="id16" action="BenutzergruppenBearbeiten"
                                                                title="#{msgs.benutzerBearbeiten}">
-                                                    <h:graphicImage id="id17"
+                                                    <h:graphicImage id="id17" alt="edit"
                                                                     value="/newpages/images/buttons/edit.gif"/>
                                                     <t:updateActionListener
                                                             property="#{BenutzergruppenForm.myBenutzergruppe}"

--- a/Kitodo/src/main/webapp/newpages/DocketEdit.xhtml
+++ b/Kitodo/src/main/webapp/newpages/DocketEdit.xhtml
@@ -84,7 +84,7 @@
                                                 </td>
                                                 <td class="eingabeBoxen_row1" align="right">
                                                     <h:commandLink id="id10" action="#{NavigationForm.Reload}">
-                                                        <h:graphicImage id="id11"
+                                                        <h:graphicImage id="id11" alt="reload"
                                                                         value="/newpages/images/reload.gif"/>
                                                     </h:commandLink>
                                                 </td>

--- a/Kitodo/src/main/webapp/newpages/DocketList.xhtml
+++ b/Kitodo/src/main/webapp/newpages/DocketList.xhtml
@@ -106,7 +106,7 @@
                                                 <!-- Bearbeiten-Schaltknopf -->
                                                 <h:commandLink id="id21" action="DocketEdit"
                                                                title="#{msgs.editDocket}">
-                                                    <h:graphicImage id="id22"
+                                                    <h:graphicImage id="id22" alt="edit"
                                                                     value="/newpages/images/buttons/edit.gif"/>
                                                     <t:updateActionListener
                                                             property="#{DocketForm.myDocket}" value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/LdapGruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/LdapGruppenAlle.xhtml
@@ -110,7 +110,7 @@
                                                     <!-- Bearbeiten-Schaltknopf -->
                                                     <h:commandLink id="id20" action="LdapGruppenBearbeiten"
                                                                    title="#{msgs.ldapgruppeBearbeiten}">
-                                                        <h:graphicImage id="id21"
+                                                        <h:graphicImage id="id21" alt="edit"
                                                                         value="/newpages/images/buttons/edit.gif"/>
                                                         <t:updateActionListener
                                                                 property="#{LdapGruppenForm.myLdapGruppe}" value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/MassImport.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MassImport.xhtml
@@ -77,7 +77,8 @@
                                                 </td>
                                                 <td class="eingabeBoxen_row1" align="right">
                                                     <h:commandLink id="idnp2" action="#{NavigationForm.Reload}">
-                                                        <h:graphicImage id="idnp4" value="/newpages/images/reload.gif"/>
+                                                        <h:graphicImage id="idnp4" value="/newpages/images/reload.gif"
+                                                                        alt="reload"/>
                                                     </h:commandLink>
                                                 </td>
                                             </tr>

--- a/Kitodo/src/main/webapp/newpages/MassImportPage2.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MassImportPage2.xhtml
@@ -75,7 +75,7 @@
                                                 </td>
                                                 <td class="eingabeBoxen_row1" align="right">
                                                     <h:commandLink id="idnp2" action="#{NavigationForm.Reload}">
-                                                        <h:graphicImage id="idnp4" value="/newpages/images/reload.gif"/>
+                                                        <h:graphicImage id="idnp4" alt="reload" value="/newpages/images/reload.gif"/>
                                                     </h:commandLink>
                                                 </td>
                                             </tr>

--- a/Kitodo/src/main/webapp/newpages/MassImportPage3.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MassImportPage3.xhtml
@@ -54,7 +54,6 @@
                                 </h:panelGroup>
                             </h:panelGrid>
 
-
                             <table border="0" align="center" width="100%" cellpadding="15">
                                 <tr>
                                     <td>
@@ -82,7 +81,7 @@
 
                                                         <h:commandLink id="utid21" action="#{MassImportForm.downloadDocket}">
                                                             <h:graphicImage id="utid24"
-                                                                            alt="/newpages/images/buttons/laufzettel_wide.png"
+                                                                            alt="download docket"
                                                                             value="/newpages/images/buttons/laufzettel_wide.png"
                                                                             style="vertical-align:middle"/>
                                                             <h:outputText value="#{msgs.laufzettelDrucken}"/>
@@ -90,7 +89,7 @@
 
                                                         <h:commandLink id="utid20" action="#{MassImportForm.prepare}">
                                                             <h:graphicImage id="utid25"
-                                                                            alt="/newpages/images/buttons/star_blue.gif"
+                                                                            alt="prepare"
                                                                             value="/newpages/images/buttons/star_blue.gif"
                                                                             style="vertical-align:middle"/>
                                                             <h:outputText value="#{msgs.weiterenVorgangAnlegen}"/>

--- a/Kitodo/src/main/webapp/newpages/MultiMassImportPage2.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MultiMassImportPage2.xhtml
@@ -76,7 +76,7 @@
                                                 </td>
                                                 <td class="eingabeBoxen_row1" align="right">
                                                     <h:commandLink id="idnp2" action="#{NavigationForm.Reload}">
-                                                        <h:graphicImage id="idnp4" value="/newpages/images/reload.gif"/>
+                                                        <h:graphicImage id="idnp4" value="/newpages/images/reload.gif" alt="reload"/>
                                                     </h:commandLink>
                                                 </td>
                                             </tr>

--- a/Kitodo/src/main/webapp/newpages/NewProcess/inc_process.xhtml
+++ b/Kitodo/src/main/webapp/newpages/NewProcess/inc_process.xhtml
@@ -36,7 +36,8 @@
     </h:selectOneMenu>
     <h:commandLink action="#{ProzesskopieForm.templateAuswahlAuswerten}" rendered="#{ProzesskopieForm.useTemplates}"
                    title="#{msgs.AuswaehlenAusVorhandenenProzessen}">
-        <h:graphicImage value="/newpages/images/buttons/copy.gif" style="vertical-align:middle; margin-right:3px"/>
+        <h:graphicImage alt="" value="/newpages/images/buttons/copy.gif"
+                        style="vertical-align:middle; margin-right:3px"/>
         <h:outputText value="#{msgs.uebernehmen}"/>
     </h:commandLink>
     <!-- aus dem Opac auswaehlen -->
@@ -66,7 +67,8 @@
                  onkeypress="return checkOpac('OpacRequest',event)"/>
     <h:commandLink action="#{ProzesskopieForm.evaluateOpac}" id="performOpacQuery"
                    rendered="#{ProzesskopieForm.useOpac}" title="#{msgs.opacAbfragen}">
-        <h:graphicImage value="/newpages/images/buttons/opac.gif" style="vertical-align:middle; margin-right:3px"/>
+        <h:graphicImage alt="query opac" value="/newpages/images/buttons/opac.gif"
+                        style="vertical-align:middle; margin-right:3px"/>
         <h:outputText value="#{msgs.uebernehmen}"/>
     </h:commandLink>
     </h:panelGrid>

--- a/Kitodo/src/main/webapp/newpages/ProjektFilegroupPopup.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjektFilegroupPopup.xhtml
@@ -50,7 +50,7 @@
                                     </td>
                                     <td class="eingabeBoxen_row1" align="right">
                                         <h:commandLink id="id3" action="#{NavigationForm.Reload}">
-                                            <h:graphicImage id="id4" value="/newpages/images/reload.gif"/>
+                                            <h:graphicImage id="id4" value="/newpages/images/reload.gif" alt="reload"/>
                                         </h:commandLink>
                                     </td>
                                 </tr>

--- a/Kitodo/src/main/webapp/newpages/ProjekteAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjekteAlle.xhtml
@@ -131,10 +131,12 @@
 
                                                 <h:graphicImage id="id2341"
                                                                 value="/newpages/images/check_true.gif"
-                                                                rendered="#{item.projectIsArchived}"/>
+                                                                rendered="#{item.projectIsArchived}"
+                                                                alt="archived"/>
                                                 <h:graphicImage id="id2342"
                                                                 value="/newpages/images/check_false.gif"
-                                                                rendered="#{!item.projectIsArchived}"/>
+                                                                rendered="#{!item.projectIsArchived}"
+                                                                alt="not archived"/>
                                             </t:column>
                                             <t:column id="id26" style="text-align:center"
                                                       rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
@@ -144,7 +146,7 @@
                                                 <!-- Bearbeiten-Schaltknopf -->
                                                 <h:commandLink id="id28" action="ProjekteBearbeiten"
                                                                title="#{msgs.projektBearbeiten}">
-                                                    <h:graphicImage id="id29"
+                                                    <h:graphicImage alt="edit" id="id29"
                                                                     value="/newpages/images/buttons/edit.gif"/>
                                                     <t:updateActionListener property="#{ProjekteForm.myProjekt}"
                                                                             value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
@@ -87,7 +87,7 @@
                                                 </td>
                                                 <td class="eingabeBoxen_row1" align="right">
                                                     <h:commandLink id="id10" action="#{NavigationForm.Reload}">
-                                                        <h:graphicImage id="id11"
+                                                        <h:graphicImage id="id11" alt="reload"
                                                                         value="/newpages/images/reload.gif"/>
                                                     </h:commandLink>
                                                 </td>
@@ -598,7 +598,7 @@
                                                                                             action="#{ProjekteForm.filegroupDelete}"
                                                                                             title="#{msgs.filegroupLoeschen}"
                                                                                             onclick="if (!confirm('#{msgs.sollDieserEintragWirklichGeloeschtWerden}?')) return">
-                                                                                        <h:graphicImage
+                                                                                        <h:graphicImage alt="delete"
                                                                                                 value="images/buttons/waste1a_20px.gif"/>
                                                                                         <t:updateActionListener
                                                                                                 property="#{ProjekteForm.myFilegroup}"
@@ -887,7 +887,7 @@
                                                                                 </h:panelGrid>
 
                                                                                 <h:panelGroup id="pcid16">
-                                                                                    <t:graphicImage forceId="true" id="vzid36"
+                                                                                    <t:graphicImage forceId="true" id="vzid36" alt=""
                                                                                                     rendered="#{ProjekteForm.projectProgressImage != ''}"
                                                                                                     value="#{HelperForm.servletPathWithHostAsUrl}/pages/imagesTemp/#{ProjekteForm.projectProgressImage}"/>
 

--- a/Kitodo/src/main/webapp/newpages/RegelsaetzeAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/RegelsaetzeAlle.xhtml
@@ -105,10 +105,12 @@
                                             </f:facet>
                                             <h:graphicImage id="id17"
                                                             value="/newpages/images/check_true.gif"
-                                                            rendered="#{item.orderMetadataByRuleset}"/>
+                                                            rendered="#{item.orderMetadataByRuleset}"
+                                                            alt="order metadata by ruleset"/>
                                             <h:graphicImage id="id18"
                                                             value="/newpages/images/check_false.gif"
-                                                            rendered="#{!item.orderMetadataByRuleset}"/>
+                                                            rendered="#{!item.orderMetadataByRuleset}"
+                                                            alt="do not order metadata by ruleset"/>
                                         </t:column>
 
                                         <h:column id="id19"
@@ -119,7 +121,7 @@
                                             <!-- Bearbeiten-Schaltknopf -->
                                             <h:commandLink id="id21" action="RegelsaetzeBearbeiten"
                                                            title="#{msgs.regelsatzBearbeiten}">
-                                                <h:graphicImage id="id22"
+                                                <h:graphicImage id="id22" alt="edit ruleset"
                                                                 value="/newpages/images/buttons/edit.gif"/>
                                                 <t:updateActionListener
                                                         property="#{RegelsaetzeForm.myRegelsatz}" value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/RegelsaetzeBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/RegelsaetzeBearbeiten.xhtml
@@ -84,7 +84,7 @@
                                                 </td>
                                                 <td class="eingabeBoxen_row1" align="right">
                                                     <h:commandLink id="id10" action="#{NavigationForm.Reload}">
-                                                        <h:graphicImage id="id11"
+                                                        <h:graphicImage id="id11" alt="reload"
                                                                         value="/newpages/images/reload.gif"/>
                                                     </h:commandLink>
                                                 </td>

--- a/Kitodo/src/main/webapp/newpages/aktiveNutzer.xhtml
+++ b/Kitodo/src/main/webapp/newpages/aktiveNutzer.xhtml
@@ -112,7 +112,7 @@
                                                 <f:facet name="header">
                                                     <h:outputText id="id21" value="Browser"/>
                                                 </f:facet>
-                                                <h:graphicImage
+                                                <h:graphicImage alt="browser"
                                                         value="/newpages/images/browser/#{item.browserIcon}"
                                                         width="30" height="30" style="float:left;margin-right:4px"/>
                                                 <h:outputText id="id22" value="#{item.browser}"/>

--- a/Kitodo/src/main/webapp/newpages/calendar.xhtml
+++ b/Kitodo/src/main/webapp/newpages/calendar.xhtml
@@ -290,7 +290,7 @@
                                                 <!-- Buttons to copy and remove blocks -->
                                                 <h:commandLink title="#{msgs['calendar.block.addFirst']}"
                                                                rendered="#{CalendarForm.blank}" styleClass="actionLink">
-                                                    <h:graphicImage style="vertical-align: text-bottom;"
+                                                    <h:graphicImage style="vertical-align: text-bottom;" alt=""
                                                                     value="/newpages/images/buttons/edit_20.gif"
                                                                     rendered="#{CalendarForm.blank}"/>
                                                 </h:commandLink>
@@ -298,7 +298,7 @@
                                                                action="#{CalendarForm.copyBlockClick}"
                                                                onclick="if(!addClickQuery()){return false;}"
                                                                rendered="#{not CalendarForm.blank}" styleClass="actionLink">
-                                                    <h:graphicImage style="vertical-align: text-bottom;"
+                                                    <h:graphicImage style="vertical-align: text-bottom;" alt=""
                                                                     value="/newpages/images/buttons/star_blue.gif"
                                                                     rendered="#{not CalendarForm.blank}"/>
                                                 </h:commandLink>
@@ -307,7 +307,7 @@
                                                                action="#{CalendarForm.removeBlockClick}"
                                                                onclick="if(!removeClickQuery()){return false;}"
                                                                styleClass="actionLink">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="delete"
                                                             value="/newpages/images/buttons/waste1_20px.gif"/>
                                                 </h:commandLink>
                                             </div>
@@ -335,7 +335,7 @@
                                                                        onclick="if(!deleteClickQuery()){return false;}"
                                                                        styleClass="rightText"
                                                                        style="margin-left: 8px; margin-top: -2px;">
-                                                            <h:graphicImage
+                                                            <h:graphicImage alt="delete"
                                                                     value="/newpages/images/buttons/waste1_20px.gif"/>
                                                         </h:commandLink>
 
@@ -413,7 +413,7 @@
                                                 <!-- Add button -->
                                                 <h:commandLink title="#{msgs['calendar.issue.add']}"
                                                                action="#{CalendarForm.addIssueClick}">
-                                                    <h:graphicImage style="margin-left: -5px;"
+                                                    <h:graphicImage style="margin-left: -5px;" alt="add"
                                                                     value="/newpages/images/buttons/star_blue.gif"/>
                                                 </h:commandLink>
 

--- a/Kitodo/src/main/webapp/newpages/inc/Process_Filter.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/Process_Filter.xhtml
@@ -32,13 +32,13 @@
         <!--Filter zur user-Liste hinzufuegen -->
         <h:commandLink id="newFilterubid11" action="#{Form.addFilterToUser}" title="#{msgs.addFilter}"
                        style="margin-left:5px">
-            <h:graphicImage id="newFilterubid12" alt="Filter" value="/newpages/images/buttons/save1.gif"/>
+            <h:graphicImage id="newFilterubid12" alt="filter" value="/newpages/images/buttons/save1.gif"/>
         </h:commandLink>
 
         <!-- remove filter from list -->
         <h:commandLink id="removeFilterubid11" action="#{Form.removeFilterFromUser}" title="#{msgs.removeFilter}"
                        style="margin-left:5px">
-            <h:graphicImage id="removeFilterubid12" alt="Filter" value="/newpages/images/buttons/waste1_20px.gif"/>
+            <h:graphicImage id="removeFilterubid12" alt="filter" value="/newpages/images/buttons/waste1_20px.gif"/>
         </h:commandLink>
     </h:panelGroup>
     </h:panelGrid>

--- a/Kitodo/src/main/webapp/newpages/inc/Step_Filter.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/Step_Filter.xhtml
@@ -32,13 +32,13 @@
         <!--Filter zur User-Liste hinzufuegen -->
         <h:commandLink id="newFilterubid11" action="#{Form.addFilterToUser}" title="#{msgs.addFilter}"
                        style="margin-left:5px">
-            <h:graphicImage id="newFilterubid12" alt="Filter" value="/newpages/images/buttons/save1.gif"/>
+            <h:graphicImage id="newFilterubid12" alt="filter" value="/newpages/images/buttons/save1.gif"/>
         </h:commandLink>
 
         <!-- remove filter from list -->
         <h:commandLink id="removeFilterubid11" action="#{Form.removeFilterFromUser}" title="#{msgs.removeFilter}"
                        style="margin-left:5px">
-            <h:graphicImage id="removeFilterubid12" alt="Filter" value="/newpages/images/buttons/waste1_20px.gif"/>
+            <h:graphicImage id="removeFilterubid12" alt="filter" value="/newpages/images/buttons/waste1_20px.gif"/>
         </h:commandLink>
     </h:panelGroup>
     </h:panelGrid>

--- a/Kitodo/src/main/webapp/newpages/inc/ajaxPlusMinusButton.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/ajaxPlusMinusButton.xhtml
@@ -21,9 +21,9 @@
 
     <h:commandLink  style="color:black" id="plusminusbutton">
         <f:ajax render="auflistung">
-            <h:graphicImage value="/newpages/images/plus.gif"
+            <h:graphicImage value="/newpages/images/plus.gif" alt="show details"
                             style="margin-right:4px" rendered="#{!item.panelShown}"/>
-            <h:graphicImage value="/newpages/images/minus.gif"
+            <h:graphicImage value="/newpages/images/minus.gif" alt="hide details"
                             style="margin-right:4px" rendered="#{item.panelShown}"/>
             <t:updateActionListener value="#{item.panelShown?false:true}"
                                     property="#{item.panelShown}"/>

--- a/Kitodo/src/main/webapp/newpages/inc/datascroller.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/datascroller.xhtml
@@ -21,11 +21,11 @@
     <h:panelGroup rendered="#{mypage.totalResults > LoginForm.myBenutzer.tableSize}">
     <!-- erste und vorherige Seite -->
     <h:commandLink action="#{mypage.cmdMoveFirst}" id="gofirst">
-        <h:graphicImage url="/newpages/images/datascroller/arrow-first.gif"
+        <h:graphicImage alt="go to first page" url="/newpages/images/datascroller/arrow-first.gif"
                         style="margin-right:4px;vertical-align: middle;"/>
     </h:commandLink>
     <h:commandLink action="#{mypage.cmdMovePrevious}" id="goprevious">
-        <h:graphicImage url="/newpages/images/datascroller/arrow-previous.gif"
+        <h:graphicImage alt="go to previous page" url="/newpages/images/datascroller/arrow-previous.gif"
                         style="margin-right:4px;vertical-align: middle;"/>
     </h:commandLink>
 
@@ -48,11 +48,11 @@
 
     <!-- nächste und letzte Seite -->
     <h:commandLink action="#{mypage.cmdMoveNext}" id="gonext">
-        <h:graphicImage url="/newpages/images/datascroller/arrow-next.gif"
+        <h:graphicImage alt="go to next page" url="/newpages/images/datascroller/arrow-next.gif"
                         style="margin-left:4px;margin-right:4px;vertical-align: middle;"/>
     </h:commandLink>
     <h:commandLink action="#{mypage.cmdMoveLast}" id="golast">
-        <h:graphicImage url="/newpages/images/datascroller/arrow-last.gif"
+        <h:graphicImage alt="go to last page" url="/newpages/images/datascroller/arrow-last.gif"
                         style="margin-right:4px;vertical-align: middle;"/>
     </h:commandLink>
     </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/inc/tbl_Kopf.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/tbl_Kopf.xhtml
@@ -37,7 +37,7 @@
                    cellspacing="0" border="0">
             <tr valign="top">
                 <td style="padding-left:1px;">
-                    <h:graphicImage value="#{HelperForm.applicationLogo}"/>
+                    <h:graphicImage value="#{HelperForm.applicationLogo}" alt="Kitodo"/>
                 </td>
                 <td valign="middle" align="center">
 

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste.xhtml
@@ -51,19 +51,19 @@
                 <h:outputText value="#{msgs.auswahl2}"/>
                 <h:commandLink action="#{AktuelleSchritteForm.selectionAll}" id="selectAll"
                                title="#{msgs.alleAuswaehlen}" style="margin-left:10px">
-                    <h:graphicImage value="/newpages/images/check_true.gif"/>
+                    <h:graphicImage value="/newpages/images/check_true.gif" alt="select all"/>
                 </h:commandLink>
                 <h:commandLink action="#{AktuelleSchritteForm.selectionNone}" id="selectnone"
                                title="#{msgs.auswahlEntfernen}" style="margin-left:5px">
-                    <h:graphicImage value="/newpages/images/check_false.gif"/>
+                    <h:graphicImage value="/newpages/images/check_false.gif" alt="select none"/>
                 </h:commandLink>
             </t:div>
         </f:facet>
         <h:commandLink id="myself1">
             <h:graphicImage value="/newpages/images/check_true.gif" style="margin-right:4px"
-                            rendered="#{item.selected}"/>
+                            rendered="#{item.selected}" alt="select all"/>
             <h:graphicImage value="/newpages/images/check_false.gif" style="margin-right:4px"
-                            rendered="#{!item.selected}"/>
+                            rendered="#{!item.selected}" alt="select none"/>
             <t:updateActionListener value="#{item.selected?false:true}" property="#{item.selected}"/>
             <f:ajax render="myself1"/>
         </h:commandLink>
@@ -85,21 +85,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort1"
                                rendered="#{AktuelleSchritteForm.sortierung=='schrittAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="schrittDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort2"
                                rendered="#{AktuelleSchritteForm.sortierung=='schrittDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="schrittAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort3"
                                rendered="#{AktuelleSchritteForm.sortierung!='schrittDesc' and AktuelleSchritteForm.sortierung!='schrittAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="schrittAsc"/>
                 </h:commandLink>
@@ -107,8 +107,8 @@
         </f:facet>
     
         <h:commandLink id="myself" style="color:black">
-            <h:graphicImage value="/newpages/images/plus.gif" style="margin-right:4px" rendered="#{!item.panelShown}"/>
-            <h:graphicImage value="/newpages/images/minus.gif" style="margin-right:4px" rendered="#{item.panelShown}"/>
+            <h:graphicImage value="/newpages/images/plus.gif" alt="plus" style="margin-right:4px" rendered="#{!item.panelShown}"/>
+            <h:graphicImage value="/newpages/images/minus.gif" alt="minus" style="margin-right:4px" rendered="#{item.panelShown}"/>
             <t:updateActionListener value="#{item.panelShown?false:true}" property="#{item.panelShown}"/>
             <h:outputText value="#{item.title}"/>
             <f:ajax render="auflistungIntern myself"/>
@@ -131,21 +131,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort6"
                                rendered="#{AktuelleSchritteForm.sortierung=='prozessAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="prozessDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort7"
                                rendered="#{AktuelleSchritteForm.sortierung=='prozessDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="prozessAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort8"
                                rendered="#{AktuelleSchritteForm.sortierung!='prozessDesc' and AktuelleSchritteForm.sortierung!='prozessAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="prozessAsc"/>
                 </h:commandLink>
@@ -154,7 +154,7 @@
         <h:panelGrid columns="2">
             <!-- Bearbeiten-Schaltknopf: konkrete Prozesse -->
             <h:commandLink action="ProzessverwaltungBearbeiten" id="edit1" title="#{msgs.prozessBearbeiten}">
-                <h:graphicImage value="/newpages/images/buttons/goInto.gif" style="margin-right:3px"/>
+                <h:graphicImage value="/newpages/images/buttons/goInto.gif" style="margin-right:3px" alt="Edit"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item.process}"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}" value=""/>
             </h:commandLink>
@@ -170,21 +170,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort10"
                                rendered="#{AktuelleSchritteForm.sortierung=='prozessdateAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="prozessdateDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort11"
                                rendered="#{AktuelleSchritteForm.sortierung=='prozessdateDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="prozessdateAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort12"
                                rendered="#{AktuelleSchritteForm.sortierung!='prozessdateDesc' and AktuelleSchritteForm.sortierung!='prozessdateAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="prozessdateAsc"/>
                 </h:commandLink>
@@ -201,21 +201,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort13"
                                rendered="#{AktuelleSchritteForm.sortierung=='modulesAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="modulesDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort14"
                                rendered="#{AktuelleSchritteForm.sortierung=='modulesDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="modulesAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort15"
                                rendered="#{AktuelleSchritteForm.sortierung!='modulesDesc' and AktuelleSchritteForm.sortierung!='modulesAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="modulesAsc"/>
                 </h:commandLink>
@@ -232,21 +232,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort16"
                                rendered="#{AktuelleSchritteForm.sortierung=='projektAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="projektDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort17"
                                rendered="#{AktuelleSchritteForm.sortierung=='projektDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="projektAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort18"
                                rendered="#{AktuelleSchritteForm.sortierung!='projektDesc' and AktuelleSchritteForm.sortierung!='projektAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="projektAsc"/>
                 </h:commandLink>
@@ -264,21 +264,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort19"
                                rendered="#{AktuelleSchritteForm.sortierung=='sperrungenAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="sperrungenDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort20"
                                rendered="#{AktuelleSchritteForm.sortierung=='sperrungenDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="sperrungenAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort21"
                                rendered="#{AktuelleSchritteForm.sortierung!='sperrungenDesc' and AktuelleSchritteForm.sortierung!='sperrungenAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="sperrungenAsc"/>
                 </h:commandLink>
@@ -296,21 +296,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort19a"
                                rendered="#{AktuelleSchritteForm.sortierung=='batchAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="batchDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort20a"
                                rendered="#{AktuelleSchritteForm.sortierung=='batchDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="batchAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort21a"
                                rendered="#{AktuelleSchritteForm.sortierung!='batchDesc' and AktuelleSchritteForm.sortierung!='batchAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="batchAsc"/>
                 </h:commandLink>
@@ -327,21 +327,21 @@
                 <!-- Sortierung Asc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort22"
                                rendered="#{AktuelleSchritteForm.sortierung=='statusAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="statusDesc"/>
                 </h:commandLink>
                 <!-- Sortierung Desc -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort23"
                                rendered="#{AktuelleSchritteForm.sortierung=='statusDesc'}">
-                    <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                    <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="statusAsc"/>
                 </h:commandLink>
                 <!-- Sortierung none -->
                 <h:commandLink action="#{AktuelleSchritteForm.filterAlleStart}" id="sort24"
                                rendered="#{AktuelleSchritteForm.sortierung!='statusDesc' and AktuelleSchritteForm.sortierung!='statusAsc'}">
-                    <h:graphicImage value="/newpages/images/sorting/none.gif"
+                    <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                     style="vertical-align:middle;margin-left:5px"/>
                     <t:updateActionListener property="#{AktuelleSchritteForm.sortierung}" value="statusAsc"/>
                 </h:commandLink>
@@ -396,7 +396,7 @@
         <h:commandLink id="take" action="#{AktuelleSchritteForm.schrittDurchBenutzerUebernehmen}"
                        rendered="#{(item.processingStatusEnum == 'OPEN' and !item.batchStep) || (item.processingStatusEnum == 'OPEN' and item.batchStep and !item.batchSize)}"
                        title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
-            <h:graphicImage value="/newpages/images/buttons/admin2a.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/admin2a.gif" alt="edit"/>
             <t:updateActionListener property="#{AktuelleSchritteForm.mySchritt}" value="#{item}"/>
         </h:commandLink>
     
@@ -404,7 +404,7 @@
         <h:commandLink action="#{AktuelleSchritteForm.editStep}" id="view1"
                        rendered="#{(item.processingStatusEnum == 'INWORK' and item.processingUser.id == LoginForm.myBenutzer.id and !item.batchStep) || (item.processingStatusEnum == 'INWORK' and item.processingUser.id == LoginForm.myBenutzer.id and item.batchStep and !item.batchSize)}"
                        title="#{msgs.inBearbeitungDurch}: #{item.processingUser!=null and item.processingUser.id!=0 ? item.processingUser.fullName:''}">
-            <h:graphicImage value="/newpages/images/buttons/admin1b.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/admin1b.gif" alt="edit"/>
             <t:updateActionListener property="#{AktuelleSchritteForm.mySchritt}" value="#{item}"/>
         </h:commandLink>
     
@@ -412,7 +412,7 @@
         <h:commandLink action="#{AktuelleSchritteForm.editStep}" id="view2"
                        rendered="#{item.processingStatusEnum == 'INWORK' and item.processingUser.id != LoginForm.myBenutzer.id and (!item.batchStep || !item.batchSize)}"
                        title="#{msgs.inBearbeitungDurch}: #{(item.processingUser!=null and item.processingUser.id!=0 ? item.processingUser.fullName : '')}">
-            <h:graphicImage value="/newpages/images/buttons/admin1c.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/admin1c.gif" alt="edit"/>
             <t:updateActionListener property="#{AktuelleSchritteForm.mySchritt}" value="#{item}"/>
         </h:commandLink>
     
@@ -420,14 +420,14 @@
         <h:commandLink id="batch" action="#{AktuelleSchritteForm.takeOverBatch}"
                        rendered="#{item.processingStatusEnum == 'OPEN' and item.batchStep and item.batchSize}"
                        title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
-            <h:graphicImage value="/newpages/images/buttons/admin3a.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/admin3a.gif" alt="edit"/>
             <t:updateActionListener property="#{AktuelleSchritteForm.step}" value="#{item}"/>
         </h:commandLink>
         <!-- edit batch step -->
         <h:commandLink id="batchInWork" action="#{AktuelleSchritteForm.batchesEdit}"
                        rendered="#{item.processingStatusEnum == 'INWORK' and item.processingUser.id == LoginForm.myBenutzer.id and item.batchStep and item.batchSize}"
                        title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
-            <h:graphicImage value="/newpages/images/buttons/admin3.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/admin3.gif" alt="edit"/>
             <t:updateActionListener property="#{AktuelleSchritteForm.step}" value="#{item}"/>
         </h:commandLink>
     
@@ -438,7 +438,7 @@
                        title="#{msgs.inBearbeitungDurch}: #{(item.processingUser!=null and item.processingUser.id!=0 ? item.processingUser.fullName : '')}">
     
     
-            <h:graphicImage value="/newpages/images/buttons/admin3c.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/admin3c.gif" alt="edit"/>
             <t:updateActionListener property="#{AktuelleSchritteForm.step}" value="#{item}"/>
         </h:commandLink>
     </t:column>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste.xhtml
@@ -154,7 +154,7 @@
         <h:panelGrid columns="2">
             <!-- Bearbeiten-Schaltknopf: konkrete Prozesse -->
             <h:commandLink action="ProzessverwaltungBearbeiten" id="edit1" title="#{msgs.prozessBearbeiten}">
-                <h:graphicImage value="/newpages/images/buttons/goInto.gif" style="margin-right:3px" alt="Edit"/>
+                <h:graphicImage value="/newpages/images/buttons/goInto.gif" style="margin-right:3px" alt="edit"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item.process}"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}" value=""/>
             </h:commandLink>
@@ -348,7 +348,8 @@
             </t:div>
         </f:facet>
     
-        <h:graphicImage value="#{item.processingStatusEnum.bigImagePath}" title="#{item.processingStatusEnum.title}"/>
+        <h:graphicImage alt="" value="#{item.processingStatusEnum.bigImagePath}"
+                        title="#{item.processingStatusEnum.title}"/>
     
         <h:outputText value="!" style="color:red;font-weight:bold;font-size:20px;margin-left:5px"
                       rendered="#{item.priority == 1}"/>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste_Action.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste_Action.xhtml
@@ -35,7 +35,7 @@
                         <h:commandLink action="#{AktuelleSchritteForm.uploadFromHomeAlle}"
                                        title="#{msgs.verzeichnisFertigHochladen}"
                                        onclick="if (!confirm('#{msgs.upload}?')) return">
-                            <h:graphicImage value="/newpages/images/buttons/load_up1.gif"
+                            <h:graphicImage value="/newpages/images/buttons/load_up1.gif" alt="upload"
                                             style="margin-right:3px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.verzeichnisFertigHochladen}"/>
                         </h:commandLink>
@@ -44,7 +44,7 @@
                         <h:commandLink action="#{AktuelleSchritteForm.DownloadToHomePage}"
                                        title="#{msgs.alleTrefferDieserSeiteInMeinHomeverzeichnis}"
                                        onclick="if (!confirm('#{msgs.download}?')) return">
-                            <h:graphicImage value="/newpages/images/buttons/load_down1.gif"
+                            <h:graphicImage value="/newpages/images/buttons/load_down1.gif" alt="download page"
                                             style="margin-right:3px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.alleTrefferDieserSeiteInMeinHomeverzeichnis}"/>
                         </h:commandLink>
@@ -53,7 +53,7 @@
                         <h:commandLink action="#{AktuelleSchritteForm.downloadToHomeHits}"
                                        title="#{msgs.gesamtesTreffersetInMeinHomeverzeichnis}"
                                        onclick="if (!confirm('#{msgs.download}?')) return">
-                            <h:graphicImage value="/newpages/images/buttons/load_down1.gif"
+                            <h:graphicImage value="/newpages/images/buttons/load_down1.gif" alt="download set"
                                             style="margin-right:3px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.gesamtesTreffersetInMeinHomeverzeichnis}"/>
                         </h:commandLink>
@@ -69,7 +69,7 @@
                         <h:commandLink  action="#{AktuelleSchritteForm.calcHomeImages}">
                             <!-- FIXME: this may destroy JS on the page; wrong usage of f:ajax? -->
                             <f:ajax render="calcNumber"></f:ajax>
-                            <h:graphicImage value="/newpages/images/reload.gif" style="margin-right:4px"
+                            <h:graphicImage value="/newpages/images/reload.gif" style="margin-right:4px" alt="reload"
                                             rendered="#{item.selected}"/>
                         </h:commandLink>
 
@@ -84,7 +84,7 @@
                     <h:panelGroup>
 
                         <span class="toggle" data-for="toggle-1">
-                            <h:graphicImage value="/newpages/images/buttons/view3.gif"
+                            <h:graphicImage value="/newpages/images/buttons/view3.gif" alt="view"
                                             style="margin-left:5px;margin-right:8px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.filterAnpassen}"/>
                         </span>
@@ -124,7 +124,7 @@
                     <h:panelGroup id="viewgroup">
 
                         <span class="toggle" data-for="toggle-2">
-                            <h:graphicImage value="/newpages/images/buttons/view3.gif"
+                            <h:graphicImage value="/newpages/images/buttons/view3.gif" alt="view"
                                             style="margin-left:5px;margin-right:8px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.anzeigeAnpassen}"/>
                         </span>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Action.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Action.xhtml
@@ -135,7 +135,7 @@
                                         rendered="#{AktuelleSchritteForm.mySchritt.stepPlugin != null and AktuelleSchritteForm.mySchritt.stepPlugin != ''}"
                                         action="#{AktuelleSchritteForm.callStepPlugin}"
                                         title="#{msgs.stepPlugin} (#{AktuelleSchritteForm.mySchritt.stepPlugin})">
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt=""
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText
                                             value="#{msgs.stepPlugin} (#{AktuelleSchritteForm.mySchritt.stepPlugin})"/>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Action.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Action.xhtml
@@ -110,7 +110,7 @@
                                                    rendered="#{(AktuelleSchritteForm.mySchritt.process.blockedUsers != null) and (AktuelleSchritteForm.mySchritt.process.blockedUsers.id == LoginForm.myBenutzer.id)}"
                                                    action="#{AktuelleSchritteForm.sperrungAufheben}"
                                                    title="#{msgs.oderSperrungAufheben}">
-                                        <h:graphicImage value="/newpages/images/buttons/key2a.gif"
+                                        <h:graphicImage value="/newpages/images/buttons/key2a.gif" alt="release lock"
                                                         style="margin-left:10px;margin-right:3px;vertical-align:middle"/>
                                         <h:outputText value="#{msgs.oderSperrungAufheben}"
                                                       style="font-weight:bold;font-style:underline"/>
@@ -124,7 +124,7 @@
                                         rendered="#{AktuelleSchritteForm.mySchritt.typExportRus and AktuelleSchritteForm.mySchritt.prozess.benutzerGesperrt == null}"
                                         action="#{AktuelleSchritteForm.DownloadRusExport}"
                                         title="#{msgs.russischeMetadatenExportieren}">
-                                    <h:graphicImage value="/newpages/images/buttons/rus.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/rus.gif" alt=""
                                                     style="margin-right:3px;vertical-align:middle" />
                                     <h:outputText value="#{msgs.russischeMetadatenExportieren}" />
                                 </h:commandLink>
@@ -146,7 +146,7 @@
                                                rendered="#{AktuelleSchritteForm.mySchritt.typeModuleName != null and AktuelleSchritteForm.mySchritt.typeModuleName != ''}"
                                                action="#{AktuelleSchritteForm.executeModule}"
                                                title="#{msgs.modulStarten} (#{AktuelleSchritteForm.mySchritt.typeModuleName})">
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt=""
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText
                                             value="#{msgs.modulStarten} (#{AktuelleSchritteForm.mySchritt.typeModuleName})"/>
@@ -160,7 +160,7 @@
                                     <t:updateActionListener
                                             property="#{AktuelleSchritteForm.scriptPath}"
                                             value="#{AktuelleSchritteForm.mySchritt.typeAutomaticScriptPath}"/>
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt="execute script"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText
                                             value="#{msgs.scriptAusfuehren}: #{AktuelleSchritteForm.mySchritt.scriptName1}"/>
@@ -173,7 +173,7 @@
                                     <t:updateActionListener
                                             property="#{AktuelleSchritteForm.scriptPath}"
                                             value="#{AktuelleSchritteForm.mySchritt.typeAutomaticScriptPath2}"/>
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt="execute script"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText
                                             value="#{msgs.scriptAusfuehren}: #{AktuelleSchritteForm.mySchritt.scriptName2}"/>
@@ -186,7 +186,7 @@
                                     <t:updateActionListener
                                             property="#{AktuelleSchritteForm.scriptPath}"
                                             value="#{AktuelleSchritteForm.mySchritt.typeAutomaticScriptPath3}"/>
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt="execute script"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText
                                             value="#{msgs.scriptAusfuehren}: #{AktuelleSchritteForm.mySchritt.scriptName3}"/>
@@ -199,7 +199,7 @@
                                     <t:updateActionListener
                                             property="#{AktuelleSchritteForm.scriptPath}"
                                             value="#{AktuelleSchritteForm.mySchritt.typeAutomaticScriptPath4}"/>
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt="execute script"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText
                                             value="#{msgs.scriptAusfuehren}: #{AktuelleSchritteForm.mySchritt.scriptName4}"/>
@@ -213,7 +213,7 @@
                                             property="#{AktuelleSchritteForm.scriptPath}"
                                             value="#{AktuelleSchritteForm.mySchritt.typeAutomaticScriptPath5}"/>
 
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt="execute script"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText
                                             value="#{msgs.scriptAusfuehren}: #{AktuelleSchritteForm.mySchritt.scriptName5}"/>
@@ -223,7 +223,7 @@
                                                rendered="#{0==1 and AktuelleSchritteForm.mySchritt.process.blockedUsers == null}"
                                                action="#{AktuelleSchritteForm.downloadTiffHeader}"
                                                title="#{msgs.dateiMitTiffHeaderSpeichern}">
-                                    <h:graphicImage value="/newpages/images/buttons/tif.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/tif.gif" alt="download tiff header"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.dateiMitTiffHeaderSpeichern}"/>
                                 </h:commandLink>
@@ -240,7 +240,7 @@
                                                rendered="#{AktuelleSchritteForm.mySchritt.typeExportDMS and AktuelleSchritteForm.mySchritt.process.blockedUsers == null}"
                                                action="#{AktuelleSchritteForm.exportDMS}"
                                                title="#{msgs.importDms}">
-                                    <h:graphicImage value="/newpages/images/buttons/dms.png"
+                                    <h:graphicImage value="/newpages/images/buttons/dms.png" alt="export to dms"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.importDms}"/>
                                 </h:commandLink>
@@ -250,7 +250,7 @@
                                                rendered="#{AktuelleSchritteForm.mySchritt.typeMetadata and AktuelleSchritteForm.mySchritt.process.blockedUsers == null}"
                                                action="#{Metadaten.readXml}"
                                                title="#{msgs.metadatenBearbeiten}">
-                                    <h:graphicImage value="/newpages/images/buttons/view1.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/view1.gif" alt="read xml"
                                                     style="margin-left:7px;margin-right:10px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.metadatenBearbeiten}"/>
                                     <t:updateActionListener
@@ -267,7 +267,7 @@
                                                action="#{AktuelleSchritteForm.schrittDurchBenutzerZurueckgeben}"
                                                title="#{msgs.bearbeitungDiesesSchrittesAbgeben}"
                                                onclick="if (!confirm('#{msgs.bearbeitungDiesesSchrittesWirklichAbgeben}')) return">
-                                    <h:graphicImage value="/newpages/images/buttons/cancel3.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/cancel3.gif" alt="cancel"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.bearbeitungDiesesSchrittesAbgeben}"/>
                                 </h:commandLink>
@@ -275,7 +275,7 @@
                                 <!-- Schritt zurückgeben an vorherige Station für Korrekturzwecke -->
                                 <h:panelGroup rendered="#{AktuelleSchritteForm.sizeOfPreviousStepsForProblemReporting > 0}">
                                     <span class="toggle" data-for="toggle-1">
-                                        <h:graphicImage
+                                        <h:graphicImage alt="step back"
                                                 value="/newpages/images/buttons/step_back_20px.gif"
                                                 style="margin-right:3px;vertical-align:middle"/>
                                         <h:outputText
@@ -317,7 +317,7 @@
 
                                     <span class="toggle" data-for="toggle-2">
 
-                                        <h:graphicImage
+                                        <h:graphicImage alt="step forward"
                                                 value="/newpages/images/buttons/step_for_20px.gif"
                                                 style="margin-right:3px;vertical-align:middle"/>
                                         <h:outputText
@@ -357,7 +357,7 @@
                                                action="#{AktuelleSchritteForm.schrittDurchBenutzerAbschliessen}"
                                                title="#{msgs.diesenSchrittAbschliessen}"
                                                onclick="if (!confirm('#{msgs.diesenSchrittAbschliessen}?')) return">
-                                    <h:graphicImage value="/newpages/images/buttons/ok.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/ok.gif" alt="ok"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.diesenSchrittAbschliessen}"/>
                                 </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Properties.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Properties.xhtml
@@ -97,7 +97,7 @@
 
                                     <h:commandLink action="AktuelleSchritteBearbeiten" title="#{msgs.bearbeiten}"
                                                    rendered="#{AktuelleSchritteForm.mySchritt.processingUser.id == LoginForm.myBenutzer.id and proc.currentStepAccessCondition != 'READ'}">
-                                        <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                                        <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.processProperty}" value="#{proc}"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.container}" value="0"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.modusBearbeiten}"
@@ -108,7 +108,7 @@
 
                                     <h:commandLink action="#{AktuelleSchritteForm.duplicateProperty}" title="#{msgs.duplicate}"
                                                    rendered="#{proc.duplicationAllowed}">
-                                        <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                        <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.processProperty}" value="#{proc}"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.container}" value="0"/>
                                     </h:commandLink>
@@ -148,7 +148,7 @@
                                         <h:panelGroup
                                                 rendered="#{AktuelleSchritteForm.mySchritt.processingUser.id == LoginForm.myBenutzer.id and process_item.currentStepAccessCondition != 'READ'}">
                                             <h:commandLink action="AktuelleSchritteBearbeiten" title="#{msgs.bearbeiten}">
-                                                <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                                                <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                                                 <t:updateActionListener property="#{AktuelleSchritteForm.container}"
                                                                         value="#{container}"/>
                                                 <t:updateActionListener property="#{AktuelleSchritteForm.modusBearbeiten}"
@@ -159,7 +159,7 @@
 
                                             <h:commandLink action="#{AktuelleSchritteForm.duplicateContainer}" title="#{msgs.duplicate}"
                                                            rendered="#{process_item.duplicationAllowed}">
-                                                <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                                <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="edit"/>
                                                 <t:updateActionListener property="#{AktuelleSchritteForm.container}"
                                                                         value="#{container}"/>
                                             </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Action.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Action.xhtml
@@ -40,7 +40,7 @@
                                                title="#{script}">
                                     <t:updateActionListener property="#{AktuelleSchritteForm.batchHelper.script}"
                                                             value="#{script}"/>
-                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt="execute action"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.scriptAusfuehren}: #{script}"/>
                                 </h:commandLink>
@@ -54,7 +54,7 @@
                             <h:commandLink id="action9"
                                            rendered="#{AktuelleSchritteForm.batchHelper.currentStep.typeExportDMS}"
                                            action="#{AktuelleSchritteForm.batchHelper.exportDMS}" title="#{msgs.importDms}">
-                                <h:graphicImage value="/newpages/images/buttons/dms.png"
+                                <h:graphicImage value="/newpages/images/buttons/dms.png" alt="export to dms"
                                                 style="margin-right:3px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.importDms}"/>
                             </h:commandLink>
@@ -63,7 +63,7 @@
                             <h:panelGroup>
 
                                 <span class="toggle" data-for="toggle-1">
-                                    <h:graphicImage value="/newpages/images/buttons/step_back_20px.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/step_back_20px.gif" alt="step back"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.korrekturmeldungAnVorherigeStationSenden}"/>
                                 </span>
@@ -107,7 +107,7 @@
 
                                 <span class="toggle" data-for="toggle-2">
 
-                                    <h:graphicImage value="/newpages/images/buttons/step_for_20px.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/step_for_20px.gif" alt="step forward"
                                                     style="margin-right:3px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.meldungUeberProblemloesungAnNachchfolgendeStationSenden}"/>
                                 </span>
@@ -149,7 +149,7 @@
                                            action="#{AktuelleSchritteForm.batchHelper.batchDurchBenutzerZurueckgeben}"
                                            title="#{msgs.bearbeitungDiesesSchrittesAbgeben}"
                                            onclick="if (!confirm('#{msgs.bearbeitungDiesesSchrittesWirklichAbgeben}')) return">
-                                <h:graphicImage value="/newpages/images/buttons/cancel3.gif"
+                                <h:graphicImage value="/newpages/images/buttons/cancel3.gif" alt="cancel"
                                                 style="margin-right:3px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.bearbeitungDiesesSchrittesAbgeben}"/>
                             </h:commandLink>
@@ -158,7 +158,7 @@
                                            action="#{AktuelleSchritteForm.batchHelper.batchDurchBenutzerAbschliessen}"
                                            title="#{msgs.diesenSchrittAbschliessen}"
                                            onclick="if (!confirm('#{msgs.diesenSchrittAbschliessen}?')) return">
-                                <h:graphicImage value="/newpages/images/buttons/ok.gif"
+                                <h:graphicImage value="/newpages/images/buttons/ok.gif" alt="ok"
                                                 style="margin-right:3px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.diesenSchrittAbschliessen}"/>
                             </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Properties.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Properties.xhtml
@@ -59,7 +59,7 @@
 
                                     <h:commandLink action="BatchesEdit" title="#{msgs.bearbeiten}"
                                                    rendered="#{AktuelleSchritteForm.batchHelper.currentStep.processingUser.id == LoginForm.myBenutzer.id and proc.currentStepAccessCondition != 'READ'}">
-                                        <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                                        <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.batchHelper.processProperty}"
                                                                 value="#{proc}"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.batchHelper.container}" value="0"/>
@@ -71,7 +71,7 @@
 
                                     <h:commandLink action="#{AktuelleSchritteForm.batchHelper.duplicateProperty}"
                                                    title="#{msgs.duplicate}" rendered="#{proc.duplicationAllowed}">
-                                        <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                        <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.batchHelper.processProperty}"
                                                                 value="#{proc}"/>
                                         <t:updateActionListener property="#{AktuelleSchritteForm.batchHelper.container}" value="0"/>
@@ -113,7 +113,7 @@
                                         <h:panelGroup
                                                 rendered="#{AktuelleSchritteForm.batchHelper.currentStep.processingUser.id == LoginForm.myBenutzer.id and process_item.currentStepAccessCondition != 'READ'}">
                                             <h:commandLink action="BatchesEdit" title="#{msgs.bearbeiten}">
-                                                <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                                                <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                                                 <t:updateActionListener property="#{AktuelleSchritteForm.batchHelper.container}"
                                                                         value="#{container}"/>
                                                 <t:updateActionListener property="#{AktuelleSchritteForm.modusBearbeiten}"
@@ -124,7 +124,7 @@
                                             <h:commandLink action="#{AktuelleSchritteForm.batchHelper.duplicateContainer}"
                                                            title="#{msgs.duplicate}"
                                                            rendered="#{process_item.duplicationAllowed}">
-                                                <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                                <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                                 <t:updateActionListener property="#{AktuelleSchritteForm.batchHelper.container}"
                                                                         value="#{container}"/>
                                             </h:commandLink>
@@ -164,7 +164,7 @@
 
                         <h:commandLink action="batchesEdit" title="#{msgs.bearbeiten}"
                                        rendered="#{AktuelleSchritteForm.batchHelper.currentStep.bearbeitungsbenutzer.id == LoginForm.myBenutzer.id}">
-                            <h:graphicImage value="/newpages/images/buttons/edit.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                             <x:updateActionListener property="#{AktuelleSchritteForm.batchHelper.processProperty}" value="#{proc}" />
                             <x:updateActionListener property="#{BatchForm.batchHelper.container}" value="0" />
                             <x:updateActionListener property="#{AktuelleSchritteForm.modusBearbeiten}" value="eigenschaft" />
@@ -173,7 +173,7 @@
 
                         <h:commandLink action="#{AktuelleSchritteForm.batchHelper.duplicateContainerForAll}" title="#{msgs.duplicateForAll}"
                                        rendered="#{AktuelleSchritteForm.batchHelper.currentStep.bearbeitungsbenutzer.id == LoginForm.myBenutzer.id}">
-                            <h:graphicImage value="/newpages/images/buttons/copy.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                             <x:updateActionListener property="#{AktuelleSchritteForm.batchHelper.processProperty}" value="#{proc}" />
                         </h:commandLink>
                     </htm:td>
@@ -195,13 +195,13 @@
                         <h:panelGroup
                                 rendered="#{AktuelleSchritteForm.batchHelper.currentStep.bearbeitungsbenutzer.id == LoginForm.myBenutzer.id and propInd + 1 == propCount}">
                             <h:commandLink action="batchesEdit" title="#{msgs.bearbeiten}">
-                                <h:graphicImage value="/newpages/images/buttons/edit.gif" />
+                                <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                                 <x:updateActionListener property="#{AktuelleSchritteForm.batchHelper.container}" value="#{container}" />
                                 <x:updateActionListener property="#{AktuelleSchritteForm.modusBearbeiten}" value="eigenschaft" />
                                 <a4j:support event="onchange" reRender="editBatch" />
                             </h:commandLink>
                             <h:commandLink action="#{AktuelleSchritteForm.batchHelper.duplicateContainerForAll}" title="#{msgs.duplicateForAll}">
-                                <h:graphicImage value="/newpages/images/buttons/copy.gif" />
+                                <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                 <x:updateActionListener property="#{AktuelleSchritteForm.batchHelper.container}" value="#{container}" />
                             </h:commandLink>
                         </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
@@ -94,9 +94,9 @@
                 <!--<f:ajax render="myself1"/>-->
             </h:commandLink>
             <!--<a4j:commandLink reRender="myself1" id="myself1">-->
-            <!--<h:graphicImage value="/newpages/images/check_true.gif" style="margin-right:4px"-->
+            <!--<h:graphicImage value="/newpages/images/check_true.gif" alt="select all" style="margin-right:4px"-->
             <!--rendered="#{item.selected}"/>-->
-            <!--<h:graphicImage value="/newpages/images/check_false.gif" style="margin-right:4px"-->
+            <!--<h:graphicImage value="/newpages/images/check_false.gif" alt="select none" style="margin-right:4px"-->
             <!--rendered="#{!item.selected}"/>-->
             <!--<x:updateActionListener value="#{item.selected?false:true}" property="#{item.selected}"/>-->
             <!--<a4j:ajaxListener type="org.ajax4jsf.ajax.ForceRender"/>-->
@@ -215,13 +215,13 @@
                         <f:facet name="header">
                             <h:outputText value="#{msgs.status}"/>
                         </f:facet>
-                        <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}"
+                        <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}" alt=""
                                         title="#{step.processingStatusEnum.title}"
                                         rendered="#{step.processingStatusEnum == 'OPEN' || step.processingStatusEnum == 'LOCKED'}"/>
-                        <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}"
+                        <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}" alt=""
                                         title="#{step.processingStatusEnum.title}: #{step.processingUser!=null and step.processingUser.id!=0?step.processingUser.fullName:''} (#{step.processingTime !=null?step.processingTimeAsFormattedString:''})  - #{step.editTypeEnum.title}"
                                         rendered="#{(step.processingStatusEnum == 'DONE' || step.processingStatusEnum == 'INWORK') and !HelperForm.anonymized}"/>
-                        <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}"
+                        <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}" alt=""
                                         title="#{step.processingStatusEnum.title}: #{step.editTypeEnum.title}"
                                         rendered="#{(step.processingStatusEnum == 'DONE' || step.processingStatusEnum == 'INWORK') and HelperForm.anonymized}"/>
                     </h:column>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
@@ -76,19 +76,19 @@
                     <h:outputText value="#{msgs.auswahl2}"/>
                     <h:commandLink action="#{ProzessverwaltungForm.SelectionAll}" id="selectall"
                                    title="#{msgs.alleAuswaehlen}" style="margin-left:10px">
-                        <h:graphicImage value="/newpages/images/check_true.gif"/>
+                        <h:graphicImage value="/newpages/images/check_true.gif" alt="select all"/>
                     </h:commandLink>
                     <h:commandLink action="#{ProzessverwaltungForm.SelectionNone}" id="selectnone"
                                    title="#{msgs.auswahlEntfernen}" style="margin-left:5px">
-                        <h:graphicImage value="/newpages/images/check_false.gif"/>
+                        <h:graphicImage value="/newpages/images/check_false.gif" alt="select none"/>
                     </h:commandLink>
                 </t:div>
             </f:facet>
             <h:commandLink id="myself1">
                 <h:graphicImage value="/newpages/images/check_true.gif" style="margin-right:4px"
-                                rendered="#{item.selected}"/>
+                                alt="select all" rendered="#{item.selected}"/>
                 <h:graphicImage value="/newpages/images/check_false.gif" style="margin-right:4px"
-                                rendered="#{!item.selected}"/>
+                                alt="select none" rendered="#{!item.selected}"/>
                 <t:updateActionListener value="#{item.selected?false:true}" property="#{item.selected}"/>
                 <!-- FIXME: this breaks the JS on the page: -->
                 <!--<f:ajax render="myself1"/>-->
@@ -120,21 +120,21 @@
                     <!-- Sortierung Asc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort13a"
                                    rendered="#{ProzessverwaltungForm.sortierung=='batchAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="batchDesc"/>
                     </h:commandLink>
                     <!-- Sortierung Desc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort14a"
                                    rendered="#{ProzessverwaltungForm.sortierung=='batchDesc'}">
-                        <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="batchAsc"/>
                     </h:commandLink>
                     <!-- Sortierung none -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort15a"
                                    rendered="#{ProzessverwaltungForm.sortierung!='batchDesc' and ProzessverwaltungForm.sortierung!='batchAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/none.gif"
+                        <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="batchAsc"/>
                     </h:commandLink>
@@ -158,21 +158,21 @@
                     <!-- Sortierung Asc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort1"
                                    rendered="#{ProzessverwaltungForm.sortierung=='titelAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="titelDesc"/>
                     </h:commandLink>
                     <!-- Sortierung Desc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort2"
                                    rendered="#{ProzessverwaltungForm.sortierung=='titelDesc'}">
-                        <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="titelAsc"/>
                     </h:commandLink>
                     <!-- Sortierung none -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort3"
                                    rendered="#{ProzessverwaltungForm.sortierung!='titelDesc' and ProzessverwaltungForm.sortierung!='titelAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/none.gif"
+                        <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="titelAsc"/>
                     </h:commandLink>
@@ -180,9 +180,9 @@
             </f:facet>
 
             <h:commandLink id="myself" style="color:black">
-                <h:graphicImage value="/newpages/images/plus.gif" style="margin-right:4px"
+                <h:graphicImage value="/newpages/images/plus.gif" alt="plus" style="margin-right:4px"
                                 rendered="#{!item.panelShown}"/>
-                <h:graphicImage value="/newpages/images/minus.gif" style="margin-right:4px"
+                <h:graphicImage value="/newpages/images/minus.gif" alt="minus" style="margin-right:4px"
                                 rendered="#{item.panelShown}"/>
                 <t:updateActionListener value="#{item.panelShown?false:true}" property="#{item.panelShown}"/>
                 <h:outputText value="#{item.title}"/>
@@ -240,7 +240,7 @@
                     <!-- Sortierung Asc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort4"
                                    rendered="#{ProzessverwaltungForm.sortierung=='vorgangsdatumAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}"
                                                 value="vorgangsdatumDesc"/>
@@ -248,7 +248,7 @@
                     <!-- Sortierung Desc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort5"
                                    rendered="#{ProzessverwaltungForm.sortierung=='vorgangsdatumDesc'}">
-                        <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}"
                                                 value="vorgangsdatumAsc"/>
@@ -256,7 +256,7 @@
                     <!-- Sortierung none -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort6"
                                    rendered="#{ProzessverwaltungForm.sortierung!='vorgangsdatumDesc' and ProzessverwaltungForm.sortierung!='vorgangsdatumAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/none.gif"
+                        <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}"
                                                 value="vorgangsdatumAsc"/>
@@ -277,34 +277,34 @@
                     <!-- Sortierung Asc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort7"
                                    rendered="#{ProzessverwaltungForm.sortierung=='fortschrittAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="fortschrittDesc"/>
                     </h:commandLink>
                     <!-- Sortierung Desc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort8"
                                    rendered="#{ProzessverwaltungForm.sortierung=='fortschrittDesc'}">
-                        <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="fortschrittAsc"/>
                     </h:commandLink>
                     <!-- Sortierung none -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort9"
                                    rendered="#{ProzessverwaltungForm.sortierung!='fortschrittDesc' and ProzessverwaltungForm.sortierung!='fortschrittAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/none.gif"
+                        <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="fortschrittAsc"/>
                     </h:commandLink>
                 </t:div>
             </f:facet>
-            <h:graphicImage value="/newpages/images/fortschritt/ende_links.gif" rendered="true"/>
-            <h:graphicImage value="/newpages/images/fortschritt/gr.gif"
+            <h:graphicImage value="/newpages/images/fortschritt/ende_links.gif" alt="" rendered="true"/>
+            <h:graphicImage value="/newpages/images/fortschritt/gr.gif" alt="open"
                             style="width:#{item.progressOpen * 0.8}px;height:10px"/>
-            <h:graphicImage value="/newpages/images/fortschritt/ge.gif"
+            <h:graphicImage value="/newpages/images/fortschritt/ge.gif" alt="in process"
                             style="width:#{item.progressInProcessing * 0.8}px;height:10px"/>
-            <h:graphicImage value="/newpages/images/fortschritt/rt.gif"
+            <h:graphicImage value="/newpages/images/fortschritt/rt.gif" alt="closed"
                             style="width:#{item.progressClosed * 0.8}px;height:10px"/>
-            <h:graphicImage value="/newpages/images/fortschritt/ende_rechts.gif" rendered="true"/>
+            <h:graphicImage value="/newpages/images/fortschritt/ende_rechts.gif" rendered="true" alt=""/>
         </t:column>
 
         <t:column style="text-align:center">
@@ -315,21 +315,21 @@
                     <!-- Sortierung Asc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort10"
                                    rendered="#{ProzessverwaltungForm.sortierung=='projektAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="projektDesc"/>
                     </h:commandLink>
                     <!-- Sortierung Desc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort11"
                                    rendered="#{ProzessverwaltungForm.sortierung=='projektDesc'}">
-                        <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="projektAsc"/>
                     </h:commandLink>
                     <!-- Sortierung none -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort12"
                                    rendered="#{ProzessverwaltungForm.sortierung!='projektDesc' and ProzessverwaltungForm.sortierung!='projektAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/none.gif"
+                        <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="projektAsc"/>
                     </h:commandLink>
@@ -347,21 +347,21 @@
                     <!-- Sortierung Asc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort13"
                                    rendered="#{ProzessverwaltungForm.sortierung=='sperrungenAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/asc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/asc.gif" alt="sort ascending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="sperrungenDesc"/>
                     </h:commandLink>
                     <!-- Sortierung Desc -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort14"
                                    rendered="#{ProzessverwaltungForm.sortierung=='sperrungenDesc'}">
-                        <h:graphicImage value="/newpages/images/sorting/desc.gif"
+                        <h:graphicImage value="/newpages/images/sorting/desc.gif" alt="sort descending"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="sperrungenAsc"/>
                     </h:commandLink>
                     <!-- Sortierung none -->
                     <h:commandLink action="#{ProzessverwaltungForm.FilterAlleStart}" id="sort15"
                                    rendered="#{ProzessverwaltungForm.sortierung!='sperrungenDesc' and ProzessverwaltungForm.sortierung!='sperrungenAsc'}">
-                        <h:graphicImage value="/newpages/images/sorting/none.gif"
+                        <h:graphicImage value="/newpages/images/sorting/none.gif" alt="no sorting"
                                         style="vertical-align:middle;margin-left:5px"/>
                         <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="sperrungenAsc"/>
                     </h:commandLink>
@@ -379,7 +379,7 @@
             <h:commandLink action="#{ProzessverwaltungForm.editProcess}" id="action10"
                            rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen'}"
                            title="#{msgs.prozessBearbeiten}">
-                <h:graphicImage value="/newpages/images/buttons/goInto.gif" style="margin-right:5px"/>
+                <h:graphicImage value="/newpages/images/buttons/goInto.gif" alt="edit process" style="margin-right:5px"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}" value=""/>
             </h:commandLink>
@@ -388,7 +388,7 @@
             <h:commandLink action="#{ProzessverwaltungForm.editProcess}" id="action11"
                            rendered="#{(LoginForm.maximaleBerechtigung == 1) and (ProzessverwaltungForm.modusAnzeige=='vorlagen')}"
                            title="#{msgs.prozessBearbeiten}">
-                <h:graphicImage value="/newpages/images/buttons/goInto.gif" style="margin-right:5px"/>
+                <h:graphicImage value="/newpages/images/buttons/goInto.gif" alt="edit template" style="margin-right:5px"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}" value=""/>
             </h:commandLink>
@@ -397,7 +397,7 @@
             <h:commandLink action="#{ProzessverwaltungForm.DownloadTiffHeader}" id="action12"
                            title="#{msgs.dateiMitTiffHeaderSpeichern}"
                            rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and 0==1}">
-                <h:graphicImage value="/newpages/images/buttons/tif.gif" style="margin-right:1px"/>
+                <h:graphicImage value="/newpages/images/buttons/tif.gif" alt="tif export" style="margin-right:1px"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
             </h:commandLink>
 
@@ -405,14 +405,14 @@
             <h:commandLink action="#{ProzessverwaltungForm.DownloadMultiTiff}" id="action13"
                            title="#{msgs.multiTiffDownloaden}"
                            rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and LoginForm.maximaleBerechtigung == 1 and 0==1}">
-                <h:graphicImage value="/newpages/images/buttons/view3.gif" style="margin-right:3px"/>
+                <h:graphicImage value="/newpages/images/buttons/view3.gif" alt="multiple tiff export" style="margin-right:3px"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
             </h:commandLink>
 
             <!-- Metadaten-Schaltknopf -->
             <h:commandLink action="#{Metadaten.readXml}" id="action14" title="#{msgs.metadatenBearbeiten}123"
                            rendered="#{(LoginForm.maximaleBerechtigung != 1) and (LoginForm.maximaleBerechtigung != 2) and item.blockedUsers == null and ProzessverwaltungForm.modusAnzeige!='vorlagen'}">
-                <h:graphicImage value="/newpages/images/buttons/view1.gif" style="margin-right:10px"/>
+                <h:graphicImage value="/newpages/images/buttons/view1.gif" alt="view" style="margin-right:10px"/>
                 <f:param name="nurLesen" value="true"/>
                 <f:param name="ProzesseID" value="#{item.id}"/>
                 <f:param name="BenutzerID" value="#{LoginForm.myBenutzer.id}"/>
@@ -424,7 +424,7 @@
                 <!-- Metadaten-Schaltknopf -->
                 <h:commandLink action="#{Metadaten.readXml}" id="action15" title="#{msgs.metadatenBearbeiten}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen'}">
-                    <h:graphicImage value="/newpages/images/buttons/view1.gif" style="margin-right:10px"/>
+                    <h:graphicImage value="/newpages/images/buttons/view1.gif" alt="view" style="margin-right:10px"/>
                     <f:param name="ProzesseID" value="#{item.id}"/>
                     <f:param name="BenutzerID" value="#{LoginForm.myBenutzer.id}"/>
                     <f:param name="zurueck" value="ProzessverwaltungAlle"/>
@@ -434,7 +434,7 @@
                 <h:commandLink action="#{ProzessverwaltungForm.DownloadToHome}" id="action16"
                                title="#{msgs.imHomeVerzeichnisVerlinken}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and !item.imageFolderInUse}">
-                    <h:graphicImage value="/newpages/images/buttons/load_down2.gif" style="margin-right:2px"/>
+                    <h:graphicImage value="/newpages/images/buttons/load_down2.gif" alt="download" style="margin-right:2px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
 
@@ -443,7 +443,7 @@
                                title="#{msgs.imHomeVerzeichnisVerlinkenTrotzBearbeitung}"
                                onclick="if (!confirm('#{msgs.warningAdminBeforeLinking}')) return"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and item.imageFolderInUse}">
-                    <h:graphicImage value="/newpages/images/buttons/load_down3.gif" style="margin-right:2px"/>
+                    <h:graphicImage value="/newpages/images/buttons/load_down3.gif" alt="download" style="margin-right:2px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
 
@@ -452,14 +452,14 @@
                                title="#{msgs.ausHomeverzeichnisEntfernen}"
                                onclick="if (!confirm('#{msgs.ausHomeverzeichnisEntfernen}?')) return"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen'}">
-                    <h:graphicImage value="/newpages/images/buttons/load_up2.gif" style="margin-right:2px"/>
+                    <h:graphicImage value="/newpages/images/buttons/load_up2.gif" alt="upload" style="margin-right:2px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
 
                 <!-- XML Export-Schaltknopf -->
                 <h:commandLink id="ubid119" action="#{ProzessverwaltungForm.CreateXML}" title="#{msgs.createXML}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen'}">
-                    <h:graphicImage id="ubid120" alt="sorta" value="/newpages/images/buttons/xml.gif"
+                    <h:graphicImage id="ubid120" alt="xml export" value="/newpages/images/buttons/xml.gif"
                                     style="margin-right:2px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
@@ -468,7 +468,7 @@
                 <h:commandLink id="ubid1119" action="#{ProzessverwaltungForm.downloadDocket}"
                                title="#{msgs.laufzettelDrucken}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen'}">
-                    <h:graphicImage id="ubid1120" alt="sorta" value="/newpages/images/buttons/laufzettel.png"
+                    <h:graphicImage id="ubid1120" alt="docket export" value="/newpages/images/buttons/laufzettel.png"
                                     style="margin-right:2px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
@@ -477,40 +477,40 @@
                 <!-- Mets-Export-Schaltknopf -->
                 <h:commandLink action="#{ProzessverwaltungForm.ExportMets}" id="action19" title="#{msgs.exportMets}"
                                rendered="#{(ProzessverwaltungForm.modusAnzeige!='vorlagen' and (LoginForm.maximaleBerechtigung == 2 || LoginForm.maximaleBerechtigung == 1)) and item.tifDirectoryExists}">
-                    <h:graphicImage value="/newpages/images/buttons/mets.png" style="margin-right:2px"/>
+                    <h:graphicImage value="/newpages/images/buttons/mets.png" alt="mets export" style="margin-right:2px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
 
                 <!-- Mets-Export-Schaltknopf greyed -->
                 <h:graphicImage
                         rendered="#{(ProzessverwaltungForm.modusAnzeige!='vorlagen' and (LoginForm.maximaleBerechtigung == 2 || LoginForm.maximaleBerechtigung == 1)) and !item.tifDirectoryExists}"
-                        value="/newpages/images/buttons/metsGreyed.png" style="margin-right:2px"
+                        value="/newpages/images/buttons/metsGreyed.png" alt="mets export unavailable" style="margin-right:2px"
                         title="#{msgs.exportMets}"/>
 
                 <!-- PDF-Export-Schaltknopf -->
                 <h:commandLink action="#{ProzessverwaltungForm.ExportPdf}" id="action20" title="#{msgs.exportPdf}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and (LoginForm.maximaleBerechtigung == 2 || LoginForm.maximaleBerechtigung == 1) and item.tifDirectoryExists}">
-                    <h:graphicImage value="/newpages/images/buttons/pdf.png" style="margin-right:2px"/>
+                    <h:graphicImage value="/newpages/images/buttons/pdf.png" alt="pdf export" style="margin-right:2px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
 
                 <!-- PDF-Export-Schaltknopf greyed -->
                 <h:graphicImage
                         rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and (LoginForm.maximaleBerechtigung == 2 || LoginForm.maximaleBerechtigung == 1) and !item.tifDirectoryExists}"
-                        value="/newpages/images/buttons/pdfGreyed.png" style="margin-right:2px"
+                        value="/newpages/images/buttons/pdfGreyed.png" alt="pdf export unavailable" style="margin-right:2px"
                         title="#{msgs.exportPdf}"/>
 
                 <!-- DMS-Export-Schaltknopf -->
                 <h:commandLink action="#{ProzessverwaltungForm.ExportDMS}" id="action21" title="#{msgs.importDms}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and (LoginForm.maximaleBerechtigung == 2 || LoginForm.maximaleBerechtigung == 1) and item.tifDirectoryExists}">
-                    <h:graphicImage value="/newpages/images/buttons/dms.png" style="margin-right:0px"/>
+                    <h:graphicImage value="/newpages/images/buttons/dms.png" alt="dms export" style="margin-right:0px"/>
                     <t:updateActionListener property="#{ProzessverwaltungForm.myProzess}" value="#{item}"/>
                 </h:commandLink>
 
                 <!-- PDF-Export-Schaltknopf greyed -->
                 <h:graphicImage
                         rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and (LoginForm.maximaleBerechtigung == 2 || LoginForm.maximaleBerechtigung == 1) and !item.tifDirectoryExists}"
-                        value="/newpages/images/buttons/dmsGreyed.png" style="margin-right:2px"
+                        value="/newpages/images/buttons/dmsGreyed.png" alt="dms export unavailable" style="margin-right:2px"
                         title="#{msgs.importDms}"/>
 
                 <!-- ProzessKopie-Schaltknopf -->
@@ -518,9 +518,9 @@
                                title="#{item.containsUnreachableSteps?msgs.prozessvorlageMitUnvollstaendigenSchrittdetails:msgs.eineKopieDieserProzessvorlageAnlegen}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige=='vorlagen'}">
                     <h:graphicImage value="/newpages/images/buttons/star_blue.gif" style="margin-right:3px"
-                                    rendered="#{!item.containsUnreachableSteps}"/>
+                                    alt="" rendered="#{!item.containsUnreachableSteps}"/>
                     <h:graphicImage value="/newpages/images/buttons/star_red.gif" style="margin-right:3px"
-                                    rendered="#{item.containsUnreachableSteps}"/>
+                                    alt="" rendered="#{item.containsUnreachableSteps}"/>
                     <t:updateActionListener property="#{ProzesskopieForm.prozessVorlage}" value="#{item}"/>
                 </h:commandLink>
 
@@ -528,9 +528,9 @@
                 <h:commandLink action="#{MassImportForm.prepare}" id="action222" title="#{msgs.MassenImport}"
                                rendered="#{ProzessverwaltungForm.modusAnzeige=='vorlagen' and HelperForm.massImportAllowed}">
                     <h:graphicImage value="/newpages/images/buttons/star_blue_multi.png" style="margin-right:3px"
-                                    rendered="#{!item.containsUnreachableSteps}"/>
+                                    alt="mass import" rendered="#{!item.containsUnreachableSteps}"/>
                     <h:graphicImage value="/newpages/images/buttons/star_red.gif" style="margin-right:3px"
-                                    rendered="#{item.containsUnreachableSteps}"/>
+                                    alt="mass import unavailable" rendered="#{item.containsUnreachableSteps}"/>
                     <t:updateActionListener property="#{MassImportForm.template}" value="#{item}"/>
                 </h:commandLink>
 
@@ -568,4 +568,3 @@
         </tr>
     </table>
 </ui:composition>
-

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste_Action.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste_Action.xhtml
@@ -40,7 +40,7 @@
                                 id="action1" action="#{ProzessverwaltungForm.UploadFromHomeAlle}"
                                 title="#{msgs.verzeichnisFertigAusHomeverzeichnisEntfernen}"
                                 onclick="if (!confirm('#{msgs.upload}?')) return">
-                            <h:graphicImage value="/newpages/images/buttons/load_up_set_20px.gif"
+                            <h:graphicImage value="/newpages/images/buttons/load_up_set_20px.gif" alt="upload set"
                                             style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.verzeichnisFertigAusHomeverzeichnisEntfernen}"/>
                         </h:commandLink>
@@ -51,7 +51,7 @@
                             <span class="toggle" data-for="toggle-9">
                                 <h:commandLink id="downloadswitcher">
                                     <f:ajax render="download"/>
-                                    <h:graphicImage value="/newpages/images/buttons/load_down_set_20px.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/load_down_set_20px.gif" alt="download set"
                                                     style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.imHomeVerzeichnisVerlinken}"/>
                                 </h:commandLink>
@@ -94,7 +94,7 @@
                             <span class="toggle" data-for="toggle-1">
                                 <h:commandLink id="agoraswitcher">
                                     <f:ajax render="agoradownload"/>
-                                    <h:graphicImage value="/newpages/images/buttons/dms.png"
+                                    <h:graphicImage value="/newpages/images/buttons/dms.png" alt="dms"
                                                     style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.metadatenFuerDMSExportieren}"/>
                                 </h:commandLink>
@@ -138,7 +138,7 @@
                                 rendered="#{ProzessverwaltungForm.modusAnzeige=='aktuell' and ProzessverwaltungForm.page.totalResults > 0 }">
 
                             <span class="toggle" data-for="toggle-2">
-                                <h:graphicImage value="/newpages/images/buttons/step_for_20px.gif"
+                                <h:graphicImage value="/newpages/images/buttons/step_for_20px.gif" alt="step forward"
                                                 style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.bearbeitungsstatusHochsetzen}"/>
                             </span>
@@ -181,7 +181,7 @@
                                 rendered="#{ProzessverwaltungForm.modusAnzeige=='aktuell' and ProzessverwaltungForm.page.totalResults > 0 }">
 
                             <span class="toggle" data-for="toggle-3">
-                                <h:graphicImage value="/newpages/images/buttons/step_back_20px.gif"
+                                <h:graphicImage value="/newpages/images/buttons/step_back_20px.gif" alt="step backward"
                                                 style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.bearbeitungsstatusRuntersetzen}"/>
                             </span>
@@ -225,7 +225,7 @@
                                 rendered="#{LoginForm.maximaleBerechtigung == 1 and ProzessverwaltungForm.modusAnzeige=='aktuell'  and ProzessverwaltungForm.page.totalResults > 0 }">
 
                             <span class="toggle" data-for="toggle-4">
-                                <h:graphicImage value="/newpages/images/buttons/admin4b.gif"
+                                <h:graphicImage value="/newpages/images/buttons/admin4b.gif" alt="edit"
                                                 style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.kitodoScriptAusfuehren}"/>
                             </span>
@@ -322,7 +322,7 @@
                         <h:panelGroup
                                 rendered="#{ProzessverwaltungForm.modusAnzeige=='aktuell' and ProzessverwaltungForm.page.totalResults > 0 }">
 
-                            <h:graphicImage value="/newpages/images/buttons/excel20.png"
+                            <h:graphicImage value="/newpages/images/buttons/excel20.png" alt="excel export"
                                             style="margin-left:5px;margin-right:8px;vertical-align:middle"/>
                             <h:commandLink action="#{ProzessverwaltungForm.generateResult}" title="#{msgs.createExcel}">
                                 <h:outputText value="#{msgs.createExcel}"/>
@@ -331,7 +331,7 @@
 
                         <h:panelGroup
                                 rendered="#{ProzessverwaltungForm.modusAnzeige=='aktuell' and ProzessverwaltungForm.page.totalResults > 0 }">
-                            <h:graphicImage value="/newpages/images/buttons/pdf.png"
+                            <h:graphicImage value="/newpages/images/buttons/pdf.png" alt="pdf export"
                                             style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                             <h:commandLink action="#{ProzessverwaltungForm.generateResultAsPdf}"
                                            title="#{msgs.createPdf}">
@@ -344,7 +344,7 @@
                                 rendered="#{ProzessverwaltungForm.modusAnzeige=='aktuell' and ProzessverwaltungForm.page.totalResults > 0 }">
 
                             <span class="toggle" data-for="toggle-5">
-                                <h:graphicImage value="/newpages/images/buttons/statistik1_20px.gif"
+                                <h:graphicImage value="/newpages/images/buttons/statistik1_20px.gif" alt="statistics"
                                                 style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.anzahlMetadatenUndImagesErmitteln}"/>
                             </span>
@@ -383,7 +383,7 @@
                                 rendered="#{ProzessverwaltungForm.modusAnzeige=='aktuell' and ProzessverwaltungForm.page.totalResults > 0 }">
 
                             <span class="toggle" data-for="toggle-6">
-                                <h:graphicImage value="/newpages/images/buttons/statistik4_20px.gif"
+                                <h:graphicImage value="/newpages/images/buttons/statistik4_20px.gif" alt="statistics"
                                                 style="margin-left:0px;margin-right:0px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.statistischeAuswertung}"/>
                             </span>
@@ -470,7 +470,7 @@
                         <h:panelGroup>
 
                             <span class="toggle" data-for="toggle-7">
-                                <h:graphicImage value="/newpages/images/buttons/view3.gif"
+                                <h:graphicImage value="/newpages/images/buttons/view3.gif" alt="view"
                                                 style="margin-left:5px;margin-right:8px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.filterAnpassen}"/>
                             </span>
@@ -500,7 +500,7 @@
                         <h:panelGroup>
 
                             <span class="toggle" data-for="toggle-8">
-                                <h:graphicImage value="/newpages/images/buttons/view3.gif"
+                                <h:graphicImage value="/newpages/images/buttons/view3.gif" alt="view"
                                                 style="margin-left:5px;margin-right:8px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.anzeigeAnpassen}"/>
                             </span>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste_Anzahlen.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste_Anzahlen.xhtml
@@ -51,7 +51,7 @@
             <f:facet name="header">
                 <h:outputText value="#{msgs.relativeAnzahl}"/>
             </f:facet>
-            <h:graphicImage value="/newpages/images/fortschritt/rt.gif"
+            <h:graphicImage value="/newpages/images/fortschritt/rt.gif" alt=""
                             style="width:#{item.relImages * 1}%;height:10px" title="#{item.images} #{msgs.images}"/>
         </h:column>
 
@@ -66,7 +66,7 @@
             <f:facet name="header">
                 <h:outputText value="#{msgs.relativeAnzahl}"/>
             </f:facet>
-            <h:graphicImage value="/newpages/images/fortschritt/ge.gif"
+            <h:graphicImage value="/newpages/images/fortschritt/ge.gif" alt=""
                             style="width:#{item.relDocstructs * 1}%;height:10px"
                             title="#{item.docstructs} #{msgs.docstructs}"/>
         </h:column>
@@ -82,7 +82,7 @@
             <f:facet name="header">
                 <h:outputText value="#{msgs.relativeAnzahl}"/>
             </f:facet>
-            <h:graphicImage value="/newpages/images/fortschritt/gr.gif"
+            <h:graphicImage value="/newpages/images/fortschritt/gr.gif" alt=""
                             style="width:#{item.relMetadata * 1}%;height:10px" title="#{item.metadata} #{msgs.metadata}"/>
         </h:column>
     </t:dataTable>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste_Statistik.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste_Statistik.xhtml
@@ -187,7 +187,7 @@
                 </h4>
                 <h:outputText value="#{element.htmlTableRenderer.rendering}" escape="false"/>
                 <h:commandLink action="#{ProzessverwaltungForm.CreateExcel}" title="#{msgs.createExcel}">
-                    <h:graphicImage value="/newpages/images/buttons/excel20.png"/>
+                    <h:graphicImage alt="create excel" value="/newpages/images/buttons/excel20.png"/>
                     <h:outputText value="  #{msgs.createExcel}"/>
                     <t:updateActionListener value="#{element}" property="#{ProzessverwaltungForm.myCurrentTable}"/>
                 </h:commandLink>
@@ -207,7 +207,7 @@
                                   rendered="#{element.dataTable.showableInTable}"/>
                     <h:commandLink action="#{ProzessverwaltungForm.CreateExcel}" title="#{msgs.createExcel}"
                                    rendered="#{element.dataTable.showableInTable}">
-                        <h:graphicImage value="/newpages/images/buttons/excel20.png"/>
+                        <h:graphicImage alt="create excel" value="/newpages/images/buttons/excel20.png"/>
                         <h:outputText value="  #{msgs.createExcel}"/>
                         <t:updateActionListener value="#{element}" property="#{ProzessverwaltungForm.myCurrentTable}"/>
                     </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Properties.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Properties.xhtml
@@ -64,7 +64,7 @@
                         </td>
                         <td class="standardTable_ColumnCentered">
                             <h:commandLink action="ProzessverwaltungBearbeiten" title="#{msgs.bearbeiten}">
-                                <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                                <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                                 <t:updateActionListener property="#{ProzessverwaltungForm.processProperty}" value="#{proc}"/>
                                 <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="0"/>
                                 <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}"
@@ -72,7 +72,7 @@
                                 <!-- <a4j:support event="onchange" reRender="editBatch" />-->
                             </h:commandLink>
                             <h:commandLink action="#{ProzessverwaltungForm.duplicateProperty}" title="#{msgs.duplicate}">
-                                <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                 <t:updateActionListener property="#{ProzessverwaltungForm.processProperty}" value="#{proc}"/>
                                 <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="0"/>
                             </h:commandLink>
@@ -109,7 +109,7 @@
                                 rowspan="#{ProzessverwaltungForm.containers[container].propertyListSizeString}">
                                 <!-- edit container -->
                                 <h:commandLink action="ProzessverwaltungBearbeiten" title="#{msgs.bearbeiten}">
-                                    <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                                    <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                                     <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="#{container}"/>
                                     <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}"
                                                             value="eigenschaft"/>
@@ -117,7 +117,7 @@
                                 </h:commandLink>
                                 <!-- duplicate container -->
                                 <h:commandLink action="#{ProzessverwaltungForm.duplicateContainer}" title="#{msgs.duplicate}">
-                                    <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                    <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                     <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="#{container}"/>
                                 </h:commandLink>
                             </td>
@@ -142,14 +142,14 @@
                     <td class="standardTable_ColumnCentered" rowspan="''+#{ProzessverwaltungForm.containers[container]}" rendered="#{cont != container }">
 
                         <h:commandLink action="ProzessverwaltungBearbeiten" title="#{msgs.bearbeiten}">
-                            <h:graphicImage value="/newpages/images/buttons/edit.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                             <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="#{container}" />
                             <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}" value="eigenschaft" />
 
                         </h:commandLink>
 
                         <h:commandLink action="#{ProzessverwaltungForm.duplicateContainer}" title="#{msgs.duplicate}">
-                            <h:graphicImage value="/newpages/images/buttons/copy.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                             <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="#{container}" />
                         </h:commandLink>
                     </td>
@@ -174,13 +174,13 @@
                     </td>
                     <td class="standardTable_ColumnCentered">
                         <h:commandLink action="ProzessverwaltungBearbeiten" title="#{msgs.bearbeiten}">
-                            <h:graphicImage value="/newpages/images/buttons/edit.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                             <t:updateActionListener property="#{ProzessverwaltungForm.processProperty}" value="#{proc}" />
                             <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="0" />
                             <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}" value="eigenschaft" />
                         </h:commandLink>
                         <h:commandLink action="#{ProzessverwaltungForm.duplicateContainer}" title="#{msgs.duplicate}">
-                            <h:graphicImage value="/newpages/images/buttons/copy.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                             <t:updateActionListener property="#{ProzessverwaltungForm.processProperty}" value="#{proc}" />
                             <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="0" />
                         </h:commandLink>
@@ -200,12 +200,12 @@
 
                     <td class="standardTable_ColumnCentered">
                         <h:commandLink action="ProzessverwaltungBearbeiten" title="#{msgs.bearbeiten}" rendered="#{propInd + 1 == propCount}">
-                            <h:graphicImage value="/newpages/images/buttons/edit.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                             <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="#{container}" />
                             <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}" value="eigenschaft" />
                         </h:commandLink>
                         <h:commandLink action="#{ProzessverwaltungForm.duplicateContainer}" title="#{msgs.duplicate}" rendered="#{propInd + 1 == propCount}">
-                            <h:graphicImage value="/newpages/images/buttons/copy.gif" />
+                            <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                             <t:updateActionListener property="#{ProzessverwaltungForm.container}" value="#{container}" />
                         </h:commandLink>
                     </td>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Prozessdetails.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Prozessdetails.xhtml
@@ -31,7 +31,7 @@
                                 </td>
                                 <td class="main_statistikboxen_row1" align="right">
                                     <h:commandLink action="#{ProzessverwaltungForm.Reload}">
-                                        <h:graphicImage value="/newpages/images/reload.gif"/>
+                                        <h:graphicImage value="/newpages/images/reload.gif" alt="reload"/>
                                     </h:commandLink>
                                 </td>
                             </tr>
@@ -50,7 +50,7 @@
                                                 <td rowspan="2" align="right">
                                                     <h:commandLink title="#{msgs.prozessdetailsBearbeiten}"
                                                                    action="#{NavigationForm.Reload}" style=";margin-right:20px">
-                                                        <h:graphicImage value="/newpages/images/buttons/edit_20.gif"/>
+                                                        <h:graphicImage value="/newpages/images/buttons/edit_20.gif" alt="edit"/>
                                                         <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}"
                                                                                 value="prozess"/>
                                                     </h:commandLink>
@@ -101,9 +101,9 @@
                                                 <h:outputText value="#{msgs.inAuswahllisteAnzeigen}:"/>
                                             </td>
                                             <td>
-                                                <h:graphicImage value="/newpages/images/check_false.gif"
+                                                <h:graphicImage value="/newpages/images/check_false.gif" alt="do not show in list"
                                                                 rendered="#{not ProzessverwaltungForm.myProzess.inChoiceListShown}"/>
-                                                <h:graphicImage value="/newpages/images/check_true.gif"
+                                                <h:graphicImage value="/newpages/images/check_true.gif" alt="show in list"
                                                                 rendered="#{ProzessverwaltungForm.myProzess.inChoiceListShown}"/>
                                             </td>
                                         </tr>
@@ -113,9 +113,9 @@
                                                 <h:outputText value="#{msgs.istTemplate}:"/>
                                             </td>
                                             <td>
-                                                <h:graphicImage value="/newpages/images/check_false.gif"
+                                                <h:graphicImage value="/newpages/images/check_false.gif" alt="is not template"
                                                                 rendered="#{not ProzessverwaltungForm.myProzess.template}"/>
-                                                <h:graphicImage value="/newpages/images/check_true.gif"
+                                                <h:graphicImage value="/newpages/images/check_true.gif" alt="is template"
                                                                 rendered="#{ProzessverwaltungForm.myProzess.template}"/>
                                             </td>
                                         </tr>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Schritte.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Schritte.xhtml
@@ -41,7 +41,7 @@
             <!-- Schaltknopf: Reihenfolge nach oben -->
             <h:commandLink action="#{ProzessverwaltungForm.reihenfolgeUp}"
                              rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                <h:graphicImage value="/newpages/images/buttons/order_up_klein.gif"
+                <h:graphicImage value="/newpages/images/buttons/order_up_klein.gif" alt="sort ascending"
                                 style="margin-left:5px;vertical-align:middle"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.mySchritt}"
                                         value="#{item}"/>
@@ -50,7 +50,7 @@
             <!-- Schaltknopf: Reihenfolge nach unten -->
             <h:commandLink action="#{ProzessverwaltungForm.reihenfolgeDown}"
                              rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                <h:graphicImage value="/newpages/images/buttons/order_down_klein.gif"
+                <h:graphicImage value="/newpages/images/buttons/order_down_klein.gif" alt="sort descending"
                                 style="vertical-align:middle"/>
                 <t:updateActionListener property="#{ProzessverwaltungForm.mySchritt}"
                                         value="#{item}"/>
@@ -65,9 +65,9 @@
             </f:facet>
 
             <h:commandLink id="myself" style="color:black">
-                <h:graphicImage value="/newpages/images/plus.gif"
+                <h:graphicImage value="/newpages/images/plus.gif" alt="show details"
                                 style="margin-right:4px" rendered="#{!item.panelShown}"/>
-                <h:graphicImage value="/newpages/images/minus.gif"
+                <h:graphicImage value="/newpages/images/minus.gif" alt="hide details"
                                 style="margin-right:4px" rendered="#{item.panelShown}"/>
                 <t:updateActionListener value="#{item.panelShown?false:true}"
                                         property="#{item.panelShown}"/>
@@ -89,9 +89,9 @@
             <f:facet name="header">
                 <t:div>
                     <t:headerLink immediate="true">
-                        <h:graphicImage value="/newpages/images/plus.gif"
+                        <h:graphicImage value="/newpages/images/plus.gif" alt="show"
                                         style="margin-right:4px;" rendered="#{isCollapsed}"/>
-                        <h:graphicImage value="/newpages/images/minus.gif"
+                        <h:graphicImage value="/newpages/images/minus.gif" alt="hide"
                                         style="margin-right:4px;" rendered="#{!isCollapsed}"/>
                     </t:headerLink>
                     <h:outputText value="#{item.localizedTitle}"
@@ -105,14 +105,14 @@
                 <!--<p:commandButton onclick="PF('detailsSmall').toggle()" value="Testbutton" type="button" />-->
                     <f:facet name="show">
                         <h:panelGroup>
-                            <h:graphicImage value="/newpages/images/minus.gif"
+                            <h:graphicImage value="/newpages/images/minus.gif" alt="hide"
                                             style="margin-right:5px"/>
                             <h:outputText value="#{item.localizedTitle}"/>
                         </h:panelGroup>
                     </f:facet>
                     <f:facet name="hide">
                         <h:panelGroup>
-                            <h:graphicImage value="/newpages/images/plus.gif"
+                            <h:graphicImage value="/newpages/images/plus.gif" alt="show"
                                             style="margin-right:5px"/>
                             <h:outputText value="#{item.localizedTitle}"/>
                         </h:panelGroup>
@@ -137,14 +137,14 @@
             <h:panelGrid columns="2" id="statuscolumn">
 
                 <h:graphicImage value="#{item.processingStatusEnum.bigImagePath}"
-                                title="#{item.processingStatusEnum.title}"/>
+                                title="#{item.processingStatusEnum.title}" alt=""/>
 
                 <h:panelGrid columns="1" cellpadding="0" cellspacing="0"
                              rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
                     <!-- Bearbeitungsstatus hoch und runter -->
                     <h:commandLink action="#{ProzessverwaltungForm.SchrittStatusUp}"
                                      title="#{msgs.statusHoeherSetzen}">
-                        <h:graphicImage
+                        <h:graphicImage alt="status up"
                                 value="/newpages/images/buttons/order_right_klein.gif"/>
                         <t:updateActionListener
                                 property="#{ProzessverwaltungForm.mySchrittReload}"
@@ -154,7 +154,7 @@
                     <!-- Bearbeitungsstatus hoch und runter -->
                     <h:commandLink action="#{ProzessverwaltungForm.SchrittStatusDown}"
                                      title="#{msgs.statusRunterSetzen}">
-                        <h:graphicImage
+                        <h:graphicImage alt="status down"
                                 value="/newpages/images/buttons/order_left_klein.gif"/>
                         <t:updateActionListener
                                 property="#{ProzessverwaltungForm.mySchrittReload}"
@@ -173,7 +173,7 @@
             <!-- Bearbeiten-Schaltknopf -->
             <h:commandLink action="inc_Prozessverwaltung/schritt"
                            title="#{msgs.detailsDesSchritts}">
-                <h:graphicImage value="/newpages/images/buttons/goInto.gif"/>
+                <h:graphicImage value="/newpages/images/buttons/goInto.gif" alt="details"/>
                 <t:updateActionListener
                         property="#{ProzessverwaltungForm.mySchrittReload}" value="#{item}"/>
                 <t:updateActionListener

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Vorlagen.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Vorlagen.xhtml
@@ -64,7 +64,7 @@
         <!-- Bearbeiten-Schaltknopf -->
         <h:commandLink action="inc_Prozessverwaltung/vorlage"
                        title="#{msgs.vorlageBearbeiten}">
-            <h:graphicImage value="/newpages/images/buttons/goInto.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/goInto.gif" alt="edit"/>
             <t:updateActionListener
                     property="#{ProzessverwaltungForm.myVorlageReload}" value="#{item}"/>
         </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Werkstuecke.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Werkstuecke.xhtml
@@ -64,7 +64,7 @@
         <!-- Bearbeiten-Schaltknopf -->
         <h:commandLink action="ProzessverwaltungBearbeitenWerkstueck"
                        title="#{msgs.werkstueckBearbeiten}">
-            <h:graphicImage value="/newpages/images/buttons/goInto.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/goInto.gif" alt="edit"/>
             <t:updateActionListener
                     property="#{ProzessverwaltungForm.myWerkstueckReload}"
                     value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Benutzer.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Benutzer.xhtml
@@ -46,7 +46,7 @@
         <!-- Löschen-Schaltknopf -->
         <h:commandLink action="#{ProzessverwaltungForm.BenutzerLoeschen}"
                        title="#{msgs.berechtigungLoeschen}">
-            <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete"/>
             <t:updateActionListener
                     property="#{ProzessverwaltungForm.myBenutzer}" value="#{item}"/>
         </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_BenutzerPopup.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_BenutzerPopup.xhtml
@@ -79,7 +79,7 @@
                                     <h:commandLink
                                             action="#{ProzessverwaltungForm.BenutzerHinzufuegen}"
                                             title="#{msgs.uebernehmen}">
-                                        <h:graphicImage value="/newpages/images/buttons/addUser.gif"/>
+                                        <h:graphicImage alt="add user" value="/newpages/images/buttons/addUser.gif"/>
                                         <t:updateActionListener
                                                 property="#{ProzessverwaltungForm.myBenutzer}" value="#{item}"/>
                                     </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Benutzergruppen.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Benutzergruppen.xhtml
@@ -48,7 +48,7 @@
         <h:commandLink
                 action="#{ProzessverwaltungForm.BenutzergruppeLoeschen}"
                 title="#{msgs.berechtigungLoeschen}">
-            <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif"/>
+            <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete user group"/>
             <t:updateActionListener
                     property="#{ProzessverwaltungForm.myBenutzergruppe}" value="#{item}"/>
         </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_BenutzergruppenPopup.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_BenutzergruppenPopup.xhtml
@@ -61,7 +61,7 @@
                                     <h:commandLink
                                             action="#{ProzessverwaltungForm.BenutzergruppeHinzufuegen}"
                                             title="#{msgs.uebernehmen}">
-                                        <h:graphicImage value="/newpages/images/buttons/addUser.gif"/>
+                                        <h:graphicImage value="/newpages/images/buttons/addUser.gif" alt="add user"/>
                                         <t:updateActionListener
                                                 property="#{ProzessverwaltungForm.myBenutzergruppe}"
                                                 value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Details.xhtml
@@ -27,7 +27,7 @@
                 </td>
                 <td class="main_statistikboxen_row1" align="right">
                     <h:commandLink action="#{ProzessverwaltungForm.Reload}">
-                        <h:graphicImage value="/newpages/images/reload.gif"/>
+                        <h:graphicImage value="/newpages/images/reload.gif" alt="reload"/>
                     </h:commandLink>
                 </td>
             </tr>
@@ -46,7 +46,7 @@
                             <td rowspan="2" align="right">
                                 <h:commandLink title="#{msgs.bearbeiten}" action="#{NavigationForm.Reload}"
                                                style=";margin-right:20px">
-                                    <h:graphicImage value="/newpages/images/buttons/edit_20.gif"/>
+                                    <h:graphicImage value="/newpages/images/buttons/edit_20.gif" alt="reload"/>
                                     <t:updateActionListener property="#{ProzessverwaltungForm.modusBearbeiten}"
                                                             value="schritt"/>
                                 </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/vorlage_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/vorlage_box_Details.xhtml
@@ -26,7 +26,7 @@
                 </td>
                 <td class="main_statistikboxen_row1" align="right">
                     <h:commandLink action="#{ProzessverwaltungForm.Reload}">
-                        <h:graphicImage value="/newpages/images/reload.gif"/>
+                        <h:graphicImage value="/newpages/images/reload.gif" alt="reload"/>
                     </h:commandLink>
                 </td>
             </tr>
@@ -45,7 +45,7 @@
                             <td rowspan="2" align="right">
                                 <h:commandLink title="#{msgs.bearbeiten}"
                                                action="#{NavigationForm.Reload}">
-                                    <h:graphicImage value="/newpages/images/buttons/edit_20.gif"/>
+                                    <h:graphicImage value="/newpages/images/buttons/edit_20.gif" alt="edit"/>
                                     <t:updateActionListener
                                             property="#{ProzessverwaltungForm.modusBearbeiten}"
                                             value="vorlage"/>
@@ -54,7 +54,7 @@
                                 <h:commandLink title="#{msgs.loeschen}"
                                                action="#{ProzessverwaltungForm.VorlageLoeschen}"
                                                style="margin-right:20px">
-                                    <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif"/>
+                                    <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete"/>
                                 </h:commandLink>
                             </td>
                         </tr>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/vorlage_box_Eigenschaften.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/vorlage_box_Eigenschaften.xhtml
@@ -57,7 +57,7 @@
             <!-- Bearbeiten-Schaltknopf -->
             <h:commandLink action="inc_Prozessverwaltung/vorlage"
                            title="#{msgs.bearbeiten}">
-                <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                 <t:updateActionListener
                         property="#{ProzessverwaltungForm.myVorlageEigenschaft}"
                         value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/werkstueck_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/werkstueck_box_Details.xhtml
@@ -24,7 +24,7 @@
             </td>
             <td class="main_statistikboxen_row1" align="right">
                 <h:commandLink action="#{ProzessverwaltungForm.Reload}">
-                    <h:graphicImage value="/newpages/images/reload.gif"/>
+                    <h:graphicImage value="/newpages/images/reload.gif" alt="reload"/>
                 </h:commandLink>
             </td>
         </tr>
@@ -44,7 +44,7 @@
 
                             <h:commandLink title="#{msgs.loeschen}"
                                            action="#{ProzessverwaltungForm.WerkstueckLoeschen}" style="margin-right:20px">
-                                <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif"/>
+                                <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete"/>
                             </h:commandLink>
 
                         </td>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/werkstueck_box_Eigenschaften.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/werkstueck_box_Eigenschaften.xhtml
@@ -56,7 +56,7 @@
             <!-- Bearbeiten-Schaltknopf -->
             <h:commandLink action="ProzessverwaltungBearbeitenWerkstueck"
                            title="#{msgs.bearbeiten}">
-                <h:graphicImage value="/newpages/images/buttons/edit.gif"/>
+                <h:graphicImage value="/newpages/images/buttons/edit.gif" alt="edit"/>
                 <t:updateActionListener
                         property="#{ProzessverwaltungForm.myWerkstueckEigenschaft}"
                         value="#{item}"/>

--- a/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticCorrection.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticCorrection.xhtml
@@ -153,7 +153,7 @@
 
                 <h:commandLink action="#{Form.CreateExcel}" title="#{msgs.createExcel}"
                                rendered="#{element.dataTable.showableInTable and (Form.statisticsManager3.targetResultOutput== 'table' || Form.statisticsManager3.targetResultOutput=='chartAndTable')}">
-                    <h:graphicImage value="/newpages/images/buttons/excel20.png"/>
+                    <h:graphicImage alt="create excel" value="/newpages/images/buttons/excel20.png"/>
                     <h:outputText value="  #{msgs.createExcel}"/>
                     <t:updateActionListener value="#{element}" property="#{Form.myCurrentTable}"/>
                 </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticProduction.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticProduction.xhtml
@@ -152,7 +152,7 @@
 
                 <h:commandLink action="#{Form.CreateExcel}" title="#{msgs.createExcel}"
                                rendered="#{element.dataTable.showableInTable and (Form.statisticsManager1.targetResultOutput== 'table' || Form.statisticsManager1.targetResultOutput=='chartAndTable')}">
-                    <h:graphicImage value="/newpages/images/buttons/excel20.png"/>
+                    <h:graphicImage value="/newpages/images/buttons/excel20.png" alt="create excel"/>
                     <h:outputText value="  #{msgs.createExcel}"/>
                     <t:updateActionListener value="#{element}" property="#{Form.myCurrentTable}"/>
                 </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticStorage.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticStorage.xhtml
@@ -152,7 +152,7 @@
 
                 <h:commandLink action="#{Form.CreateExcel}" title="#{msgs.createExcel}"
                                rendered="#{element.dataTable.showableInTable and (Form.statisticsManager4.targetResultOutput== 'table' || Form.statisticsManager4.targetResultOutput=='chartAndTable')}">
-                    <h:graphicImage value="/newpages/images/buttons/excel20.png"/>
+                    <h:graphicImage value="/newpages/images/buttons/excel20.png" alt="create excel"/>
                     <h:outputText value="  #{msgs.createExcel}"/>
                     <t:updateActionListener value="#{element}" property="#{Form.myCurrentTable}"/>
                 </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticThroughput.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_statistic/StatisticThroughput.xhtml
@@ -155,7 +155,7 @@
                 </h4>
                 <h:outputText value="#{element.htmlTableRenderer.rendering}" escape="false"/>
                 <h:commandLink action="#{ProzessverwaltungForm.CreateExcel}" title="#{msgs.createExcel}">
-                    <h:graphicImage value="/newpages/images/buttons/excel20.png"/>
+                    <h:graphicImage value="/newpages/images/buttons/excel20.png" alt="create excel"/>
                     <h:outputText value="  #{msgs.createExcel}"/>
                     <t:updateActionListener value="#{element}" property="#{ProzessverwaltungForm.myCurrentTable}"/>
                 </h:commandLink>
@@ -175,7 +175,7 @@
                                   rendered="#{element.dataTable.showableInTable}"/>
                     <h:commandLink action="#{ProzessverwaltungForm.CreateExcel}" title="#{msgs.createExcel}"
                                    rendered="#{element.dataTable.showableInTable}">
-                        <h:graphicImage value="/newpages/images/buttons/excel20.png"/>
+                        <h:graphicImage value="/newpages/images/buttons/excel20.png" alt="create excel"/>
                         <h:outputText value="  #{msgs.createExcel}"/>
                         <t:updateActionListener value="#{element}" property="#{ProzessverwaltungForm.myCurrentTable}"/>
                     </h:commandLink>

--- a/Kitodo/src/main/webapp/newpages/modulemanager.xhtml
+++ b/Kitodo/src/main/webapp/newpages/modulemanager.xhtml
@@ -120,7 +120,7 @@
                                                                                action="#{ModuleServerForm.startModule}"
                                                                                rendered="#{item.moduleClient.status=='not active'}"
                                                                                title="initialize">
-                                                                    <h:graphicImage
+                                                                    <h:graphicImage alt="start task"
                                                                             value="/newpages/images/icons/start_task.gif"/>
                                                                     <t:updateActionListener value="#{item}"
                                                                                             property="#{ModuleServerForm.myModule}"/>
@@ -129,7 +129,7 @@
                                                                                action="#{ModuleServerForm.stopModule}"
                                                                                rendered="#{item.moduleClient.status=='active'}"
                                                                                title="shutdown">
-                                                                    <h:graphicImage id="id20"
+                                                                    <h:graphicImage id="id20" alt="stop task"
                                                                                     value="/newpages/images/icons/stop_task.gif"/>
                                                                     <t:updateActionListener value="#{item}"
                                                                                             property="#{ModuleServerForm.myModule}"/>
@@ -138,7 +138,7 @@
                                                                         rendered="#{item.moduleClient.status=='active'}"
                                                                         action="#{ModuleServerForm.startShortSessionTest}"
                                                                         title="shortsession">
-                                                                    <h:graphicImage
+                                                                    <h:graphicImage alt="execute task"
                                                                             value="/newpages/images/icons/execute_task.gif"/>
                                                                     <t:updateActionListener value="#{item}"
                                                                                             property="#{ModuleServerForm.myModule}"/>

--- a/Kitodo/src/main/webapp/newpages/plugins/MultipleManifestationMillenniumImport.xhtml
+++ b/Kitodo/src/main/webapp/newpages/plugins/MultipleManifestationMillenniumImport.xhtml
@@ -66,13 +66,13 @@
                 <h:outputText value="#{msgs.auswahl}"/>
             </f:facet>
             <h:commandLink action="#{MassImportForm.plugin.addDocstruct}">
-                <h:graphicImage value="/newpages/images/plus.gif" style="margin-right:4px"/>
+                <h:graphicImage value="/newpages/images/plus.gif" style="margin-right:4px" alt="add docstruct"/>
 
             </h:commandLink>
 
             <h:commandLink action="#{MassImportForm.plugin.deleteDocstruct}"
                            rendered="#{MassImportForm.docstructssize > 1}">
-                <h:graphicImage value="/newpages/images/minus.gif" style="margin-right:4px"/>
+                <h:graphicImage value="/newpages/images/minus.gif" style="margin-right:4px" alt="remove docstruct"/>
                 <t:updateActionListener property="#{MassImportForm.plugin.docstruct}" value="#{docstruct}"/>
             </h:commandLink>
         </h:column>

--- a/Kitodo/src/main/webapp/newpages/plugins/SotonImport.xhtml
+++ b/Kitodo/src/main/webapp/newpages/plugins/SotonImport.xhtml
@@ -59,11 +59,11 @@
                 <h:outputText value="#{msgs.auswahl}"/>
             </f:facet>
             <h:commandLink action="#{MassImportForm.plugin.addDocstruct}">
-                <h:graphicImage value="/newpages/images/plus.gif" style="margin-right:4px"/>
+                <h:graphicImage value="/newpages/images/plus.gif" style="margin-right:4px" alt="add docstruct"/>
             </h:commandLink>
             <h:commandLink action="#{MassImportForm.plugin.deleteDocstruct}"
                            rendered="#{MassImportForm.docstructssize > 1}">
-                <h:graphicImage value="/newpages/images/minus.gif" style="margin-right:4px"/>
+                <h:graphicImage value="/newpages/images/minus.gif" style="margin-right:4px" alt="remove docstruct"/>
                 <t:updateActionListener property="#{MassImportForm.plugin.docstruct}" value="#{docstruct}"/>
             </h:commandLink>
         </h:column>

--- a/Kitodo/src/main/webapp/newpages/taskmanager.xhtml
+++ b/Kitodo/src/main/webapp/newpages/taskmanager.xhtml
@@ -71,7 +71,7 @@
 
                                                 <h:commandLink id="id8" action="#{NavigationForm.Reload}"
                                                                style="margin-right:15px">
-                                                    <h:graphicImage id="id9"
+                                                    <h:graphicImage id="id9" alt="reload"
                                                                     value="/newpages/images/icons/reload.png"
                                                                     style="margin-right:3px;margin-left:15px;vertical-align:bottom"/>
                                                     <h:outputText id="id10" value="#{msgs.listeAktualisieren}"/>
@@ -80,7 +80,7 @@
                                                 <h:commandLink
                                                         action="#{LongRunningTasksForm.clearFinishedTasks}"
                                                         style="margin-right:15px">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="clear finished tasks"
                                                             value="/newpages/images/icons/progress_remAll.gif"
                                                             style="margin-right:3px;vertical-align:bottom"/>
                                                     <h:outputText
@@ -90,7 +90,7 @@
                                                 <h:commandLink id="id11"
                                                                action="#{LongRunningTasksForm.clearAllTasks}"
                                                                style="margin-right:15px">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="clear all tasks"
                                                             value="/newpages/images/icons/progress_remAll2.gif"
                                                             style="margin-right:3px;vertical-align:bottom"/>
                                                     <h:outputText id="id12"
@@ -99,11 +99,11 @@
 
                                                 <h:commandLink id="id13"
                                                                action="#{LongRunningTasksForm.toggleRunning}">
-                                                    <h:graphicImage id="id14"
+                                                    <h:graphicImage id="id14" alt="start task"
                                                                     rendered="#{!LongRunningTasksForm.running}"
                                                                     value="/newpages/images/icons/start_task.gif"
                                                                     style="margin-right:3px;vertical-align:bottom"/>
-                                                    <h:graphicImage id="id15"
+                                                    <h:graphicImage id="id15" alt="stop task"
                                                                     rendered="#{LongRunningTasksForm.running}"
                                                                     value="/newpages/images/icons/stop_task.gif"
                                                                     style="margin-right:3px;vertical-align:bottom"/>
@@ -145,22 +145,22 @@
                                                     <h:outputText id="id24" value="#{msgs.fortschritt}"/>
                                                 </f:facet>
 
-                                                <h:graphicImage
+                                                <h:graphicImage alt=""
                                                         value="/newpages/images/fortschritt/ende_links.gif"
                                                         rendered="true"/>
-                                                <h:graphicImage id="id25"
+                                                <h:graphicImage id="id25" alt=""
                                                                 value="/newpages/images/fortschritt/gr.gif"
                                                                 style="width:#{item.progress * 0.8}px;height:10px"
                                                                 rendered="#{item.progress!=-1}"/>
-                                                <h:graphicImage id="id26"
+                                                <h:graphicImage id="id26" alt=""
                                                                 value="/newpages/images/fortschritt/ge.gif"
                                                                 style="width:#{(100 - item.progress) * 0.8}px;height:10px"
                                                                 rendered="#{item.progress!=-1}"/>
-                                                <h:graphicImage id="id27"
+                                                <h:graphicImage id="id27" alt=""
                                                                 value="/newpages/images/fortschritt/rt.gif"
                                                                 style="width:#{100 * 0.8}px;height:10px"
                                                                 rendered="#{item.progress==-1}"/>
-                                                <h:graphicImage
+                                                <h:graphicImage alt=""
                                                         value="/newpages/images/fortschritt/ende_rechts.gif"
                                                         rendered="true"/>
                                             </t:column>
@@ -182,7 +182,7 @@
                                                             </h:panelGrid>
                                                         </div>
                                                     </f:facet>
-                                                    <h:graphicImage id="id32" style="margin-right:5px"
+                                                    <h:graphicImage id="id32" style="margin-right:5px" alt=""
                                                                     value="/newpages/images/icons/exclamation.png"/>
                                                 </t:popup>
 
@@ -199,7 +199,7 @@
                                                 <h:commandLink id="id36"
                                                                action="#{LongRunningTasksForm.moveTaskUp}"
                                                                title="#{msgs.start}">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="move task up"
                                                             value="/newpages/images/buttons/order_up_klein.gif"/>
                                                     <t:updateActionListener value="#{item}"
                                                                             property="#{LongRunningTasksForm.task}"/>
@@ -208,7 +208,7 @@
                                                 <h:commandLink id="id37"
                                                                action="#{LongRunningTasksForm.moveTaskDown}"
                                                                style="margin-right:5px" title="#{msgs.start}">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="move task down"
                                                             value="/newpages/images/buttons/order_down_klein.gif"/>
                                                     <t:updateActionListener value="#{item}"
                                                                             property="#{LongRunningTasksForm.task}"/>
@@ -218,7 +218,7 @@
                                                 <h:commandLink id="id39"
                                                                action="#{LongRunningTasksForm.executeTask}"
                                                                title="#{msgs.start}" rendered="#{item.startable}">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="start task"
                                                             value="/newpages/images/icons/start_task.gif"/>
                                                     <t:updateActionListener value="#{item}"
                                                                             property="#{LongRunningTasksForm.task}"/>
@@ -229,7 +229,7 @@
                                                                action="#{LongRunningTasksForm.cancelTask}"
                                                                title="#{msgs.stop}"
                                                                rendered="#{item.stopable}">
-                                                    <h:graphicImage id="id41"
+                                                    <h:graphicImage id="id41" alt="stop task"
                                                                     value="/newpages/images/icons/stop_task.gif"/>
                                                     <t:updateActionListener value="#{item}"
                                                                             property="#{LongRunningTasksForm.task}"/>
@@ -240,7 +240,7 @@
                                                                action="#{LongRunningTasksForm.removeTask}"
                                                                title="#{msgs.loeschen}"
                                                                rendered="#{item.deleteable}">
-                                                    <h:graphicImage
+                                                    <h:graphicImage alt="remove task"
                                                             value="/newpages/images/icons/progress_rem.gif"/>
                                                     <t:updateActionListener value="#{item}"
                                                                             property="#{LongRunningTasksForm.task}"/>

--- a/Kitodo/src/main/webapp/pages/Metadaten2oben.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten2oben.xhtml
@@ -35,7 +35,7 @@
                                 <tr valign="top">
                                     <td width="20%" height="48">
                                         <h:commandLink action="#{Metadaten.goMain}" target="_parent">
-                                            <h:graphicImage value="#{HelperForm.applicationLogo}"/>
+                                            <h:graphicImage alt="Kitodo" value="#{HelperForm.applicationLogo}"/>
                                         </h:commandLink>
                                     </td>
                                     <td valign="middle" align="center">

--- a/Kitodo/src/main/webapp/pages/Metadaten2rechts.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten2rechts.xhtml
@@ -107,7 +107,7 @@
 
         <a4j:status>
             <f:facet name="start">
-                <h:graphicImage value="/newpages/images/ajaxload_small.gif" style="position: fixed;top: 35px;right: 15px;"/>
+                <h:graphicImage alt="" value="/newpages/images/ajaxload_small.gif" style="position: fixed;top: 35px;right: 15px;"/>
             </f:facet>
         </a4j:status>
 

--- a/Kitodo/src/main/webapp/pages/Metadaten3links.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten3links.xhtml
@@ -61,10 +61,10 @@
                                     <h:commandLink action="#{NavigationForm.Reload}" target="links">
                                         <t:updateActionListener property="#{item.node.expanded}"
                                                                 value="#{not item.node.expanded}"/>
-                                        <h:graphicImage value="/newpages/images/plus.gif"
+                                        <h:graphicImage value="/newpages/images/plus.gif" alt=""
                                                         rendered="#{item.node.hasChildren and not item.node.expanded}"
                                                         style="border: 0px none;margin-top:0px;margin-right:3px;margin-left:#{item.niveau * 10 + 5}px;"/>
-                                        <h:graphicImage value="/newpages/images/minus.gif"
+                                        <h:graphicImage value="/newpages/images/minus.gif" alt=""
                                                         rendered="#{item.node.hasChildren and item.node.expanded}"
                                                         style="border: 0px none;margin-top:0px;margin-right:3px;margin-left:#{item.niveau * 10 + 5}px;"/>
                                     </h:commandLink>
@@ -116,10 +116,10 @@
                                             </div>
                                         </f:facet>
 
-                                        <h:graphicImage value="/newpages/images/document.png"
+                                        <h:graphicImage value="/newpages/images/document.png" alt=""
                                                         rendered="#{item.node.hasChildren}"
                                                         style="margin-right:2px;vertical-align:middle"/>
-                                        <h:graphicImage value="/newpages/images/document.png"
+                                        <h:graphicImage value="/newpages/images/document.png" alt=""
                                                         rendered="#{!item.node.hasChildren}"
                                                         style="margin-right:2px;vertical-align:middle;margin-left:#{item.niveau * 10 + 17}px;"/>
 

--- a/Kitodo/src/main/webapp/pages/incMeta/BaumZumVerschieben.xhtml
+++ b/Kitodo/src/main/webapp/pages/incMeta/BaumZumVerschieben.xhtml
@@ -37,7 +37,7 @@
                                  closePopupOnExitingPopup="true" displayAtDistanceX="15"
                                  displayAtDistanceY="-40">
 
-                            <h:graphicImage value="/newpages/images/spacer.gif"
+                            <h:graphicImage value="/newpages/images/spacer.gif" alt=""
                                             rendered="#{item.node.hasChildren}"
                                             style="border: 0px none;margin-top:1px;margin-left:#{item.niveau * 15 + 5};"/>
 
@@ -83,10 +83,10 @@
                                 </div>
                             </f:facet>
 
-                            <h:graphicImage value="/newpages/images/document.png"
+                            <h:graphicImage value="/newpages/images/document.png" alt=""
                                             rendered="#{item.node.hasChildren}"
                                             style="margin-right:2px;vertical-align:middle"/>
-                            <h:graphicImage value="/newpages/images/document.png"
+                            <h:graphicImage value="/newpages/images/document.png" alt=""
                                             rendered="#{!item.node.hasChildren}"
                                             style="margin-right:2px;vertical-align:middle;margin-left:#{item.niveau * 10 + 17};"/>
 
@@ -119,7 +119,7 @@
                 <div style="border: 2px dashed silver">
                     <h:commandLink target="_self" action="#{NavigationForm.Reload}"
                                    style="margin:5px" title="#{msgs.verschiebenAbbrechen}">
-                        <h:graphicImage value="/newpages/images/buttons/cancel1.gif"
+                        <h:graphicImage value="/newpages/images/buttons/cancel1.gif" alt="cancel"
                                         style="border: 0px;vertical-align:middle;"/>
                         <h:outputText value="#{msgs.abbrechen}"
                                       title="#{msgs.verschiebenAbbrechen}"/>

--- a/Kitodo/src/main/webapp/pages/incMeta/Bild.xhtml
+++ b/Kitodo/src/main/webapp/pages/incMeta/Bild.xhtml
@@ -179,7 +179,7 @@
                 <h:commandLink action="#{Metadaten.zoomImageOut}" id="zoomMinus"
                                  style="margin-left: 0px;margin-right:5px">
                     <f:ajax render="BildArea myBild imageform"/>
-                    <h:graphicImage value="/newpages/images/zoom-.gif" style="border: 0px;vertical-align:middle"/>
+                    <h:graphicImage alt="zoom out" value="/newpages/images/zoom-.gif" style="border: 0px;vertical-align:middle"/>
                 </h:commandLink>
 
                 <!-- aktuelle Seite anzeigen -->
@@ -201,7 +201,7 @@
                 <h:commandLink action="#{Metadaten.zoomImageIn}" id="zoomPlus"
                                  style="margin-left: 7px;margin-right:9px">
                     <f:ajax render="BildArea myBild imageform"/>
-                    <h:graphicImage value="/newpages/images/zoom+.gif" style="border: 0px;vertical-align:middle"/>
+                    <h:graphicImage alt="zoom in" value="/newpages/images/zoom+.gif" style="border: 0px;vertical-align:middle"/>
                 </h:commandLink>
                 <!-- // Zoom -->
 
@@ -209,13 +209,13 @@
                 <h:commandLink action="#{Metadaten.rotateLeft}" id="rotateLeft"
                                  style="margin-left: 7px;margin-right:0px">
                     <f:ajax render="BildArea myBild imageform"/>
-                    <h:graphicImage value="/newpages/images/rotateLeft.gif" style="border: 0px;vertical-align:middle"/>
+                    <h:graphicImage alt="rotate left" value="/newpages/images/rotateLeft.gif" style="border: 0px;vertical-align:middle"/>
                 </h:commandLink>
 
                 <h:commandLink action="#{Metadaten.rotateRight}" id="rotateRight"
                                  style="margin-left: 0px;margin-right:9px">
                     <f:ajax render="BildArea myBild imageform"/>
-                    <h:graphicImage value="/newpages/images/rotateRight.gif" style="border: 0px;vertical-align:middle"/>
+                    <h:graphicImage alt="rotate right" value="/newpages/images/rotateRight.gif" style="border: 0px;vertical-align:middle"/>
                 </h:commandLink>
                 <!-- // rotation-->
 
@@ -235,7 +235,7 @@
                 <h:commandLink id="ocrButton" action="#{Metadaten.showOcrResult}"
                                  rendered="#{Metadaten.showOcrButton}">
                     <f:ajax render="BildArea myBild"/>
-                    <h:graphicImage value="/newpages/images/buttons/ocr.png"
+                    <h:graphicImage alt="ocr" value="/newpages/images/buttons/ocr.png"
                                     style="margin-left:14px;vertical-align:middle"/>
                 </h:commandLink>
 
@@ -265,7 +265,7 @@
         </h:panelGroup>
 
         <!-- das Bild selbst -->
-        <h:graphicImage value="#{Metadaten.bild}" rendered="#{Metadaten.bildNummer != '-1'}" onclick="focusForPicture()"/>
+        <h:graphicImage alt="" value="#{Metadaten.bild}" rendered="#{Metadaten.bildNummer != '-1'}" onclick="focusForPicture()"/>
     </t:panelGroup>
 
 

--- a/Kitodo/src/main/webapp/pages/incMeta/Paginierung.xhtml
+++ b/Kitodo/src/main/webapp/pages/incMeta/Paginierung.xhtml
@@ -96,13 +96,13 @@
                                 <h:commandLink rendered="#{Metadaten.paginierungSeitenProImage!=1}"
                                                  title="#{msgs.seitenzaehlung}">
                                     <f:ajax render="PaginierungActionBox myMessages mygrid10"/>
-                                    <h:graphicImage
+                                    <h:graphicImage alt=""
                                             value="/newpages/images/buttons/paginierung_seite_inactive.svg"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <t:updateActionListener value="1"
                                                             property="#{Metadaten.paginierungSeitenProImage}"/>
                                 </h:commandLink>
-                                <h:graphicImage
+                                <h:graphicImage alt=""
                                         rendered="#{Metadaten.paginierungSeitenProImage==1}"
                                         value="/newpages/images/buttons/paginierung_seite.svg"
                                         style="margin-left:4px;margin-right:6px;vertical-align:middle"
@@ -111,13 +111,13 @@
                                 <h:commandLink rendered="#{Metadaten.paginierungSeitenProImage!=2}"
                                                  title="#{msgs.spaltenzaehlung}">
                                     <f:ajax render="PaginierungActionBox myMessages mygrid10"/>
-                                    <h:graphicImage
+                                    <h:graphicImage alt=""
                                             value="/newpages/images/buttons/paginierung_spalte_inactive.svg"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <t:updateActionListener value="2"
                                                             property="#{Metadaten.paginierungSeitenProImage}"/>
                                 </h:commandLink>
-                                <h:graphicImage
+                                <h:graphicImage alt=""
                                         rendered="#{Metadaten.paginierungSeitenProImage==2}"
                                         value="/newpages/images/buttons/paginierung_spalte.svg"
                                         style="margin-left:4px;margin-right:6px;vertical-align:middle"
@@ -142,7 +142,7 @@
                                         rendered="#{Metadaten.paginierungSeitenProImage!=4}"
                                         title="#{msgs.blattzaehlungrectoverso}">
                                     <f:ajax render="PaginierungActionBox myMessages mygrid10"/>
-                                    <h:graphicImage
+                                    <h:graphicImage alt=""
                                             value="/newpages/images/buttons/paginierung_blatt_rectoverso_inactive.svg"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <t:updateActionListener value="4"
@@ -164,7 +164,7 @@
                                     <t:updateActionListener value="5"
                                                             property="#{Metadaten.paginierungSeitenProImage}"/>
                                 </h:commandLink>
-                                <h:graphicImage
+                                <h:graphicImage alt=""
                                         rendered="#{Metadaten.paginierungSeitenProImage==5}"
                                         value="/newpages/images/buttons/paginierung_seite_rectoverso.svg"
                                         style="margin-left:4px;margin-right:6px;vertical-align:middle"
@@ -180,7 +180,7 @@
                                     <t:updateActionListener value="6"
                                                             property="#{Metadaten.paginierungSeitenProImage}"/>
                                 </h:commandLink>
-                                <h:graphicImage
+                                <h:graphicImage alt=""
                                         rendered="#{Metadaten.paginierungSeitenProImage==6}"
                                         value="/newpages/images/buttons/paginierung_doppelseite.svg"
                                         style="margin-left:4px;margin-right:6px;vertical-align:middle"
@@ -226,7 +226,7 @@
                         <tr>
                             <td class="eingabeBoxen_row2">
                                 <h:commandLink action="#{Metadaten.moveSeltectedPagesUp}">
-                                    <h:graphicImage value="/newpages/images/buttons/up_20px.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/up_20px.gif" alt="move up"
                                                     style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.moveSeltectedPagesUp}"/>
                                 </h:commandLink>
@@ -235,7 +235,7 @@
                         <tr>
                             <td class="eingabeBoxen_row2">
                                 <h:commandLink action="#{Metadaten.moveSeltectedPagesDown}">
-                                    <h:graphicImage value="/newpages/images/buttons/down_20px.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/down_20px.gif" alt="move down"
                                                     style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.moveSeltectedPagesDown}"/>
                                 </h:commandLink>
@@ -245,7 +245,7 @@
                             <td class="eingabeBoxen_row2">
                                 <h:commandLink action="#{Metadaten.deleteSeltectedPages}"
                                                onclick="if (!confirm('#{msgs.wirklichAusfuehren}?')) return false">
-                                    <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete"
                                                     style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.deleteSeltectedPages}"/>
                                 </h:commandLink>
@@ -254,7 +254,7 @@
                         <tr>
                             <td class="eingabeBoxen_row2">
                                 <h:commandLink action="#{Metadaten.reOrderPagination}">
-                                    <h:graphicImage value="/newpages/images/buttons/reload.gif"
+                                    <h:graphicImage value="/newpages/images/buttons/reload.gif" alt="reload"
                                                     style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <h:outputText value="#{msgs.reOrder}"/>
                                 </h:commandLink>

--- a/Kitodo/src/main/webapp/pages/incMeta/Paginierung.xhtml
+++ b/Kitodo/src/main/webapp/pages/incMeta/Paginierung.xhtml
@@ -126,13 +126,13 @@
                                 <h:commandLink rendered="#{Metadaten.paginierungSeitenProImage!=3}"
                                                  title="#{msgs.blattzaehlung}">
                                     <f:ajax render="PaginierungActionBox myMessages mygrid10"/>
-                                    <h:graphicImage
+                                    <h:graphicImage alt=""
                                             value="/newpages/images/buttons/paginierung_blatt_inactive.svg"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <t:updateActionListener value="3"
                                                             property="#{Metadaten.paginierungSeitenProImage}"/>
                                 </h:commandLink>
-                                <h:graphicImage
+                                <h:graphicImage alt=""
                                         rendered="#{Metadaten.paginierungSeitenProImage==3}"
                                         value="/newpages/images/buttons/paginierung_blatt.svg"
                                         style="margin-left:4px;margin-right:6px;vertical-align:middle"
@@ -148,7 +148,7 @@
                                     <t:updateActionListener value="4"
                                                             property="#{Metadaten.paginierungSeitenProImage}"/>
                                 </h:commandLink>
-                                <h:graphicImage
+                                <h:graphicImage alt=""
                                         rendered="#{Metadaten.paginierungSeitenProImage==4}"
                                         value="/newpages/images/buttons/paginierung_blatt_rectoverso.svg"
                                         style="margin-left:4px;margin-right:6px;vertical-align:middle"
@@ -158,7 +158,7 @@
                                         rendered="#{Metadaten.paginierungSeitenProImage!=5}"
                                         title="#{msgs.seitenzaehlungrectoverso}">
                                     <f:ajax render="PaginierungActionBox myMessages mygrid10"/>
-                                    <h:graphicImage
+                                    <h:graphicImage alt=""
                                             value="/newpages/images/buttons/paginierung_seite_rectoverso_inactive.svg"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <t:updateActionListener value="5"
@@ -174,7 +174,7 @@
                                         rendered="#{Metadaten.paginierungSeitenProImage!=6}"
                                         title="#{msgs.seitenzaehlungdoppelseiten}">
                                     <f:ajax render="PaginierungActionBox,myMessages,mygrid10"/>
-                                    <h:graphicImage
+                                    <h:graphicImage alt=""
                                             value="/newpages/images/buttons/paginierung_doppelseite_inactive.svg"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                     <t:updateActionListener value="6"

--- a/Kitodo/src/main/webapp/pages/incMeta/PersonenUndMetadaten.xhtml
+++ b/Kitodo/src/main/webapp/pages/incMeta/PersonenUndMetadaten.xhtml
@@ -89,14 +89,14 @@
                 <h:column rendered="#{not Metadaten.nurLesenModus}">
                     <!-- copy-Schaltknopf -->
                     <h:commandLink id="l7" action="#{Metadaten.copyPerson}" title="#{msgs.personendatenKopieren}">
-                        <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                        <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                         <f:param name="ID" value="#{Item.identifier}"/>
                         <t:updateActionListener property="#{Metadaten.curPerson}" value="#{Item}"/>
                     </h:commandLink>
 
                     <!-- delete-Schaltknopf -->
                     <h:commandLink id="l6" action="#{Metadaten.deletePerson}" title="#{msgs.personendatenLoeschen}">
-                        <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" style="margin-left:3px"/>
+                        <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete" style="margin-left:3px"/>
                         <f:param name="ID" value="#{Item.identifier}"/>
                         <t:updateActionListener property="#{Metadaten.curPerson}" value="#{Item}"/>
                     </h:commandLink>
@@ -164,11 +164,11 @@
                                         <h:commandLink action="#{aGroup.copy}"
                                                        rendered="#{aGroup.copyable and not Metadaten.nurLesenModus}"
                                                        title="#{msgs.metadatenKopieren}">
-                                            <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                            <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                         </h:commandLink>
                                         <h:commandLink action="#{aGroup.delete}" rendered="#{not Metadaten.nurLesenModus}"
                                                        title="#{msgs.metadatenLoeschen}">
-                                            <h:graphicImage
+                                            <h:graphicImage alt="delete"
                                                     value="/newpages/images/buttons/waste1a_20px.gif"
                                                     style="margin-left:3px"/>
                                         </h:commandLink>
@@ -222,11 +222,11 @@
                                         <h:commandLink action="#{aGroup.copy}"
                                                        rendered="#{aGroup.copyable and not Metadaten.nurLesenModus}"
                                                        title="#{msgs.metadatenKopieren}">
-                                            <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                                            <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                                         </h:commandLink>
                                         <h:commandLink action="#{aGroup.delete}" rendered="#{not Metadaten.nurLesenModus}"
                                                        title="#{msgs.metadatenLoeschen}">
-                                            <h:graphicImage
+                                            <h:graphicImage alt="delete"
                                                     value="/newpages/images/buttons/waste1a_20px.gif"
                                                     style="margin-left:3px"/>
                                         </h:commandLink>
@@ -310,20 +310,20 @@
                 <h:column rendered="#{not Metadaten.nurLesenModus}">
                     <!-- copy-Schaltknopf -->
                     <h:commandLink id="l5" action="#{Metadaten.copy}" title="#{msgs.metadatenKopieren}">
-                        <h:graphicImage value="/newpages/images/buttons/copy.gif"/>
+                        <h:graphicImage value="/newpages/images/buttons/copy.gif" alt="copy"/>
                         <f:param name="ID" value="#{Item.identifier}"/>
                         <t:updateActionListener property="#{Metadaten.curMetadatum}" value="#{Item}"/>
                     </h:commandLink>
                     <!-- transliterate-Schaltknopf -->
                     <h:commandLink action="#{Metadaten.transliterate}" rendered="#{Item.typ=='russian Title'}"
                                    title="#{msgs.diesesFeldTransliterieren}">
-                        <h:graphicImage value="/newpages/images/buttons/translit.gif" style="margin-left:3px"/>
+                        <h:graphicImage value="/newpages/images/buttons/translit.gif" alt="transliterate" style="margin-left:3px"/>
                         <f:param name="ID" value="#{Item.identifier}"/>
                         <t:updateActionListener property="#{Metadaten.curMetadatum}" value="#{Item}"/>
                     </h:commandLink>
                     <!-- delete-Schaltknopf -->
                     <h:commandLink id="l4" action="#{Metadaten.delete}" title="#{msgs.metadatenLoeschen}">
-                        <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" style="margin-left:3px"/>
+                        <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete" style="margin-left:3px"/>
                         <f:param name="ID" value="#{Item.identifier}"/>
                         <t:updateActionListener property="#{Metadaten.curMetadatum}" value="#{Item}"/>
                     </h:commandLink>
@@ -349,7 +349,7 @@
                                        rendered="#{Metadaten.sizeOfRoles!=0}">
 
 
-                            <h:graphicImage value="/newpages/images/buttons/new.gif"
+                            <h:graphicImage value="/newpages/images/buttons/new.gif" alt="new person"
                                             style="border: 0px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.neuePersonHinzufuegen}"/>
                         </h:commandLink>
@@ -358,7 +358,7 @@
                         <h:commandLink id="l1" action="#{Metadaten.Hinzufuegen}" style="margin-left:2px"
                                        title="#{msgs.neuesMetadatumAnlegen}"
                                        rendered="#{Metadaten.sizeOfMetadata!=0}">
-                            <h:graphicImage value="/newpages/images/buttons/new.gif"
+                            <h:graphicImage value="/newpages/images/buttons/new.gif" alt="new metadata"
                                             style="border: 0px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.neueMetadatenHinzufuegen}"/>
                         </h:commandLink>
@@ -366,7 +366,7 @@
                         <h:commandLink id="l3" action="#{Metadaten.showAddNewMetadataGroup}" style="margin-left:2px"
                                        title="#{msgs.addNewMetadataGroup}"
                                        rendered="#{Metadaten.addNewMetadataGroupLinkShowing}">
-                            <h:graphicImage value="/newpages/images/buttons/new.gif"
+                            <h:graphicImage value="/newpages/images/buttons/new.gif" alt="new metadata group"
                                             style="border: 0px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.addNewMetadataGroup}"/>
                         </h:commandLink>

--- a/Kitodo/src/main/webapp/pages/incMeta/Strukturdaten.xhtml
+++ b/Kitodo/src/main/webapp/pages/incMeta/Strukturdaten.xhtml
@@ -73,7 +73,7 @@
 
                         <h:commandLink action="#{Metadaten.currentStartpage}">
                             <f:ajax render="pageStartGroup"/>
-                            <h:graphicImage value="/newpages/images/buttons/left_20px.gif"
+                            <h:graphicImage value="/newpages/images/buttons/left_20px.gif" alt="start page"
                                             style="border: 0px;vertical-align:middle;"/>
                             <t:updateActionListener value="#{Metadaten.bildNummer}" property="#{Metadaten.pageNumber}"/>
                         </h:commandLink>
@@ -92,7 +92,7 @@
                         </h:panelGroup>
                         <h:commandLink action="#{Metadaten.currentEndpage}">
                             <f:ajax render="pageEndGroup"/>
-                            <h:graphicImage value="/newpages/images/buttons/left_20px.gif"
+                            <h:graphicImage value="/newpages/images/buttons/left_20px.gif" alt="end page"
                                             style="border: 0px;vertical-align:middle;"/>
                             <t:updateActionListener value="#{Metadaten.bildNummer}" property="#{Metadaten.pageNumber}"/>
                         </h:commandLink>
@@ -123,7 +123,7 @@
                         <!-- Knoten nach oben -->
                         <h:commandLink action="#{Metadaten.nodeUp}" title="#{msgs.docstructNachObenSchieben}"
                                        target="links">
-                            <h:graphicImage value="/newpages/images/buttons/sort_up_20px.gif"
+                            <h:graphicImage value="/newpages/images/buttons/sort_up_20px.gif" alt="move up"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.docstructNachObenSchieben}"/>
                         </h:commandLink>
@@ -131,7 +131,7 @@
                         <!-- Knoten nach unten -->
                         <h:commandLink action="#{Metadaten.nodeDown}" title="#{msgs.docstructNachUntenSchieben}"
                                        target="links">
-                            <h:graphicImage value="/newpages/images/buttons/sort_down_20px.gif"
+                            <h:graphicImage value="/newpages/images/buttons/sort_down_20px.gif" alt="move down"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.docstructNachUntenSchieben}"/>
                         </h:commandLink>
@@ -139,7 +139,7 @@
                         <!-- Knoten an andere Stelle schieben -->
                         <h:commandLink action="Metdaten2rechts" title="#{msgs.docstructAnAndereStelleSchieben}"
                                        target="rechts">
-                            <h:graphicImage value="/newpages/images/buttons/sort_left_20px.gif"
+                            <h:graphicImage value="/newpages/images/buttons/sort_left_20px.gif" alt="move"
                                             style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.docstructAnAndereStelleSchieben}"/>
                             <t:updateActionListener property="#{Metadaten.modusStrukturelementVerschieben}" value="true"/>
@@ -148,7 +148,7 @@
                         <!-- DocstructType ändern -->
                         <h:panelGroup>
                             <jd:hideableController for="changeDocStructType" title="#{msgs.docstructTypeAendern}">
-                                <h:graphicImage value="/newpages/images/buttons/sort_down_20px.gif"
+                                <h:graphicImage value="/newpages/images/buttons/sort_down_20px.gif" alt="change type"
                                                 style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.docstructTypeAendern}"/>
                             </jd:hideableController>
@@ -174,7 +174,7 @@
                         <h:panelGroup>
                             <jd:hideableController for="addZusaetzlicheDocstructs"
                                                    title="#{msgs.strukturelementeAusOpacHinzufuegen}">
-                                <h:graphicImage value="/newpages/images/buttons/sort_down_20px.gif"
+                                <h:graphicImage value="/newpages/images/buttons/sort_down_20px.gif" alt="add structural elements from opac"
                                                 style="margin-left:4px;margin-right:6px;vertical-align:middle"/>
                                 <h:outputText value="#{msgs.strukturelementeAusOpacHinzufuegen}"/>
                             </jd:hideableController>
@@ -233,7 +233,7 @@
                         <!-- OCR-Button -->
                         <h:outputLink rendered="#{Metadaten.showOcrButton}" target="_blank" value="#{Metadaten.ocrAcdress}"
                                       title="#{msgs.ocr}">
-                            <h:graphicImage value="/newpages/images/buttons/ocr.png"
+                            <h:graphicImage value="/newpages/images/buttons/ocr.png" alt="ocr"
                                             style="margin-left:4px;margin-right:7px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.ocr}"/>
                         </h:outputLink>
@@ -247,7 +247,7 @@
                                            style="margin-top:2px;display:block; text-decoration:none"
                                            actionOpen="#{Metadaten.showOcrPopup}" center="true"
                                            title="#{msgs.ocr}" immediate="true">
-                                <h:graphicImage value="/newpages/images/buttons/ocr.png"
+                                <h:graphicImage value="/newpages/images/buttons/ocr.png" alt="ocr"
                                                 style="margin-left:4px;margin-right:7px;vertical-align:middle" />
                                 <h:outputText style="border-bottom: #a24033 dashed 1px;"
                                               value="#{msgs.ocr}" />
@@ -257,7 +257,7 @@
                         <!-- Knoten löschen -->
                         <h:commandLink rendered="#{Metadaten.isNotRootElement}" action="#{Metadaten.deleteNode}"
                                        title="#{msgs.strukturelementLoeschen}" target="links">
-                            <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif"
+                            <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" alt="delete"
                                             style="margin-left:4px;margin-right:7px;vertical-align:middle"/>
                             <h:outputText value="#{msgs.strukturelementLoeschen}"/>
                         </h:commandLink>
@@ -300,7 +300,7 @@
                             <h:panelGroup rendered="#{Metadaten.treeProperties.showpagesasajax==true}">
                                 <t:inputText id="pagestart" forceId="true" value="#{Metadaten.ajaxSeiteStart}"/>
                                 <!--
-                                <h:graphicImage value="/newpages/images/calendarImages/drop1.gif"
+                                <h:graphicImage value="/newpages/images/calendarImages/drop1.gif" alt=""
                                                 onclick="document.getElementById('formular2:suggestion').callSuggestion(true);"
                                                 alt="" />
                                 -->
@@ -390,13 +390,13 @@
                     <h:commandLink id="s1" action="#{Metadaten.addPages}"
                                    style="margin-top:175px;margin-left:10px;margin-right:10px;display:block">
                         <f:ajax render="menuZugehoerigeSeiten BildArea myBild"/>
-                        <h:graphicImage value="/newpages/images/buttons/order_right.gif"/>
+                        <h:graphicImage value="/newpages/images/buttons/order_right.gif" alt="move left"/>
                     </h:commandLink>
                     <!-- nach links -->
                     <h:commandLink id="s2" action="#{Metadaten.removePages}"
                                      style="margin-top:7px;margin-left:10px;margin-right:10px;display:block">
                         <f:ajax render="menuZugehoerigeSeiten BildArea myBild"/>
-                        <h:graphicImage value="/newpages/images/buttons/order_left.gif"/>
+                        <h:graphicImage value="/newpages/images/buttons/order_left.gif" alt="move right"/>
                     </h:commandLink>
                 </h:panelGroup>
 


### PR DESCRIPTION
This adds the required alt attribute to images where it has been missing, since their absence resulted in a very cluttered log when using Kitodo.Production.