### PR TITLE
Use maven property to set log4j-core version

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.6.2</version>
+            <version>${log4j.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Missed a location of log4j in #1057 - this pull request should fix this.