### PR TITLE
Extend findBy.... for multiple related objects

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/BatchService.java
@@ -16,9 +16,10 @@ import com.sun.research.ws.wadl.HTTPMethods;
 import de.sub.goobi.helper.Helper;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -254,13 +255,13 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO> {
      * @return list of JSON objects with batches for specific process title
      */
     public List<JSONObject> findByProcessTitle(String title) throws DataException {
-        List<JSONObject> batches = new ArrayList<>();
+        Set<Integer> processIds = new HashSet<>();
 
         List<JSONObject> processes = serviceManager.getProcessService().findByTitle(title, true);
         for (JSONObject process : processes) {
-            batches.addAll(findByProcessId(getIdFromJSONObject(process)));
+            processIds.add(getIdFromJSONObject(process));
         }
-        return batches;
+        return searcher.findDocuments(createSetQuery("processes.id", processIds, true).toString());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/HistoryService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/HistoryService.java
@@ -14,9 +14,10 @@ package org.kitodo.services.data;
 import com.sun.research.ws.wadl.HTTPMethods;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -237,13 +238,13 @@ public class HistoryService extends SearchService<History, HistoryDTO> {
      * @return JSON objects with history for specific process title
      */
     public List<JSONObject> findByProcessTitle(String processTitle) throws DataException {
-        List<JSONObject> histories = new ArrayList<>();
+        Set<Integer> processIds = new HashSet<>();
 
         List<JSONObject> processes = serviceManager.getProcessService().findByTitle(processTitle, true);
         for (JSONObject process : processes) {
-            histories.add(findByProcessId(getIdFromJSONObject(process)));
+            processIds.add(getIdFromJSONObject(process));
         }
-        return histories;
+        return searcher.findDocuments(createSetQuery("process", processIds, true).toString());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
@@ -18,7 +18,9 @@ import de.sub.goobi.helper.ProjectHelper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
 
@@ -294,13 +296,13 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO> {
      * @return list of JSON objects with projects for specific process title
      */
     public List<JSONObject> findByProcessTitle(String title) throws DataException {
-        List<JSONObject> projects = new ArrayList<>();
+        Set<Integer> processIds = new HashSet<>();
 
         List<JSONObject> processes = serviceManager.getProcessService().findByTitle(title, true);
         for (JSONObject process : processes) {
-            projects.add(findByProcessId(getIdFromJSONObject(process)));
+            processIds.add(getIdFromJSONObject(process));
         }
-        return projects;
+        return searcher.findDocuments(createSetQuery("processes.id", processIds, true).toString());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/TemplateService.java
@@ -15,7 +15,9 @@ import com.sun.research.ws.wadl.HTTPMethods;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -236,26 +238,21 @@ public class TemplateService extends SearchService<Template, TemplateDTO> {
      *            of property
      * @return list of JSON objects with templates for specific property
      */
-    public List<JSONObject> findByProperty(String title, String value) throws DataException {
-        List<JSONObject> templates = new ArrayList<>();
+    List<JSONObject> findByProperty(String title, String value) throws DataException {
+        Set<Integer> propertyIds = new HashSet<>();
 
-        List<JSONObject> properties = serviceManager.getPropertyService().findByTitleAndValue(title, value);
-        for (JSONObject property : properties) {
-            templates.addAll(findByPropertyId(getIdFromJSONObject(property)));
+        List<JSONObject> properties;
+        if (value == null) {
+            properties = serviceManager.getPropertyService().findByTitle(title, true);
+        } else if (title == null) {
+            properties = serviceManager.getPropertyService().findByValue(value, true);
+        } else {
+            properties = serviceManager.getPropertyService().findByTitleAndValue(title, value);
         }
-        return templates;
-    }
-
-    /**
-     * Simulate relationship between property and template type.
-     *
-     * @param id
-     *            of property
-     * @return list of JSON objects with templates for specific property id
-     */
-    private List<JSONObject> findByPropertyId(Integer id) throws DataException {
-        QueryBuilder query = createSimpleQuery("properties.id", id, true);
-        return searcher.findDocuments(query.toString());
+        for (JSONObject property : properties) {
+            propertyIds.add(getIdFromJSONObject(property));
+        }
+        return searcher.findDocuments(createSetQuery("properties.id", propertyIds, true).toString());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/UserService.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -455,25 +457,14 @@ public class UserService extends SearchService<User, UserDTO> {
      * @return list of JSON objects with users for specific filter
      */
     List<JSONObject> findByFilter(String value) throws DataException {
-        List<JSONObject> users = new ArrayList<>();
+        Set<Integer> filterIds = new HashSet<>();
 
         List<JSONObject> filters = serviceManager.getFilterService().findByValue(value, true);
-        for (JSONObject filter : filters) {
-            users.addAll(findByFilterId(getIdFromJSONObject(filter)));
-        }
-        return users;
-    }
 
-    /**
-     * Simulate relationship between filter and user type.
-     *
-     * @param id
-     *            of filter
-     * @return list of JSON objects with users for specific filter id
-     */
-    private List<JSONObject> findByFilterId(Integer id) throws DataException {
-        QueryBuilder query = createSimpleQuery("filters.id", id, true);
-        return searcher.findDocuments(query.toString());
+        for (JSONObject filter : filters) {
+            filterIds.add(getIdFromJSONObject(filter));
+        }
+        return searcher.findDocuments(createSetQuery("filters.id", filterIds, true).toString());
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -272,9 +272,9 @@ public class MockDatabase {
     }
 
     private static void insertProcessProperties() throws DAOException, DataException {
-        Property firstProcessProperty = new Property();
+        Process firstProcess = serviceManager.getProcessService().getById(1);
 
-        Process process = serviceManager.getProcessService().getById(1);
+        Property firstProcessProperty = new Property();
         firstProcessProperty.setTitle("Process Property");
         firstProcessProperty.setValue("first value");
         firstProcessProperty.setObligatory(true);
@@ -283,7 +283,7 @@ public class MockDatabase {
         LocalDate localDate = new LocalDate(2017, 1, 14);
         firstProcessProperty.setCreationDate(localDate.toDate());
         firstProcessProperty.setContainer(1);
-        firstProcessProperty.getProcesses().add(process);
+        firstProcessProperty.getProcesses().add(firstProcess);
         serviceManager.getPropertyService().save(firstProcessProperty);
 
         Property secondProcessProperty = new Property();
@@ -295,7 +295,7 @@ public class MockDatabase {
         localDate = new LocalDate(2017, 1, 15);
         secondProcessProperty.setCreationDate(localDate.toDate());
         secondProcessProperty.setContainer(2);
-        secondProcessProperty.getProcesses().add(process);
+        secondProcessProperty.getProcesses().add(firstProcess);
         serviceManager.getPropertyService().save(secondProcessProperty);
 
         Property thirdProcessProperty = new Property();
@@ -307,13 +307,30 @@ public class MockDatabase {
         localDate = new LocalDate(2017, 7, 15);
         thirdProcessProperty.setCreationDate(localDate.toDate());
         thirdProcessProperty.setContainer(2);
-        thirdProcessProperty.getProcesses().add(process);
+        thirdProcessProperty.getProcesses().add(firstProcess);
         serviceManager.getPropertyService().save(thirdProcessProperty);
 
-        process.getProperties().add(firstProcessProperty);
-        process.getProperties().add(secondProcessProperty);
-        process.getProperties().add(thirdProcessProperty);
-        serviceManager.getProcessService().save(process);
+        Process secondProcess = serviceManager.getProcessService().getById(2);
+        Property fourthProcessProperty = new Property();
+        fourthProcessProperty.setTitle("Korrektur notwendig");
+        fourthProcessProperty.setValue("improved ids");
+        fourthProcessProperty.setObligatory(false);
+        fourthProcessProperty.setType(PropertyType.CommandLink);
+        fourthProcessProperty.setChoice("chosen");
+        localDate = new LocalDate(2017, 7, 15);
+        fourthProcessProperty.setCreationDate(localDate.toDate());
+        fourthProcessProperty.setContainer(2);
+        fourthProcessProperty.getProcesses().add(secondProcess);
+        serviceManager.getPropertyService().save(fourthProcessProperty);
+
+        firstProcess.getProperties().add(firstProcessProperty);
+        firstProcess.getProperties().add(secondProcessProperty);
+        firstProcess.getProperties().add(thirdProcessProperty);
+        serviceManager.getProcessService().save(firstProcess);
+
+        secondProcess.getProperties().add(fourthProcessProperty);
+        serviceManager.getProcessService().save(secondProcess);
+
     }
 
     private static void insertProjects() throws DAOException, DataException {

--- a/Kitodo/src/test/java/org/kitodo/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/ProcessServiceIT.java
@@ -210,9 +210,14 @@ public class ProcessServiceIT {
     public void shouldFindByProperty() throws Exception {
         ProcessService processService = new ProcessService();
 
-        List<JSONObject> processes = processService.findByProperty("Process Property", "first value");
+        List<JSONObject> processes = processService.findByProperty("Korrektur notwendig", null);
         Integer actual = processes.size();
-        Integer expected = 1;
+        Integer expected = 2;
+        assertEquals("Processes were not found in index!", expected, actual);
+
+        processes = processService.findByProperty("Process Property", "first value");
+        actual = processes.size();
+        expected = 1;
         assertEquals("Process was not found in index!", expected, actual);
 
         processes = processService.findByProperty("firstTemplate title", "first value");

--- a/Kitodo/src/test/java/org/kitodo/services/data/PropertyServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/PropertyServiceIT.java
@@ -56,7 +56,7 @@ public class PropertyServiceIT {
         PropertyService propertyService = new PropertyService();
 
         Long amount = propertyService.count();
-        assertEquals("Properties were not counted correctly!", Long.valueOf(7), amount);
+        assertEquals("Properties were not counted correctly!", Long.valueOf(8), amount);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class PropertyServiceIT {
 
         String query = matchQuery("type", "process").operator(Operator.AND).toString();
         Long amount = propertyService.count(query);
-        assertEquals("Properties were not counted correctly!", Long.valueOf(3), amount);
+        assertEquals("Properties were not counted correctly!", Long.valueOf(4), amount);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class PropertyServiceIT {
         PropertyService propertyService = new PropertyService();
 
         Long amount = propertyService.countDatabaseRows();
-        assertEquals("Properties were not counted correctly!", Long.valueOf(7), amount);
+        assertEquals("Properties were not counted correctly!", Long.valueOf(8), amount);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class PropertyServiceIT {
     public void shouldFindTemplateProperty() throws Exception {
         PropertyService propertyService = new PropertyService();
 
-        Property templateProperty = propertyService.getById(6);
+        Property templateProperty = propertyService.getById(7);
         String actual = templateProperty.getTitle();
         String expected = "firstTemplate title";
         assertEquals("Template property was not found in database - title doesn't match!", expected, actual);
@@ -108,7 +108,7 @@ public class PropertyServiceIT {
     public void shouldFindWorkpieceProperty() throws Exception {
         PropertyService propertyService = new PropertyService();
 
-        Property workpieceProperty = propertyService.getById(4);
+        Property workpieceProperty = propertyService.getById(5);
         String actual = workpieceProperty.getTitle();
         String expected = "FirstWorkpiece Property";
         assertEquals("Workpiece property was not found in database - title doesn't match!", expected, actual);
@@ -123,7 +123,7 @@ public class PropertyServiceIT {
         PropertyService propertyService = new PropertyService();
 
         List<Property> properties = propertyService.getAll();
-        assertEquals("Not all properties were found in database!", 7, properties.size());
+        assertEquals("Not all properties were found in database!", 8, properties.size());
     }
 
     @Test
@@ -133,22 +133,22 @@ public class PropertyServiceIT {
         Property property = new Property();
         property.setTitle("To Remove");
         propertyService.save(property);
-        Property foundProperty = propertyService.getById(8);
+        Property foundProperty = propertyService.getById(9);
         assertEquals("Additional property was not inserted in database!", "To Remove", foundProperty.getTitle());
 
         propertyService.remove(foundProperty);
         exception.expect(DAOException.class);
-        propertyService.getById(8);
+        propertyService.getById(9);
 
         property = new Property();
         property.setTitle("To remove");
         propertyService.save(property);
-        foundProperty = propertyService.getById(9);
+        foundProperty = propertyService.getById(10);
         assertEquals("Additional property was not inserted in database!", "To remove", foundProperty.getTitle());
 
-        propertyService.remove(9);
+        propertyService.remove(10);
         exception.expect(DAOException.class);
-        propertyService.getById(9);
+        propertyService.getById(10);
     }
 
     @Test


### PR DESCRIPTION
Use createSetQuery. It is more efficient to query only once for related objects instead of query for every single object.