### PR TITLE
Prevent thread leakage

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <phase.prop>install</phase.prop>
-        <maxAllowedViolations>87</maxAllowedViolations>
+        <maxAllowedViolations>40</maxAllowedViolations>
     </properties>
 
     <dependencies>

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
@@ -47,6 +47,20 @@ public abstract class KitodoRestClient implements RestClientInterface {
     }
 
     /**
+     * Create REST client.
+     *
+     * @param host
+     *            default host is localhost
+     * @param port
+     *            default port ist 9200
+     * @param protocol
+     *            default protocol is http
+     */
+    private void initiateClient(String host, Integer port, String protocol) {
+        restClient = RestClient.builder(new HttpHost(host, port, protocol)).build();
+    }
+
+    /**
      * Get information about client server.
      *
      * @return information about the server
@@ -108,20 +122,6 @@ public abstract class KitodoRestClient implements RestClientInterface {
      */
     public void closeClient() throws IOException {
         restClient.close();
-    }
-
-    /**
-     * Create REST client.
-     *
-     * @param host
-     *            default host is localhost
-     * @param port
-     *            default port ist 9200
-     * @param protocol
-     *            default protocol is http
-     */
-    private void initiateClient(String host, Integer port, String protocol) {
-        restClient = RestClient.builder(new HttpHost(host, port, protocol)).build();
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
@@ -16,12 +16,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
-import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Response;
@@ -36,6 +36,18 @@ import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
 public class IndexRestClient extends KitodoRestClient {
 
     private static final Logger logger = LogManager.getLogger(IndexRestClient.class);
+
+    private static IndexRestClient instance = null;
+
+    private IndexRestClient() {}
+
+    public static IndexRestClient getInstance() {
+        if (Objects.equals(instance, null)) {
+            instance = new IndexRestClient();
+            instance.initiateClient();
+        }
+        return instance;
+    }
 
     /**
      * Add document to the index. This method will be used for add or update of

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
@@ -37,6 +37,9 @@ public class IndexRestClient extends KitodoRestClient {
 
     private static final Logger logger = LogManager.getLogger(IndexRestClient.class);
 
+    /**
+     * IndexRestClient singleton.
+     */
     private static IndexRestClient instance = null;
 
     private IndexRestClient() {}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
@@ -48,8 +48,12 @@ public class IndexRestClient extends KitodoRestClient {
      */
     public static IndexRestClient getInstance() {
         if (Objects.equals(instance, null)) {
-            instance = new IndexRestClient();
-            instance.initiateClient();
+            synchronized (IndexRestClient.class) {
+                if (Objects.equals(instance, null)) {
+                    instance = new IndexRestClient();
+                    instance.initiateClient();
+                }
+            }
         }
         return instance;
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
@@ -41,6 +41,11 @@ public class IndexRestClient extends KitodoRestClient {
 
     private IndexRestClient() {}
 
+    /**
+     * Return singleton variable of type IndexRestClient.
+     *
+     * @return unique instance of IndexRestClient
+     */
     public static IndexRestClient getInstance() {
         if (Objects.equals(instance, null)) {
             instance = new IndexRestClient();

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/Indexer.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/Indexer.java
@@ -76,8 +76,6 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
             response = "Incorrect HTTP method!";
         }
 
-        restClient.closeClient();
-
         return response;
     }
 
@@ -96,8 +94,6 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
         } else {
             response = "Incorrect HTTP method!";
         }
-
-        restClient.closeClient();
 
         return response;
     }
@@ -121,8 +117,6 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
         } else {
             response = "Incorrect HTTP method!";
         }
-
-        restClient.closeClient();
 
         return response;
     }
@@ -165,7 +159,6 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
         String serverInformation = null;
         try {
             serverInformation = restClient.getServerInformation();
-            restClient.closeClient();
         } catch (IOException e) {
             logger.error(e.getMessage());
         }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/Indexer.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/Indexer.java
@@ -128,8 +128,7 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
     }
 
     private IndexRestClient initiateRestClient() {
-        IndexRestClient restClient = new IndexRestClient();
-        restClient.initiateClient();
+        IndexRestClient restClient = IndexRestClient.getInstance();
         restClient.setIndex(index);
         restClient.setType(type);
         return restClient;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -35,6 +35,9 @@ public class SearchRestClient extends KitodoRestClient {
 
     private static final Logger logger = LogManager.getLogger(SearchRestClient.class);
 
+    /**
+     * SearchRestClient singleton.
+     */
     private static SearchRestClient instance = null;
 
     private SearchRestClient() {}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -46,8 +46,12 @@ public class SearchRestClient extends KitodoRestClient {
      */
     public static SearchRestClient getInstance() {
         if (Objects.equals(instance, null)) {
-            instance = new SearchRestClient();
-            instance.initiateClient();
+            synchronized (SearchRestClient.class){
+                if (Objects.equals(instance, null)) {
+                    instance = new SearchRestClient();
+                    instance.initiateClient();
+                }
+            }
         }
         return instance;
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
@@ -33,6 +34,18 @@ import org.kitodo.data.exceptions.DataException;
 public class SearchRestClient extends KitodoRestClient {
 
     private static final Logger logger = LogManager.getLogger(SearchRestClient.class);
+
+    private static SearchRestClient instance = null;
+
+    private SearchRestClient() {}
+
+    public static SearchRestClient getInstance() {
+        if (Objects.equals(instance, null)) {
+            instance = new SearchRestClient();
+            instance.initiateClient();
+        }
+        return instance;
+    }
 
     /**
      * Count amount of documents responding to given query.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -46,7 +46,7 @@ public class SearchRestClient extends KitodoRestClient {
      */
     public static SearchRestClient getInstance() {
         if (Objects.equals(instance, null)) {
-            synchronized (SearchRestClient.class){
+            synchronized (SearchRestClient.class) {
                 if (Objects.equals(instance, null)) {
                     instance = new SearchRestClient();
                     instance.initiateClient();

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -39,6 +39,11 @@ public class SearchRestClient extends KitodoRestClient {
 
     private SearchRestClient() {}
 
+    /**
+     * Return singleton variable of type SearchRestClient.
+     *
+     * @return unique instance of SearchRestClient
+     */
     public static SearchRestClient getInstance() {
         if (Objects.equals(instance, null)) {
             instance = new SearchRestClient();

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
@@ -248,8 +248,7 @@ public class Searcher extends Index {
     }
 
     private SearchRestClient initiateRestClient() {
-        SearchRestClient restClient = new SearchRestClient();
-        restClient.initiateClient();
+        SearchRestClient restClient = SearchRestClient.getInstance();
         restClient.setIndex(index);
         restClient.setType(type);
         return restClient;

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/IndexRestClientIT.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/IndexRestClientIT.java
@@ -114,8 +114,7 @@ public class IndexRestClientIT {
     }
 
     private static IndexRestClient initializeRestClient() {
-        IndexRestClient restClient = new IndexRestClient();
-        restClient.initiateClient();
+        IndexRestClient restClient = IndexRestClient.getInstance();
         restClient.setIndex(testIndexName);
         restClient.setType("indexer");
         return restClient;

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearchRestClientIT.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearchRestClientIT.java
@@ -115,16 +115,14 @@ public class SearchRestClientIT {
     }
 
     private static SearchRestClient initializeSearchRestClient() {
-        SearchRestClient restClient = new SearchRestClient();
-        restClient.initiateClient();
+        SearchRestClient restClient = SearchRestClient.getInstance();
         restClient.setIndex(testIndexName);
         restClient.setType("testsearchclient");
         return restClient;
     }
 
     private static IndexRestClient initializeIndexRestClient() {
-        IndexRestClient restClient = new IndexRestClient();
-        restClient.initiateClient();
+        IndexRestClient restClient = IndexRestClient.getInstance();
         restClient.setIndex(testIndexName);
         restClient.setType("testsearchclient");
         return restClient;

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearcherIT.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/search/SearcherIT.java
@@ -257,8 +257,7 @@ public class SearcherIT {
     }
 
     private static IndexRestClient initializeIndexRestClient() {
-        IndexRestClient restClient = new IndexRestClient();
-        restClient.initiateClient();
+        IndexRestClient restClient = IndexRestClient.getInstance();
         restClient.setIndex(testIndexName);
         restClient.setType("testsearch");
         return restClient;

--- a/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
@@ -722,84 +722,108 @@ public class IndexingForm {
      * Starts the process of indexing batches to the ElasticSearch index.
      */
     public void startBatchIndexing() {
-        startIndexing(ObjectType.BATCH, batchWorker);
+        if (getBatchCount() > 0) {
+            startIndexing(ObjectType.BATCH, batchWorker);
+        }
     }
 
     /**
      * Starts the process of indexing dockets to the ElasticSearch index.
      */
     public void startDocketIndexing() {
-        startIndexing(ObjectType.DOCKET, docketWorker);
+        if (getDocketCount() > 0) {
+            startIndexing(ObjectType.DOCKET, docketWorker);
+        }
     }
 
     /**
      * Starts the process of indexing processes to the ElasticSearch index.
      */
     public void startProcessIndexing() {
-        startIndexing(ObjectType.PROCESS, processWorker);
+        if (getProcessCount() > 0) {
+            startIndexing(ObjectType.PROCESS, processWorker);
+        }
     }
 
     /**
      * Starts the process of indexing projects to the ElasticSearch index.
      */
     public void startProjectIndexing() {
-        startIndexing(ObjectType.PROJECT, projectWorker);
+        if (getProjectCount() > 0) {
+            startIndexing(ObjectType.PROJECT, projectWorker);
+        }
     }
 
     /**
      * Starts the process of indexing properties to the ElasticSearch index.
      */
     public void startPropertyIndexing() {
-        startIndexing(ObjectType.PROPERTY, propertyWorker);
+        if (getPropertyCount() > 0) {
+            startIndexing(ObjectType.PROPERTY, propertyWorker);
+        }
     }
 
     /**
      * Starts the process of indexing rulesets to the ElasticSearch index.
      */
     public void startRulesetIndexing() {
-        startIndexing(ObjectType.RULESET, rulesetWorker);
+        if (getRulesetCount() > 0) {
+            startIndexing(ObjectType.RULESET, rulesetWorker);
+        }
     }
 
     /**
      * Starts the process of indexing tasks to the ElasticSearch index.
      */
     public void startTaskIndexing() {
-        startIndexing(ObjectType.TASK, taskWorker);
+        if (getTaskCount() > 0) {
+            startIndexing(ObjectType.TASK, taskWorker);
+        }
     }
 
     /**
      * Starts the process of indexing templates to the ElasticSearch index.
      */
     public void startTemplateIndexing() {
-        startIndexing(ObjectType.TEMPLATE, templateWorker);
+        if (getTemplateCount() > 0) {
+            startIndexing(ObjectType.TEMPLATE, templateWorker);
+        }
     }
 
     /**
      * Starts the process of indexing users to the ElasticSearch index.
      */
     public void startUserIndexing() {
-        startIndexing(ObjectType.USER, userWorker);
+        if (getUserCount() > 0) {
+            startIndexing(ObjectType.USER, userWorker);
+        }
     }
 
     /**
      * Starts the process of indexing user groups to the ElasticSearch index.
      */
     public void startUserGroupIndexing() {
-        startIndexing(ObjectType.USERGROUP, usergroupWorker);
+        if (getUserGroupCount() > 0) {
+            startIndexing(ObjectType.USERGROUP, usergroupWorker);
+        }
     }
 
     /**
      * Starts the process of indexing workpieces to the ElasticSearch index.
      */
     public void startWorkpieceIndexing() {
-        startIndexing(ObjectType.WORKPIECE, workpieceWorker);
+        if (getWorkpieceCount() > 0) {
+            startIndexing(ObjectType.WORKPIECE, workpieceWorker);
+        }
     }
 
     /**
      * Starts the process of indexing filters to the ElasticSearch index.
      */
     public void startFilterIndexing() {
-        startIndexing(ObjectType.FILTER, filterWorker);
+        if (getFilterCount() > 0) {
+            startIndexing(ObjectType.FILTER, filterWorker);
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
@@ -47,7 +47,7 @@ import org.omnifaces.cdi.PushContext;
 @ApplicationScoped
 public class IndexingForm {
 
-    private static IndexRestClient indexRestClient = new IndexRestClient();
+    private static IndexRestClient indexRestClient = IndexRestClient.getInstance();
     private static final String MAPPING_STARTED_MESSAGE = "mapping_started";
     private static final String MAPPING_FINISHED_MESSAGE = "mapping_finished";
     private static final String MAPPING_FAILED_MESSAGE = "mapping_failed";
@@ -197,7 +197,6 @@ public class IndexingForm {
             objectIndexingStates.put(objectType, indexingStates.NO_STATE);
         }
 
-        indexRestClient.initiateClient();
         indexRestClient.setIndex(ConfigMain.getParameter("elasticsearch.index", "kitodo"));
     }
 

--- a/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
@@ -109,7 +109,7 @@ public class IndexingForm {
 
     private boolean indexingAll = false;
 
-    private enum indexStates {
+    private enum IndexStates {
         NO_STATE,
         DELETE_ERROR,
         DELETE_SUCCESS,
@@ -117,18 +117,18 @@ public class IndexingForm {
         MAPPING_SUCCESS,
     }
 
-    private enum indexingStates {
+    private enum IndexingStates {
         NO_STATE,
         INDEXING_STARTED,
         INDEXING_SUCCESSFUL,
         INDEXING_FAILED,
     }
 
-    private indexStates currentState = indexStates.NO_STATE;
+    private IndexStates currentState = IndexStates.NO_STATE;
 
     private Map<ObjectType, LocalDateTime> lastIndexed = new EnumMap<>(ObjectType.class);
 
-    private Map<ObjectType, indexingStates> objectIndexingStates = new EnumMap<>(ObjectType.class);
+    private Map<ObjectType, IndexingStates> objectIndexingStates = new EnumMap<>(ObjectType.class);
 
     private LocalDateTime indexingStartedTime;
 
@@ -194,7 +194,7 @@ public class IndexingForm {
         }
 
         for (ObjectType objectType : ObjectType.values()) {
-            objectIndexingStates.put(objectType, indexingStates.NO_STATE);
+            objectIndexingStates.put(objectType, IndexingStates.NO_STATE);
         }
 
         indexRestClient.setIndex(ConfigMain.getParameter("elasticsearch.index", "kitodo"));
@@ -692,14 +692,14 @@ public class IndexingForm {
     }
 
     private void startIndexing(ObjectType type, IndexWorker worker) {
-        currentState = indexStates.NO_STATE;
+        currentState = IndexStates.NO_STATE;
         int attempts = 0;
         while (attempts < 10) {
             try {
                 if (Objects.equals(currentIndexState, ObjectType.NONE)) {
                     indexingStartedTime = LocalDateTime.now();
                     currentIndexState = type;
-                    objectIndexingStates.put(type, indexingStates.INDEXING_STARTED);
+                    objectIndexingStates.put(type, IndexingStates.INDEXING_STARTED);
                     pollingChannel.send(INDEXING_STARTED_MESSAGE + currentIndexState);
                     indexerThread = new Thread((worker));
                     indexerThread.setDaemon(true);
@@ -870,18 +870,18 @@ public class IndexingForm {
             String mappingStateMessage;
             if (readMapping().equals("")) {
                 if (indexRestClient.createIndex()) {
-                    currentState = indexStates.MAPPING_SUCCESS;
+                    currentState = IndexStates.MAPPING_SUCCESS;
                     mappingStateMessage = MAPPING_FINISHED_MESSAGE;
                 } else {
-                    currentState = indexStates.MAPPING_ERROR;
+                    currentState = IndexStates.MAPPING_ERROR;
                     mappingStateMessage = MAPPING_FAILED_MESSAGE;
                 }
             } else {
                 if (indexRestClient.createIndex(readMapping())) {
-                    currentState = indexStates.MAPPING_SUCCESS;
+                    currentState = IndexStates.MAPPING_SUCCESS;
                     mappingStateMessage = MAPPING_FINISHED_MESSAGE;
                 } else {
-                    currentState = indexStates.MAPPING_ERROR;
+                    currentState = IndexStates.MAPPING_ERROR;
                     mappingStateMessage = MAPPING_FAILED_MESSAGE;
                 }
             }
@@ -889,7 +889,7 @@ public class IndexingForm {
                 pollingChannel.send(mappingStateMessage);
             }
         } catch (CustomResponseException | IOException | ParseException e) {
-            currentState = indexStates.MAPPING_ERROR;
+            currentState = IndexStates.MAPPING_ERROR;
             if (updatePollingChannel) {
                 pollingChannel.send(MAPPING_FAILED_MESSAGE);
             }
@@ -908,11 +908,11 @@ public class IndexingForm {
         try {
             indexRestClient.deleteIndex();
             resetGlobalProgress();
-            currentState = indexStates.DELETE_SUCCESS;
+            currentState = IndexStates.DELETE_SUCCESS;
             updateMessage = DELETION_FINISHED_MESSAGE;
         } catch (IOException e) {
             logger.error(e.getMessage());
-            currentState = indexStates.DELETE_ERROR;
+            currentState = IndexStates.DELETE_ERROR;
             updateMessage = DELETION_FAILED_MESSAGE;
         }
         if (updatePollingChannel) {
@@ -952,9 +952,9 @@ public class IndexingForm {
                 lastIndexed.put(currentIndexState, LocalDateTime.now());
                 currentIndexState = ObjectType.NONE;
                 if (numberOfObjects == 0) {
-                    objectIndexingStates.put(currentType, indexingStates.NO_STATE);
+                    objectIndexingStates.put(currentType, IndexingStates.NO_STATE);
                 } else {
-                    objectIndexingStates.put(currentType, indexingStates.INDEXING_SUCCESSFUL);
+                    objectIndexingStates.put(currentType, IndexingStates.INDEXING_SUCCESSFUL);
                 }
                 indexerThread.interrupt();
                 pollingChannel.send(INDEXING_FINISHED_MESSAGE + currentType + "!");
@@ -1012,7 +1012,7 @@ public class IndexingForm {
      *
      * @return state of ES index
      */
-    public indexStates getIndexState() {
+    public IndexStates getIndexState() {
         return currentState;
     }
 
@@ -1020,9 +1020,9 @@ public class IndexingForm {
      *
      * @param objectType
      *
-     * @return indexing state of the given object type
+     * @return indexing state of the given object type.
      */
-    public indexingStates getObjectIndexState(ObjectType objectType) {
+    public IndexingStates getObjectIndexState(ObjectType objectType) {
         return objectIndexingStates.get(objectType);
     }
 
@@ -1031,8 +1031,8 @@ public class IndexingForm {
      *
      * @return 'indexing failed' state variable
      */
-    public indexingStates getIndexingFailedState() {
-        return indexingStates.INDEXING_FAILED;
+    public IndexingStates getIndexingFailedState() {
+        return IndexingStates.INDEXING_FAILED;
     }
 
     /**
@@ -1040,8 +1040,8 @@ public class IndexingForm {
      *
      * @return 'indexing successful' state variable
      */
-    public indexingStates getIndexingSuccessfulState() {
-        return indexingStates.INDEXING_SUCCESSFUL;
+    public IndexingStates getIndexingSuccessfulState() {
+        return IndexingStates.INDEXING_SUCCESSFUL;
     }
 
     /**
@@ -1049,8 +1049,8 @@ public class IndexingForm {
      *
      * @return 'indexing started' state variable
      */
-    public indexingStates getIndexingStartedState() {
-        return indexingStates.INDEXING_STARTED;
+    public IndexingStates getIndexingStartedState() {
+        return IndexingStates.INDEXING_STARTED;
     }
 
     /**
@@ -1061,16 +1061,16 @@ public class IndexingForm {
      *
      * @return static variable for global indexing state
      */
-    public indexingStates getAllObjectsIndexingState() {
+    public IndexingStates getAllObjectsIndexingState() {
         for (ObjectType objectType : ObjectType.values()) {
-            if (Objects.equals(objectIndexingStates.get(objectType), indexingStates.INDEXING_FAILED)) {
-                return indexingStates.INDEXING_FAILED;
+            if (Objects.equals(objectIndexingStates.get(objectType), IndexingStates.INDEXING_FAILED)) {
+                return IndexingStates.INDEXING_FAILED;
             }
-            if (Objects.equals(objectIndexingStates.get(objectType), indexingStates.NO_STATE)) {
-                return indexingStates.NO_STATE;
+            if (Objects.equals(objectIndexingStates.get(objectType), IndexingStates.NO_STATE)) {
+                return IndexingStates.NO_STATE;
             }
         }
-        return indexingStates.INDEXING_SUCCESSFUL;
+        return IndexingStates.INDEXING_SUCCESSFUL;
     }
 
 }

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -170,8 +170,7 @@ public class MockDatabase {
     }
 
     private static IndexRestClient initializeIndexRestClient() {
-        IndexRestClient restClient = new IndexRestClient();
-        restClient.initiateClient();
+        IndexRestClient restClient = IndexRestClient.getInstance();
         restClient.setIndex(testIndexName);
         return restClient;
     }


### PR DESCRIPTION
Reuse unique instances of SearchRestClient and IndexRestClient to solve the problem of leaking threads.