### PR TITLE
Save temporary files in temp folder

### DIFF
--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
@@ -212,7 +212,7 @@ public class ModsPlugin implements Plugin {
     /**
      * Path of the output file for the XSL transformation.
      */
-    private static final String TEMP_FILENAME = "tempMETSMODS.xml";
+    private static final String TEMP_FILENAME = "tempMETSMODS";
 
     /**
      * Filename of the XSL transformation file. This filename is being loaded
@@ -522,13 +522,15 @@ public class ModsPlugin implements Plugin {
 
                 MetsMods mm = new MetsMods(preferences);
 
-                xmlOutputter.output(metsDocument, new FileWriter(TEMP_FILENAME));
+                File tempFile = File.createTempFile(TEMP_FILENAME, ".xml");
 
-                mm.read(TEMP_FILENAME);
+                xmlOutputter.output(metsDocument, new FileWriter(tempFile.getAbsoluteFile()));
+
+                mm.read(tempFile.getAbsolutePath());
                 // reviewing the constructed DigitalDocument can be done via
                 // "System.out.println(mm.getDigitalDocument());"
 
-                deleteFile(TEMP_FILENAME);
+                deleteFile(tempFile.getAbsolutePath());
                 DigitalDocument dd = mm.getDigitalDocument();
                 ff = new XStream(preferences);
                 ff.setDigitalDocument(dd);
@@ -718,7 +720,7 @@ public class ModsPlugin implements Plugin {
         TransformerFactoryImpl impl = new TransformerFactoryImpl();
 
         try {
-	     File outputFile = File.createTempFile(outputXMLFilename, "xml");
+            File outputFile = File.createTempFile(outputXMLFilename, "xml");
 
             FileOutputStream outputStream = new FileOutputStream(outputFile);
 
@@ -735,7 +737,7 @@ public class ModsPlugin implements Plugin {
             xslfoTransformer.transform(saxSource, saxResult);
 
             Document resultDoc = builder.build(outputFile);
-            deleteFile(outputXMLFilename + ".xml");
+            deleteFile(outputFile.getAbsolutePath());
 
             return resultDoc;
 

--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
@@ -710,18 +710,15 @@ public class ModsPlugin implements Plugin {
 
         String xmlString = xmlOutputter.outputString(inputXML);
 
-        String inputXMLFilename = dmdSecCounter + "_original_SRW_MODS.xml";
-        String outputXMLFilename = dmdSecCounter + "_xslTransformedSRU.xml";
+        String outputXMLFilename = dmdSecCounter + "_xslTransformedSRU";
         dmdSecCounter++;
-
-        File outputFile = new File(outputXMLFilename);
 
         StreamSource transformSource = new StreamSource(stylesheetfile);
 
         TransformerFactoryImpl impl = new TransformerFactoryImpl();
 
         try {
-            xmlOutputter.output(inputXML, new FileWriter(inputXMLFilename));
+	     File outputFile = File.createTempFile(outputXMLFilename, "xml");
 
             FileOutputStream outputStream = new FileOutputStream(outputFile);
 
@@ -738,9 +735,7 @@ public class ModsPlugin implements Plugin {
             xslfoTransformer.transform(saxSource, saxResult);
 
             Document resultDoc = builder.build(outputFile);
-
-            deleteFile(inputXMLFilename);
-            deleteFile(outputXMLFilename);
+            deleteFile(outputXMLFilename + ".xml");
 
             return resultDoc;
 


### PR DESCRIPTION
The ModsPlugin saves several temporary files used for XML transformation. These files were previously saved in locations where the tomcat user might not have had write access to in some setups. With the changes in these commits, the temporary files are now saved to temporary folders on the individual operating systems. 

This solves issue https://github.com/kitodo/kitodo-production/issues/1000