### PR TITLE
Remove unneeded code in try-with-resources statements

### DIFF
--- a/Kitodo-Docket/src/main/java/org/kitodo/docket/Docket.java
+++ b/Kitodo-Docket/src/main/java/org/kitodo/docket/Docket.java
@@ -30,8 +30,6 @@ public class Docket implements DocketInterface {
 
         try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
             exportDocket.startExport(docketData, fileOutputStream, new File(xslFileUri));
-        } catch (IOException e) {
-            throw new IOException(e.getMessage());
         }
 
         return file;
@@ -45,8 +43,6 @@ public class Docket implements DocketInterface {
 
         try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
             exportDocket.startExport(docketData, fileOutputStream, new File(xslFileUri));
-        } catch (IOException e) {
-            throw new IOException(e.getMessage());
         }
 
         return file;


### PR DESCRIPTION
The try-with-resources statements do not need the catch block.

Signed-off-by: Stefan Weil <sw@weilnetz.de>