### PR TITLE
Replace value type for properties HashMap in SearchResult object

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchResult.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchResult.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
  */
 public class SearchResult {
     private Integer id;
-    private HashMap<String, String> properties;
+    private HashMap<String, Object> properties;
 
     /**
      * Get id.
@@ -43,9 +43,9 @@ public class SearchResult {
      * Get properties of search result.
      *
      * @return HashMap of properties - key is name of field and value is value
-     *         of field
+     *         of field (possible Integer, String, JSONArray)
      */
-    public HashMap<String, String> getProperties() {
+    public HashMap<String, Object> getProperties() {
         return properties;
     }
 
@@ -53,9 +53,9 @@ public class SearchResult {
      * Set properties of search result.
      *
      * @param properties
-     *            HashMap - key is name of field and value is value of field
+     *            HashMap - key is name of field and value is value of field (possible Integer, String, JSONArray)
      */
-    public void setProperties(HashMap<String, String> properties) {
+    public void setProperties(HashMap<String, Object> properties) {
         this.properties = properties;
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
@@ -151,10 +151,10 @@ public class Searcher extends Index {
         SearchResult searchResult = new SearchResult();
 
         searchResult.setId(Integer.valueOf(jsonObject.get("_id").toString()));
-        HashMap<String, String> properties = new HashMap<>();
+        HashMap<String, Object> properties = new HashMap<>();
         JSONObject result = (JSONObject) jsonObject.get("_source");
-        Set<Map.Entry<String, String>> entries = result.entrySet();
-        for (Map.Entry<String, String> entry : entries) {
+        Set<Map.Entry<String, Object>> entries = result.entrySet();
+        for (Map.Entry<String, Object> entry : entries) {
             properties.put(entry.getKey(), entry.getValue());
         }
         searchResult.setProperties(properties);

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearcherIT.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearcherIT.java
@@ -71,14 +71,14 @@ public class SearcherIT {
         SearchResult result = searcher.findDocument(query);
         Integer id = result.getId();
         assertEquals("Incorrect result - id doesn't match to given number!", 2, id.intValue());
-        String title = result.getProperties().get("title");
+        String title = (String) result.getProperties().get("title");
         assertEquals("Incorrect result - title doesn't match to given plain text!", "Batch2", title);
 
         query = "{\n\"match\" : {\n\"title\" : \"Batch1\"}\n}";
         result = searcher.findDocument(query);
         id = result.getId();
         assertEquals("Incorrect result - id doesn't match to given plain text!", 1, id.intValue());
-        title = result.getProperties().get("title");
+        title = (String) result.getProperties().get("title");
         assertEquals("Incorrect result - title doesn't match to given plain text!", "Batch1", title);
 
         query = "{\n\"match\" : {\n\"title\" : \"Nonexistent\"}\n}";

--- a/Kitodo/src/test/java/org/kitodo/services/data/BatchServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/BatchServiceIT.java
@@ -96,7 +96,7 @@ public class BatchServiceIT {
         BatchService batchService = new BatchService();
 
         SearchResult batch = batchService.findById(1);
-        String actual = batch.getProperties().get("title");
+        String actual = (String) batch.getProperties().get("title");
         String expected = "First batch";
         assertEquals("Batch was not found in index!", expected, actual);
     }

--- a/Kitodo/src/test/java/org/kitodo/services/data/DocketServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/DocketServiceIT.java
@@ -69,7 +69,7 @@ public class DocketServiceIT {
         DocketService docketService = new DocketService();
 
         SearchResult docket = docketService.findById(1);
-        String actual = docket.getProperties().get("title");
+        String actual = (String) docket.getProperties().get("title");
         String expected = "default";
         assertEquals("Docket was not found in index!", expected, actual);
     }
@@ -89,7 +89,7 @@ public class DocketServiceIT {
         DocketService docketService = new DocketService();
 
         SearchResult docket = docketService.findByFile("docket.xsl");
-        String actual = docket.getProperties().get("file");
+        String actual = (String) docket.getProperties().get("file");
         String expected = "docket.xsl";
         assertEquals("Docket was not found in index!", expected, actual);
     }

--- a/Kitodo/src/test/java/org/kitodo/services/data/HistoryServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/HistoryServiceIT.java
@@ -96,7 +96,7 @@ public class HistoryServiceIT {
         HistoryService historyService = new HistoryService();
 
         SearchResult history = historyService.findById(1);
-        String actual = history.getProperties().get("stringValue");
+        String actual = (String) history.getProperties().get("stringValue");
         String expected = "History";
         assertEquals("History was not found in index!", expected, actual);
 
@@ -126,7 +126,7 @@ public class HistoryServiceIT {
         HistoryService historyService = new HistoryService();
 
         List<SearchResult> history = historyService.findByStringValue("History");
-        String actual = history.get(0).getProperties().get("stringValue");
+        String actual = (String) history.get(0).getProperties().get("stringValue");
         String expected = "History";
         assertEquals("History was not found in index!", expected, actual);
     }

--- a/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
@@ -95,7 +95,7 @@ public class ProjectServiceIT {
         ProjectService projectService = new ProjectService();
 
         SearchResult project = projectService.findById(1);
-        String actual = project.getProperties().get("title");
+        String actual = (String) project.getProperties().get("title");
         String expected = "First project";
         assertEquals("Project was not found in index!", expected, actual);
     }

--- a/Kitodo/src/test/java/org/kitodo/services/data/RulesetServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/RulesetServiceIT.java
@@ -69,7 +69,7 @@ public class RulesetServiceIT {
         RulesetService rulesetService = new RulesetService();
 
         SearchResult ruleset = rulesetService.findById(1);
-        String actual = ruleset.getProperties().get("title");
+        String actual = (String) ruleset.getProperties().get("title");
         String expected = "SLUBDD";
         assertEquals("Ruleset was not found in index!", expected, actual);
     }
@@ -89,7 +89,7 @@ public class RulesetServiceIT {
         RulesetService rulesetService = new RulesetService();
 
         SearchResult ruleset = rulesetService.findByFile("ruleset_slubdd.xml");
-        String actual = ruleset.getProperties().get("file");
+        String actual = (String) ruleset.getProperties().get("file");
         String expected = "ruleset_slubdd.xml";
         assertEquals("Ruleset was not found in index!", expected, actual);
     }

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserGroupServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserGroupServiceIT.java
@@ -124,7 +124,7 @@ public class UserGroupServiceIT {
         UserGroupService userGroupService = new UserGroupService();
 
         SearchResult userGroup = userGroupService.findById(1);
-        String actual = userGroup.getProperties().get("title");
+        String actual = (String) userGroup.getProperties().get("title");
         String expected = "Admin";
         assertEquals("User group was not found in index!", expected, actual);
     }

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
@@ -130,7 +130,7 @@ public class UserServiceIT {
         UserService userService = new UserService();
 
         SearchResult user = userService.findById(1);
-        String actual = user.getProperties().get("login");
+        String actual = (String) user.getProperties().get("login");
         String expected = "kowal";
         assertEquals("User was not found in index!", expected, actual);
     }


### PR DESCRIPTION
Change is forced by possibility that to field of String type will be inserted Integer or JSONArray. After that, retrieving of data is impossible.