### PR TITLE
Move user filters to filter table

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Filter.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Filter.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.database.beans;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * Filter bean.
+ */
+@Entity
+@Table(name = "filter")
+public class Filter extends BaseBean {
+
+    private static final long serialVersionUID = -5187937660333984868L;
+
+    @Column(name = "value", columnDefinition = "longtext")
+    private String value;
+
+    @Column(name = "creationDate")
+    private Date creationDate;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "FK_filter_user_id"))
+    private User user;
+
+    /**
+     * Get filter value.
+     *
+     * @return filter value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Set filter value.
+     *
+     * @param value filter
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Get creation date.
+     *
+     * @return creation date as Date
+     */
+    public Date getCreationDate() {
+        return this.creationDate;
+    }
+
+    /**
+     * Set creation date.
+     *
+     * @param creationDate
+     *            as Date
+     */
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    /**
+     * Get user.
+     *
+     * @return user
+     */
+    public User getUser() {
+        return this.user;
+    }
+
+    /**
+     * Set user.
+     *
+     * @param user
+     *            object
+     */
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Property.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Property.java
@@ -57,9 +57,6 @@ public class Property extends BaseBean implements Comparable<Property> {
     private List<Template> templates;
 
     @ManyToMany(mappedBy = "properties", cascade = CascadeType.PERSIST)
-    private List<User> users;
-
-    @ManyToMany(mappedBy = "properties", cascade = CascadeType.PERSIST)
     private List<Workpiece> workpieces;
 
     @Transient
@@ -306,28 +303,6 @@ public class Property extends BaseBean implements Comparable<Property> {
      */
     public void setTemplates(List<Template> templates) {
         this.templates = templates;
-    }
-
-    /**
-     * Get users list or new empty list.
-     *
-     * @return users list or new empty list
-     */
-    public List<User> getUsers() {
-        if (this.users == null) {
-            this.users = new ArrayList<>();
-        }
-        return this.users;
-    }
-
-    /**
-     * Set users.
-     * 
-     * @param users
-     *            as List
-     */
-    public void setUsers(List<User> users) {
-        this.users = users;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
@@ -17,6 +17,7 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -93,11 +94,8 @@ public class User extends BaseBean {
     @ManyToMany(mappedBy = "users")
     private List<Project> projects;
 
-    @ManyToMany(cascade = CascadeType.ALL)
-    @JoinTable(name = "user_x_property", joinColumns = {
-            @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "FK_user_x_property_user_id")) }, inverseJoinColumns = {
-                    @JoinColumn(name = "property_id", foreignKey = @ForeignKey(name = "FK_user_x_property_property_id")) })
-    private List<Property> properties;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<Filter> filters;
 
     /**
      * Constructor for User Entity.
@@ -106,7 +104,7 @@ public class User extends BaseBean {
         this.userGroups = new ArrayList<>();
         this.projects = new ArrayList<>();
         this.tasks = new ArrayList<>();
-        this.properties = new ArrayList<>();
+        this.filters = new ArrayList<>();
     }
 
     public String getLogin() {
@@ -277,15 +275,25 @@ public class User extends BaseBean {
         this.css = css;
     }
 
-    public List<Property> getProperties() {
-        if (this.properties == null) {
-            this.properties = new ArrayList<>();
+    /**
+     * Get user filters.
+     *
+     * @return list of user filters
+     */
+    public List<Filter> getFilters() {
+        if (this.filters == null) {
+            this.filters = new ArrayList<>();
         }
-        return this.properties;
+        return this.filters;
     }
 
-    public void setProperties(List<Property> properties) {
-        this.properties = properties;
+    /**
+     * Set user filters.
+     *
+     * @param filters list of user filters
+     */
+    public void setFilters(List<Filter> filters) {
+        this.filters = filters;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
@@ -218,8 +218,8 @@ public abstract class BaseDAO implements Serializable {
 
     protected List retrieveAllObjects(Class cls) {
         Session session = Helper.getHibernateSession();
-        Criteria criteria = session.createCriteria(cls);
-        return criteria.list();
+        Query query = session.createQuery("FROM " + cls.getSimpleName());
+        return query.list();
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FilterDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FilterDAO.java
@@ -63,6 +63,13 @@ public class FilterDAO extends BaseDAO {
         return retrieveObjects(query);
     }
 
+    /**
+     * Save filter object to database.
+     * 
+     * @param filter
+     *            object to be saved
+     * @return saved object
+     */
     public Filter save(Filter filter) throws DAOException {
         storeObject(filter);
         return (Filter) retrieveObject(Filter.class, filter.getId());

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FilterDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FilterDAO.java
@@ -1,0 +1,107 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.database.persistence;
+
+import java.util.List;
+
+import org.kitodo.data.database.beans.Filter;
+import org.kitodo.data.database.exceptions.DAOException;
+
+/**
+ * DAO class for Filter bean.
+ */
+public class FilterDAO extends BaseDAO {
+
+    private static final long serialVersionUID = 234210246673032251L;
+
+    /**
+     * Find filter object by id.
+     *
+     * @param id
+     *            of searched object
+     * @return result
+     * @throws DAOException
+     *             an exception that can be thrown from the underlying find()
+     *             procedure failure.
+     */
+    public Filter find(Integer id) throws DAOException {
+        Filter result = (Filter) retrieveObject(Filter.class, id);
+        if (result == null) {
+            throw new DAOException("Object can not be found in database");
+        }
+        return result;
+    }
+
+    /**
+     * The function findAll() retrieves all properties from the database.
+     *
+     * @return all persisted templates' properties
+     */
+    @SuppressWarnings("unchecked")
+    public List<Filter> findAll() {
+        return retrieveAllObjects(Filter.class);
+    }
+
+    /**
+     * Find properties by query.
+     *
+     * @param query
+     *            as String
+     * @return list of properties
+     */
+    @SuppressWarnings("unchecked")
+    public List<Filter> search(String query) throws DAOException {
+        return retrieveObjects(query);
+    }
+
+    public Filter save(Filter filter) throws DAOException {
+        storeObject(filter);
+        return (Filter) retrieveObject(Filter.class, filter.getId());
+    }
+
+    /**
+     * The function remove() removes a filter
+     *
+     * @param filter
+     *            to be removed
+     * @throws DAOException
+     *             an exception that can be thrown from the underlying save()
+     *             procedure upon database failure.
+     */
+    public void remove(Filter filter) throws DAOException {
+        removeObject(filter);
+    }
+
+    /**
+     * The function remove() removes a filter
+     *
+     * @param id
+     *            of filter to be removed
+     * @throws DAOException
+     *             an exception that can be thrown from the underlying save()
+     *             procedure upon database failure.
+     */
+    public void remove(Integer id) throws DAOException {
+        removeObject(id);
+    }
+
+    /**
+     * Count filter objects in table.
+     *
+     * @param query
+     *            as String
+     * @return amount of objects as Long
+     */
+    public Long count(String query) throws DAOException {
+        return retrieveAmount(query);
+    }
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/FilterType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/FilterType.java
@@ -15,23 +15,21 @@ import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.json.simple.JSONObject;
-import org.kitodo.data.database.beans.Property;
+import org.kitodo.data.database.beans.Filter;
 
 /**
- * Implementation of Property Type.
+ * Type class for Filter bean.
  */
-public class PropertyType extends BaseType<Property> {
+public class FilterType extends BaseType<Filter> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public HttpEntity createDocument(Property property) {
+    public HttpEntity createDocument(Filter filter) {
 
         JSONObject propertyObject = new JSONObject();
-        propertyObject.put("title", property.getTitle());
-        propertyObject.put("value", property.getValue());
-        propertyObject.put("processes", addObjectRelation(property.getProcesses()));
-        propertyObject.put("templates", addObjectRelation(property.getTemplates()));
-        propertyObject.put("workpieces", addObjectRelation(property.getWorkpieces()));
+        propertyObject.put("value", filter.getValue());
+        Integer user = filter.getUser() != null ? filter.getUser().getId() : null;
+        propertyObject.put("user", user);
 
         return new NStringEntity(propertyObject.toJSONString(), ContentType.APPLICATION_JSON);
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/UserType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/UserType.java
@@ -35,7 +35,7 @@ public class UserType extends BaseType<User> {
         userObject.put("location", user.getLocation());
         userObject.put("metadataLanguage", user.getMetadataLanguage());
         userObject.put("userGroups", addObjectRelation(user.getUserGroups()));
-        userObject.put("properties", addObjectRelation(user.getProperties()));
+        userObject.put("filters", addObjectRelation(user.getFilters()));
 
         return new NStringEntity(userObject.toJSONString(), ContentType.APPLICATION_JSON);
     }

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_9__Move_user_property_to_filter_table.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_9__Move_user_property_to_filter_table.sql
@@ -1,0 +1,60 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+--
+-- Migration: Move user property to filter table
+
+-- 1. Create filter table
+
+CREATE TABLE filter (
+  id INT(11) NOT NULL,
+  value longtext DEFAULT NULL,
+  creationDate datetime DEFAULT NULL,
+  indexAction VARCHAR(6),
+  user_id INT(11),
+  PRIMARY KEY (id)
+);
+
+-- 2. Move filters from property table to filter table
+
+INSERT INTO filter (id, value, creationDate)
+       SELECT id, value, creationDate
+       FROM property
+       WHERE title = '_filter';
+
+-- 3. Update table with id
+
+UPDATE filter AS f, user_x_property AS p SET f.user_id = p.user_id WHERE p.property_id = f.id;
+
+-- 4. Drop foreign keys from user_x_property table
+
+ALTER TABLE user_x_property DROP FOREIGN KEY `FK_user_x_property_user_id`;
+ALTER TABLE user_x_property DROP FOREIGN KEY `FK_user_x_property_property_id`;
+
+-- 5. Drop user_x_property table
+
+DROP TABLE user_x_property;
+
+-- 6. Introduce auto_increment to filter table
+
+ALTER TABLE filter
+  CHANGE id id INT(11) NOT NULL AUTO_INCREMENT;
+
+-- 7. Add foreign keys to user table
+
+ALTER TABLE filter ENGINE=InnoDB;
+ALTER TABLE filter
+  ADD CONSTRAINT `FK_filter_x_user_id`
+FOREIGN KEY (user_id) REFERENCES user (id);
+
+-- 8. Delete all filters from property table
+
+DELETE FROM property WHERE title = '_filter';

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/FilterTypeTest.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/FilterTypeTest.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.elasticsearch.index.type;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.Test;
+import org.kitodo.data.database.beans.Filter;
+import org.kitodo.data.database.beans.User;
+
+/**
+ * Test class for FilterType.
+ */
+public class FilterTypeTest {
+
+    private static List<Filter> prepareData() {
+        List<Filter> filters = new ArrayList<>();
+
+        User firstUser = new User();
+        firstUser.setId(1);
+
+        Filter firstFilter = new Filter();
+        firstFilter.setId(1);
+        firstFilter.setValue("\"id:1\"");
+        firstFilter.setUser(firstUser);
+
+        Filter secondFilter = new Filter();
+        firstFilter.setId(2);
+        secondFilter.setValue("\"id:2\"");
+        secondFilter.setUser(firstUser);
+
+        filters.add(firstFilter);
+        filters.add(secondFilter);
+
+        return filters;
+    }
+
+    @Test
+    public void shouldCreateDocument() throws Exception {
+        FilterType propertyType = new FilterType();
+        JSONParser parser = new JSONParser();
+
+        Filter property = prepareData().get(0);
+        HttpEntity document = propertyType.createDocument(property);
+        JSONObject actual = (JSONObject) parser.parse(EntityUtils.toString(document));
+        JSONObject expected = (JSONObject) parser.parse("{\"value\":\"\\\"id:1\\\"\",\"user\":1}");
+        assertEquals("Filter JSONObject doesn't match to given JSONObject!", expected, actual);
+
+        property = prepareData().get(1);
+        document = propertyType.createDocument(property);
+        actual = (JSONObject) parser.parse(EntityUtils.toString(document));
+        expected = (JSONObject) parser.parse("{\"value\":\"\\\"id:2\\\"\",\"user\":1}");
+        assertEquals("Filter JSONObject doesn't match to given JSONObject!", expected, actual);
+    }
+
+    @Test
+    public void shouldCreateDocuments() throws Exception {
+        FilterType filterType = new FilterType();
+
+        List<Filter> filters = prepareData();
+        HashMap<Integer, HttpEntity> documents = filterType.createDocuments(filters);
+        assertEquals("HashMap of documents doesn't contain given amount of elements!", 2, documents.size());
+    }
+}

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/PropertyTypeTest.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/PropertyTypeTest.java
@@ -24,7 +24,6 @@ import org.json.simple.parser.JSONParser;
 import org.junit.Test;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Property;
-import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.beans.Template;
 
 /**
@@ -36,7 +35,6 @@ public class PropertyTypeTest {
 
         List<Property> properties = new ArrayList<>();
         List<Process> processes = new ArrayList<>();
-        List<User> users = new ArrayList<>();
         List<Template> templates = new ArrayList<>();
 
         Process firstProcess = new Process();
@@ -46,10 +44,6 @@ public class PropertyTypeTest {
         Process secondProcess = new Process();
         secondProcess.setId(2);
         processes.add(secondProcess);
-
-        User user = new User();
-        user.setId(1);
-        users.add(user);
 
         Template template = new Template();
         template.setId(1);
@@ -65,16 +59,9 @@ public class PropertyTypeTest {
         Property secondProperty = new Property();
         secondProperty.setId(2);
         secondProperty.setTitle("Property2");
-        secondProperty.setValue("users");
-        secondProperty.setUsers(users);
+        secondProperty.setValue("templates");
+        secondProperty.setTemplates(templates);
         properties.add(secondProperty);
-
-        Property thirdProperty = new Property();
-        thirdProperty.setId(3);
-        thirdProperty.setTitle("Property3");
-        thirdProperty.setValue("templates");
-        thirdProperty.setTemplates(templates);
-        properties.add(thirdProperty);
 
         return properties;
     }
@@ -87,24 +74,17 @@ public class PropertyTypeTest {
         Property property = prepareData().get(0);
         HttpEntity document = propertyType.createDocument(property);
         JSONObject actual = (JSONObject) parser.parse(EntityUtils.toString(document));
-        JSONObject expected = (JSONObject) parser.parse(
-                "{\"title\":\"Property1\",\"value\":\"processes\",\"workpieces\":[],\"processes\":[{\"id\":1},"
-                        + "{\"id\":2}],\"templates\":[],\"users\":[]}");
-        assertEquals("Batch JSONObject doesn't match to given JSONObject!", expected, actual);
+        JSONObject expected = (JSONObject) parser
+                .parse("{\"title\":\"Property1\",\"value\":\"processes\",\"workpieces\":[],\"processes\":[{\"id\":1},"
+                        + "{\"id\":2}],\"templates\":[]}");
+        assertEquals("Property JSONObject doesn't match to given JSONObject!", expected, actual);
 
         property = prepareData().get(1);
         document = propertyType.createDocument(property);
         actual = (JSONObject) parser.parse(EntityUtils.toString(document));
-        expected = (JSONObject) parser.parse("{\"title\":\"Property2\",\"value\":\"users\",\"workpieces\":[],"
-                + "\"processes\":[],\"templates\":[],\"users\":[{\"id\":1}]}");
-        assertEquals("Batch JSONObject doesn't match to given JSONObject!", expected, actual);
-
-        property = prepareData().get(2);
-        document = propertyType.createDocument(property);
-        actual = (JSONObject) parser.parse(EntityUtils.toString(document));
-        expected = (JSONObject) parser.parse("{\"title\":\"Property3\",\"value\":\"templates\",\"workpieces\":[],"
-                + "\"processes\":[],\"templates\":[{\"id\":1}],\"users\":[]}");
-        assertEquals("Batch JSONObject doesn't match to given JSONObject!", expected, actual);
+        expected = (JSONObject) parser.parse("{\"title\":\"Property2\",\"value\":\"templates\",\"workpieces\":[],"
+                + "\"processes\":[],\"templates\":[{\"id\":1}]}");
+        assertEquals("Property JSONObject doesn't match to given JSONObject!", expected, actual);
     }
 
     @Test
@@ -113,6 +93,6 @@ public class PropertyTypeTest {
 
         List<Property> properties = prepareData();
         HashMap<Integer, HttpEntity> documents = propertyType.createDocuments(properties);
-        assertEquals("HashMap of documents doesn't contain given amount of elements!", 3, documents.size());
+        assertEquals("HashMap of documents doesn't contain given amount of elements!", 2, documents.size());
     }
 }

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/UserTypeTest.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/UserTypeTest.java
@@ -22,7 +22,7 @@ import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.Test;
-import org.kitodo.data.database.beans.Property;
+import org.kitodo.data.database.beans.Filter;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.beans.UserGroup;
 
@@ -35,7 +35,7 @@ public class UserTypeTest {
 
         List<User> users = new ArrayList<>();
         List<UserGroup> userGroups = new ArrayList<>();
-        List<Property> properties = new ArrayList<>();
+        List<Filter> filters = new ArrayList<>();
 
         UserGroup firstUserGroup = new UserGroup();
         firstUserGroup.setId(1);
@@ -45,13 +45,13 @@ public class UserTypeTest {
         secondUserGroup.setId(2);
         userGroups.add(secondUserGroup);
 
-        Property firstProperty = new Property();
-        firstProperty.setId(1);
-        properties.add(firstProperty);
+        Filter firstFilter = new Filter();
+        firstFilter.setId(1);
+        filters.add(firstFilter);
 
-        Property secondProperty = new Property();
-        secondProperty.setId(2);
-        properties.add(secondProperty);
+        Filter secondFilter = new Filter();
+        secondFilter.setId(2);
+        filters.add(secondFilter);
 
         User firstUser = new User();
         firstUser.setId(1);
@@ -70,7 +70,7 @@ public class UserTypeTest {
         secondUser.setActive(true);
         secondUser.setLocation("Berlin");
         secondUser.setUserGroups(userGroups);
-        secondUser.setProperties(properties);
+        secondUser.setFilters(filters);
         users.add(secondUser);
 
         User thirdUser = new User();
@@ -78,7 +78,7 @@ public class UserTypeTest {
         thirdUser.setName("Peter");
         thirdUser.setSurname("Müller");
         thirdUser.setLogin("pmueller");
-        thirdUser.setProperties(properties);
+        thirdUser.setFilters(filters);
         users.add(thirdUser);
 
         return users;
@@ -94,7 +94,7 @@ public class UserTypeTest {
         JSONObject actual = (JSONObject) parser.parse(EntityUtils.toString(document));
         JSONObject expected = (JSONObject) parser.parse("{\"ldapLogin\":null,\"userGroups\":[],"
                 + "\"surname\":\"Kowalski\",\"name\":\"Jan\",\"metadataLanguage\":null,\"login\":\"jkowalski\","
-                + "\"active\":\"true\",\"location\":\"Dresden\",\"properties\":[]}");
+                + "\"active\":\"true\",\"location\":\"Dresden\",\"filters\":[]}");
         assertEquals("User JSONObject doesn't match to given JSONObject!", expected, actual);
 
         user = prepareData().get(1);
@@ -102,7 +102,7 @@ public class UserTypeTest {
         actual = (JSONObject) parser.parse(EntityUtils.toString(document));
         expected = (JSONObject) parser.parse("{\"ldapLogin\":null,\"userGroups\":[{\"id\":1},{\"id\":2}],"
                 + "\"surname\":\"Nowak\",\"name\":\"Anna\",\"metadataLanguage\":null,\"active\":\"true\","
-                + "\"location\":\"Berlin\",\"login\":\"anowak\",\"properties\":[{\"id\":1},{\"id\":2}]}");
+                + "\"location\":\"Berlin\",\"login\":\"anowak\",\"filters\":[{\"id\":1},{\"id\":2}]}");
         assertEquals("User JSONObject doesn't match to given JSONObject!", expected, actual);
 
         user = prepareData().get(2);
@@ -110,7 +110,7 @@ public class UserTypeTest {
         actual = (JSONObject) parser.parse(EntityUtils.toString(document));
         expected = (JSONObject) parser.parse("{\"login\":\"pmueller\",\"ldapLogin\":null,\"userGroups\":[],"
                 + "\"surname\":\"Müller\",\"name\":\"Peter\",\"metadataLanguage\":null,\"active\":\"true\","
-                + "\"location\":null,\"properties\":[{\"id\":1},{\"id\":2}]}");
+                + "\"location\":null,\"filters\":[{\"id\":1},{\"id\":2}]}");
         assertEquals("User JSONObject doesn't match to given JSONObject!", expected, actual);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/ServiceManager.java
+++ b/Kitodo/src/main/java/org/kitodo/services/ServiceManager.java
@@ -13,6 +13,7 @@ package org.kitodo.services;
 
 import org.kitodo.services.data.BatchService;
 import org.kitodo.services.data.DocketService;
+import org.kitodo.services.data.FilterService;
 import org.kitodo.services.data.HistoryService;
 import org.kitodo.services.data.LdapGroupService;
 import org.kitodo.services.data.ProcessService;
@@ -31,6 +32,7 @@ public class ServiceManager {
 
     private BatchService batchService;
     private DocketService docketService;
+    private FilterService filterService;
     private HistoryService historyService;
     private LdapGroupService ldapGroupService;
     private PropertyService propertyService;
@@ -54,6 +56,12 @@ public class ServiceManager {
     private void initializeDocketService() {
         if (docketService == null) {
             docketService = new DocketService();
+        }
+    }
+
+    private void initializeFilterService() {
+        if (filterService == null) {
+            filterService = new FilterService();
         }
     }
 
@@ -153,6 +161,16 @@ public class ServiceManager {
     public DocketService getDocketService() {
         initializeDocketService();
         return docketService;
+    }
+
+    /**
+     * Initialize FilterService if it is not yet initialized and next return it.
+     *
+     * @return FilterService object
+     */
+    public FilterService getFilterService() {
+        initializeFilterService();
+        return filterService;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/FilterService.java
@@ -1,0 +1,144 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.services.data;
+
+import com.sun.research.ws.wadl.HTTPMethods;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.index.query.Operator;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.kitodo.data.database.beans.Filter;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.database.persistence.FilterDAO;
+import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
+import org.kitodo.data.elasticsearch.index.Indexer;
+import org.kitodo.data.elasticsearch.index.type.FilterType;
+import org.kitodo.data.elasticsearch.search.SearchResult;
+import org.kitodo.data.elasticsearch.search.Searcher;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.services.data.base.SearchService;
+
+/**
+ * Service for Filter bean.
+ */
+public class FilterService extends SearchService<Filter> {
+
+    private FilterDAO filterDAO = new FilterDAO();
+    private FilterType filterType = new FilterType();
+    private Indexer<Filter, FilterType> indexer = new Indexer<>(Filter.class);
+
+    /**
+     * Constructor with searcher's assigning.
+     */
+    public FilterService() {
+        super(new Searcher(Filter.class));
+    }
+
+    /**
+     * Method saves filter object to database.
+     *
+     * @param filter
+     *            object
+     */
+    public void saveToDatabase(Filter filter) throws DAOException {
+        filterDAO.save(filter);
+    }
+
+    /**
+     * Method saves filter document to the index of Elastic Search.
+     *
+     * @param filter
+     *            object
+     */
+    public void saveToIndex(Filter filter) throws CustomResponseException, IOException {
+        indexer.setMethod(HTTPMethods.PUT);
+        indexer.performSingleRequest(filter, filterType);
+    }
+
+    /**
+     * Find in database.
+     *
+     * @param id
+     *            as Integer
+     * @return Property
+     */
+    public Filter find(Integer id) throws DAOException {
+        return filterDAO.find(id);
+    }
+
+    /**
+     * Find all properties in database.
+     *
+     * @return list of all properties
+     */
+    public List<Filter> findAll() {
+        return filterDAO.findAll();
+    }
+
+    /**
+     * Search by query in database.
+     *
+     * @param query
+     *            as String
+     * @return list of properties
+     */
+    public List<Filter> search(String query) throws DAOException {
+        return filterDAO.search(query);
+    }
+
+    /**
+     * Method removes filter object from database.
+     *
+     * @param filter
+     *            object
+     */
+    public void removeFromDatabase(Filter filter) throws DAOException {
+        filterDAO.remove(filter);
+    }
+
+    /**
+     * Method removes property object from database.
+     *
+     * @param id
+     *            of property object
+     */
+    public void removeFromDatabase(Integer id) throws DAOException {
+        filterDAO.remove(id);
+    }
+
+    /**
+     * Method removes filter object from index of Elastic Search.
+     *
+     * @param filter
+     *            object
+     */
+    public void removeFromIndex(Filter filter) throws CustomResponseException, IOException {
+        indexer.setMethod(HTTPMethods.DELETE);
+        indexer.performSingleRequest(filter, filterType);
+    }
+
+    /**
+     * Find filters with exact value.
+     *
+     * @param value
+     *            of the searched filter
+     * @param contains
+     *            of the searched filter
+     * @return list of search results with properties
+     */
+    public List<SearchResult> findByValue(String value, boolean contains) throws DataException {
+        QueryBuilder query = createSimpleQuery("value", value, contains, Operator.AND);
+        return searcher.findDocuments(query.toString());
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/PropertyService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Property;
 import org.kitodo.data.database.beans.Template;
-import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.beans.Workpiece;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.persistence.PropertyDAO;
@@ -83,9 +82,6 @@ public class PropertyService extends TitleSearchService<Property> {
             throws CustomResponseException, DataException, IOException {
         for (Process process : property.getProcesses()) {
             serviceManager.getProcessService().saveToIndex(process);
-        }
-        for (User user : property.getUsers()) {
-            serviceManager.getUserService().saveToIndex(user);
         }
         for (Template template : property.getTemplates()) {
             serviceManager.getTemplateService().saveToIndex(template);
@@ -163,7 +159,7 @@ public class PropertyService extends TitleSearchService<Property> {
      * @param value
      *            of the searched property
      * @param contains
-     *            of the searched batches
+     *            of the searched property
      * @return list of search results with properties
      */
     public List<SearchResult> findByValue(String value, boolean contains) throws DataException {
@@ -172,7 +168,7 @@ public class PropertyService extends TitleSearchService<Property> {
     }
 
     /**
-     * Find batches with exact title and type. Necessary to assure that user
+     * Find properties with exact title and type. Necessary to assure that user
      * pickup type from the list which contains enums.
      *
      * @param title

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -56,6 +56,7 @@
         <!-- Die einzelnen Mappings -->
         <mapping class="org.kitodo.data.database.beans.Batch"/>
         <mapping class="org.kitodo.data.database.beans.Docket"/>
+        <mapping class="org.kitodo.data.database.beans.Filter"/>
         <mapping class="org.kitodo.data.database.beans.History"/>
         <mapping class="org.kitodo.data.database.beans.LdapGroup"/>
         <mapping class="org.kitodo.data.database.beans.Process"/>

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -58,7 +58,7 @@ public class MockDatabase {
             insertWorkpieceProperties();
             insertTemplates();
             insertTemplateProperties();
-            insertUserProperties();
+            insertUserFilters();
             insertTasks();
             insertHistory();
         }
@@ -111,7 +111,7 @@ public class MockDatabase {
         serviceManager.getProcessService().save(firstProcess);
     }
 
-    public static void insertLdapGroups() throws DAOException {
+    private static void insertLdapGroups() throws DAOException {
         LdapGroup firstLdapGroup = new LdapGroup();
         firstLdapGroup.setTitle("LG");
         firstLdapGroup.setHomeDirectory("..//test_directory/");
@@ -512,35 +512,25 @@ public class MockDatabase {
         serviceManager.getUserGroupService().save(thirdUserGroup);
     }
 
-    private static void insertUserProperties() throws DAOException, DataException {
+    private static void insertUserFilters() throws DAOException, DataException {
         User user = serviceManager.getUserService().find(1);
 
-        Property firstUserProperty = new Property();
-        firstUserProperty.setTitle("FirstUserProperty");
-        firstUserProperty.setValue("first value");
-        firstUserProperty.setObligatory(true);
-        firstUserProperty.setType(PropertyType.general);
-        firstUserProperty.setChoice("choice");
+        Filter firstUserFilter = new Filter();
+        firstUserFilter.setValue("\"id:1\"");
         LocalDate localDate = new LocalDate(2017, 1, 14);
-        firstUserProperty.setCreationDate(localDate.toDate());
-        firstUserProperty.setContainer(1);
-        firstUserProperty.getUsers().add(user);
-        serviceManager.getPropertyService().save(firstUserProperty);
+        firstUserFilter.setCreationDate(localDate.toDate());
+        firstUserFilter.setUser(user);
+        serviceManager.getFilterService().save(firstUserFilter);
 
-        Property secondUserProperty = new Property();
-        secondUserProperty.setTitle("secondUserProperty");
-        secondUserProperty.setValue("second");
-        secondUserProperty.setObligatory(false);
-        secondUserProperty.setType(PropertyType.CommandLink);
-        secondUserProperty.setChoice("chosen");
+        Filter secondUserFilter = new Filter();
+        secondUserFilter.setValue("\"id:2\"");
         localDate = new LocalDate(2017, 1, 15);
-        secondUserProperty.setCreationDate(localDate.toDate());
-        secondUserProperty.setContainer(2);
-        secondUserProperty.getUsers().add(user);
-        serviceManager.getPropertyService().save(secondUserProperty);
+        secondUserFilter.setCreationDate(localDate.toDate());
+        secondUserFilter.setUser(user);
+        serviceManager.getFilterService().save(secondUserFilter);
 
-        user.getProperties().add(firstUserProperty);
-        user.getProperties().add(secondUserProperty);
+        user.getFilters().add(firstUserFilter);
+        user.getFilters().add(secondUserFilter);
         serviceManager.getUserService().save(user);
     }
 

--- a/Kitodo/src/test/java/org/kitodo/services/data/FilterServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/FilterServiceIT.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.services.data;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Filter;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration tests for FilterService.
+ */
+public class FilterServiceIT {
+
+    @BeforeClass
+    public static void prepareDatabase() throws DAOException, DataException {
+        MockDatabase.insertProcessesFull();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() {
+        // MockDatabase.cleanDatabase();
+    }
+
+    @Before
+    public void multipleInit() throws InterruptedException {
+        Thread.sleep(1000);
+    }
+
+    @Test
+    public void shouldFindFilter() throws Exception {
+        FilterService filterService = new FilterService();
+
+        Filter filter = filterService.find(1);
+        String actual = filter.getValue();
+        String expected = "\"id:1\"";
+        assertEquals("Filter was not found in database!", expected, actual);
+    }
+
+    @Test
+    public void shouldFindAllFilters() throws Exception {
+        FilterService filterService = new FilterService();
+
+        List<Filter> filters = filterService.findAll();
+        assertEquals("Not all filters were found in database!", 2, filters.size());
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/services/data/PropertyServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/PropertyServiceIT.java
@@ -56,7 +56,7 @@ public class PropertyServiceIT {
 
         actual = processProperty.getValue();
         expected = "first value";
-        assertEquals("Process property was not found in database - value doesn'T match!", expected, actual);
+        assertEquals("Process property was not found in database - value doesn't match!", expected, actual);
     }
 
     @Test
@@ -71,20 +71,6 @@ public class PropertyServiceIT {
         actual = templateProperty.getValue();
         expected = "first value";
         assertEquals("Template property was not found in database - value doesn'T match!", expected, actual);
-    }
-
-    @Test
-    public void shouldFindUserProperty() throws Exception {
-        PropertyService propertyService = new PropertyService();
-
-        Property userProperty = propertyService.find(7);
-        String actual = userProperty.getTitle();
-        String expected = "FirstUserProperty";
-        assertEquals("User property was not found in database - title doesn't match!", expected, actual);
-
-        actual = userProperty.getValue();
-        expected = "first value";
-        assertEquals("User property was not found in database - value doesn'T match!", expected, actual);
     }
 
     @Test
@@ -106,7 +92,7 @@ public class PropertyServiceIT {
         PropertyService propertyService = new PropertyService();
 
         List<Property> properties = propertyService.findAll();
-        assertEquals("Not all properties were found in database!", 8, properties.size());
+        assertEquals("Not all properties were found in database!", 6, properties.size());
     }
 
     @Test
@@ -116,21 +102,21 @@ public class PropertyServiceIT {
         Property property = new Property();
         property.setTitle("To Remove");
         propertyService.save(property);
-        Property foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(9));
+        Property foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(7));
         assertEquals("Additional property was not inserted in database!", "To Remove", foundProperty.getTitle());
 
         propertyService.remove(foundProperty);
-        foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(9));
+        foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(7));
         assertEquals("Additional property was not removed from database!", null, foundProperty);
 
         property = new Property();
         property.setTitle("To remove");
         propertyService.save(property);
-        foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(10));
+        foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(8));
         assertEquals("Additional property was not inserted in database!", "To remove", foundProperty.getTitle());
 
-        propertyService.remove(10);
-        foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(10));
+        propertyService.remove(8);
+        foundProperty = propertyService.convertSearchResultToObject(propertyService.findById(8));
         assertEquals("Additional property was not removed from database!", null, foundProperty);
     }
 
@@ -150,7 +136,7 @@ public class PropertyServiceIT {
 
         List<SearchResult> properties = propertyService.findByValue("second", true);
         Integer actual = properties.size();
-        Integer expected = 4;
+        Integer expected = 3;
         assertEquals("Properties were not found in index!", expected, actual);
 
         properties = propertyService.findByValue("second value", true);

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
@@ -273,18 +273,18 @@ public class UserServiceIT {
     }
 
     @Test
-    public void shouldFindByProperty() throws Exception {
+    public void shouldFindByFilter() throws Exception {
         UserService userService = new UserService();
 
-        List<SearchResult> users = userService.findByProperty("FirstUserProperty", "first value");
+        List<SearchResult> users = userService.findByFilter("\"id:1\"");
         Integer actual = users.size();
         Integer expected = 1;
         assertEquals("User was not found in index!", expected, actual);
 
-        users = userService.findByProperty("firstTemplate title", "first value");
+        users = userService.findByFilter("\"id:5\"");
         actual = users.size();
         expected = 0;
-        assertEquals("User was not found in index!", expected, actual);
+        assertEquals("User was found in index!", expected, actual);
     }
 
     @Test

--- a/Kitodo/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/hibernate.cfg.xml
@@ -36,6 +36,7 @@
         <!-- Die einzelnen Mappings -->
         <mapping class="org.kitodo.data.database.beans.Batch"/>
         <mapping class="org.kitodo.data.database.beans.Docket"/>
+        <mapping class="org.kitodo.data.database.beans.Filter"/>
         <mapping class="org.kitodo.data.database.beans.History"/>
         <mapping class="org.kitodo.data.database.beans.LdapGroup"/>
         <mapping class="org.kitodo.data.database.beans.Process"/>


### PR DESCRIPTION
This pull request removes overhead of storing user filters inside the property table.

- flyway migration
- hibernate mapping
- bean class
- DAO class
- type class
- service class
- adjustment of dependent classes
- tests 