### PR TITLE
Fix null pointer exception on accessing not existing list entry

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
@@ -569,8 +569,12 @@ public class ProzesskopieForm {
                         if (allChildren != null) {
                             myTempStruct = allChildren.get(0);
                         } else {
-                            logger.debug("There is no child element for document type " + this.docType
-                                                 + " and meta data field " + field.getTitel());
+                            List<String> translationFields = new ArrayList<>();
+                            translationFields.add(field.getTitel());
+                            translationFields.add(this.docType);
+                            String translation = Helper.getTranslation("ErrorAdditionalFieldsNoChildForDocType", translationFields);
+                            Helper.setMeldung(translation);
+                            logger.info(translation);
                         }
                     }
                     if (field.getDocstruct().equals("boundbook")) {

--- a/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
@@ -565,7 +565,13 @@ public class ProzesskopieForm {
                     /* welches Docstruct */
                     DocStruct myTempStruct = this.myRdf.getDigitalDocument().getLogicalDocStruct();
                     if (field.getDocstruct().equals("firstchild")) {
-                        myTempStruct = this.myRdf.getDigitalDocument().getLogicalDocStruct().getAllChildren().get(0);
+                        List<DocStruct> allChildren = this.myRdf.getDigitalDocument().getLogicalDocStruct().getAllChildren();
+                        if (allChildren != null) {
+                            myTempStruct = allChildren.get(0);
+                        } else {
+                            logger.debug("There is no child element for document type " + this.docType
+                                                 + " and meta data field " + field.getTitel());
+                        }
                     }
                     if (field.getDocstruct().equals("boundbook")) {
                         myTempStruct = this.myRdf.getDigitalDocument().getPhysicalDocStruct();

--- a/Goobi/src/messages/messages_de.properties
+++ b/Goobi/src/messages/messages_de.properties
@@ -38,6 +38,7 @@ ExportNewspaperBatchTask=Zeitungsgesamtausgabe ins DMS exportieren
 ExportSerialBatchTask=Fortlaufendes Sammelwerk ins DMS exportieren
 Erfassung\ der\ Struktur-Metadaten\ (Erfassung\ der\ Seitenpaginierung,\ Nacherfassung\ fehlender\ Strukturen,\ Erstellung\ Metadaten-Strukturbaum)=Erfassung der Struktur-Metadaten (Erfassung der Seitenpaginierung, Nacherfassung fehlender Strukturen, Erstellung Metadaten-Strukturbaum)
 Erfassung\ der\ Strukturdaten\ (Erfassung\ der\ Seitenpaginierung,\ Nacherfassung\ fehlender\ Strukturen,\ Erstellung\ Metadaten-Strukturbaum)=Erfassung der Strukturdaten (Erfassung der Seitenpaginierung, Nacherfassung fehlender Strukturen, Erstellung Metadaten-Strukturbaum)
+ErrorAdditionalFieldsNoChildForDocType=M\u00F6glicherweise kann das Metadatum {0} nicht als Kindelement beim Medientyp {1} genutzt werden.
 ErrorDMSExport=Vorgang {0} konnte aufgrund eines Fehlers nicht exportiert werden\: {1}
 ErrorMetsEditorImageRenaming=Es kam zu einem Fehler w\u00E4hrend der Umbenennung der Bilder.
 ErrorTemplateSelectionIsEmpty=Es wurde keine Vorlage ausgew\u00E4hlt.

--- a/Goobi/src/messages/messages_en.properties
+++ b/Goobi/src/messages/messages_en.properties
@@ -36,6 +36,7 @@ Eigenschaft=property
 EmptyTask=Example of a long-running task
 Erfassung\ der\ Struktur-Metadaten\ (Erfassung\ der\ Seitenpaginierung,\ Nacherfassung\ fehlender\ Strukturen,\ Erstellung\ Metadaten-Strukturbaum)=Capture of structure metadata (pagination
 Erfassung\ der\ Strukturdaten\ (Erfassung\ der\ Seitenpaginierung,\ Nacherfassung\ fehlender\ Strukturen,\ Erstellung\ Metadaten-Strukturbaum)=Capture of structure data (pagination
+ErrorAdditionalFieldsNoChildForDocType=It is maybe impossible that meta data {0] could not be added as child element to media type {1}.
 ErrorDMSExport=Process {0} could not be exported because of an error\: {1}
 ErrorMetsEditorImageRenaming=There was an error during the renaming of images.
 ErrorTemplateSelectionIsEmpty=No template selected.


### PR DESCRIPTION
Instead of ignoring a possible null pointer exception like in previous versions check for amount of child elements and log a debug message in case that there are no child elements.