### PR TITLE
Translate message tags inside a template

### DIFF
--- a/Kitodo/src/main/webapp/newpages/ProzessverwaltungSuche.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProzessverwaltungSuche.xhtml
@@ -170,7 +170,7 @@
                                                                                  style="width:175px; margin-right:3px">
                                                                     <f:selectItems value="#{SearchForm.stepstatus}"
                                                                                     var="stepstatus"
-                                                                                    itemLabel="#{stepstatus.title}"
+                                                                                    itemLabel="#{msgs.get(stepstatus.title)}"
                                                                                     itemValue="#{stepstatus.searchString}"/>
                                                                 </h:selectOneMenu>
                                                                 <h:selectOneMenu value="#{SearchForm.stepname}"

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste.xhtml
@@ -349,7 +349,7 @@
         </f:facet>
     
         <h:graphicImage alt="" value="#{item.processingStatusEnum.bigImagePath}"
-                        title="#{item.processingStatusEnum.title}"/>
+                        title="#{msgs.get(item.processingStatusEnum.title)}"/>
     
         <h:outputText value="!" style="color:red;font-weight:bold;font-size:20px;margin-left:5px"
                       rendered="#{item.priority == 1}"/>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste_DetailsKlein.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/Schritte_Liste_DetailsKlein.xhtml
@@ -91,7 +91,7 @@
                             <h:outputText value="#{msgs.aktualisierungstyp}:"/>
                         </td>
                         <td>
-                            <h:outputText value="#{item.editTypeEnum.title}"/>
+                            <h:outputText value="#{msgs.get(item.editTypeEnum.title)}"/>
                         </td>
                     </tr>
                 </table>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Details.xhtml
@@ -74,7 +74,7 @@
                                     <h:outputText value="#{msgs.status}:"/>
                                 </td>
                                 <td>
-                                    <h:outputText value="#{AktuelleSchritteForm.mySchritt.processingStatusEnum.title}"/>
+                                    <h:outputText value="#{msgs.get(AktuelleSchritteForm.mySchritt.processingStatusEnum.title)}"/>
                                 </td>
                             </tr>
                             <ui:fragment rendered="#{AktuelleSchritteForm.mySchritt.processingBegin !=null and !HelperForm.anonymized}">
@@ -105,7 +105,7 @@
                                         <h:outputText value="#{msgs.aktualisierungstyp}:"/>
                                     </td>
                                     <td>
-                                        <h:outputText value="#{AktuelleSchritteForm.mySchritt.editTypeEnum.title}"/>
+                                        <h:outputText value="#{msgs.get(AktuelleSchritteForm.mySchritt.editTypeEnum.title)}"/>
                                     </td>
                                 </tr>
                             </ui:fragment>

--- a/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Details.xhtml
@@ -98,7 +98,7 @@
                                 </td>
                                 <td>
                                     <h:outputText
-                                            value="#{AktuelleSchritteForm.batchHelper.currentStep.processingStatusEnum.title}"/>
+                                            value="#{msgs.get(AktuelleSchritteForm.batchHelper.currentStep.processingStatusEnum.title)}"/>
                                 </td>
                             </tr>
 
@@ -131,7 +131,7 @@
                                     </td>
                                     <td>
                                         <h:outputText
-                                                value="#{AktuelleSchritteForm.batchHelper.currentStep.editTypeEnum.title}"/>
+                                                value="#{msgs.get(AktuelleSchritteForm.batchHelper.currentStep.editTypeEnum.title)}"/>
                                     </td>
                                 </tr>
                             </ui:fragment>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
@@ -216,13 +216,13 @@
                             <h:outputText value="#{msgs.status}"/>
                         </f:facet>
                         <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}" alt=""
-                                        title="#{step.processingStatusEnum.title}"
+                                        title="#{msgs.get(step.processingStatusEnum.title)}"
                                         rendered="#{step.processingStatusEnum == 'OPEN' || step.processingStatusEnum == 'LOCKED'}"/>
                         <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}" alt=""
-                                        title="#{step.processingStatusEnum.title}: #{step.processingUser!=null and step.processingUser.id!=0?step.processingUser.fullName:''} (#{step.processingTime !=null?step.processingTimeAsFormattedString:''})  - #{step.editTypeEnum.title}"
+                                        title="#{msgs.get(step.processingStatusEnum.title)}: #{step.processingUser!=null and step.processingUser.id!=0?step.processingUser.fullName:''} (#{step.processingTime !=null?step.processingTimeAsFormattedString:''})  - #{msgs.get(step.editTypeEnum.title)}"
                                         rendered="#{(step.processingStatusEnum == 'DONE' || step.processingStatusEnum == 'INWORK') and !HelperForm.anonymized}"/>
                         <h:graphicImage value="#{step.processingStatusEnum.smallImagePath}" alt=""
-                                        title="#{step.processingStatusEnum.title}: #{step.editTypeEnum.title}"
+                                        title="#{msgs.get(step.processingStatusEnum.title)}: #{msgs.get(step.editTypeEnum.title)}"
                                         rendered="#{(step.processingStatusEnum == 'DONE' || step.processingStatusEnum == 'INWORK') and HelperForm.anonymized}"/>
                     </h:column>
 

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Schritte.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Schritte.xhtml
@@ -137,7 +137,7 @@
             <h:panelGrid columns="2" id="statuscolumn">
 
                 <h:graphicImage value="#{item.processingStatusEnum.bigImagePath}"
-                                title="#{item.processingStatusEnum.title}" alt=""/>
+                                title="#{msgs.get(item.processingStatusEnum.title)}" alt=""/>
 
                 <h:panelGrid columns="1" cellpadding="0" cellspacing="0"
                              rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Schritte_box_DetailsKlein.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Schritte_box_DetailsKlein.xhtml
@@ -95,7 +95,7 @@
                             <h:outputText value="#{msgs.aktualisierungstyp}:"/>
                         </td>
                         <td>
-                            <h:outputText value="#{item.editTypeEnum.title}"/>
+                            <h:outputText value="#{msgs.get(item.editTypeEnum.title)}"/>
                         </td>
                     </tr>
                 </ui:fragment>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Details.xhtml
@@ -148,7 +148,7 @@
                                 <h:outputText value="#{msgs.status}:"/>
                             </td>
                             <td>
-                                <h:outputText value="#{ProzessverwaltungForm.mySchritt.processingStatusEnum.title}"/>
+                                <h:outputText value="#{msgs.get(ProzessverwaltungForm.mySchritt.processingStatusEnum.title)}"/>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
The el calls (e.g. #{item.processingStatusEnum.title}) return only message tags and not the translation. 
By adding the msgs.get() the message tags are translated inside the template.