### PR TITLE
Replace a4j status tag and enclose JS in CDATA sections

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -544,6 +544,13 @@
             <version>2.0.2-beta</version>
             <scope>test</scope>
         </dependency>
+        <!-- PRIMEFACES -->
+        <!-- https://mvnrepository.com/artifact/org.primefaces/primefaces -->
+        <dependency>
+            <groupId>org.primefaces</groupId>
+            <artifactId>primefaces</artifactId>
+            <version>6.1</version>
+        </dependency>
     </dependencies>
 
 

--- a/Kitodo/src/main/webapp/newpages/NewProcess/Page1.xhtml
+++ b/Kitodo/src/main/webapp/newpages/NewProcess/Page1.xhtml
@@ -161,47 +161,47 @@
             </table>
 
             <script type="text/javascript">
-            //<![CDATA[
-                function getKeyCode(e) {
-                    var keycode;
+                //<![CDATA[
+                    function getKeyCode(e) {
+                        var keycode;
 
-                    keycode = e.keyCode ? e.keyCode : e.charCode;
-                    //alert('keycode ' + keycode);
+                        keycode = e.keyCode ? e.keyCode : e.charCode;
+                        //alert('keycode ' + keycode);
 
-                    return keycode;
-                }
+                        return keycode;
+                    }
 
-                function checkOpac(commandId, e) {
-                    var keycode;
+                    function checkOpac(commandId, e) {
+                        var keycode;
 
-                    keycode = getKeyCode(e);
+                        keycode = getKeyCode(e);
 
-                    e.stopPropagation();
-                    if (keycode == 36) {
-                        return false;
-                    } else if ((keycode == 13) && (commandId == 'OpacRequest')) {
-                        element = document.getElementById('pageform1:performOpacQuery');
-                        if (element) {
-                            element.click();
+                        e.stopPropagation();
+                        if (keycode == 36) {
+                            return false;
+                        } else if ((keycode == 13) && (commandId == 'OpacRequest')) {
+                            element = document.getElementById('pageform1:performOpacQuery');
+                            if (element) {
+                                element.click();
 
+                                return false;
+                            }
+                        } else {
+                            return true;
+                        }
+
+                        return true;
+
+                    }
+
+                    function ignoreEnterKey(e) {
+                        var keycode;
+                        keycode = getKeyCode(e);
+                        if (keycode == 13) {
                             return false;
                         }
-                    } else {
                         return true;
                     }
-
-                    return true;
-
-                }
-
-                function ignoreEnterKey(e) {
-                    var keycode;
-                    keycode = getKeyCode(e);
-                    if (keycode == 13) {
-                        return false;
-                    }
-                    return true;
-                }
                 //]]>
             </script>
         </h:body>

--- a/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/newpages/ProjekteBearbeiten.xhtml
@@ -1075,8 +1075,10 @@
             </table>
 
             <script type="text/javascript">
-                var tabView1 = new YAHOO.widget.TabView('projectform:demo');
-                var tabView2 = new YAHOO.widget.TabView('projectform:staticticdemo');
+                //<![CDATA[
+                    var tabView1 = new YAHOO.widget.TabView('projectform:demo');
+                    var tabView2 = new YAHOO.widget.TabView('projectform:staticticdemo');
+                //]]>
             </script>
 
         </h:body>

--- a/Kitodo/src/main/webapp/newpages/error.xhtml
+++ b/Kitodo/src/main/webapp/newpages/error.xhtml
@@ -130,18 +130,20 @@
             </table>
 
             <script language="javascript" type="text/javascript">
-                function toggle(id) {
-                    var style = document.getElementById(id).style;
-                    if ("block" == style.display) {
-                        style.display = "none";
-                        document.getElementById("buttonOff").style.display = "inline";
-                        document.getElementById("buttonOn").style.display = "none";
-                    } else {
-                        style.display = "block";
-                        document.getElementById("buttonOff").style.display = "none";
-                        document.getElementById("buttonOn").style.display = "inline";
+                //<![CDATA[
+                    function toggle(id) {
+                        var style = document.getElementById(id).style;
+                        if ("block" == style.display) {
+                            style.display = "none";
+                            document.getElementById("buttonOff").style.display = "inline";
+                            document.getElementById("buttonOn").style.display = "none";
+                        } else {
+                            style.display = "block";
+                            document.getElementById("buttonOff").style.display = "none";
+                            document.getElementById("buttonOn").style.display = "inline";
+                        }
                     }
-                }
+                //]]>
             </script>
 
         </h:body>

--- a/Kitodo/src/main/webapp/newpages/inc/Process_Filter.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/Process_Filter.xhtml
@@ -72,12 +72,13 @@
     </h:panelGroup>
 
     </h:panelGrid>
-    <script type="text/javascript"><!--
-    function setFilter() {
-        var myFilter = document.getElementById('select').value;
-        document.getElementById('filterfield').value = myFilter;
-    }
-    -->
+    <script type="text/javascript">
+        //<![CDATA[
+            function setFilter() {
+                var myFilter = document.getElementById('select').value;
+                document.getElementById('filterfield').value = myFilter;
+            }
+        //]]>
     </script>
     <!--
     <h:panelGrid id="myFilterGrid" width="100%" columnClasses="standardTable_ColumnRight" rowClasses="standardTable_Row_bottom" columns="1">

--- a/Kitodo/src/main/webapp/newpages/inc/Step_Filter.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/Step_Filter.xhtml
@@ -73,12 +73,13 @@
     </h:panelGroup>
 
     </h:panelGrid>
-    <script type="text/javascript"><!--
-    function setFilter() {
-        var myFilter = document.getElementById('select').value;
-        document.getElementById('filterfield').value = myFilter;
-    }
-    -->
+    <script type="text/javascript">
+        //<![CDATA[
+            function setFilter() {
+                var myFilter = document.getElementById('select').value;
+                document.getElementById('filterfield').value = myFilter;
+            }
+        //]]>
     </script>
     <!--
     <h:panelGrid id="myFilterGrid" width="100%" columnClasses="standardTable_ColumnRight" rowClasses="standardTable_Row_bottom" columns="1">

--- a/Kitodo/src/main/webapp/newpages/inc/tbl_Fuss.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/tbl_Fuss.xhtml
@@ -33,6 +33,7 @@
 
                             <h:commandLink action="statischImpressum" value="#{msgs.impressum}" id="impr"/>
                             <script type="javascript">
+                                //<![CDATA[
                                     function submitEnter(commandId, e) {
                                         var keycode;
                                         if (window.event) keycode = window.event.keyCode;
@@ -91,9 +92,8 @@
                                             document.getElementById(targetElement).click();
                                         }
                                     }
-
-                                </script>
-
+                                //]]>
+                            </script>
                         </td>
                     </tr>
                 </table>

--- a/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_AktuelleSchritte/schritt_box_Details.xhtml
@@ -131,10 +131,11 @@
     </tr>
     </table>
 
-    <script src="../../js/tiny_mce/tiny_mce.js" type="text/javascript"></script>
+    <script src="../../js/tiny_mce/tiny_mce.js" type="text/javascript"/>
 
     <script type="text/javascript">
-        tinyMCE
+        //<![CDATA[
+            tinyMCE
                 .init({
                     mode: "exact",
                     elements: "htmleditorform:myTextArea",
@@ -153,5 +154,6 @@
                     theme_advanced_statusbar_location: "bottom",
                     theme_advanced_resizing: true
                 });
+        //]]>
     </script>
 </ui:composition>

--- a/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Batches/batch_box_Details.xhtml
@@ -163,10 +163,11 @@
     </tr>
     </table>
 
-    <script src="../../js/tiny_mce/tiny_mce.js" type="text/javascript"></script>
+    <script src="../../js/tiny_mce/tiny_mce.js" type="text/javascript"/>
 
     <script type="text/javascript">
-        tinyMCE
+        //<![CDATA[
+            tinyMCE
                 .init({
                     mode: "exact",
                     elements: "htmleditorform:myTextArea",
@@ -185,5 +186,6 @@
                     theme_advanced_statusbar_location: "bottom",
                     theme_advanced_resizing: true
                 });
+        //]]>
     </script>
 </ui:composition>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Prozessdetails.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/prozess_box_Prozessdetails.xhtml
@@ -262,7 +262,8 @@
     <h:outputScript name="#{HelperForm.servletPathWithHostAsUrl}/js/tiny_mce/tiny_mce.js" target="head"/>
 
     <script type="text/javascript">
-        tinyMCE
+        //<![CDATA[
+            tinyMCE
                 .init({
                     mode: "exact",
                     elements: "htmleditorform:myTextArea",
@@ -281,5 +282,6 @@
                     theme_advanced_statusbar_location: "bottom",
                     theme_advanced_resizing: true
                 });
+        //]]>
     </script>
 </ui:composition>

--- a/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Details.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc_Prozessverwaltung/schritt_box_Details.xhtml
@@ -338,34 +338,33 @@
     <!-- // Box für die Bearbeitung der Details -->
 
     <script type="text/javascript">
-        <!--
-        // Funktion, die Änderungen prüft
-        function chkManuellAutomatischSetzen(element) {
-            //alert(element.id);
-            if (element.id != "chkmanuell1")
-                document.getElementById("chkmanuell1").checked = false;
-            if (element.id != "chkmanuell2")
-                document.getElementById("chkmanuell2").checked = false;
-            if (element.id != "chkmanuell3")
-                document.getElementById("chkmanuell3").checked = false;
-            if (element.id != "chkmanuell4")
-                document.getElementById("chkmanuell4").checked = false;
-            //  		if (element.id != "chkautomatisch") document.getElementById("chkautomatisch").checked=false;
-            txtAutomatischAnzeigen();
-            //element.checked=true;
-        }
-
-        function txtAutomatischAnzeigen() {
-            var myelement = document.getElementById("chkautomatisch");
-            if (myelement != null) {
-                if (document.getElementById("chkautomatisch").checked) {
-                    document.getElementById("scripttable").style.display = "inline";
-                } else {
-                    document.getElementById("scripttable").style.display = "none";
-                }
+        //<![CDATA[
+            // Funktion, die Änderungen prüft
+            function chkManuellAutomatischSetzen(element) {
+                //alert(element.id);
+                if (element.id != "chkmanuell1")
+                    document.getElementById("chkmanuell1").checked = false;
+                if (element.id != "chkmanuell2")
+                    document.getElementById("chkmanuell2").checked = false;
+                if (element.id != "chkmanuell3")
+                    document.getElementById("chkmanuell3").checked = false;
+                if (element.id != "chkmanuell4")
+                    document.getElementById("chkmanuell4").checked = false;
+                //  		if (element.id != "chkautomatisch") document.getElementById("chkautomatisch").checked=false;
+                txtAutomatischAnzeigen();
+                //element.checked=true;
             }
 
-        }
-        //-->
+            function txtAutomatischAnzeigen() {
+                var myelement = document.getElementById("chkautomatisch");
+                if (myelement != null) {
+                    if (document.getElementById("chkautomatisch").checked) {
+                        document.getElementById("scripttable").style.display = "inline";
+                    } else {
+                        document.getElementById("scripttable").style.display = "none";
+                    }
+                }
+            }
+        //]]>
     </script>
 </ui:composition>

--- a/Kitodo/src/main/webapp/pages/Metadaten2.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten2.xhtml
@@ -22,27 +22,27 @@
         <ui:include src="/newpages/inc/head.xhtml" />
 
         <script type="text/javascript">
+            //<![CDATA[
+                function checkFrameLoad() {
 
-            function checkFrameLoad() {
+                    var testObject = rechts.document.getElementById("metadatenRechts");
+                    if (testObject != null) {
+                    } else {
+                        rechts.location.href = rechts.location.href;
+                    }
+                    testObject = oben.document.getElementById("formularOben");
+                    if (testObject != null) {
+                    } else {
+                        oben.location.href = oben.location.href;
+                    }
 
-                var testObject = rechts.document.getElementById("metadatenRechts");
-                if (testObject != null) {
-                } else {
-                    rechts.location.href = rechts.location.href;
+                    testObject = links.document.getElementById("treeform:tabelle");
+                    if (testObject != null) {
+                    } else {
+                        links.location.href = links.location.href;
+                    }
                 }
-                testObject = oben.document.getElementById("formularOben");
-                if (testObject != null) {
-                } else {
-                    oben.location.href = oben.location.href;
-                }
-
-                testObject = links.document.getElementById("treeform:tabelle");
-                if (testObject != null) {
-                } else {
-                    links.location.href = links.location.href;
-                }
-            }
-
+            //]]>
         </script>
 
         <frameset rows="59px,*" bordercolor="#003399" onload="setTimeout('checkFrameLoad()',100);">

--- a/Kitodo/src/main/webapp/pages/Metadaten2rechts.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten2rechts.xhtml
@@ -28,81 +28,81 @@
 
         <script type="text/javascript" src="${pageContext.request.contextPath}/js/jquery-2.1.1.min.js"/>
         <script type="text/javascript">
-        //<![CDATA[
-            jQuery.noConflict();
-            // leave $ to RichFaces' prototype.js
+            //<![CDATA[
+                jQuery.noConflict();
+                // leave $ to RichFaces' prototype.js
 
-            /*
-             * The function toAjaxUrl() converts an absolute URL of a norm data record
-             * to the relative URL we need to actually retrieve this norm data record,
-             * using a reverse proxy to get along with Javascript's same origin policy.
-             *
-             * @param URL
-             *            of a norm data record
-             * @return access URL via reverse proxy
-             */
-            function toAjaxUrl(url) {
-                return url.replace(new RegExp("^.*?://[^/]+/(.*)$", ""), function ($0, $1) {
-                    return "${pageContext.request.contextPath}/" + $1 + "/about/rdf";
-                });
-            }
+                /*
+                 * The function toAjaxUrl() converts an absolute URL of a norm data record
+                 * to the relative URL we need to actually retrieve this norm data record,
+                 * using a reverse proxy to get along with Javascript's same origin policy.
+                 *
+                 * @param URL
+                 *            of a norm data record
+                 * @return access URL via reverse proxy
+                 */
+                function toAjaxUrl(url) {
+                    return url.replace(new RegExp("^.*?://[^/]+/(.*)$", ""), function ($0, $1) {
+                        return "${pageContext.request.contextPath}/" + $1 + "/about/rdf";
+                    });
+                }
 
-            /*
-             * The function setNameFromRecord() retrieves a norm data record using AJAX
-             * and puts the first and last name in the corresponding form fields.
-             *
-             * @param recordID
-             *            id of the input element holding the URL of the record
-             * @param firstnameID
-             *            id of the input element to put the first name
-             * @param lastnameID
-             *            id of the input element to put the last name
-             */
-            function setNameFromRecord(recordID, firstnameID, lastnameID) {
-                var url = toAjaxUrl(document.getElementById(recordID).value);
-                jQuery.ajax({
-                    url: url,
-                    dataType: "xml",
-                    error: function (jqXHR, textStatus, errorThrown) {
-                        alert("${msgs.getNormDataRecordFailed} " + errorThrown);
-                    }
-                })
-                        .done(function (data) {
-                            var preferredName = data.getElementsByTagName("gndo:preferredNameEntityForThePerson")[0];
-                            document.getElementById(firstnameID).value = preferredName.getElementsByTagName("gndo:forename")[0].textContent;
-                            document.getElementById(lastnameID).value = preferredName.getElementsByTagName("gndo:surname")[0].textContent;
-                            try {
-                                A4J.AJAX.Submit("_viewRoot", "formular2", null, null);
-                            } catch (e) {
-                                document.getElementById("formular2").submit();
-                            }
-                        });
-            }
+                /*
+                 * The function setNameFromRecord() retrieves a norm data record using AJAX
+                 * and puts the first and last name in the corresponding form fields.
+                 *
+                 * @param recordID
+                 *            id of the input element holding the URL of the record
+                 * @param firstnameID
+                 *            id of the input element to put the first name
+                 * @param lastnameID
+                 *            id of the input element to put the last name
+                 */
+                function setNameFromRecord(recordID, firstnameID, lastnameID) {
+                    var url = toAjaxUrl(document.getElementById(recordID).value);
+                    jQuery.ajax({
+                        url: url,
+                        dataType: "xml",
+                        error: function (jqXHR, textStatus, errorThrown) {
+                            alert("${msgs.getNormDataRecordFailed} " + errorThrown);
+                        }
+                    })
+                            .done(function (data) {
+                                var preferredName = data.getElementsByTagName("gndo:preferredNameEntityForThePerson")[0];
+                                document.getElementById(firstnameID).value = preferredName.getElementsByTagName("gndo:forename")[0].textContent;
+                                document.getElementById(lastnameID).value = preferredName.getElementsByTagName("gndo:surname")[0].textContent;
+                                try {
+                                    A4J.AJAX.Submit("_viewRoot", "formular2", null, null);
+                                } catch (e) {
+                                    document.getElementById("formular2").submit();
+                                }
+                            });
+                }
 
-            /*
-             * The function getNormDateNeuPerson() retrieves a norm data record using
-             * AJAX from the form to add a new person as metadata. The first and last
-             * name from the records will be put in the corresponding form fields.
-             */
-            function getNormDataNeuPerson() {
-                setNameFromRecord("formular2:normDataRecord", "formular2:vorname", "formular2:nachname");
-            }
+                /*
+                 * The function getNormDateNeuPerson() retrieves a norm data record using
+                 * AJAX from the form to add a new person as metadata. The first and last
+                 * name from the records will be put in the corresponding form fields.
+                 */
+                function getNormDataNeuPerson() {
+                    setNameFromRecord("formular2:normDataRecord", "formular2:vorname", "formular2:nachname");
+                }
 
-            /*
-             * The function getNormDataPersonenUndMetadaten() retrieves a norm data
-             * record using AJAX from the form showing all metadata. The first and last
-             * name from the records will be put in the corresponding form fields.
-             *
-             * @param actionLink
-             *            link corresponding to the group of fields to update
-             */
-            function getNormDataPersonenUndMetadaten(actionLink) {
-                var actionLinkID = actionLink.id;
-                var recordID = actionLinkID.replace(/:clicker$/, ":record");
-                var firstnameID = actionLinkID.replace(/:clicker$/, ":firstname");
-                var lastnameID = actionLinkID.replace(/:clicker$/, ":lastname");
-                setNameFromRecord(recordID, firstnameID, lastnameID);
-            }
+                /*
+                 * The function getNormDataPersonenUndMetadaten() retrieves a norm data
+                 * record using AJAX from the form showing all metadata. The first and last
+                 * name from the records will be put in the corresponding form fields.
+                 *
+                 * @param actionLink
+                 *            link corresponding to the group of fields to update
+                 */
+                function getNormDataPersonenUndMetadaten(actionLink) {
+                    var actionLinkID = actionLink.id;
+                    var recordID = actionLinkID.replace(/:clicker$/, ":record");
+                    var firstnameID = actionLinkID.replace(/:clicker$/, ":firstname");
+                    var lastnameID = actionLinkID.replace(/:clicker$/, ":lastname");
+                    setNameFromRecord(recordID, firstnameID, lastnameID);
+                }
             //]]>
         </script>
 
@@ -322,219 +322,219 @@
     </f:view>
 
     <script type="text/javascript">
-        <!--
-        // Funktion, die Aenderungen prueft
-        function styleAnpassen(element) {
-            // element.className = "metadatenInputChange";
-            // document.getElementById("formular4:DatenGeaendert").value = "1";
-            // document.getElementById("formular2:y1").style.display='block';
-            // document.getElementById("formular2:x1").style.display='block';
-            // document.getElementById("formular2:y2").style.border='2px dashed red';
-            // document.getElementById("formular2:x2").style.border='2px dashed silver';
-            // document.getElementById("formular2:y2").style.padding='3px';
-            // document.getElementById("formular2:x2").style.padding='3px';
-        }
-
-        function styleAnpassenPerson(element) {
-            // bei den DropDowns-den Parent (als die _$ta) als Rahmen aendern
-            // element.parentNode.className = "metadatenInputChange";
-            // document.getElementById("formular4:DatenGeaendert").value = "1";
-            // document.getElementById("formular2:y1").style.display='block';
-            // document.getElementById("formular2:x1").style.display='block';
-            // document.getElementById("formular2:y2").style.border='2px dashed red';
-            // document.getElementById("formular2:x2").style.border='2px dashed silver';
-            // document.getElementById("formular2:y2").style.padding='3px';
-            // document.getElementById("formular2:x2").style.padding='3px';
-        }
-
-        function setSecretElement(invalue) {
-            document.getElementById("secretElement").value = invalue;
-            addableTypenAnzeigen();
-        }
-
-        function TreeReloaden() {
-            addableTypenAnzeigen();
-            var mybutton = parent["links"].document.getElementById("reloadMyTree");
-            if (mybutton != null) {
-                mybutton.click;
+        //<![CDATA[
+            // Funktion, die Aenderungen prueft
+            function styleAnpassen(element) {
+                // element.className = "metadatenInputChange";
+                // document.getElementById("formular4:DatenGeaendert").value = "1";
+                // document.getElementById("formular2:y1").style.display='block';
+                // document.getElementById("formular2:x1").style.display='block';
+                // document.getElementById("formular2:y2").style.border='2px dashed red';
+                // document.getElementById("formular2:x2").style.border='2px dashed silver';
+                // document.getElementById("formular2:y2").style.padding='3px';
+                // document.getElementById("formular2:x2").style.padding='3px';
             }
 
-        }
-
-        function addableTypenAnzeigen() {
-
-            //var treereloadelement = parent.oben.document.getElementById("treeReload");
-            ////alert(treereloadelement);
-            //if (treereloadelement!=null){
-            //alert(treereloadelement.value);
-            //alert(treereloadelement.value=="");
-            //if (treereloadelement.value!=""){
-            //	alert("jetzt wird reloaded");
-            //	treereloadelement.value ="";
-            //	// parent.oben.document.getElementById("formularOben:treeReloadButton").click();
-            //	var mybutton = parent.oben.document.getElementById("formularOben:treeReloadButton");
-            //	alert (mybutton);
-            //	mybutton.click();
-            //	alert("reloaded");
-            //}
-            //}
-
-            // alert("hallo " + document.getElementById("secretElement").value);
-            wert = 1;
-            element = document.getElementById("secretElement");
-            if (element != null) {
-                if (element.value != null && element.value != "")
-                    wert = element.value;
+            function styleAnpassenPerson(element) {
+                // bei den DropDowns-den Parent (als die _$ta) als Rahmen aendern
+                // element.parentNode.className = "metadatenInputChange";
+                // document.getElementById("formular4:DatenGeaendert").value = "1";
+                // document.getElementById("formular2:y1").style.display='block';
+                // document.getElementById("formular2:x1").style.display='block';
+                // document.getElementById("formular2:y2").style.border='2px dashed red';
+                // document.getElementById("formular2:x2").style.border='2px dashed silver';
+                // document.getElementById("formular2:y2").style.padding='3px';
+                // document.getElementById("formular2:x2").style.padding='3px';
             }
 
-            if (document.getElementById("auswahlAddable1") == null
-                    || document.getElementById("auswahlAddable2") == null)
-                return;
-
-            if (wert == 1 || wert == 2) {
-                //alert("ist eins oder zwei");
-                document.getElementById("auswahlAddable1").style.display = 'block';
-                document.getElementById("auswahlAddable2").style.display = 'none';
+            function setSecretElement(invalue) {
+                document.getElementById("secretElement").value = invalue;
+                addableTypenAnzeigen();
             }
 
-            if (wert == 3 || wert == 4) {
-                //alert("ist drei oder vier");
-                document.getElementById("auswahlAddable1").style.display = 'none';
-                document.getElementById("auswahlAddable2").style.display = 'block';
-            }
-        }
+            function TreeReloaden() {
+                addableTypenAnzeigen();
+                var mybutton = parent["links"].document.getElementById("reloadMyTree");
+                if (mybutton != null) {
+                    mybutton.click;
+                }
 
-        function paginierungWertAnzeigen(element) {
-            var inputBoxElement = document.getElementById("paginierungWert");
-            inputBoxElement.style.display = (element.value == 3 ? 'none' : '');
-            if (element.value == 2 || element.value == 5) {
-                inputBoxElement.value = 'I';
             }
-            if (element.value == 1 || element.value == 4) {
-                inputBoxElement.value = '1';
-            }
-            if (element.value == 6) {
-                inputBoxElement.value = '';
-            }
-        }
 
-        function focusForPicture() {
-            //alert(document.getElementById("hiddenBildNummer").value);
-            //alert(document.getElementById("formular1:BildNummer").value);
-            //alert(document.getElementsByName("formular2:myCheckboxes").length);
-            for (i = 0; i < document.getElementsByName("formular2:myCheckboxes").length; i++) {
-                if (i == document.getElementById("hiddenBildNummer").value - 1) {
-                    if (i + 1 < document
-                                    .getElementsByName("formular2:myCheckboxes").length) {
-                        document.getElementsByName("formular2:myCheckboxes")[i + 1]
-                                .focus();
-                    }
-                    document.getElementsByName("formular2:myCheckboxes")[i].focus();
+            function addableTypenAnzeigen() {
+
+                //var treereloadelement = parent.oben.document.getElementById("treeReload");
+                ////alert(treereloadelement);
+                //if (treereloadelement!=null){
+                //alert(treereloadelement.value);
+                //alert(treereloadelement.value=="");
+                //if (treereloadelement.value!=""){
+                //	alert("jetzt wird reloaded");
+                //	treereloadelement.value ="";
+                //	// parent.oben.document.getElementById("formularOben:treeReloadButton").click();
+                //	var mybutton = parent.oben.document.getElementById("formularOben:treeReloadButton");
+                //	alert (mybutton);
+                //	mybutton.click();
+                //	alert("reloaded");
+                //}
+                //}
+
+                // alert("hallo " + document.getElementById("secretElement").value);
+                wert = 1;
+                element = document.getElementById("secretElement");
+                if (element != null) {
+                    if (element.value != null && element.value != "")
+                        wert = element.value;
+                }
+
+                if (document.getElementById("auswahlAddable1") == null
+                        || document.getElementById("auswahlAddable2") == null)
+                    return;
+
+                if (wert == 1 || wert == 2) {
+                    //alert("ist eins oder zwei");
+                    document.getElementById("auswahlAddable1").style.display = 'block';
+                    document.getElementById("auswahlAddable2").style.display = 'none';
+                }
+
+                if (wert == 3 || wert == 4) {
+                    //alert("ist drei oder vier");
+                    document.getElementById("auswahlAddable1").style.display = 'none';
+                    document.getElementById("auswahlAddable2").style.display = 'block';
                 }
             }
-        }
 
-        function submitEnter(commandId, e) {
-            var keycode;
-            if (window.event)
-                keycode = window.event.keyCode;
-            else if (e)
-                keycode = e.which;
-            else
-                return true;
-
-            if (keycode == 13) {
-                document.getElementById(commandId).click();
-                return false;
-            } else
-                return true;
-        }
-
-        document.documentElement.onkeypress = function (event) {
-            //alert("Sie haben die Taste mit dem Wert " + event.which + " gedrueckt");
-            myButton = null;
-            event = event || window.event; // IE sucks
-            var key = event.which || event.keyCode; // IE uses .keyCode, Moz uses .which
-
-            // -----------  previous20 image - cursor up
-            if ((key == 76 || key == 12 || key == 40) && // "L" "^L" or "l"
-                    event.shiftKey && event.ctrlKey) {
-                myButton = document.getElementById("formularBild:imageBack20");
-                //goToImageBack();
-                if (event.preventDefault) {
-                    event.preventDefault();
-                } else {
-                    event.returnValue = false;
-                } // IE sucks
+            function paginierungWertAnzeigen(element) {
+                var inputBoxElement = document.getElementById("paginierungWert");
+                inputBoxElement.style.display = (element.value == 3 ? 'none' : '');
+                if (element.value == 2 || element.value == 5) {
+                    inputBoxElement.value = 'I';
+                }
+                if (element.value == 1 || element.value == 4) {
+                    inputBoxElement.value = '1';
+                }
+                if (element.value == 6) {
+                    inputBoxElement.value = '';
+                }
             }
 
-            // -----------  previous image - cursor left
-            if ((key == 76 || key == 12 || key == 37) && // "L" "^L" or "l"
-                    event.shiftKey && event.ctrlKey) {
-                myButton = document.getElementById("formularBild:imageBack");
-                //goToImageBack();
-                if (event.preventDefault) {
-                    event.preventDefault();
-                } else {
-                    event.returnValue = false;
-                } // IE sucks
+            function focusForPicture() {
+                //alert(document.getElementById("hiddenBildNummer").value);
+                //alert(document.getElementById("formular1:BildNummer").value);
+                //alert(document.getElementsByName("formular2:myCheckboxes").length);
+                for (i = 0; i < document.getElementsByName("formular2:myCheckboxes").length; i++) {
+                    if (i == document.getElementById("hiddenBildNummer").value - 1) {
+                        if (i + 1 < document
+                                        .getElementsByName("formular2:myCheckboxes").length) {
+                            document.getElementsByName("formular2:myCheckboxes")[i + 1]
+                                    .focus();
+                        }
+                        document.getElementsByName("formular2:myCheckboxes")[i].focus();
+                    }
+                }
             }
 
-            // -----------  next image - cursor right
-            if ((key == 76 || key == 12 || key == 39) && // "L" "^L" or "l"
-                    event.shiftKey && event.ctrlKey) {
-                myButton = document.getElementById("formularBild:imageNext");
-                //goToImageNext();
-                if (event.preventDefault) {
-                    event.preventDefault();
-                } else {
-                    event.returnValue = false;
-                } // IE sucks
+            function submitEnter(commandId, e) {
+                var keycode;
+                if (window.event)
+                    keycode = window.event.keyCode;
+                else if (e)
+                    keycode = e.which;
+                else
+                    return true;
+
+                if (keycode == 13) {
+                    document.getElementById(commandId).click();
+                    return false;
+                } else
+                    return true;
             }
 
-            // -----------  next image - cursor down
-            if ((key == 76 || key == 12 || key == 38) && // "L" "^L" or "l"
-                    event.shiftKey && event.ctrlKey) {
-                myButton = document.getElementById("formularBild:imageNext20");
-                //goToImageNext();
-                if (event.preventDefault) {
-                    event.preventDefault();
-                } else {
-                    event.returnValue = false;
-                } // IE sucks
-            }
+            document.documentElement.onkeypress = function (event) {
+                //alert("Sie haben die Taste mit dem Wert " + event.which + " gedrueckt");
+                myButton = null;
+                event = event || window.event; // IE sucks
+                var key = event.which || event.keyCode; // IE uses .keyCode, Moz uses .which
 
-            // -----------  first image - pos1
-            if ((key == 76 || key == 12 || key == 36) && // "L" "^L" or "l"
-                    event.shiftKey && event.ctrlKey) {
-                myButton = document.getElementById("formularBild:imageFirst");
-                //goToImageNext();
-                if (event.preventDefault) {
-                    event.preventDefault();
-                } else {
-                    event.returnValue = false;
-                } // IE sucks
-            }
+                // -----------  previous20 image - cursor up
+                if ((key == 76 || key == 12 || key == 40) && // "L" "^L" or "l"
+                        event.shiftKey && event.ctrlKey) {
+                    myButton = document.getElementById("formularBild:imageBack20");
+                    //goToImageBack();
+                    if (event.preventDefault) {
+                        event.preventDefault();
+                    } else {
+                        event.returnValue = false;
+                    } // IE sucks
+                }
 
-            // -----------  last image - end
-            if ((key == 76 || key == 12 || key == 35) && // "L" "^L" or "l"
-                    event.shiftKey && event.ctrlKey) {
-                myButton = document.getElementById("formularBild:imageLast");
-                //goToImageNext();
-                if (event.preventDefault) {
-                    event.preventDefault();
-                } else {
-                    event.returnValue = false;
-                } // IE sucks
-            }
+                // -----------  previous image - cursor left
+                if ((key == 76 || key == 12 || key == 37) && // "L" "^L" or "l"
+                        event.shiftKey && event.ctrlKey) {
+                    myButton = document.getElementById("formularBild:imageBack");
+                    //goToImageBack();
+                    if (event.preventDefault) {
+                        event.preventDefault();
+                    } else {
+                        event.returnValue = false;
+                    } // IE sucks
+                }
 
-            // ---------- click my Button
-            try {
-                if (myButton != null)
-                    myButton.click();
-            } catch (e) {
+                // -----------  next image - cursor right
+                if ((key == 76 || key == 12 || key == 39) && // "L" "^L" or "l"
+                        event.shiftKey && event.ctrlKey) {
+                    myButton = document.getElementById("formularBild:imageNext");
+                    //goToImageNext();
+                    if (event.preventDefault) {
+                        event.preventDefault();
+                    } else {
+                        event.returnValue = false;
+                    } // IE sucks
+                }
+
+                // -----------  next image - cursor down
+                if ((key == 76 || key == 12 || key == 38) && // "L" "^L" or "l"
+                        event.shiftKey && event.ctrlKey) {
+                    myButton = document.getElementById("formularBild:imageNext20");
+                    //goToImageNext();
+                    if (event.preventDefault) {
+                        event.preventDefault();
+                    } else {
+                        event.returnValue = false;
+                    } // IE sucks
+                }
+
+                // -----------  first image - pos1
+                if ((key == 76 || key == 12 || key == 36) && // "L" "^L" or "l"
+                        event.shiftKey && event.ctrlKey) {
+                    myButton = document.getElementById("formularBild:imageFirst");
+                    //goToImageNext();
+                    if (event.preventDefault) {
+                        event.preventDefault();
+                    } else {
+                        event.returnValue = false;
+                    } // IE sucks
+                }
+
+                // -----------  last image - end
+                if ((key == 76 || key == 12 || key == 35) && // "L" "^L" or "l"
+                        event.shiftKey && event.ctrlKey) {
+                    myButton = document.getElementById("formularBild:imageLast");
+                    //goToImageNext();
+                    if (event.preventDefault) {
+                        event.preventDefault();
+                    } else {
+                        event.returnValue = false;
+                    } // IE sucks
+                }
+
+                // ---------- click my Button
+                try {
+                    if (myButton != null)
+                        myButton.click();
+                } catch (e) {
+                }
             }
-        }
-        //-->
+        //]]>
     </script>
 </html>

--- a/Kitodo/src/main/webapp/pages/Metadaten2rechts.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten2rechts.xhtml
@@ -18,6 +18,7 @@
     xmlns:h="http://xmlns.jcp.org/jsf/html"
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
+    xmlns:p="http://primefaces.org/ui"
     >
 
     <f:view locale="#{SpracheForm.locale}">
@@ -25,7 +26,7 @@
 
         <h:body style="margin: 0px 2px 2px 2px;" class="metadatenRechtsBody" onload="addableTypenAnzeigen();TreeReloaden()">
 
-        <script type="text/javascript" src="${pageContext.request.contextPath}/js/jquery-2.1.1.min.js"></script>
+        <script type="text/javascript" src="${pageContext.request.contextPath}/js/jquery-2.1.1.min.js"/>
         <script type="text/javascript">
         //<![CDATA[
             jQuery.noConflict();
@@ -105,11 +106,11 @@
             //]]>
         </script>
 
-        <a4j:status>
+        <p:ajaxStatus>
             <f:facet name="start">
-                <h:graphicImage alt="" value="/newpages/images/ajaxload_small.gif" style="position: fixed;top: 35px;right: 15px;"/>
+                <p:graphicImage alt="" name="/newpages/images/ajaxload_small.gif" style="position: fixed;top: 35px;right: 15px;"/>
             </f:facet>
-        </a4j:status>
+        </p:ajaxStatus>
 
         <h:form id="formular1" style="margin:0px">
             <table id="navigation" cellpadding="2" cellspacing="0"

--- a/Kitodo/src/main/webapp/pages/Metadaten3links.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten3links.xhtml
@@ -188,7 +188,7 @@
                     return true;
                     //	}
                 } catch (err) {
-                    parent.rechts.location.href = "Metadaten2rechts.jsf";
+                    parent.rechts.location.href = "Metadaten2rechts.xhtml";
                 }
             }
 

--- a/Kitodo/src/main/webapp/pages/Metadaten3links.xhtml
+++ b/Kitodo/src/main/webapp/pages/Metadaten3links.xhtml
@@ -169,64 +169,65 @@
 
         </h:body>
     </f:view>
-    <script type="text/javascript"><!--
-    // Funktion, die dynamisch das Stylesheet zuweist
-    function styleAnpassen2(element) {
-        try {
-            //	if (parent.rechts.document.getElementById("formular4:DatenGeaendert").value == "1"){
-            //		// Daten sind ungespeichert, also Warnung ausgeben und abbrechen
-            //		alert(document.getElementById("formWarn:Warnmeldung").value);
-            //		//return false;
-            //	}else{
-            // Daten sind gespeichert, also den Klick weitergeben
-            var galleryLinks;
-            galleryLinks = document.getElementsByTagName('a');
-            for (var i = 0; i < galleryLinks.length; i++)
-                galleryLinks[i].className = "document";
-            element.className = "documentSelected";
-            return true;
-            //	}
-        } catch (err) {
-            parent.rechts.location.href = "Metadaten2rechts.jsf";
-        }
-    }
+    <script type="text/javascript">
+        //<![CDATA[
+            // Funktion, die dynamisch das Stylesheet zuweist
+            function styleAnpassen2(element) {
+                try {
+                    //	if (parent.rechts.document.getElementById("formular4:DatenGeaendert").value == "1"){
+                    //		// Daten sind ungespeichert, also Warnung ausgeben und abbrechen
+                    //		alert(document.getElementById("formWarn:Warnmeldung").value);
+                    //		//return false;
+                    //	}else{
+                    // Daten sind gespeichert, also den Klick weitergeben
+                    var galleryLinks;
+                    galleryLinks = document.getElementsByTagName('a');
+                    for (var i = 0; i < galleryLinks.length; i++)
+                        galleryLinks[i].className = "document";
+                    element.className = "documentSelected";
+                    return true;
+                    //	}
+                } catch (err) {
+                    parent.rechts.location.href = "Metadaten2rechts.jsf";
+                }
+            }
 
 
-    function reloadRightFrame() {
-        var myelement = parent.rechts.document.getElementById("formular2:docStructVerschiebenAbbrechen");
-        if (myelement != null) {
-            myelement.click();
-        }
-        var myelement1 = parent.rechts.document.getElementById("formular2:docStructReload");
-        if (myelement1 != null) {
-            myelement1.click();
-        }
-    }
+            function reloadRightFrame() {
+                var myelement = parent.rechts.document.getElementById("formular2:docStructVerschiebenAbbrechen");
+                if (myelement != null) {
+                    myelement.click();
+                }
+                var myelement1 = parent.rechts.document.getElementById("formular2:docStructReload");
+                if (myelement1 != null) {
+                    myelement1.click();
+                }
+            }
 
-    var DHTML = (document.getElementById || document.all || document.layers);
-    var texttop = 10;
+            var DHTML = (document.getElementById || document.all || document.layers);
+            var texttop = 10;
 
-    function getObj(name) {
-        if (document.getElementById) {
-            this.obj = document.getElementById(name);
-            this.style = document.getElementById(name).style;
-        }
-        else if (document.all) {
-            this.obj = document.all[name];
-            this.style = document.all[name].style;
-        }
-        else if (document.layers) {
-            this.obj = document.layers[name];
-            this.style = document.layers[name];
-        }
-    }
+            function getObj(name) {
+                if (document.getElementById) {
+                    this.obj = document.getElementById(name);
+                    this.style = document.getElementById(name).style;
+                }
+                else if (document.all) {
+                    this.obj = document.all[name];
+                    this.style = document.all[name].style;
+                }
+                else if (document.layers) {
+                    this.obj = document.layers[name];
+                    this.style = document.layers[name];
+                }
+            }
 
-    function move(amount) {
-        if (!DHTML) return;
-        var x = new getObj('treeform:tabelle');
-        texttop += amount;
-        x.style.top = texttop;
-    }
-    //-->
+            function move(amount) {
+                if (!DHTML) return;
+                var x = new getObj('treeform:tabelle');
+                texttop += amount;
+                x.style.top = texttop;
+            }
+        //]]>
     </script>
 </html>


### PR DESCRIPTION
- replace `a4j:status` tag with `p:ajaxStatus` tag from PrimeFaces in `Metadaten2rechts.xhtml`
- enclose inline JS in Facelets in CDATA sections to prevent errors caused by characters that would be illegal in XML (like `&` or `<` for example)