### PR TITLE
Navigation menu update

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/AktuelleSchritteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/AktuelleSchritteForm.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
@@ -166,6 +167,14 @@ public class AktuelleSchritteForm extends BasisForm {
             return null;
         }
         return "/newpages/AktuelleSchritteAlle";
+    }
+
+    /**
+     * This method initializes the task list without any filter whenever the bean is created.
+     */
+    @PostConstruct
+    public void initializeTaskList() {
+        filterAlleStart();
     }
 
     private void sortList(Criteria inCrit) {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BatchForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BatchForm.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
@@ -222,6 +223,19 @@ public class BatchForm extends BasisForm {
         filterBatches();
         filterProcesses();
         return "/newpages/BatchesAll";
+    }
+
+    /**
+     * This method initializes the batch list without any filter whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeBatchList() {
+        try {
+            filterAlleStart();
+        } catch (DAOException e) {
+            logger.error("DAOException while filtering batches", e);
+        }
+        setModusBearbeiten("");
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -121,7 +121,7 @@ public class BenutzergruppenForm extends BasisForm {
     }
 
     /**
-     * This method the user group list without applying any filters whenever the bean is constructed.
+     * This method initializes the user group list without applying any filters whenever the bean is constructed.
      */
     @PostConstruct
     public void initializeUserGroupList() {
@@ -133,6 +133,10 @@ public class BenutzergruppenForm extends BasisForm {
         return this.zurueck;
     }
 
+    /**
+     * Method being used as viewAction for user group edit form.
+     * If 'userGroupId' is '0', the form for creating a new user group will be displayed.
+     */
     public void loadUserGroup() {
         try {
             if(!Objects.equals(this.userGroupId, 0)) {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -16,6 +16,7 @@ import de.sub.goobi.helper.Page;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Objects;
 
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
@@ -38,10 +39,12 @@ public class BenutzergruppenForm extends BasisForm {
     private static final long serialVersionUID = 8051160917458068675L;
     private UserGroup myBenutzergruppe = new UserGroup();
     private final ServiceManager serviceManager = new ServiceManager();
+    private int userGroupId;
 
     public String Neu() {
         this.myBenutzergruppe = new UserGroup();
-        return "/newpages/BenutzergruppenBearbeiten";
+        this.userGroupId = 0;
+        return "/newpages/BenutzergruppenBearbeiten?faces-redirect=true";
     }
 
     /**
@@ -52,7 +55,7 @@ public class BenutzergruppenForm extends BasisForm {
     public String Speichern() {
         try {
             this.serviceManager.getUserGroupService().save(this.myBenutzergruppe);
-            return "/newpages/BenutzergruppenAlle";
+            return "/newpages/BenutzergruppenAlle?faces-redirect=true";
         } catch (DAOException e) {
             Helper.setFehlerMeldung("Error, could not save", e.getMessage());
             return null;
@@ -95,7 +98,7 @@ public class BenutzergruppenForm extends BasisForm {
             Helper.setFehlerMeldung("Error, ElasticSearch incorrect server response", e.getMessage());
             return null;
         }
-        return "/newpages/BenutzergruppenAlle";
+        return "/newpages/BenutzergruppenAlle?faces-redirect=true";
     }
 
     /**
@@ -130,6 +133,16 @@ public class BenutzergruppenForm extends BasisForm {
         return this.zurueck;
     }
 
+    public void loadUserGroup() {
+        try {
+            if(!Objects.equals(this.userGroupId, 0)) {
+                setMyBenutzergruppe(this.serviceManager.getUserGroupService().find(this.userGroupId));
+            }
+        } catch (DAOException e) {
+            Helper.setFehlerMeldung("Error retrieving project with ID '" + this.userGroupId + "'; ", e.getMessage());
+        }
+    }
+
     /*
      * Getter und Setter
      */
@@ -142,5 +155,9 @@ public class BenutzergruppenForm extends BasisForm {
         Helper.getHibernateSession().clear();
         this.myBenutzergruppe = myBenutzergruppe;
     }
+
+    public void setUserGroupId(int id) { this.userGroupId = id; }
+
+    public int getUserGroupId() { return this.userGroupId; }
 
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -28,6 +28,7 @@ import org.kitodo.data.database.persistence.SimpleDAO;
 import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
 import org.kitodo.services.ServiceManager;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -114,6 +115,14 @@ public class BenutzergruppenForm extends BasisForm {
             return null;
         }
         return "/newpages/BenutzergruppenAlle";
+    }
+
+    /**
+     * This method the user group list without applying any filters whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeUserGroupList() {
+        filterKein();
     }
 
     public String FilterKeinMitZurueck() {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -59,6 +60,7 @@ public class BenutzerverwaltungForm extends BasisForm {
     private boolean hideInactiveUsers = true;
     private final ServiceManager serviceManager = new ServiceManager();
     private static final Logger logger = LogManager.getLogger(BenutzerverwaltungForm.class);
+    private int userId;
 
     /**
      * New user.
@@ -72,7 +74,8 @@ public class BenutzerverwaltungForm extends BasisForm {
         this.myClass.setLogin("");
         this.myClass.setLdapLogin("");
         this.myClass.setPasswordDecrypted("Passwort");
-        return "/newpages/BenutzerBearbeiten";
+        this.userId = 0;
+        return "/newpages/BenutzerBearbeiten?faces-redirect=true";
     }
 
     /**
@@ -417,5 +420,23 @@ public class BenutzerverwaltungForm extends BasisForm {
     public boolean getLdapUsage() {
         return ConfigCore.getBooleanParameter("ldap_use");
     }
+
+    /**
+     * Method being used as viewAction for user edit form.
+     * If 'userId' is '0', the form for creating a new user will be displayed.
+     */
+    public void loadMyClass() {
+        try {
+            if(!Objects.equals(this.userId, 0)) {
+                setMyClass(this.serviceManager.getUserService().find(this.userId));
+            }
+        } catch (DAOException e) {
+            Helper.setFehlerMeldung("Error retrieving user with ID '" + this.userId + "'; ", e.getMessage());
+        }
+    }
+
+    public int getUserId() { return this.userId; }
+
+    public void setUserId(int id) { this.userId = id; }
 
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
@@ -98,6 +99,15 @@ public class BenutzerverwaltungForm extends BasisForm {
         }
         return "/newpages/BenutzerAlle";
     }
+
+    /**
+     * This method initializes the user list without any filters whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeUserList() {
+        filterKein();
+    }
+
 
     public String filterKeinMitZurueck() {
         filterKein();

--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -17,6 +17,7 @@ import de.sub.goobi.helper.Page;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
@@ -45,10 +46,12 @@ public class DocketForm extends BasisForm {
     private Docket myDocket = new Docket();
     private final ServiceManager serviceManager = new ServiceManager();
     private static final Logger logger = LogManager.getLogger(DocketForm.class);
+    private int docketId;
 
     public String Neu() {
         this.myDocket = new Docket();
-        return "/newpages/DocketEdit";
+        this.docketId = 0;
+        return "/newpages/DocketEdit?faces-redirect=true";
     }
 
     /**
@@ -60,7 +63,7 @@ public class DocketForm extends BasisForm {
         try {
             if (hasValidRulesetFilePath(myDocket, ConfigCore.getParameter("xsltFolder"))) {
                 this.serviceManager.getDocketService().save(myDocket);
-                return "/newpages/DocketList";
+                return "/newpages/DocketList?faces-redirect=true";
             } else {
                 Helper.setFehlerMeldung("DocketNotFound");
                 return null;
@@ -109,7 +112,7 @@ public class DocketForm extends BasisForm {
             logger.error(e);
             return null;
         }
-        return "/newpages/DocketList";
+        return "/newpages/DocketList?faces-redirect=true";
     }
 
     private boolean hasAssignedProcesses(Docket d) throws ParseException, CustomResponseException, IOException {
@@ -155,6 +158,20 @@ public class DocketForm extends BasisForm {
         return this.zurueck;
     }
 
+    /**
+     * Method being used as viewAction for docket edit form.
+     * If 'docketId' is '0', the form for creating a new docket will be displayed.
+     */
+    public void loadDocket() {
+        try {
+            if(!Objects.equals(this.docketId, 0)) {
+                setMyDocket(this.serviceManager.getDocketService().find(this.docketId));
+            }
+        } catch (DAOException e) {
+            Helper.setFehlerMeldung("Error retrieving docket with ID '" + this.docketId + "'; ", e.getMessage());
+        }
+    }
+
     /*
      * Getter und Setter
      */
@@ -167,4 +184,8 @@ public class DocketForm extends BasisForm {
         Helper.getHibernateSession().clear();
         this.myDocket = docket;
     }
+
+    public int getDocketId() { return this.docketId; }
+
+    public void setDocketId(int id) { this.docketId = id; }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -34,6 +34,10 @@ import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.data.ProcessService;
 
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+
 @ManagedBean
 @ViewScoped
 public class DocketForm extends BasisForm {
@@ -136,6 +140,14 @@ public class DocketForm extends BasisForm {
             return null;
         }
         return "/newpages/DocketList";
+    }
+
+    /**
+     * This method initializes the docket list without any filter whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeDocketList() {
+        filterKein();
     }
 
     public String filterKeinMitZurueck() {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/LdapGruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/LdapGruppenForm.java
@@ -22,6 +22,7 @@ import org.kitodo.data.database.beans.LdapGroup;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.services.ServiceManager;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -84,6 +85,14 @@ public class LdapGruppenForm extends BasisForm {
             return null;
         }
         return "/newpages/LdapGruppenAlle";
+    }
+
+    /**
+     * This method initializes the ldap group list without applying any filters whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeLdapGroupList() {
+        filterKein();
     }
 
     public String FilterKeinMitZurueck() {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/LdapGruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/LdapGruppenForm.java
@@ -25,17 +25,20 @@ import org.kitodo.services.ServiceManager;
 import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
+import java.util.Objects;
 
 @ManagedBean
 @ViewScoped
 public class LdapGruppenForm extends BasisForm {
     private static final long serialVersionUID = -5644561256582235244L;
     private LdapGroup myLdapGruppe = new LdapGroup();
+    private int itemId;
     private final ServiceManager serviceManager = new ServiceManager();
 
     public String Neu() {
         this.myLdapGruppe = new LdapGroup();
-        return "/newpages/LdapGruppenBearbeiten";
+        this.itemId = 0;
+        return "/newpages/LdapGruppenBearbeiten?faces-redirect=true";
     }
 
     /**
@@ -46,7 +49,7 @@ public class LdapGruppenForm extends BasisForm {
     public String Speichern() {
         try {
             this.serviceManager.getLdapGroupService().save(this.myLdapGruppe);
-            return "/newpages/LdapGruppenAlle";
+            return "/newpages/LdapGruppenAlle?faces-redirect=true";
         } catch (DAOException e) {
             Helper.setFehlerMeldung("Could not save", e.getMessage());
             return null;
@@ -88,7 +91,21 @@ public class LdapGruppenForm extends BasisForm {
     }
 
     /**
-     * This method initializes the ldap group list without applying any filters whenever the bean is constructed.
+     * Method being used as viewAction for ldap group edit form.
+     * If 'itemId' is '0', the form for creating a new ldap group will be displayed.
+     */
+    public void loadLdapGroup() {
+        try {
+            if (!Objects.equals(this.itemId, 0)) {
+                setMyLdapGruppe(this.serviceManager.getLdapGroupService().find(this.itemId));
+            }
+        } catch (DAOException e) {
+            Helper.setFehlerMeldung("Error retrieving Ldap group with ID '" + this.itemId + "'; ", e.getMessage());
+        }
+    }
+
+    /**
+     * This method initializes the ldap group list without filters.
      */
     @PostConstruct
     public void initializeLdapGroupList() {
@@ -112,4 +129,7 @@ public class LdapGruppenForm extends BasisForm {
         this.myLdapGruppe = myLdapGruppe;
     }
 
+    public void setItemId(int id) { this.itemId = id; }
+
+    public int getItemId() { return this.itemId; }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/LoginForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/LoginForm.java
@@ -194,13 +194,6 @@ public class LoginForm {
      */
 
     /**
-     * Bearbeitungsvorgang abbrechen.
-     */
-    public String PasswortAendernAbbrechen() {
-        return "/newpages/Main";
-    }
-
-    /**
      * neues Passwort übernehmen.
      */
     public String PasswortAendernSpeichern() {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -813,6 +813,10 @@ public class ProjekteForm extends BasisForm {
         this.showStatistics = showStatistics;
     }
 
+    /**
+     * Method being used as viewAction for project edit form.
+     * If 'itemId' is '0', the form for creating a new project will be displayed.
+     */
     public void loadProject() {
         try {
             if(!Objects.equals(this.itemId, 0)) {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
@@ -94,6 +95,8 @@ public class ProjekteForm extends BasisForm {
     private String projectStatVolumes;
     private boolean showStatistics;
 
+    private int itemId;
+
     public ProjekteForm() {
         super();
     }
@@ -152,7 +155,8 @@ public class ProjekteForm extends BasisForm {
 
     public String newProject() {
         this.myProjekt = new Project();
-        return "/newpages/ProjekteBearbeiten";
+        this.itemId = 0;
+        return "/newpages/ProjekteBearbeiten?faces-redirect=true";
     }
 
     /**
@@ -808,5 +812,20 @@ public class ProjekteForm extends BasisForm {
     public void setShowStatistics(boolean showStatistics) {
         this.showStatistics = showStatistics;
     }
+
+    public void loadProject() {
+        try {
+            if(!Objects.equals(this.itemId, 0)) {
+                setMyProjekt(this.serviceManager.getProjectService().find(this.itemId));
+            }
+        } catch (DAOException e) {
+            Helper.setFehlerMeldung("Error retrieving project with ID '" + this.itemId + "'; ", e.getMessage());
+        }
+
+    }
+
+    public void setItemId(int id) { this.itemId = id; }
+
+    public int getItemId() { return this.itemId; }
 
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
@@ -253,6 +254,14 @@ public class ProjekteForm extends BasisForm {
             return null;
         }
         return "/newpages/ProjekteAlle";
+    }
+
+    /**
+     * This method initializes the project list without any filters whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeProjectList() {
+        filterKein();
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -451,7 +451,7 @@ public class ProzessverwaltungForm extends BasisForm {
             FilterAktuelleProzesse();
         }
         else {
-            System.err.println("ERROR: did not recognize link ID '"+originLink+"'.");
+            logger.error("ERROR: did not recognize link ID '" + originLink + "'.");
         }
         setFilter("");
     }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -35,16 +35,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
@@ -439,6 +432,28 @@ public class ProzessverwaltungForm extends BasisForm {
         }
         this.modusAnzeige = "vorlagen";
         return "/newpages/ProzessverwaltungAlle";
+    }
+
+    /**
+     * This method initializes the process list without any filter whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeProcessList() {
+        Map<String,String> params = FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap();
+        String originLink = params.get("linkId");
+        if (Objects.equals(originLink, "newProcess")) {
+            NeuenVorgangAnlegen();
+        }
+        else if (Objects.equals(originLink, "templates")) {
+            FilterVorlagen();
+        }
+        else if (Objects.equals(originLink, "allProcesses")) {
+            FilterAktuelleProzesse();
+        }
+        else {
+            System.err.println("ERROR: did not recognize link ID '"+originLink+"'.");
+        }
+        setFilter("");
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RegelsaetzeForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RegelsaetzeForm.java
@@ -17,6 +17,7 @@ import de.sub.goobi.helper.Page;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
@@ -44,10 +45,12 @@ public class RegelsaetzeForm extends BasisForm {
     private Ruleset myRegelsatz = new Ruleset();
     private final ServiceManager serviceManager = new ServiceManager();
     private static final Logger logger = LogManager.getLogger(RegelsaetzeForm.class);
+    private int rulesetId;
 
     public String Neu() {
         this.myRegelsatz = new Ruleset();
-        return "/newpages/RegelsaetzeBearbeiten";
+        this.rulesetId = 0;
+        return "/newpages/RegelsaetzeBearbeiten?faces-redirect=true";
     }
 
     /**
@@ -148,6 +151,18 @@ public class RegelsaetzeForm extends BasisForm {
         return this.zurueck;
     }
 
+    public void loadRuleset() {
+        try {
+            if(!Objects.equals(this.rulesetId, 0)) {
+                setMyRegelsatz(this.serviceManager.getRulesetService().find(this.rulesetId));
+            } else {
+                setMyRegelsatz(null);
+            }
+        } catch (DAOException e) {
+            Helper.setFehlerMeldung("Error retrieving ruleset with ID '" + this.rulesetId + "'; ", e.getMessage());
+        }
+    }
+
     /*
      * Getter und Setter
      */
@@ -160,4 +175,8 @@ public class RegelsaetzeForm extends BasisForm {
         Helper.getHibernateSession().clear();
         this.myRegelsatz = inPreference;
     }
+
+    public void setRulesetId(int id) { this.rulesetId = id; }
+
+    public int getRulesetId() { return this.rulesetId; }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RegelsaetzeForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RegelsaetzeForm.java
@@ -33,6 +33,10 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
 import org.kitodo.services.ServiceManager;
 
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+
 @ManagedBean
 @ViewScoped
 public class RegelsaetzeForm extends BasisForm {
@@ -129,6 +133,14 @@ public class RegelsaetzeForm extends BasisForm {
             return null;
         }
         return "/newpages/RegelsaetzeAlle";
+    }
+
+    /**
+     * This method initializes the ruleset list without applying any filters whenever the bean is constructed.
+     */
+    @PostConstruct
+    public void initializeRulesetList() {
+        filterKein();
     }
 
     public String FilterKeinMitZurueck() {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RegelsaetzeForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RegelsaetzeForm.java
@@ -151,6 +151,10 @@ public class RegelsaetzeForm extends BasisForm {
         return this.zurueck;
     }
 
+    /**
+     * Method being used as viewAction for ruleset edit form.
+     * If 'rulesetId' is '0', the form for creating a new ruleset will be displayed.
+     */
     public void loadRuleset() {
         try {
             if(!Objects.equals(this.rulesetId, 0)) {

--- a/Kitodo/src/main/java/de/sub/goobi/helper/Helper.java
+++ b/Kitodo/src/main/java/de/sub/goobi/helper/Helper.java
@@ -98,11 +98,7 @@ public class Helper implements Serializable, Observer {
         /* einen bestimmten übergebenen Parameter ermitteln */
         FacesContext context = FacesContext.getCurrentInstance();
         Map requestParams = context.getExternalContext().getRequestParameterMap();
-        String myParameter = (String) requestParams.get(Parameter);
-        if (myParameter == null) {
-            myParameter = "";
-        }
-        return myParameter;
+        return (String) requestParams.get(Parameter);
     }
 
     /**

--- a/Kitodo/src/main/webapp/newpages/AktuelleSchritteAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/AktuelleSchritteAlle.xhtml
@@ -43,8 +43,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="newMain"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.aktuelleSchritte}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/AktuelleSchritteBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/AktuelleSchritteBearbeiten.xhtml
@@ -47,11 +47,11 @@
                             <h:panelGrid id="id1" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id2">
-                                    <h:commandLink id="id3" value="#{msgs.startseite}"
-                                                   action="newMain"/>
+                                    <h:link id="id3" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id4" value="#{msgs.aktuelleSchritte}"
-                                                   action="AktuelleSchritteAlle"/>
+                                    <h:link id="id4" value="#{msgs.aktuelleSchritte}"
+                                                   outcome="/newpages/AktuelleSchritteAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id5" value="#{msgs.detailsDesArbeitsschritts}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/BatchProperties.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BatchProperties.xhtml
@@ -35,9 +35,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}" action="newMain"/>
+                                    <h:link id="id2" value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.batches}" action="BatchesAll"/>
+                                    <h:link id="id3" value="#{msgs.batches}" outcome="/newpages/BatchesAll"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.batchProperties}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/BatchesAll.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BatchesAll.xhtml
@@ -112,7 +112,7 @@
                         <!-- Breadcrumb -->
                         <h:panelGrid id="id0" width="100%" columns="1" styleClass="layoutInhaltKopf">
                             <h:panelGroup id="id1">
-                                <h:commandLink id="id2" value="#{msgs.startseite}" action="Main"/>
+                                <h:link id="id2" value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                 <f:verbatim> &#8250;&#8250; </f:verbatim>
                                 <h:outputText id="id3" value="#{msgs.batches}"/>
                             </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/BatchesEdit.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BatchesEdit.xhtml
@@ -44,9 +44,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id1" width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id2">
-                                    <h:commandLink id="id3" value="#{msgs.startseite}" action="newMain"/>
+                                    <h:link id="id3" value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id4" value="#{msgs.aktuelleSchritte}" action="AktuelleSchritteAlle"/>
+                                    <h:link id="id4" value="#{msgs.aktuelleSchritte}" outcome="/newpages/AktuelleSchritteAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id5" value="#{msgs.detailsOfBatch}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/BenutzerAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerAlle.xhtml
@@ -47,8 +47,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.benutzerverwaltung}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/BenutzerAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerAlle.xhtml
@@ -173,14 +173,12 @@
                                                     <h:outputText id="id31" value="#{msgs.auswahl}"/>
                                                 </f:facet>
                                                 <!-- Bearbeiten-Schaltknopf -->
-                                                <h:commandLink id="id32" action="BenutzerBearbeiten"
+                                                <h:link id="id32" outcome="/newpages/BenutzerBearbeiten"
                                                                title="#{msgs.benutzerBearbeiten}">
+                                                    <f:param name="id" value="#{item.id}"/>
                                                     <h:graphicImage id="id33" alt="edit"
                                                                     value="/newpages/images/buttons/edit.gif"/>
-                                                    <t:updateActionListener
-                                                            property="#{BenutzerverwaltungForm.myClass}"
-                                                            value="#{item}"/>
-                                                </h:commandLink>
+                                                </h:link>
 
                                                 <!-- LdapKonfiguration schreiben-Schaltknopf -->
                                                 <!-- 										<h:commandLink id="id34" title="#{msgs.ldapKonfigurationSchreiben}"

--- a/Kitodo/src/main/webapp/newpages/BenutzerBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerBearbeiten.xhtml
@@ -43,9 +43,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}" action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.benutzerverwaltung}" action="BenutzerAlle"/>
+                                    <h:link id="id3" value="#{msgs.benutzerverwaltung}" outcome="/newpages/BenutzerAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id4" value="#{msgs.neuenBenutzerAnlegen}"
                                                   rendered="#{BenutzerverwaltungForm.myClass.id == null}"/>

--- a/Kitodo/src/main/webapp/newpages/BenutzerBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerBearbeiten.xhtml
@@ -25,6 +25,10 @@
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
     >
+    <f:metadata>
+        <f:viewParam name="id" value="#{BenutzerverwaltungForm.userId}"/>
+        <f:viewAction action="#{BenutzerverwaltungForm.loadMyClass}"/>
+    </f:metadata>
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
         <h:body>
@@ -294,8 +298,8 @@
 
                                             <tr>
                                                 <td class="eingabeBoxen_row3" align="left">
-                                                    <h:commandButton id="id58" value="#{msgs.abbrechen}" action="BenutzerAlle"
-                                                                     immediate="true"/>
+                                                    <h:button id="id58" value="#{msgs.abbrechen}"
+                                                              outcome="/newpages/BenutzerAlle" immediate="true"/>
                                                 </td>
 
                                                 <td class="eingabeBoxen_row3" align="right">

--- a/Kitodo/src/main/webapp/newpages/BenutzerKonfiguration.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerKonfiguration.xhtml
@@ -46,8 +46,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.benutzerkonfiguration}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/BenutzerKonfiguration.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzerKonfiguration.xhtml
@@ -147,8 +147,8 @@
 
                                             <tr>
                                                 <td class="eingabeBoxen_row3" align="left">
-                                                    <h:commandButton id="id22" value="#{msgs.abbrechen}"
-                                                                     action="Main" immediate="true"/>
+                                                    <h:button id="id22" value="#{msgs.abbrechen}"
+                                                                     outcome="/newpages/Main" immediate="true"/>
                                                 </td>
                                                 <td class="eingabeBoxen_row3" align="right">
                                                     <h:commandButton id="absenden" value="#{msgs.speichern}"

--- a/Kitodo/src/main/webapp/newpages/BenutzergruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzergruppenAlle.xhtml
@@ -112,14 +112,12 @@
                                                     <h:outputText id="id15" value="#{msgs.auswahl}"/>
                                                 </f:facet>
                                                 <!-- Bearbeiten-Schaltknopf -->
-                                                <h:commandLink id="id16" action="BenutzergruppenBearbeiten"
+                                                <h:link id="id16" outcome="/newpages/BenutzergruppenBearbeiten"
                                                                title="#{msgs.benutzerBearbeiten}">
+                                                    <f:param name="id" value="#{item.id}"/>
                                                     <h:graphicImage id="id17" alt="edit"
                                                                     value="/newpages/images/buttons/edit.gif"/>
-                                                    <t:updateActionListener
-                                                            property="#{BenutzergruppenForm.myBenutzergruppe}"
-                                                            value="#{item}"/>
-                                                </h:commandLink>
+                                                </h:link>
                                             </h:column>
 
                                         </t:dataTable>

--- a/Kitodo/src/main/webapp/newpages/BenutzergruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzergruppenAlle.xhtml
@@ -46,8 +46,8 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.benutzergruppen}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/BenutzergruppenBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzergruppenBearbeiten.xhtml
@@ -47,11 +47,11 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.benutzergruppen}"
-                                                   action="BenutzergruppenAlle"/>
+                                    <h:link id="id3" value="#{msgs.benutzergruppen}"
+                                                   outcome="/newpages/BenutzergruppenAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id4" value="#{msgs.neueBenutzergruppeAnlegen}"
                                                   rendered="#{BenutzergruppenForm.myBenutzergruppe.id == null}"/>

--- a/Kitodo/src/main/webapp/newpages/BenutzergruppenBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/BenutzergruppenBearbeiten.xhtml
@@ -27,6 +27,10 @@
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
     >
+    <f:metadata>
+        <f:viewParam name="id" value="#{BenutzergruppenForm.userGroupId}"/>
+        <f:viewAction action="#{BenutzergruppenForm.loadUserGroup}"/>
+    </f:metadata>
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
         <h:body>
@@ -130,8 +134,8 @@
 
                                             <tr>
                                                 <td class="eingabeBoxen_row3" align="left">
-                                                    <h:commandButton id="id21" value="#{msgs.abbrechen}"
-                                                                     action="BenutzergruppenAlle" immediate="true"/>
+                                                    <h:button id="id21" value="#{msgs.abbrechen}"
+                                                              outcome="/newpages/BenutzergruppenAlle" immediate="true"/>
                                                 </td>
                                                 <td class="eingabeBoxen_row3" align="right">
 

--- a/Kitodo/src/main/webapp/newpages/DocketEdit.xhtml
+++ b/Kitodo/src/main/webapp/newpages/DocketEdit.xhtml
@@ -27,6 +27,10 @@
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
     >
+    <f:metadata>
+        <f:viewParam name="id" value="#{DocketForm.docketId}"/>
+        <f:viewAction action="#{DocketForm.loadDocket}"/>
+    </f:metadata>
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
         <h:body>
@@ -46,11 +50,11 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="newMain"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                            outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.dockets}"
-                                                   action="RegelsaetzeAlle"/>
+                                    <h:link id="id3" value="#{msgs.dockets}"
+                                            outcome="/newpages/DocketList"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id4" value="#{msgs.createNewDocket}"
                                                   rendered="#{DocketForm.myDocket.id == null}"/>
@@ -122,8 +126,8 @@
 
                                             <tr>
                                                 <td class="eingabeBoxen_row3" align="left">
-                                                    <h:commandButton id="id21" value="#{msgs.abbrechen}"
-                                                                     action="DocketList" immediate="true"/>
+                                                    <h:button id="id21" value="#{msgs.abbrechen}"
+                                                              outcome="DocketList" />
                                                 </td>
                                                 <td class="eingabeBoxen_row3" align="right">
                                                     <h:commandButton id="id22" value="#{msgs.loeschen}"

--- a/Kitodo/src/main/webapp/newpages/DocketList.xhtml
+++ b/Kitodo/src/main/webapp/newpages/DocketList.xhtml
@@ -46,8 +46,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                            outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.dockets}"/>
                                 </h:panelGroup>
@@ -104,13 +104,12 @@
                                                     <h:outputText id="id20" value="#{msgs.auswahl}"/>
                                                 </f:facet>
                                                 <!-- Bearbeiten-Schaltknopf -->
-                                                <h:commandLink id="id21" action="DocketEdit"
+                                                <h:link id="id21" outcome="/newpages/DocketEdit"
                                                                title="#{msgs.editDocket}">
+                                                    <f:param name="id" value="#{item.id}"/>
                                                     <h:graphicImage id="id22" alt="edit"
                                                                     value="/newpages/images/buttons/edit.gif"/>
-                                                    <t:updateActionListener
-                                                            property="#{DocketForm.myDocket}" value="#{item}"/>
-                                                </h:commandLink>
+                                                </h:link>
                                             </h:column>
 
                                         </t:dataTable>

--- a/Kitodo/src/main/webapp/newpages/LdapGruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/LdapGruppenAlle.xhtml
@@ -107,13 +107,12 @@
                                                         <h:outputText id="id19" value="#{msgs.auswahl}"/>
                                                     </f:facet>
                                                     <!-- Bearbeiten-Schaltknopf -->
-                                                    <h:commandLink id="id20" action="LdapGruppenBearbeiten"
+                                                    <h:link id="id20" outcome="/newpages/LdapGruppenBearbeiten"
                                                                    title="#{msgs.ldapgruppeBearbeiten}">
+                                                        <f:param name="id" value="#{item.id}"/>
                                                         <h:graphicImage id="id21" alt="edit"
                                                                         value="/newpages/images/buttons/edit.gif"/>
-                                                        <t:updateActionListener
-                                                                property="#{LdapGruppenForm.myLdapGruppe}" value="#{item}"/>
-                                                    </h:commandLink>
+                                                    </h:link>
                                                 </t:column>
                                             </t:dataTable>
                                             <h:commandLink id="id52" action="#{LdapGruppenForm.Neu}"

--- a/Kitodo/src/main/webapp/newpages/LdapGruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/LdapGruppenAlle.xhtml
@@ -45,8 +45,7 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.ldapgruppen}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/LdapGruppenBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/LdapGruppenBearbeiten.xhtml
@@ -46,11 +46,11 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.ldapgruppen}"
-                                                   action="LdapGruppenAlle"/>
+                                    <h:link id="id3" value="#{msgs.ldapgruppen}"
+                                                   outcome="/newpages/LdapGruppenAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id4" value="#{msgs.neueLdapgruppeAnlegen}"
                                                   rendered="#{LdapGruppenForm.myLdapGruppe.id == null}"/>

--- a/Kitodo/src/main/webapp/newpages/LdapGruppenBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/LdapGruppenBearbeiten.xhtml
@@ -27,6 +27,10 @@
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
     >
+    <f:metadata>
+        <f:viewParam name="id" value="#{LdapGruppenForm.itemId}"/>
+        <f:viewAction action="#{LdapGruppenForm.loadLdapGroup}"/>
+    </f:metadata>
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
         <h:body>
@@ -302,8 +306,8 @@
 
                                                 <tr>
                                                     <td class="eingabeBoxen_row3" align="left">
-                                                        <h:commandButton id="id68" value="#{msgs.abbrechen}"
-                                                                         action="LdapGruppenAlle" immediate="true"/>
+                                                        <h:button id="id68" value="#{msgs.abbrechen}"
+                                                                         outcome="/newpages/LdapGruppenAlle" immediate="true"/>
                                                     </td>
                                                     <td class="eingabeBoxen_row3" align="right">
                                                         <h:commandButton id="id69" value="#{msgs.loeschen}"

--- a/Kitodo/src/main/webapp/newpages/MassImport.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MassImport.xhtml
@@ -47,9 +47,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf" id="projgrid112">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink value="#{msgs.startseite}" action="Main"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}" action="ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.MassImport}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/MassImportPage2.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MassImportPage2.xhtml
@@ -47,9 +47,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf" id="projgrid112">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink value="#{msgs.startseite}" action="Main"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}" action="ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.MassImport}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/MassImportPage3.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MassImportPage3.xhtml
@@ -46,9 +46,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf" id="projgrid112">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink value="#{msgs.startseite}" action="Main"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}" action="ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.MassImport}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/MultiMassImportPage2.xhtml
+++ b/Kitodo/src/main/webapp/newpages/MultiMassImportPage2.xhtml
@@ -47,9 +47,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf" id="projgrid112">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink value="#{msgs.startseite}" action="newMain"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}" action="ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.MassImport}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/NewProcess/Page1.xhtml
+++ b/Kitodo/src/main/webapp/newpages/NewProcess/Page1.xhtml
@@ -40,9 +40,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup>
-                                    <h:commandLink value="#{msgs.startseite}" action="Main"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}" action="/newpages/ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.einenNeuenProzessAnlegen}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/NewProcess/Page2.xhtml
+++ b/Kitodo/src/main/webapp/newpages/NewProcess/Page2.xhtml
@@ -41,10 +41,10 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup>
-                                    <h:commandLink value="#{msgs.startseite}" action="Main"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}"
-                                                   action="/newpages/ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}"
+                                                   outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.einenNeuenProzessAnlegen}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/NewProcess/Page3.xhtml
+++ b/Kitodo/src/main/webapp/newpages/NewProcess/Page3.xhtml
@@ -42,11 +42,11 @@
                             <h:panelGrid id="utid31" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="utid32">
-                                    <h:commandLink id="utid33" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="utid33" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="utid34" value="#{msgs.prozessverwaltung}"
-                                                   action="/newpages/ProzessverwaltungAlle"/>
+                                    <h:link id="utid34" value="#{msgs.prozessverwaltung}"
+                                                   outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="utid35"
                                                   value="#{msgs.einenNeuenProzessAnlegen}"/>

--- a/Kitodo/src/main/webapp/newpages/PasswortAendern.xhtml
+++ b/Kitodo/src/main/webapp/newpages/PasswortAendern.xhtml
@@ -44,8 +44,8 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.passwortAendern}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/PasswortAendern.xhtml
+++ b/Kitodo/src/main/webapp/newpages/PasswortAendern.xhtml
@@ -120,8 +120,8 @@
 
                                             <tr>
                                                 <td class="eingabeBoxen_row3">
-                                                    <h:commandButton
-                                                            action="#{LoginForm.PasswortAendernAbbrechen}"
+                                                    <h:button
+                                                            outcome="/newpages/Main"
                                                             value="#{msgs.abbrechen}" immediate="true"/>
                                                     <t:commandButton id="absenden" forceId="true" type="submit"
                                                                      action="#{LoginForm.PasswortAendernSpeichern}"

--- a/Kitodo/src/main/webapp/newpages/ProjekteAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjekteAlle.xhtml
@@ -144,13 +144,12 @@
                                                     <h:outputText id="id27" value="#{msgs.auswahl}"/>
                                                 </f:facet>
                                                 <!-- Bearbeiten-Schaltknopf -->
-                                                <h:commandLink id="id28" action="ProjekteBearbeiten"
+                                                <h:link id="id28" outcome="/newpages/ProjekteBearbeiten"
                                                                title="#{msgs.projektBearbeiten}">
+                                                    <f:param name="id" value="#{item.id}"/>
                                                     <h:graphicImage alt="edit" id="id29"
                                                                     value="/newpages/images/buttons/edit.gif"/>
-                                                    <t:updateActionListener property="#{ProjekteForm.myProjekt}"
-                                                                            value="#{item}"/>
-                                                </h:commandLink>
+                                                </h:link>
                                             </t:column>
                                         </t:dataTable>
 

--- a/Kitodo/src/main/webapp/newpages/ProjekteAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjekteAlle.xhtml
@@ -45,8 +45,8 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="newMain"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.projekte}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
@@ -27,6 +27,10 @@
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
     >
+    <f:metadata>
+        <f:viewParam name="id" value="#{ProjekteForm.itemId}"/>
+        <f:viewAction action="#{ProjekteForm.loadProject}"/>
+    </f:metadata>
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
         <!-- css filepath configured for mac os x -->
@@ -1039,8 +1043,8 @@
 
                                             <tr>
                                                 <td class="eingabeBoxen_row3" align="left">
-                                                    <h:commandButton id="id121" value="#{msgs.abbrechen}"
-                                                                     action="ProjekteAlle" immediate="true"/>
+                                                    <h:button id="id121" value="#{msgs.abbrechen}"
+                                                              outcome="/newpages/ProjekteAlle" immediate="true"/>
                                                 </td>
                                                 <td class="eingabeBoxen_row3" align="right">
                                                     <h:commandButton id="id122" value="#{msgs.loeschen}"

--- a/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
@@ -49,11 +49,11 @@
                             <h:panelGrid width="100%" columns="1"
                                          styleClass="layoutInhaltKopf" id="projectgrid1">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="newMain"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.projekte}"
-                                                   action="ProjekteAlle"/>
+                                    <h:link id="id3" value="#{msgs.projekte}"
+                                                   outcome="/newpages/ProjekteAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id4" value="#{msgs.neuesProjektAnlegen}"
                                                   rendered="#{ProjekteForm.myProjekt.id == null}"/>

--- a/Kitodo/src/main/webapp/newpages/ProzessverwaltungAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProzessverwaltungAlle.xhtml
@@ -45,8 +45,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.prozessverwaltung}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/ProzessverwaltungBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProzessverwaltungBearbeiten.xhtml
@@ -43,9 +43,9 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}" action="newMain"/>
+                                    <h:link id="id2" value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.prozessverwaltung}" action="ProzessverwaltungAlle"/>
+                                    <h:link id="id3" value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id4" value="#{msgs.einenNeuenProzessAnlegen}"
                                                   rendered="#{ProzessverwaltungForm.myProzess.id == null}"/>

--- a/Kitodo/src/main/webapp/newpages/ProzessverwaltungSuche.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProzessverwaltungSuche.xhtml
@@ -39,7 +39,7 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup>
-                                    <h:commandLink value="#{msgs.startseite}" action="newMain" id="mainlink"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main" id="mainlink"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.prozessverwaltung}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/RegelsaetzeAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/RegelsaetzeAlle.xhtml
@@ -119,13 +119,12 @@
                                                 <h:outputText id="id20" value="#{msgs.auswahl}"/>
                                             </f:facet>
                                             <!-- Bearbeiten-Schaltknopf -->
-                                            <h:commandLink id="id21" action="RegelsaetzeBearbeiten"
+                                            <h:link id="id21" outcome="/newpages/RegelsaetzeBearbeiten"
                                                            title="#{msgs.regelsatzBearbeiten}">
                                                 <h:graphicImage id="id22" alt="edit ruleset"
-                                                                value="/newpages/images/buttons/edit.gif"/>
-                                                <t:updateActionListener
-                                                        property="#{RegelsaetzeForm.myRegelsatz}" value="#{item}"/>
-                                            </h:commandLink>
+							value="/newpages/images/buttons/edit.gif"/>
+                                                <f:param name="id" value="#{item.id}"/>
+                                            </h:link>
                                         </h:column>
 
                                     </t:dataTable>

--- a/Kitodo/src/main/webapp/newpages/RegelsaetzeAlle.xhtml
+++ b/Kitodo/src/main/webapp/newpages/RegelsaetzeAlle.xhtml
@@ -47,8 +47,8 @@
                         <h:panelGrid id="id0" width="100%" columns="1"
                                      styleClass="layoutInhaltKopf">
                             <h:panelGroup id="id1">
-                                <h:commandLink id="id2" value="#{msgs.startseite}"
-                                               action="Main"/>
+                                <h:link id="id2" value="#{msgs.startseite}"
+                                               outcome="/newpages/Main"/>
                                 <f:verbatim> &#8250;&#8250; </f:verbatim>
                                 <h:outputText id="id3" value="#{msgs.regelsaetze}"/>
                             </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/RegelsaetzeBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/RegelsaetzeBearbeiten.xhtml
@@ -46,11 +46,11 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="newMain"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink id="id3" value="#{msgs.regelsaetze}"
-                                                   action="RegelsaetzeAlle"/>
+                                    <h:link id="id3" value="#{msgs.regelsaetze}"
+                                                   outcome="RegelsaetzeAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id4" value="#{msgs.neuenRegelsatzAnlegen}"
                                                   rendered="#{RegelsaetzeForm.myRegelsatz.id == null}"/>

--- a/Kitodo/src/main/webapp/newpages/RegelsaetzeBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/RegelsaetzeBearbeiten.xhtml
@@ -27,6 +27,10 @@
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
     >
+    <f:metadata>
+        <f:viewParam name="id" value="#{RegelsaetzeForm.rulesetId}"/>
+        <f:viewAction action="#{RegelsaetzeForm.loadRuleset}"/>
+    </f:metadata>
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
         <h:body>
@@ -130,8 +134,8 @@
 
                                             <tr>
                                                 <td class="eingabeBoxen_row3" align="left">
-                                                    <h:commandButton id="id21" value="#{msgs.abbrechen}"
-                                                                     action="RegelsaetzeAlle" immediate="true"/>
+                                                    <h:button id="id21" value="#{msgs.abbrechen}"
+                                                              outcome="/newpages/RegelsaetzeAlle" immediate="true"/>
                                                 </td>
                                                 <td class="eingabeBoxen_row3" align="right">
                                                     <h:commandButton id="id22" value="#{msgs.loeschen}"

--- a/Kitodo/src/main/webapp/newpages/aktiveNutzer.xhtml
+++ b/Kitodo/src/main/webapp/newpages/aktiveNutzer.xhtml
@@ -44,8 +44,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.aktiveBenutzer}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/inc/tbl_Navigation.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/tbl_Navigation.xhtml
@@ -132,7 +132,7 @@
                                            outcome="/newpages/ProzessverwaltungAlle"
                                            style="#{request.getParameter('linkId') == 'allProcesses' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
                                 <f:param name="linkId" value="newProcess"/>
-                                <h:panelGroup rendered="#{request.getParameter('linkId') == 'allProcesses' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml'}">
+                                <h:panelGroup rendered="#{request.getParameter('linkId') == 'newProcess' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.neuenVorgangAnlegen}"/>
@@ -161,8 +161,10 @@
                             <!-- Menu Administration / Users -->
                             <h:link styleClass="mlink" id="users"
                                            outcome="/newpages/BenutzerAlle"
-                                           style="#{view.viewId == '/newpages/BenutzerAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{view.viewId == '/newpages/BenutzerAlle.xhtml'}">
+                                           style="#{view.viewId == '/newpages/BenutzerAlle.xhtml' or
+                                                    view.viewId == '/newpages/BenutzerBearbeiten.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/BenutzerAlle.xhtml' or
+                                                          view.viewId == '/newpages/BenutzerBearbeiten.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.users}"/>
@@ -171,8 +173,10 @@
                             <!-- Benutzergruppen -->
                             <h:link styleClass="mlink" id="groups"
                                            outcome="/newpages/BenutzergruppenAlle"
-                                           style="#{view.viewId == '/newpages/BenutzergruppenAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{view.viewId == '/newpages/BenutzergruppenAlle.xhtml'}">
+                                           style="#{view.viewId == '/newpages/BenutzergruppenAlle.xhtml' or
+                                                    view.viewId == '/newpages/BenutzergruppenBearbeiten.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/BenutzergruppenAlle.xhtml' or
+                                                          view.viewId == '/newpages/BenutzergruppenBearbeiten.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.benutzergruppen}"/>
@@ -181,8 +185,10 @@
                             <!-- Projekte -->
                             <h:link styleClass="mlink" id="projects"
                                            outcome="/newpages/ProjekteAlle"
-                                           style="#{view.viewId == '/newpages/ProjekteAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{view.viewId == '/newpages/ProjekteAlle.xhtml'}">
+                                           style="#{view.viewId == '/newpages/ProjekteAlle.xhtml' or
+                                                    view.viewId == '/newpages/ProjekteBearbeiten.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/ProjekteAlle.xhtml' or
+                                                          view.viewId == '/newpages/ProjekteBearbeiten.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.projekte}"/>
@@ -191,8 +197,10 @@
                             <!-- Regelsätze -->
                             <h:link styleClass="mlink" id="rulesets"
                                            outcome="/newpages/RegelsaetzeAlle"
-                                           style="#{view.viewId == '/newpages/RegelsaetzeAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{view.viewId == '/newpages/RegelsaetzeAlle.xhtml'}">
+                                           style="#{view.viewId == '/newpages/RegelsaetzeAlle.xhtml' or
+                                                    view.viewId == '/newpages/RegelsaetzeBearbeiten.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/RegelsaetzeAlle.xhtml' or
+                                                          view.viewId == '/newpages/RegelsaetzeBearbeiten.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.regelsaetze}"/>
@@ -201,8 +209,10 @@
                             <!-- Dockets -->
                             <h:link styleClass="mlink" id="navigation"
                                            outcome="/newpages/DocketList"
-                                           style="#{view.viewId == '/newpages/DocketList.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{view.viewId == '/newpages/DocketList.xhtml'}">
+                                           style="#{view.viewId == '/newpages/DocketList.xhtml' or
+                                                    view.viewId == '/newpages/DocketEdit.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/DocketList.xhtml' or
+                                                          view.viewId == '/newpages/DocketEdit.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.dockets}"/>
@@ -211,8 +221,10 @@
                             <!-- Ldapgruppen -->
                             <h:link styleClass="mlink" id="ldapgroups"
                                            outcome="/newpages/LdapGruppenAlle"
-                                           style="#{view.viewId == '/newpages/LdapGruppenAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{view.viewId == '/newpages/LdapGruppenAlle.xhtml'}">
+                                           style="#{view.viewId == '/newpages/LdapGruppenAlle.xhtml' or
+                                                    view.viewId == '/newpages/LdapGruppenBearbeiten.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/LdapGruppenAlle.xhtml' or
+                                                          view.viewId == '/newpages/LdapGruppenBearbeiten.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.ldapgruppen}"/>

--- a/Kitodo/src/main/webapp/newpages/inc/tbl_Navigation.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/tbl_Navigation.xhtml
@@ -40,52 +40,44 @@
                         #########################################-->
 
                         <!-- Startseite -->
-                        <h:commandLink styleClass="mlink" action="/newpages/Main" id="main"
-                                       style="#{NavigationForm.aktuell == '0' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                            <h:panelGroup rendered="#{NavigationForm.aktuell == '0'}">
+                        <h:link styleClass="mlink" outcome="/newpages/Main" id="main"
+                                       style="#{view.viewId == '/newpages/Main.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                            <h:panelGroup rendered="#{view.viewId == '/newpages/Main.xhtml'}">
                                 <f:verbatim>&#8250; </f:verbatim>
                             </h:panelGroup>
                             <h:outputText value="#{msgs.startseite}"/>
-                            <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                    value="0"/>
-                        </h:commandLink>
+                        </h:link>
 
                         <!-- ################            allgemeines             ######################-->
 
                         <h:outputText styleClass="th_menu" value="- #{msgs.allgemeines} -"/>
                         <!-- Bedienungshinweise -->
-                        <h:commandLink styleClass="mlink" action="/newpages/statischBedienung"
-                                       style="#{NavigationForm.aktuell == '10' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                            <h:panelGroup rendered="#{NavigationForm.aktuell == '10'}">
+                        <h:link styleClass="mlink" outcome="/newpages/statischBedienung"
+                                       style="#{view.viewId == '/newpages/statischBedienung.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                            <h:panelGroup rendered="#{view.viewId == '/newpages/statischBedienung.xhtml'}">
                                 <f:verbatim>&#8250; </f:verbatim>
                             </h:panelGroup>
                             <h:outputText value="#{msgs.bedienungshinweise}" />
-                            <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                    value="10" />
-                        </h:commandLink>
+                        </h:link>
 
                         <!-- technischer Hintergrund -->
-                        <h:commandLink styleClass="mlink" action="/newpages/statischTechnischerHintergrund" id="technicalBackground"
-                                       style="#{NavigationForm.aktuell == '11' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                            <h:panelGroup rendered="#{NavigationForm.aktuell == '11'}">
+                        <h:link styleClass="mlink" outcome="/newpages/statischTechnischerHintergrund" id="technicalBackground"
+                                       style="#{view.viewId == '/newpages/statischTechnischerHintergrund.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                            <h:panelGroup rendered="#{view.viewId == '/newpages/statischTechnischerHintergrund.xhtml'}">
                                 <f:verbatim>&#8250; </f:verbatim>
                             </h:panelGroup>
                             <h:outputText value="#{msgs.technischerHintergrund}"/>
-                            <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                    value="11"/>
-                        </h:commandLink>
+                        </h:link>
 
                         <!-- aktive Benutzer -->
-                        <h:commandLink styleClass="mlink" action="/newpages/aktiveNutzer" id="currentUsers"
-                                       style="#{NavigationForm.aktuell == '12' ? 'font-weight: bold;':'font-weight:normal ;'}"
+                        <h:link styleClass="mlink" outcome="/newpages/aktiveNutzer" id="currentUsers"
+                                       style="#{view.viewId == '/newpages/aktiveNutzer.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}"
                                        rendered="#{!HelperForm.anonymized}">
-                            <h:panelGroup rendered="#{NavigationForm.aktuell == '12'}">
+                            <h:panelGroup rendered="#{view.viewId == '/newpages/aktiveNutzer.xhtml'}">
                                 <f:verbatim>&#8250; </f:verbatim>
                             </h:panelGroup>
                             <h:outputText value="#{msgs.aktiveBenutzer}"/>
-                            <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                    value="12"/>
-                        </h:commandLink>
+                        </h:link>
 
                         <!-- ################            Workflow              ######################-->
 
@@ -93,91 +85,70 @@
                             <h:outputText styleClass="th_menu" value="- #{msgs.workflow} -"/>
 
                             <!-- aktuelle Schritte -->
-                            <h:commandLink styleClass="mlink" id="myTasks"
-                                           action="#{AktuelleSchritteForm.filterAlleStart}"
-                                           style="#{NavigationForm.aktuell == '20' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '20'}">
+                            <h:link styleClass="mlink" id="myTasks"
+                                           outcome="/newpages/AktuelleSchritteAlle"
+                                           style="#{view.viewId == '/newpages/AktuelleSchritteAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/AktuelleSchritteAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.aktuelleSchritte}"/>
-                                <t:updateActionListener property="#{AktuelleSchritteForm.filter}"
-                                                        value=""/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="20"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Prozess suchen -->
-                            <h:commandLink styleClass="mlink" action="ProzessverwaltungSuche" id="searchProcesses"
-                                           style="#{NavigationForm.aktuell == '21' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '21'}">
+                            <h:link styleClass="mlink" outcome="/newpages/ProzessverwaltungSuche" id="searchProcesses"
+                                           style="#{view.viewId == '/newpages/ProzessverwaltungSuche.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/ProzessverwaltungSuche.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.nachEinemBandSuchen}"/>
-                                <t:updateActionListener
-                                        property="#{ProzessverwaltungForm.filter}" value=""/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="21"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Prozessübersicht -->
-                            <h:commandLink styleClass="mlink" id="allProcesses"
+                            <h:link styleClass="mlink" id="allProcesses"
                                            rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}"
-                                           action="#{ProzessverwaltungForm.FilterAktuelleProzesse}"
-                                           style="#{NavigationForm.aktuell == '22' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '22'}">
+                                           outcome="/newpages/ProzessverwaltungAlle"
+                                           style="#{request.getParameter('linkId') == 'allProcesses' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <f:param name="linkId" value="allProcesses"/>
+                                <h:panelGroup rendered="#{request.getParameter('linkId') == 'allProcesses' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.aktuelleProzesse}"/>
-                                <t:updateActionListener
-                                        property="#{ProzessverwaltungForm.filter}" value=""/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="22"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- batches -->
-                            <h:commandLink styleClass="mlink"
+                            <h:link styleClass="mlink"
                                            rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}"
-                                           action="#{BatchForm.filterAlleStart}"
-                                           style="#{NavigationForm.aktuell == '44' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '44'}">
+                                           outcome="/newpages/BatchesAll"
+                                           style="#{view.viewId == '/newpages/BatchesAll.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/BatchesAll.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.batches}"/>
-                                <t:updateActionListener
-                                        property="#{BatchForm.modusBearbeiten}" value=""/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="44"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- neuen Vorgang anlegen -->
-                            <h:commandLink styleClass="mlink" id="newProcess"
+                            <h:link styleClass="mlink" id="newProcess"
                                            rendered="#{LoginForm.maximaleBerechtigung == 2}"
-                                           action="#{ProzessverwaltungForm.NeuenVorgangAnlegen}"
-                                           style="#{NavigationForm.aktuell == '23' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '23'}">
+                                           outcome="/newpages/ProzessverwaltungAlle"
+                                           style="#{request.getParameter('linkId') == 'allProcesses' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <f:param name="linkId" value="newProcess"/>
+                                <h:panelGroup rendered="#{request.getParameter('linkId') == 'allProcesses' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.neuenVorgangAnlegen}"/>
-                                <t:updateActionListener
-                                        property="#{ProzessverwaltungForm.filter}" value=""/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="23"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Prozessvorlagen -->
-                            <h:commandLink styleClass="mlink" id="templates"
+                            <h:link styleClass="mlink" id="templates"
                                            rendered="#{LoginForm.maximaleBerechtigung == 1}"
-                                           action="#{ProzessverwaltungForm.FilterVorlagen}"
-                                           style="#{NavigationForm.aktuell == '24' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '24'}">
+                                           outcome="/newpages/ProzessverwaltungAlle"
+                                           style="#{request.getParameter('linkId') == 'templates' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <f:param name="linkId" value="templates"/>
+                                <h:panelGroup rendered="#{request.getParameter('linkId') == 'templates' and view.viewId == '/newpages/ProzessverwaltungAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.prozessvorlagen}"/>
-                                <t:updateActionListener
-                                        property="#{ProzessverwaltungForm.filter}" value=""/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="24"/>
-                            </h:commandLink>
+                            </h:link>
 
                         </h:panelGroup>
 
@@ -188,102 +159,86 @@
                                           value="- #{msgs.administration} -"/>
 
                             <!-- Menu Administration / Users -->
-                            <h:commandLink styleClass="mlink" id="users"
-                                           action="#{BenutzerverwaltungForm.filterKein}"
-                                           style="#{NavigationForm.aktuell == '30' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '30'}">
+                            <h:link styleClass="mlink" id="users"
+                                           outcome="/newpages/BenutzerAlle"
+                                           style="#{view.viewId == '/newpages/BenutzerAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/BenutzerAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.users}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="30"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Benutzergruppen -->
-                            <h:commandLink styleClass="mlink" id="groups"
-                                           action="#{BenutzergruppenForm.filterKein}"
-                                           style="#{NavigationForm.aktuell == '31' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '31'}">
+                            <h:link styleClass="mlink" id="groups"
+                                           outcome="/newpages/BenutzergruppenAlle"
+                                           style="#{view.viewId == '/newpages/BenutzergruppenAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/BenutzergruppenAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.benutzergruppen}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="31"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Projekte -->
-                            <h:commandLink styleClass="mlink" id="projects"
-                                           action="#{ProjekteForm.filterKein}"
-                                           style="#{NavigationForm.aktuell == '32' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '32'}">
+                            <h:link styleClass="mlink" id="projects"
+                                           outcome="/newpages/ProjekteAlle"
+                                           style="#{view.viewId == '/newpages/ProjekteAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/ProjekteAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.projekte}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="32"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Regelsätze -->
-                            <h:commandLink styleClass="mlink" id="rulesets"
-                                           action="#{RegelsaetzeForm.filterKein}"
-                                           style="#{NavigationForm.aktuell == '33' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '33'}">
+                            <h:link styleClass="mlink" id="rulesets"
+                                           outcome="/newpages/RegelsaetzeAlle"
+                                           style="#{view.viewId == '/newpages/RegelsaetzeAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/RegelsaetzeAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.regelsaetze}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="33"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Dockets -->
-                            <h:commandLink styleClass="mlink" id="navigation"
-                                           action="#{DocketForm.filterKein}"
-                                           style="#{NavigationForm.aktuell == '45' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '45'}">
+                            <h:link styleClass="mlink" id="navigation"
+                                           outcome="/newpages/DocketList"
+                                           style="#{view.viewId == '/newpages/DocketList.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/DocketList.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.dockets}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="45"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Ldapgruppen -->
-                            <h:commandLink styleClass="mlink" id="ldapgroups"
-                                           action="#{LdapGruppenForm.filterKein}"
-                                           style="#{NavigationForm.aktuell == '34' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '34'}">
+                            <h:link styleClass="mlink" id="ldapgroups"
+                                           outcome="/newpages/LdapGruppenAlle"
+                                           style="#{view.viewId == '/newpages/LdapGruppenAlle.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/LdapGruppenAlle.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.ldapgruppen}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="34"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- aktive Tasks -->
-                            <h:commandLink styleClass="mlink" action="taskmanager"
+                            <h:link styleClass="mlink" outcome="/newpages/taskmanager"
                                            rendered="#{NavigationForm.showTaskManager}"
-                                           style="#{NavigationForm.aktuell == '36' ? 'font-weight: bold;':'font-weight:normal ;'}"
+                                           style="#{view.viewId == '/newpages/taskmanager.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}"
                                            id="taskmanager">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '36'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/taskmanager.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.taskmanager}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="36"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- aktive Module -->
-                            <h:commandLink styleClass="mlink" action="modulemanager"
+                            <h:link styleClass="mlink" outcome="/newpages/modulemanager"
                                            rendered="#{NavigationForm.showModuleManager}"
-                                           style="#{NavigationForm.aktuell == '35' ? 'font-weight: bold;':'font-weight:normal ;'}"
+                                           style="#{view.viewId == '/newpages/modulemanager.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}"
                                            id="modules">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '35'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/modulemanager.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.modulemanager}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="35"/>
-                            </h:commandLink>
+                            </h:link>
 
                         </h:panelGroup>
 
@@ -294,26 +249,22 @@
                                           value="- #{msgs.benutzerdaten} -"/>
 
                             <!-- Benutzerkonfiguration -->
-                            <h:commandLink styleClass="mlink" action="/newpages/BenutzerKonfiguration" id="userconfig"
-                                           style="#{NavigationForm.aktuell == '40' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '40'}">
+                            <h:link styleClass="mlink" outcome="/newpages/BenutzerKonfiguration" id="userconfig"
+                                           style="#{view.viewId == '/newpages/BenutzerKonfiguration.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/BenutzerKonfiguration.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.benutzerkonfiguration}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="40"/>
-                            </h:commandLink>
+                            </h:link>
 
                             <!-- Passwort ändern -->
-                            <h:commandLink styleClass="mlink" action="/newpages/PasswortAendern" id="changePW"
-                                           style="#{NavigationForm.aktuell == '41' ? 'font-weight: bold;':'font-weight:normal ;'}">
-                                <h:panelGroup rendered="#{NavigationForm.aktuell == '41'}">
+                            <h:link styleClass="mlink" outcome="/newpages/PasswortAendern" id="changePW"
+                                           style="#{view.viewId == '/newpages/PasswortAendern.xhtml' ? 'font-weight: bold;':'font-weight:normal ;'}">
+                                <h:panelGroup rendered="#{view.viewId == '/newpages/PasswortAendern.xhtml'}">
                                     <f:verbatim>&#8250; </f:verbatim>
                                 </h:panelGroup>
                                 <h:outputText value="#{msgs.passwortAendern}"/>
-                                <t:updateActionListener property="#{NavigationForm.aktuell}"
-                                                        value="41"/>
-                            </h:commandLink>
+                            </h:link>
                         </h:panelGroup>
 
                     </h:form>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt.xhtml
@@ -40,14 +40,13 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup>
-                                    <h:commandLink value="#{msgs.startseite}" action="/newpages/Main"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}"
-                                                   action="/newpages/ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}"
+                                                   outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessDetails}"
-                                                   action="/newpages/ProzessverwaltungBearbeiten">
-                                    </h:commandLink>
+                                    <h:link value="#{msgs.prozessDetails}"
+                                                   outcome="/newpages/ProzessverwaltungBearbeiten"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.schrittDetails}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/vorlage.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/vorlage.xhtml
@@ -40,14 +40,11 @@
                         <!-- Breadcrumb -->
                         <h:panelGrid columns="1" styleClass="layoutInhaltKopf">
                             <h:panelGroup>
-                                <h:commandLink value="#{msgs.startseite}" action="newMain"/>
+                                <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                 <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                <h:commandLink value="#{msgs.prozessverwaltung}"
-                                               action="/newpages/ProzessverwaltungAlle"/>
+                                <h:link value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                 <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                <h:commandLink value="#{msgs.prozessDetails}"
-                                               action="ProzessverwaltungBearbeiten">
-                                </h:commandLink>
+                                <h:link value="#{msgs.prozessDetails}" outcome="/newpages/ProzessverwaltungBearbeiten"/>
                                 <f:verbatim> &#8250;&#8250; </f:verbatim>
                                 <h:outputText value="#{msgs.vorlageDetails}"/>
                             </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/werkstueck.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/werkstueck.xhtml
@@ -40,14 +40,11 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid width="100%" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup>
-                                    <h:commandLink value="#{msgs.startseite}" action="newMain"/>
+                                    <h:link value="#{msgs.startseite}" outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessverwaltung}"
-                                                   action="/newpages/ProzessverwaltungAlle"/>
+                                    <h:link value="#{msgs.prozessverwaltung}" outcome="/newpages/ProzessverwaltungAlle"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
-                                    <h:commandLink value="#{msgs.prozessDetails}"
-                                                   action="ProzessverwaltungBearbeiten">
-                                    </h:commandLink>
+                                    <h:link value="#{msgs.prozessDetails}" outcome="/newpages/ProzessverwaltungBearbeiten"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText value="#{msgs.werkstueckDetails}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/modulemanager.xhtml
+++ b/Kitodo/src/main/webapp/newpages/modulemanager.xhtml
@@ -43,8 +43,8 @@
                             <!-- Breadcrumb -->
                             <h:panelGrid id="id0" columns="1" styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.aktiveModule}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/statischBedienung.xhtml
+++ b/Kitodo/src/main/webapp/newpages/statischBedienung.xhtml
@@ -43,8 +43,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.bedienungshinweise}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/statischImpressum.xhtml
+++ b/Kitodo/src/main/webapp/newpages/statischImpressum.xhtml
@@ -43,8 +43,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.impressum}"/>
                                 </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/statischTechnischerHintergrund.xhtml
+++ b/Kitodo/src/main/webapp/newpages/statischTechnischerHintergrund.xhtml
@@ -43,8 +43,8 @@
                         <h:panelGrid id="id0" width="100%" columns="1"
                                      styleClass="layoutInhaltKopf">
                             <h:panelGroup id="id1">
-                                <h:commandLink id="id2" value="#{msgs.startseite}"
-                                               action="Main"/>
+                                <h:link id="id2" value="#{msgs.startseite}"
+                                               outcome="/newpages/Main"/>
                                 <f:verbatim> &#8250;&#8250; </f:verbatim>
                                 <h:outputText id="id3" value="#{msgs.technischerHintergrund}"/>
                             </h:panelGroup>

--- a/Kitodo/src/main/webapp/newpages/taskmanager.xhtml
+++ b/Kitodo/src/main/webapp/newpages/taskmanager.xhtml
@@ -44,8 +44,8 @@
                             <h:panelGrid id="id0" width="100%" columns="1"
                                          styleClass="layoutInhaltKopf">
                                 <h:panelGroup id="id1">
-                                    <h:commandLink id="id2" value="#{msgs.startseite}"
-                                                   action="Main"/>
+                                    <h:link id="id2" value="#{msgs.startseite}"
+                                                   outcome="/newpages/Main"/>
                                     <f:verbatim> &#8250;&#8250; </f:verbatim>
                                     <h:outputText id="id3" value="#{msgs.langLaufendeAufgaben}"/>
                                 </h:panelGroup>


### PR DESCRIPTION
These changes resolve the 'one-url-behind' problem that Kitodo.Production suffers from because h:commandLink and h:commandButton elements are used for normal page to page navigation. These command components are translated into POST requests (postbacks), instead of GET requests and are responsible for said problem.
The new h:link and h:button components introduced in JSF 2, which are recommended for page to page navigation because they produce GET requests, are used in these commits to replace the command components in the navigation menu.