### PR TITLE
Update commons_io to version 2.5

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/OpacPica-Plugin/pom.xml
+++ b/OpacPica-Plugin/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>jdom</groupId>


### PR DESCRIPTION
Currently only commons_io version 1.4 get into resulting war file but for file management version 2.5 is needed.