### PR TITLE
Change used scope of 2 packages to test as only used in tests

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -296,6 +296,7 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-email</artifactId>
             <version>1.5</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -559,6 +560,7 @@
             <groupId>org.xeustechnologies</groupId>
             <artifactId>jtar</artifactId>
             <version>1.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Artefacts `commons-email` and `jtar` are only used in tests. It is not necessary to deliver this libraries with the WAR package.