### PR TITLE
Fix used URI to get norm data

### DIFF
--- a/Goobi/pages/Metadaten2rechts.jsp
+++ b/Goobi/pages/Metadaten2rechts.jsp
@@ -41,7 +41,7 @@
          --%>
             function toAjaxUrl(url){
                 return url.replace(new RegExp("^.*?://[^/]+/(.*)$", ""), function($0, $1){
-                    return "${pageContext.request.contextPath}/" + $1 + "/about/rdf";
+                    return "${pageContext.request.contextPath}/" + $1 + "/about/lds.rdf";
                 });
             }
 


### PR DESCRIPTION
This is one way to fix the "moved permanent" error message. Other way would be to find a possibility to follow redirects.

This could fix #882 .