### PR TITLE
Exclude js and css resources from requestControlFilter

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -124,6 +124,10 @@
     <filter>
         <filter-name>requestControlFilter</filter-name>
         <filter-class>de.sub.goobi.helper.servletfilter.RequestControlFilter</filter-class>
+        <init-param>
+            <param-name>excludePattern</param-name>
+            <param-value>.*\.(js|css)\.jsf</param-value>
+        </init-param>
     </filter>
 
     <filter>


### PR DESCRIPTION
This is important for using primefaces.
Resources from primefaces are supplied with the extension “.jsf” and the requestControlFilter matches for files with this extension.
Without excluding, the files wont be delivered.