### PR TITLE
Fix indenting settings for Kitodo-Java Formatter

### DIFF
--- a/config/Kitodo-IDE-formatting-Eclipse.xml
+++ b/config/Kitodo-IDE-formatting-Eclipse.xml
@@ -158,7 +158,7 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments"
                  value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="20"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
         <setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
         <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
@@ -170,7 +170,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="18"/>
         <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
         <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>


### PR DESCRIPTION
Indenting settings do not correspond with checkstyle’s expectations. This is a fix.

Checkstyle errors to fix:

Das Unterelement von 'array initialization' hat eine unerwartete Einrückungstiefe von [2 Ebenen]. Erwartet wird eine der folgenden Einrückungstiefen: [1 Ebene], [auf Höhe mit der geschweiften Klammer], [auf Höhe mit der geschweiften Klammer + 1 Ebene].

Auswahl auf “auf Höhe mit der geschweiften Klammer” gesetzt.

'lambda arguments' hat eine unerwartete Einrückungstiefe von [2 Ebenen] (erwartet: [1 Ebene]).

Auswahl auf “1 Ebene” gesetzt.
