### PR TITLE
Add the namespace declaration to Kitodo/pom.xml

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -11,7 +11,8 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kitodo</artifactId>
     <packaging>war</packaging>


### PR DESCRIPTION
One of the issues with checkout under Eclipse seems to be that the namespace declaration is missing.