### PR TITLE
Fix log4j2 usage

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
-            <version>2.6.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.portlet</groupId>

--- a/Kitodo-Docket/pom.xml
+++ b/Kitodo-Docket/pom.xml
@@ -53,9 +53,9 @@
             <version>9.0.0.4</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>jaxen</groupId>

--- a/Kitodo-Docket/src/main/resources/log4j2.xml
+++ b/Kitodo-Docket/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+<Configuration monitorInterval="60">
+    <Properties>
+        <Property name="filename">/usr/local/kitodo/logs</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
+        </Console>
+        <File name="LOGFILE" fileName="${filename}/kitodo.log">
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.kitodo" level="error">
+            <AppenderRef ref="LOGFILE" level="error" />
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="LOGFILE"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/Kitodo-Docket/src/test/resources/log4j2.xml
+++ b/Kitodo-Docket/src/test/resources/log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+<Configuration monitorInterval="60">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/Kitodo-FileManagement/pom.xml
+++ b/Kitodo-FileManagement/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.6.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>

--- a/Kitodo-PersistentIdentifier/pom.xml
+++ b/Kitodo-PersistentIdentifier/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.6.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -320,13 +320,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.6.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <!-- needed for logging in web context -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-web</artifactId>
-            <version>2.6.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -271,6 +271,12 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <version>1.8.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!--https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java-->

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -322,6 +322,12 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.6.2</version>
         </dependency>
+        <!-- needed for logging in web context -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-web</artifactId>
+            <version>2.6.2</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>

--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -349,4 +349,34 @@
         <servlet-name>Kitodo REST Service based on Jersey</servlet-name>
         <url-pattern>/rest/*</url-pattern>
     </servlet-mapping>
+
+    <!-- log4j2 for servlet 2.5 based web applications -->
+    <!-- taken from https://logging.apache.org/log4j/2.0/manual/webapp.html#Servlet-2.5 -->
+    <!-- this must be adjusted if applicaton servlet version is raised to 3.0 -->
+    <listener>
+        <listener-class>org.apache.logging.log4j.web.Log4jServletContextListener</listener-class>
+    </listener>
+
+    <filter>
+        <filter-name>log4jServletFilter</filter-name>
+        <filter-class>org.apache.logging.log4j.web.Log4jServletFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>log4jServletFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+        <dispatcher>FORWARD</dispatcher>
+        <dispatcher>INCLUDE</dispatcher>
+        <dispatcher>ERROR</dispatcher>
+        <dispatcher>ASYNC</dispatcher> <!-- Servlet 3.0 w/ disabled auto-initialization only; not supported in 2.5 -->
+    </filter-mapping>
+
+    <!-- configuration file to use -->
+    <context-param>
+        <param-name>log4jConfiguration</param-name>
+        <param-value>WEB-INF/classes/log4j2.xml</param-value>
+    </context-param>
+    <!-- end of log4j2 -->
+
 </web-app>

--- a/OpacPica-Plugin/pom.xml
+++ b/OpacPica-Plugin/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.6.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <maxAllowedViolations>1</maxAllowedViolations>
         <tomcat.baseversion>7</tomcat.baseversion>
         <tomcat.version>7.0.81</tomcat.version>
+        <log4j.version>2.6.2</log4j.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Currently log4j2 is configured but could not be used as a package was missing. Other changes are clean up commits for usage of only one logging framework.