### PR TITLE
Update JDK to Java 8 as Travis starts to remove Java 7 JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ dist: trusty
 language: java
 
 jdk:
-  - oraclejdk7
-  - openjdk7
+  - oraclejdk8
+  - openjdk8
 
 addons:
   apt:


### PR DESCRIPTION
With current update on Travis CI (2017-06-21) Travis team starts to remove Java JDK (starts with Oracle JDK 7) from its build images. Switching to a newer JDK should work as compiler target stay on Java 7.