### PR TITLE
Update README.md with information about ES version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and packaging of the application is [Maven](https://maven.apache.org/).
 ### Dependencies
 
 Available dependencies are fetched from Maven Central. Further dependencies (not available in Maven Central) are located in Kitodo/src/main/webapp/WEB-INF/lib.
-Two things that are not shipped are a Tomcat specific servlet API and an ElasticSearch server. First thing should come along with the Tomcat distribution you are building against. Second, you need to download by yourself from [ElasticSearch 5.1.1](https://www.elastic.co/downloads/past-releases/elasticsearch-5-1-1) and start before Maven build. On the Windows system ElasticSearch starts after open elasticsearch.bat file from bin folder. Additional information about running of ElasticSearch can be found [here](https://www.elastic.co/downloads/elasticsearch).
+Two things that are not shipped are a Tomcat specific servlet API and an ElasticSearch server. First thing should come along with the Tomcat distribution you are building against. Second, you need to download by yourself from [ElasticSearch 5.4.3](https://www.elastic.co/downloads/past-releases/elasticsearch-5-4-3) and start before Maven build. On the Windows system ElasticSearch starts after open elasticsearch.bat file from bin folder. Additional information about running of ElasticSearch can be found [here](https://www.elastic.co/downloads/elasticsearch).
 
 ### Vanilla build using Maven
 


### PR DESCRIPTION
Necessary version of ES is right now 5.4.3, as in version 5.3 were breaking changes.