### PR TITLE
IT tests

### DIFF
--- a/Kitodo/src/test/java/de/sub/goobi/forms/BatchFormIT.java
+++ b/Kitodo/src/test/java/de/sub/goobi/forms/BatchFormIT.java
@@ -41,7 +41,7 @@ public class BatchFormIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Test

--- a/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
+++ b/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
@@ -39,7 +39,7 @@ public class ProjekteFormIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Ignore("this test executes some updates after class")

--- a/Kitodo/src/test/java/de/sub/goobi/forms/ProzessverwaltungFormIT.java
+++ b/Kitodo/src/test/java/de/sub/goobi/forms/ProzessverwaltungFormIT.java
@@ -38,7 +38,7 @@ public class ProzessverwaltungFormIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -200,7 +200,7 @@ public class MockDatabase {
         serviceManager.getBatchService().save(fourthBatch);
     }
 
-    private static void insertDockets() throws DataException {
+    public static void insertDockets() throws DataException {
         Docket firstDocket = new Docket();
         firstDocket.setTitle("default");
         firstDocket.setFile("docket.xsl");
@@ -476,7 +476,7 @@ public class MockDatabase {
         serviceManager.getProjectService().save(project);
     }
 
-    private static void insertRulesets() throws DataException {
+    public static void insertRulesets() throws DataException {
         Ruleset firstRuleset = new Ruleset();
         firstRuleset.setTitle("SLUBDD");
         firstRuleset.setFile("ruleset_slubdd.xml");

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -226,7 +226,7 @@ public class MockDatabase {
         serviceManager.getProcessService().save(firstProcess);
     }
 
-    private static void insertLdapGroups() throws DAOException {
+    public static void insertLdapGroups() throws DAOException {
         LdapGroup firstLdapGroup = new LdapGroup();
         firstLdapGroup.setTitle("LG");
         firstLdapGroup.setHomeDirectory("..//test_directory/");

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -115,6 +115,12 @@ public class MockDatabase {
         insertHistory();
     }
 
+    public static void insertUserGroupsFull() throws DAOException, DataException {
+        insertLdapGroups();
+        insertUsers();
+        insertUserGroups();
+    }
+
     private static class ExtendedNode extends Node {
         public ExtendedNode(Settings preparedSettings, Collection<Class<? extends Plugin>> classpathPlugins) {
             super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null), classpathPlugins);

--- a/Kitodo/src/test/java/org/kitodo/services/data/BatchServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/BatchServiceIT.java
@@ -48,7 +48,7 @@ public class BatchServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/DocketServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/DocketServiceIT.java
@@ -48,7 +48,7 @@ public class DocketServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/DocketServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/DocketServiceIT.java
@@ -37,7 +37,7 @@ public class DocketServiceIT {
     @BeforeClass
     public static void prepareDatabase() throws Exception {
         MockDatabase.startNode();
-        MockDatabase.insertProcessesFull();
+        MockDatabase.insertDockets();
     }
 
     @AfterClass

--- a/Kitodo/src/test/java/org/kitodo/services/data/FilterServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/FilterServiceIT.java
@@ -47,7 +47,7 @@ public class FilterServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/services/data/HistoryServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/HistoryServiceIT.java
@@ -50,7 +50,7 @@ public class HistoryServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/LdapGroupServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/LdapGroupServiceIT.java
@@ -26,13 +26,11 @@ public class LdapGroupServiceIT {
 
     @BeforeClass
     public static void prepareDatabase() throws Exception {
-        MockDatabase.startNode();
-        MockDatabase.insertProcessesFull();
+        MockDatabase.insertLdapGroups();
     }
 
     @AfterClass
     public static void cleanDatabase() throws Exception {
-        MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
     }
 

--- a/Kitodo/src/test/java/org/kitodo/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/ProcessServiceIT.java
@@ -62,7 +62,7 @@ public class ProcessServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
@@ -53,7 +53,7 @@ public class ProjectServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/PropertyServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/PropertyServiceIT.java
@@ -47,7 +47,7 @@ public class PropertyServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/RulesetServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/RulesetServiceIT.java
@@ -48,7 +48,7 @@ public class RulesetServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/RulesetServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/RulesetServiceIT.java
@@ -37,7 +37,7 @@ public class RulesetServiceIT {
     @BeforeClass
     public static void prepareDatabase() throws Exception {
         MockDatabase.startNode();
-        MockDatabase.insertProcessesFull();
+        MockDatabase.insertRulesets();
     }
 
     @AfterClass

--- a/Kitodo/src/test/java/org/kitodo/services/data/TaskServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/TaskServiceIT.java
@@ -47,7 +47,7 @@ public class TaskServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/TemplateServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/TemplateServiceIT.java
@@ -48,7 +48,7 @@ public class TemplateServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserGroupServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserGroupServiceIT.java
@@ -47,7 +47,7 @@ public class UserGroupServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserGroupServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserGroupServiceIT.java
@@ -36,7 +36,7 @@ public class UserGroupServiceIT {
     @BeforeClass
     public static void prepareDatabase() throws Exception {
         MockDatabase.startNode();
-        MockDatabase.insertProcessesFull();
+        MockDatabase.insertUserGroupsFull();
     }
 
     @AfterClass

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
@@ -51,7 +51,7 @@ public class UserServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/services/data/WorkpieceServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/WorkpieceServiceIT.java
@@ -47,7 +47,7 @@ public class WorkpieceServiceIT {
 
     @Before
     public void multipleInit() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(500);
     }
 
     @Rule

--- a/Kitodo/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/hibernate.cfg.xml
@@ -31,7 +31,7 @@
 
         <property name="hibernate.enable_lazy_load_no_trans">true</property>
 
-        <property name="show_sql">false</property>
+        <property name="show_sql">true</property>
 
         <property name="hbm2ddl.auto">create-drop</property>
 


### PR DESCRIPTION
- decrease sleep time in tests
- insert only dockets in DocketServiceIT
- insert only ldap groups and disable usage of ES node in LdapGroupServiceIT
- insert only rulesets in RulesetServiceIT
- insert only users and users' groups in UserGroupServiceIT
- re-enable SQL logging during tests to console

Depends on #989 and #990 