### PR TITLE
Unify properties in pom.xml files of modules

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -24,7 +24,4 @@
     <artifactId>kitodo-api</artifactId>
     <name>Kitodo - API</name>
 
-    <properties>
-        <parent.basedir>${basedir}/../</parent.basedir>
-    </properties>
 </project>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -30,8 +30,6 @@
     <url>https://github.com/kitodo/kitodo-production</url>
 
     <properties>
-        <parent.basedir>${basedir}/../</parent.basedir>
-        <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
         <phase.prop>install</phase.prop>
     </properties>
 

--- a/Kitodo-PersistentIdentifier/pom.xml
+++ b/Kitodo-PersistentIdentifier/pom.xml
@@ -28,11 +28,6 @@
     <name>Kitodo - Persistent Identifier</name>
     <url>https://github.com/kitodo/kitodo-production</url>
 
-    <properties>
-        <parent.basedir>${basedir}/../</parent.basedir>
-        <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.kitodo</groupId>
@@ -52,28 +47,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
-        <resources>
-            <resource>
-                <directory>../config-local</directory>
-            </resource>
-            <resource>
-                <directory>src/main/java</directory>
-                <includes>
-                    <include>**/*.xml</include>
-                    <include>**/*.properties</include>
-                </includes>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
-                <filtering>true</filtering>
-            </testResource>
-        </testResources>
-    </build>
 </project>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -29,7 +29,6 @@
 
     <properties>
         <parent.basedir>${basedir}/../</parent.basedir>
-        <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
     </properties>
 
     <dependencies>

--- a/OpacPica-Plugin/pom.xml
+++ b/OpacPica-Plugin/pom.xml
@@ -25,11 +25,6 @@
     <artifactId>OpacPica-Plugin</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <properties>
-        <parent.basedir>${basedir}/../</parent.basedir>
-        <checkstyle.config.location>${parent.basedir}/config/checkstyle.xml</checkstyle.config.location>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>net.xeoh</groupId>


### PR DESCRIPTION
The checkstyle property was necessary when we had checkstyle in default maven build and we wanted to run single tests. Now it is not needed anymore.

Additionally, build in Kitodo - Persistent Identifier was not used. 