### PR TITLE
Fixed: "Problem with switching the language"

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/SpracheForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/SpracheForm.java
@@ -12,6 +12,7 @@
 package de.sub.goobi.forms;
 
 import de.sub.goobi.config.ConfigCore;
+import org.apache.commons.lang.LocaleUtils;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -41,11 +42,11 @@ public class SpracheForm implements Serializable {
      * The constructor of this class loads the required MessageBundle.
      */
     public SpracheForm() {
-        String p = ConfigCore.getParameter("language.force-default");
-        if (p != null && p.length() > 0) {
+        String key = ConfigCore.getParameter("language.default", "de");
+        Locale locale = new Locale.Builder().setLanguageTag(key).build();
+        if (!LocaleUtils.isAvailableLocale(locale)) {
             FacesContext context = FacesContext.getCurrentInstance();
             if (!Objects.equals(context.getViewRoot(), null)) {
-                Locale locale = new Locale(p);
                 context.getViewRoot().setLocale(locale);
                 context.getExternalContext().getSessionMap().put(SESSION_LOCALE_FIELD_ID, locale);
             }
@@ -168,7 +169,13 @@ public class SpracheForm implements Serializable {
              *  When no locale is given (no Accept-Language Http Request header is present)
              *  return default language
              */
-            return new Locale(ConfigCore.getParameter("language.default"));
+            String key = ConfigCore.getParameter("language.default", "de");
+            Locale locale = new Locale.Builder().setLanguageTag(key).build();
+            if (LocaleUtils.isAvailableLocale(locale)) {
+                return locale;
+            } else {
+                throw new IllegalArgumentException("Locale code is not valid");
+            }
         }
     }
 

--- a/Kitodo/src/main/java/de/sub/goobi/forms/SpracheForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/SpracheForm.java
@@ -42,7 +42,7 @@ public class SpracheForm implements Serializable {
      * The constructor of this class loads the required MessageBundle.
      */
     public SpracheForm() {
-        String key = ConfigCore.getParameter("language.default", "de");
+        String key = ConfigCore.getParameter("language.force-default", "de");
         Locale locale = new Locale.Builder().setLanguageTag(key).build();
         if (!LocaleUtils.isAvailableLocale(locale)) {
             FacesContext context = FacesContext.getCurrentInstance();

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -134,7 +134,7 @@ localMessages=/usr/local/kitodo/messages/
 # Start-up language: If not set, Kitodo.Production will start up with the
 # language best matching the user's Accept-Languages HTTP Request header. You
 # can override this behaviour by setting a default language here:
-# language.force-default=en 
+# language.force-default=de
 # Default language: If no Accept-Language Http Request header is present, use the following language:
 language.default=de
 # Resource bundle key for the text to show on the primary screen.

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -134,7 +134,9 @@ localMessages=/usr/local/kitodo/messages/
 # Start-up language: If not set, Kitodo.Production will start up with the
 # language best matching the user's Accept-Languages HTTP Request header. You
 # can override this behaviour by setting a default language here:
-#language.force-default=en
+# language.force-default=en 
+# Default language: If no Accept-Language Http Request header is present, use the following language:
+language.default=de
 # Resource bundle key for the text to show on the primary screen.
 # - allgemeinesTextDemo: predefined with a text listing the example logins
 #       available after setup

--- a/Kitodo/src/main/webapp/newpages/inc/tbl_Kopf.xhtml
+++ b/Kitodo/src/main/webapp/newpages/inc/tbl_Kopf.xhtml
@@ -101,7 +101,7 @@
                             <t:dataList var="availableLanguage" value="#{SpracheForm.supportedLocales}">
                                 <ui:fragment rendered="#{not availableLanguage.selected}">
                                     <span class="alterLanguage">
-                                        <h:commandLink action="#{SpracheForm.switchLanguage}"
+                                        <h:commandLink action="#{SpracheForm.switchLanguage(availableLanguage.id)}"
                                                        title="#{availableLanguage.displayLanguageTranslated}">
                                             <f:param name="locale" value="#{availableLanguage.id}"/>
                                             <h:outputText value="#{availableLanguage.displayLanguageSelf}"/>


### PR DESCRIPTION
To solve the problem with switching the language a few changes have been made. 

**First** off, the hardcoded `return Locale.GERMAN;` was replaced by an entry in the kitodo_config.properties (currently set to "de" as well).

**Secondly**, the commandLink for switching the language was not working, because the action call did not give a target language to the corresponding method (switchLanguage(String ...). 
The switchLanguage(String ...) method was altered to reload the current page after a language was selected, so that the changes were effective immediately.

**Lastly**, the constructor was altered to correctly set the forced default language, if it is present, as the current locale and as a session entry. When a value was given for the config entry "language.force-default", an exception was thrown, because sometimes the UIViewRoot was null.