### PR TITLE
Lazy data tables

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/BasisForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BasisForm.java
@@ -13,6 +13,7 @@ package de.sub.goobi.forms;
 
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
+import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.Serializable;
 import java.util.List;
@@ -31,6 +32,16 @@ public class BasisForm implements Serializable {
     protected String filter = "";
     protected User user;
     protected String sortierung = "prozessAsc";
+
+    private LazyDTOModel lazyDTOModel = null;
+
+    public LazyDTOModel getLazyDTOModel() {
+        return lazyDTOModel;
+    }
+
+    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
+        this.lazyDTOModel = lazyDTOModel;
+    }
 
     public Page getPage() {
         return this.page;

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BasisForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BasisForm.java
@@ -35,10 +35,21 @@ public class BasisForm implements Serializable {
 
     private LazyDTOModel lazyDTOModel = null;
 
+    /**
+     * Getter: return lazyDTOModel.
+     *
+     * @return LazyDTOModel
+     */
     public LazyDTOModel getLazyDTOModel() {
         return lazyDTOModel;
     }
 
+    /**
+     * Setter: set lazyDTOModel.
+     *
+     * @param lazyDTOModel
+     *            LazyDTOModel to set for this class
+     */
     public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
         this.lazyDTOModel = lazyDTOModel;
     }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BasisForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BasisForm.java
@@ -13,7 +13,6 @@ package de.sub.goobi.forms;
 
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
-import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.Serializable;
 import java.util.List;
@@ -21,6 +20,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.data.database.beans.User;
+import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 
 public class BasisForm implements Serializable {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -41,6 +41,10 @@ public class BenutzergruppenForm extends BasisForm {
     private transient ServiceManager serviceManager = new ServiceManager();
     private int userGroupId;
 
+    /**
+     * Empty default constructor that also sets the LazyDTOModel instance of this
+     * bean.
+     */
     public BenutzergruppenForm() {
         super();
         super.setLazyDTOModel(new LazyDTOModel(serviceManager.getUserGroupService()));
@@ -51,7 +55,7 @@ public class BenutzergruppenForm extends BasisForm {
      *
      * @return page address
      */
-    public String Neu() {
+    public String newUserGroup() {
         this.myBenutzergruppe = new UserGroup();
         this.userGroupId = 0;
         return "/pages/BenutzergruppenBearbeiten?faces-redirect=true";
@@ -62,7 +66,7 @@ public class BenutzergruppenForm extends BasisForm {
      *
      * @return page or empty String
      */
-    public String Speichern() {
+    public String save() {
         try {
             this.serviceManager.getUserGroupService().save(this.myBenutzergruppe);
             return filterKein();
@@ -77,7 +81,7 @@ public class BenutzergruppenForm extends BasisForm {
      *
      * @return page or empty String
      */
-    public String Loeschen() {
+    public String delete() {
         try {
             this.serviceManager.getUserGroupService().refresh(this.myBenutzergruppe);
             if (this.myBenutzergruppe.getUsers().size() > 0) {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -13,7 +13,6 @@ package de.sub.goobi.forms;
 
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
-import de.sub.goobi.model.LazyDTOModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +29,7 @@ import org.kitodo.data.database.beans.UserGroup;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.dto.UserGroupDTO;
+import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 
 @Named("BenutzergruppenForm")

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -41,14 +41,9 @@ public class BenutzergruppenForm extends BasisForm {
     private transient ServiceManager serviceManager = new ServiceManager();
     private int userGroupId;
 
-    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserGroupService());
-
-    public LazyDTOModel getLazyDTOModel() {
-        return lazyDTOModel;
-    }
-
-    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
-        this.lazyDTOModel = lazyDTOModel;
+    public BenutzergruppenForm() {
+        super();
+        super.setLazyDTOModel(new LazyDTOModel(serviceManager.getUserGroupService()));
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzergruppenForm.java
@@ -13,9 +13,9 @@ package de.sub.goobi.forms;
 
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
+import de.sub.goobi.model.LazyDTOModel;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,6 +40,16 @@ public class BenutzergruppenForm extends BasisForm {
     private UserGroup myBenutzergruppe = new UserGroup();
     private transient ServiceManager serviceManager = new ServiceManager();
     private int userGroupId;
+
+    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserGroupService());
+
+    public LazyDTOModel getLazyDTOModel() {
+        return lazyDTOModel;
+    }
+
+    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
+        this.lazyDTOModel = lazyDTOModel;
+    }
 
     /**
      * Create new user group.

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -61,6 +61,10 @@ public class BenutzerverwaltungForm extends BasisForm {
     private static final Logger logger = LogManager.getLogger(BenutzerverwaltungForm.class);
     private int userId;
 
+    /**
+     * Empty default constructor that also sets the LazyDTOModel instance of this
+     * bean.
+     */
     public BenutzerverwaltungForm() {
         super();
         super.setLazyDTOModel(new LazyDTOModel(serviceManager.getUserService()));

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -15,7 +15,6 @@ import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
 import de.sub.goobi.helper.ldap.Ldap;
-import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -49,6 +48,7 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.dto.ProjectDTO;
 import org.kitodo.dto.UserDTO;
 import org.kitodo.dto.UserGroupDTO;
+import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 
 @Named("BenutzerverwaltungForm")

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -15,6 +15,7 @@ import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
 import de.sub.goobi.helper.ldap.Ldap;
+import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -59,6 +60,16 @@ public class BenutzerverwaltungForm extends BasisForm {
     private transient ServiceManager serviceManager = new ServiceManager();
     private static final Logger logger = LogManager.getLogger(BenutzerverwaltungForm.class);
     private int userId;
+
+    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserService());
+
+    public LazyDTOModel getLazyDTOModel() {
+        return this.lazyDTOModel;
+    }
+
+    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
+        this.lazyDTOModel = lazyDTOModel;
+    }
 
     /**
      * New user.

--- a/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BenutzerverwaltungForm.java
@@ -61,14 +61,9 @@ public class BenutzerverwaltungForm extends BasisForm {
     private static final Logger logger = LogManager.getLogger(BenutzerverwaltungForm.class);
     private int userId;
 
-    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserService());
-
-    public LazyDTOModel getLazyDTOModel() {
-        return this.lazyDTOModel;
-    }
-
-    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
-        this.lazyDTOModel = lazyDTOModel;
+    public BenutzerverwaltungForm() {
+        super();
+        super.setLazyDTOModel(new LazyDTOModel(serviceManager.getUserService()));
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -43,6 +43,10 @@ public class DocketForm extends BasisForm {
     private static final Logger logger = LogManager.getLogger(DocketForm.class);
     private int docketId;
 
+    /**
+     * Empty default constructor that also sets the LazyDTOModel instance of this
+     * bean.
+     */
     public DocketForm() {
         super();
         super.setLazyDTOModel(new LazyDTOModel(serviceManager.getDocketService()));
@@ -53,7 +57,7 @@ public class DocketForm extends BasisForm {
      *
      * @return the navigation String
      */
-    public String Neu() {
+    public String newDocket() {
         this.myDocket = new Docket();
         this.docketId = 0;
         return "/pages/DocketEdit?faces-redirect=true";

--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -14,7 +14,6 @@ package de.sub.goobi.forms;
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
-import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,6 +30,7 @@ import org.kitodo.data.database.beans.Docket;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.dto.DocketDTO;
+import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.data.ProcessService;
 

--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -14,6 +14,7 @@ package de.sub.goobi.forms;
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
+import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -42,9 +43,19 @@ public class DocketForm extends BasisForm {
     private static final Logger logger = LogManager.getLogger(DocketForm.class);
     private int docketId;
 
+    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getDocketService());
+
+    public LazyDTOModel getLazyDTOModel() {
+        return this.lazyDTOModel;
+    }
+
+    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
+        this.lazyDTOModel = lazyDTOModel;
+    }
+
     /**
      * Creates a new Docket.
-     * 
+     *
      * @return the navigation String
      */
     public String Neu() {

--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -43,14 +43,9 @@ public class DocketForm extends BasisForm {
     private static final Logger logger = LogManager.getLogger(DocketForm.class);
     private int docketId;
 
-    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getDocketService());
-
-    public LazyDTOModel getLazyDTOModel() {
-        return this.lazyDTOModel;
-    }
-
-    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
-        this.lazyDTOModel = lazyDTOModel;
+    public DocketForm() {
+        super();
+        super.setLazyDTOModel(new LazyDTOModel(serviceManager.getDocketService()));
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -91,6 +91,10 @@ public class ProjekteForm extends BasisForm {
 
     private int itemId;
 
+    /**
+     * Empty default constructor that also sets the LazyDTOModel instance of this
+     * bean.
+     */
     public ProjekteForm() {
         super();
         super.setLazyDTOModel(new LazyDTOModel(serviceManager.getProjectService()));
@@ -183,7 +187,7 @@ public class ProjekteForm extends BasisForm {
     }
 
     /**
-     * Saves current project if title is not empty
+     * Saves current project if title is not empty.
      *
      * @return String
      */

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -91,18 +91,9 @@ public class ProjekteForm extends BasisForm {
 
     private int itemId;
 
-    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getProjectService());
-
-    public LazyDTOModel getLazyDTOModel() {
-        return lazyDTOModel;
-    }
-
-    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
-        this.lazyDTOModel = lazyDTOModel;
-    }
-
     public ProjekteForm() {
         super();
+        super.setLazyDTOModel(new LazyDTOModel(serviceManager.getProjectService()));
     }
 
     // making sure its cleaned up

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -16,6 +16,7 @@ import de.intranda.commons.chart.results.ChartDraw.ChartType;
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
+import de.sub.goobi.model.LazyDTOModel;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -89,6 +90,16 @@ public class ProjekteForm extends BasisForm {
     private boolean showStatistics;
 
     private int itemId;
+
+    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getProjectService());
+
+    public LazyDTOModel getLazyDTOModel() {
+        return lazyDTOModel;
+    }
+
+    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
+        this.lazyDTOModel = lazyDTOModel;
+    }
 
     public ProjekteForm() {
         super();

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -16,7 +16,6 @@ import de.intranda.commons.chart.results.ChartDraw.ChartType;
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
-import de.sub.goobi.model.LazyDTOModel;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -60,6 +59,7 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.dto.ProcessDTO;
 import org.kitodo.dto.ProjectDTO;
+import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 
 @Named("ProjekteForm")

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -56,6 +56,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
+import de.sub.goobi.model.LazyDTOModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.hssf.usermodel.HSSFCell;
@@ -139,6 +140,16 @@ public class ProzessverwaltungForm extends BasisForm {
     private static String DONEDIRECTORYNAME = "fertig/";
     private int processId;
     private int taskId;
+
+    private LazyDTOModel lazyDataModel = new LazyDTOModel(serviceManager.getProcessService());
+
+    public LazyDTOModel getLazyDataModel() {
+        return this.lazyDataModel;
+    }
+
+    public void setLazyDataModel(LazyDTOModel lazyDTOModel) {
+        this.lazyDataModel = lazyDTOModel;
+    }
 
     /**
      * Constructor.

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -29,7 +29,6 @@ import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
 import de.sub.goobi.helper.PropertyListObject;
 import de.sub.goobi.helper.WebDav;
-import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +92,7 @@ import org.kitodo.dto.ProcessDTO;
 import org.kitodo.dto.UserDTO;
 import org.kitodo.dto.UserGroupDTO;
 import org.kitodo.enums.ObjectType;
+import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.file.FileService;
 

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -29,6 +29,7 @@ import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
 import de.sub.goobi.helper.PropertyListObject;
 import de.sub.goobi.helper.WebDav;
+import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,17 +47,14 @@ import java.util.Objects;
 import java.util.TreeMap;
 
 import javax.annotation.PostConstruct;
-
 import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
-
 import javax.inject.Named;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
-import de.sub.goobi.model.LazyDTOModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.hssf.usermodel.HSSFCell;
@@ -141,20 +139,12 @@ public class ProzessverwaltungForm extends BasisForm {
     private int processId;
     private int taskId;
 
-    private LazyDTOModel lazyDataModel = new LazyDTOModel(serviceManager.getProcessService());
-
-    public LazyDTOModel getLazyDataModel() {
-        return this.lazyDataModel;
-    }
-
-    public void setLazyDataModel(LazyDTOModel lazyDTOModel) {
-        this.lazyDataModel = lazyDTOModel;
-    }
-
     /**
      * Constructor.
      */
     public ProzessverwaltungForm() {
+        super();
+        super.setLazyDTOModel(new LazyDTOModel(serviceManager.getProcessService()));
         this.anzeigeAnpassen = new HashMap<>();
         this.anzeigeAnpassen.put("lockings", false);
         this.anzeigeAnpassen.put("swappedOut", false);

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
@@ -42,14 +42,9 @@ public class RulesetForm extends BasisForm {
     private static final Logger logger = LogManager.getLogger(RulesetForm.class);
     private int rulesetId;
 
-    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getRulesetService());
-
-    public LazyDTOModel getLazyDTOModel() {
-        return lazyDTOModel;
-    }
-
-    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
-        this.lazyDTOModel = lazyDTOModel;
+    public RulesetForm() {
+        super();
+        super.setLazyDTOModel(new LazyDTOModel(serviceManager.getRulesetService()));
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
@@ -14,6 +14,7 @@ package de.sub.goobi.forms;
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
+import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -40,6 +41,16 @@ public class RulesetForm extends BasisForm {
     private transient ServiceManager serviceManager = new ServiceManager();
     private static final Logger logger = LogManager.getLogger(RulesetForm.class);
     private int rulesetId;
+
+    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getRulesetService());
+
+    public LazyDTOModel getLazyDTOModel() {
+        return lazyDTOModel;
+    }
+
+    public void setLazyDTOModel(LazyDTOModel lazyDTOModel) {
+        this.lazyDTOModel = lazyDTOModel;
+    }
 
     /**
      * Initialize new Ruleset.

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
@@ -14,7 +14,6 @@ package de.sub.goobi.forms;
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.Page;
-import de.sub.goobi.model.LazyDTOModel;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,6 +30,7 @@ import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.dto.RulesetDTO;
+import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 
 @Named("RulesetForm")

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
@@ -42,6 +42,10 @@ public class RulesetForm extends BasisForm {
     private static final Logger logger = LogManager.getLogger(RulesetForm.class);
     private int rulesetId;
 
+    /**
+     * Empty default constructor that also sets the LazyDTOModel instance of this
+     * bean.
+     */
     public RulesetForm() {
         super();
         super.setLazyDTOModel(new LazyDTOModel(serviceManager.getRulesetService()));

--- a/Kitodo/src/main/java/de/sub/goobi/model/LazyDTOModel.java
+++ b/Kitodo/src/main/java/de/sub/goobi/model/LazyDTOModel.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package de.sub.goobi.model;
+
+import static java.lang.Math.toIntExact;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.services.data.base.SearchService;
+import org.primefaces.model.LazyDataModel;
+import org.primefaces.model.SortOrder;
+
+public class LazyDTOModel extends LazyDataModel {
+
+    private static final long serialVersionUID = 8782111495680176505L;
+    private SearchService searchService;
+    private static final Logger logger = LogManager.getLogger(LazyDTOModel.class);
+
+    public LazyDTOModel(SearchService searchService) {
+        this.searchService = searchService;
+
+        try {
+            this.setRowCount(toIntExact(searchService.count()));
+        } catch (DataException e) {
+            logger.error(e.getMessage());
+            this.setRowCount(0);
+        }
+    }
+
+    @Override
+    public Object getRowData(String rowKey) {
+        try {
+            return searchService.findById(Integer.parseInt(rowKey));
+        } catch (DataException e) {
+            logger.error(e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public List load(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) {
+        try {
+            List entities;
+            if (!Objects.equals(sortField, null)
+                    && Objects.equals(sortOrder, SortOrder.ASCENDING)) {
+                entities = searchService.findAll("{\"" + sortField + "\":\"asc\" }", first, pageSize);
+            } else if (!Objects.equals(sortField, null)
+                    && Objects.equals(sortOrder, SortOrder.DESCENDING)) {
+                entities = searchService.findAll("{\"" + sortField + "\":\"desc\" }", first, pageSize);
+            } else {
+                entities = searchService.findAll(null, first, pageSize);
+            }
+            logger.info(entities.size() + " entities loaded!");
+            return entities;
+        } catch (DataException e) {
+            logger.error(e.getMessage());
+            return new LinkedList();
+        }
+    }
+}

--- a/Kitodo/src/main/java/de/sub/goobi/model/LazyDTOModel.java
+++ b/Kitodo/src/main/java/de/sub/goobi/model/LazyDTOModel.java
@@ -31,6 +31,15 @@ public class LazyDTOModel extends LazyDataModel {
     private SearchService searchService;
     private static final Logger logger = LogManager.getLogger(LazyDTOModel.class);
 
+    /**
+     * Creates a LazyDTOModel instance that allows fetching data from the data
+     * source lazily, e.g. only the number of datasets that will be displayed in the
+     * frontend.
+     *
+     * @param searchService
+     *            the searchService which is used to retrieve data from the data
+     *            source
+     */
     public LazyDTOModel(SearchService searchService) {
         this.searchService = searchService;
 

--- a/Kitodo/src/main/java/org/kitodo/model/LazyDTOModel.java
+++ b/Kitodo/src/main/java/org/kitodo/model/LazyDTOModel.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package de.sub.goobi.model;
+package org.kitodo.model;
 
 import static java.lang.Math.toIntExact;
 

--- a/Kitodo/src/main/webapp/pages/BenutzerAlle.xhtml
+++ b/Kitodo/src/main/webapp/pages/BenutzerAlle.xhtml
@@ -24,6 +24,7 @@
     xmlns:h="http://xmlns.jcp.org/jsf/html"
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
+    xmlns:p="http://primefaces.org/ui"
     >
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
@@ -110,35 +111,24 @@
                                         <!-- +++++++++++++++++  // Anzeigefilter ++++++++++++++++++++++++ -->
 
 
-                                        <!-- Datentabelle -->
-                                        <t:dataTable id="id14" styleClass="standardTable" width="100%"
-                                                     cellspacing="1px" cellpadding="1px"
-                                                     headerClass="standardTable_Header"
-                                                     rowClasses="standardTable_Row1,standardTable_Row2"
-                                                     columnClasses="standardTable_Column,standardTable_Column,standardTable_Column,standardTable_Column, standardTable_ColumnCentered"
-                                                     var="item" value="#{BenutzerverwaltungForm.page.listReload}">
+                                        <!-- List of users -->
+                                        <p:dataTable id="id14" tableStyleClass="standardTable" width="100%"
+                                                     var="item" value="#{BenutzerverwaltungForm.lazyDTOModel}"
+                                                     rows="#{LoginForm.myBenutzer.tableSize}" lazy="true"
+                                                     paginator="true">
 
-                                            <h:column id="id15">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id16" value="#{msgs.benutzer}"/>
-                                                </f:facet>
+                                            <p:column id="id15" headerText="#{msgs.benutzer}">
                                                 <h:outputText id="id17"
                                                               value="#{item.surname}, #{item.name}"
                                                               styleClass="#{not item.active?'text_light':''}"/>
-                                            </h:column>
+                                            </p:column>
 
-                                            <h:column id="id18">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id19" value="#{msgs.standort}"/>
-                                                </f:facet>
+                                            <p:column id="id18" headerText="#{msgs.standort}">
                                                 <h:outputText id="id20" value="#{item.location}"
                                                               styleClass="#{not item.active?'text_light':''}"/>
-                                            </h:column>
+                                            </p:column>
 
-                                            <h:column id="id21">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id22" value="#{msgs.benutzergruppen}"/>
-                                                </f:facet>
+                                            <p:column id="id21" headerText="#{msgs.benutzergruppen}">
                                                 <t:dataList id="id23" var="intern"
                                                             styleClass="#{not item.active?'text_light':''}"
                                                             rendered="#{item.userGroupSize != 0}"
@@ -148,12 +138,9 @@
                                                     <h:outputText id="id25" value=","
                                                                   rendered="#{rowIndex + 1 lt rowCount}"/>
                                                 </t:dataList>
-                                            </h:column>
+                                            </p:column>
 
-                                            <h:column id="id26">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id27" value="#{msgs.projekte}"/>
-                                                </f:facet>
+                                            <p:column id="id26" headerText="#{msgs.projekte}">
                                                 <t:dataList id="id28" var="intern"
                                                             styleClass="#{not item.active?'text_light':''}"
                                                             rendered="#{item.projectsSize != 0}"
@@ -163,13 +150,11 @@
                                                     <h:outputText id="id30" value=","
                                                                   rendered="#{rowIndex + 1 lt rowCount}"/>
                                                 </t:dataList>
-                                            </h:column>
+                                            </p:column>
 
-                                            <h:column
-                                                    rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id31" value="#{msgs.auswahl}"/>
-                                                </f:facet>
+                                            <p:column
+                                                    rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}"
+                                                    headerText="#{msgs.auswahl}">
                                                 <!-- Bearbeiten-Schaltknopf -->
                                                 <h:link id="id32" outcome="/pages/BenutzerBearbeiten"
                                                                title="#{msgs.benutzerBearbeiten}">
@@ -178,14 +163,6 @@
                                                                     value="/pages/images/buttons/edit.gif"/>
                                                 </h:link>
 
-                                                <!-- LdapKonfiguration schreiben-Schaltknopf -->
-                                                <!-- 										<h:commandLink id="id34" title="#{msgs.ldapKonfigurationSchreiben}"
-                                                                                                           action="#{BenutzerverwaltungForm.ldapKonfigurationSchreiben}">
-                                                <h:graphicImage id="id35" value="/pages/images/buttons/key3.gif" />
-                                                <x:updateActionListener
-                                                        property="#{BenutzerverwaltungForm.myClass}" value="#{item}" />
-                                            </h:commandLink>
-                                                -->
                                                 <!-- Benutzerprofil laden-Schaltknopf -->
                                                 <h:commandLink id="id36" title="#{msgs.benutzerprofilLaden}"
                                                                action="#{LoginForm.EinloggenAls}" style="margin-left:15px">
@@ -194,35 +171,15 @@
                                                     <f:param id="id37" name="ID" value="#{item.id}"/>
                                                 </h:commandLink>
 
-                                            </h:column>
+                                            </p:column>
 
-                                        </t:dataTable>
+                                        </p:dataTable>
                                         <h:commandLink id="id52" action="#{BenutzerverwaltungForm.newUser}"
                                                        immediate="true"
                                                        rendered="#{((LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)) and (BenutzerverwaltungForm.page.totalResults > LoginForm.myBenutzer.tableSize)}"
                                         >
                                             <h:outputText id="id62" value="#{msgs.neuenBenutzerAnlegen}"/>
                                         </h:commandLink>
-                                        <table width="100%" border="0">
-                                            <tr valign="top">
-                                                <td align="left">
-                                                    <!-- newUser-Schaltknopf -->
-                                                    <!-- 				<h:commandLink id="id38" action="#{BenutzerverwaltungForm.newUser}"
-                                                                                       immediate="true"
-                                                                                       rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                                                    <h:outputText id="id39" value="#{msgs.neuenBenutzerAnlegen}" />
-                                                </h:commandLink> -->
-                                                </td>
-                                                <td align="center">
-                                                    <!-- ===================== Datascroller für die Ergebnisse ====================== -->
-                                                    <t:aliasBean alias="#{mypage}"
-                                                                 value="#{BenutzerverwaltungForm.page}">
-                                                        <ui:include src="/pages/inc/datascroller.xhtml"/>
-                                                    </t:aliasBean>
-                                                    <!-- ===================== // Datascroller für die Ergebnisse ====================== -->
-                                                </td>
-                                            </tr>
-                                        </table>
                                     </td>
                                 </tr>
                             </table>

--- a/Kitodo/src/main/webapp/pages/BenutzerBearbeitenPopup.xhtml
+++ b/Kitodo/src/main/webapp/pages/BenutzerBearbeitenPopup.xhtml
@@ -34,7 +34,8 @@
                                     tooltip="true"/>
 
                         <!-- Data table for user groups -->
-                        <p:dataTable var="group" value="#{BenutzerverwaltungForm.userGroups}" rows="10" paginator="true">
+                        <p:dataTable var="group" value="#{BenutzergruppenForm.lazyDTOModel}"
+                                     lazy="true" rows="#{LoginForm.myBenutzer.tableSize}" paginator="true">
                             <p:column headerText="#{msgs.benutzergruppe}">
                                 <h:outputText value="#{group.title}"/>
                             </p:column>

--- a/Kitodo/src/main/webapp/pages/BenutzerBearbeitenPopupProjekte.xhtml
+++ b/Kitodo/src/main/webapp/pages/BenutzerBearbeitenPopupProjekte.xhtml
@@ -34,7 +34,8 @@
                                     tooltip="true"/>
 
                         <!-- Data table for projects -->
-                        <p:dataTable var="project" value="#{BenutzerverwaltungForm.projects}" rows="10" paginator="true">
+                        <p:dataTable var="project" value="#{ProjekteForm.lazyDTOModel}"
+                                     lazy="true" rows="#{LoginForm.myBenutzer.tableSize}" paginator="true">
                             <p:column headerText="#{msgs.projekt}">
                                 <h:outputText value="#{project.title}"/>
                             </p:column>

--- a/Kitodo/src/main/webapp/pages/BenutzergruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/pages/BenutzergruppenAlle.xhtml
@@ -62,7 +62,7 @@
                                         </h3>
 
                                         <!-- newUser-Schaltknopf -->
-                                        <h:commandLink id="id5" action="#{BenutzergruppenForm.Neu}"
+                                        <h:commandLink id="id5" action="#{BenutzergruppenForm.newUserGroup}"
                                                        immediate="true"
                                                        rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
                                             <h:outputText id="id6"
@@ -111,7 +111,7 @@
                                         </p:dataTable>
 
                                         <!-- newUser-Schaltknopf -->
-                                        <h:commandLink id="id52" action="#{BenutzergruppenForm.Neu}"
+                                        <h:commandLink id="id52" action="#{BenutzergruppenForm.newUserGroup}"
                                                        immediate="true"
                                                        rendered="#{((LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)) and (BenutzergruppenForm.page.totalResults > LoginForm.myBenutzer.tableSize)}"
 

--- a/Kitodo/src/main/webapp/pages/BenutzergruppenAlle.xhtml
+++ b/Kitodo/src/main/webapp/pages/BenutzergruppenAlle.xhtml
@@ -24,6 +24,7 @@
     xmlns:h="http://xmlns.jcp.org/jsf/html"
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
+    xmlns:p="http://primefaces.org/ui"
     >
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
@@ -73,20 +74,12 @@
                                                     infoClass="text_blue" showDetail="true" showSummary="true"
                                                     tooltip="true"/>
 
-                                        <!-- Datentabelle -->
-                                        <t:dataTable id="auflistung" styleClass="standardTable"
-                                                     width="100%" cellspacing="1px" cellpadding="1px"
-                                                     headerClass="standardTable_Header"
-                                                     rowClasses="standardTable_Row1,standardTable_Row2"
-                                                     columnClasses="standardTable_Column,standardTable_ColumnCentered"
-                                                     var="item" value="#{BenutzergruppenForm.page.listReload}"
-                                                     style="margin-top: 10px;">
-
-                                            <h:column id="id8">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id9" value="#{msgs.benutzergruppe}"/>
-                                                </f:facet>
-
+                                        <!-- List of user groups -->
+                                        <p:dataTable id="auflistung" tableStyleClass="standardTable"
+                                                     var="item" value="#{BenutzergruppenForm.lazyDTOModel}" lazy="true"
+                                                     rows="#{LoginForm.myBenutzer.tableSize}" paginator="true"
+                                                     style="margin-top: 10px; width: 100%;">
+                                            <p:column id="id8" headerText="#{msgs.benutzergruppe}">
                                                 <ui:include src="/pages/inc/ajaxPlusMinusButton.xhtml" />
                                                 <t:dataTable id="id11" styleClass="standardTable" width="90%"
                                                              style="margin-left:12px;margin-top:5px" cellspacing="1px"
@@ -102,13 +95,10 @@
                                                         <h:outputText id="id14" value="#{step.fullName}"/>
                                                     </h:column>
                                                 </t:dataTable>
-                                            </h:column>
+                                            </p:column>
 
-                                            <h:column
+                                            <p:column headerText="#{msgs.auswahl}"
                                                     rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id15" value="#{msgs.auswahl}"/>
-                                                </f:facet>
                                                 <!-- Bearbeiten-Schaltknopf -->
                                                 <h:link id="id16" outcome="/pages/BenutzergruppenBearbeiten"
                                                                title="#{msgs.benutzerBearbeiten}">
@@ -116,9 +106,9 @@
                                                     <h:graphicImage id="id17" alt="edit"
                                                                     value="/pages/images/buttons/edit.gif"/>
                                                 </h:link>
-                                            </h:column>
+                                            </p:column>
 
-                                        </t:dataTable>
+                                        </p:dataTable>
 
                                         <!-- newUser-Schaltknopf -->
                                         <h:commandLink id="id52" action="#{BenutzergruppenForm.Neu}"
@@ -129,22 +119,6 @@
                                             <h:outputText id="id62"
                                                           value="#{msgs.neueBenutzergruppeAnlegen}"/>
                                         </h:commandLink>
-                                        <table width="100%" border="0">
-                                            <tr valign="top">
-                                                <td align="left">
-
-                                                </td>
-                                                <td align="center">
-                                                    <!-- ===================== Datascroller für die Ergebnisse ====================== -->
-
-                                                    <t:aliasBean alias="#{mypage}"
-                                                                 value="#{BenutzergruppenForm.page}">
-                                                        <ui:include src="/pages/inc/datascroller.xhtml"/>
-                                                    </t:aliasBean>
-                                                    <!-- ===================== // Datascroller für die Ergebnisse ====================== -->
-                                                </td>
-                                            </tr>
-                                        </table>
                                     </td>
                                 </tr>
                             </table>

--- a/Kitodo/src/main/webapp/pages/BenutzergruppenBearbeiten.xhtml
+++ b/Kitodo/src/main/webapp/pages/BenutzergruppenBearbeiten.xhtml
@@ -138,12 +138,12 @@
                                                 <td class="eingabeBoxen_row3" align="right">
 
                                                     <h:commandButton id="id22" value="#{msgs.loeschen}"
-                                                                     action="#{BenutzergruppenForm.Loeschen}"
+                                                                     action="#{BenutzergruppenForm.delete}"
                                                                      onclick="return confirm('#{msgs.sollDieserEintragWirklichGeloeschtWerden}?')"
                                                                      rendered="#{BenutzergruppenForm.myBenutzergruppe.id != null}"/>
 
                                                     <h:commandButton id="absenden" value="#{msgs.speichern}"
-                                                                     action="#{BenutzergruppenForm.Speichern}"/>
+                                                                     action="#{BenutzergruppenForm.save}"/>
                                                 </td>
                                             </tr>
                                         </table>

--- a/Kitodo/src/main/webapp/pages/DocketList.xhtml
+++ b/Kitodo/src/main/webapp/pages/DocketList.xhtml
@@ -62,7 +62,7 @@
                                         </h3>
 
                                         <!-- newUser-Schaltknopf -->
-                                        <h:commandLink id="id5" action="#{DocketForm.Neu}"
+                                        <h:commandLink id="id5" action="#{DocketForm.newDocket}"
                                                        immediate="true"
                                                        rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
                                             <h:outputText id="id6" value="#{msgs.createNewDocket}"/>
@@ -100,7 +100,7 @@
                                             </p:column>
 
                                         </p:dataTable>
-                                        <h:commandLink id="id52" action="#{DocketForm.Neu}"
+                                        <h:commandLink id="id52" action="#{DocketForm.newDocket}"
                                                        immediate="true"
                                                        rendered="#{((LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)) and (DocketForm.page.totalResults > LoginForm.myBenutzer.tableSize)}">
                                             <h:outputText id="id62" value="#{msgs.createNewDocket}"/>

--- a/Kitodo/src/main/webapp/pages/DocketList.xhtml
+++ b/Kitodo/src/main/webapp/pages/DocketList.xhtml
@@ -24,6 +24,7 @@
     xmlns:h="http://xmlns.jcp.org/jsf/html"
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
+    xmlns:p="http://primefaces.org/ui"
     >
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
@@ -72,65 +73,38 @@
                                                     infoClass="text_blue" showDetail="true" showSummary="true"
                                                     tooltip="true"/>
 
-                                        <!-- Datentabelle -->
-                                        <t:dataTable id="id8" styleClass="standardTable" width="100%"
-                                                     cellspacing="1px" cellpadding="1px"
-                                                     headerClass="standardTable_Header"
-                                                     rowClasses="standardTable_Row1,standardTable_Row2"
-                                                     columnClasses="standardTable_Column,standardTable_Column,standardTable_ColumnCentered,standardTable_ColumnCentered"
-                                                     style="margin-top: 10px;"
-                                                     var="item" value="#{DocketForm.page.listReload}">
+                                        <!-- List of dockets -->
+                                        <p:dataTable id="id8" tableStyleClass="standardTable"
+                                                     var="item" lazy="true" paginator="true"
+                                                     rows="#{LoginForm.myBenutzer.tableSize}"
+                                                     value="#{DocketForm.lazyDTOModel}"
+                                                     style="margin-top: 10px; width: 100%;">
 
-                                            <h:column id="id9">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id10" value="#{msgs.titel}"/>
-                                                </f:facet>
+                                            <p:column id="id9" headerText="#{msgs.titel}">
                                                 <h:outputText id="id11" value="#{item.title}"/>
-                                            </h:column>
+                                            </p:column>
 
-                                            <h:column id="id12">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id13" value="#{msgs.datei}"/>
-                                                </f:facet>
+                                            <p:column id="id12" headerText="#{msgs.datei}">
                                                 <h:outputText id="id14" value="#{item.file}"/>
-                                            </h:column>
+                                            </p:column>
 
-
-                                            <h:column id="id19"
+                                            <p:column id="id19" headerText="#{msgs.auswahl}"
                                                       rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id20" value="#{msgs.auswahl}"/>
-                                                </f:facet>
-                                                <!-- Bearbeiten-Schaltknopf -->
+                                                <!-- Edit button -->
                                                 <h:link id="id21" outcome="/pages/DocketEdit"
                                                                title="#{msgs.editDocket}">
                                                     <f:param name="id" value="#{item.id}"/>
                                                     <h:graphicImage id="id22" alt="edit"
                                                                     value="/pages/images/buttons/edit.gif"/>
                                                 </h:link>
-                                            </h:column>
+                                            </p:column>
 
-                                        </t:dataTable>
+                                        </p:dataTable>
                                         <h:commandLink id="id52" action="#{DocketForm.Neu}"
                                                        immediate="true"
                                                        rendered="#{((LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)) and (DocketForm.page.totalResults > LoginForm.myBenutzer.tableSize)}">
                                             <h:outputText id="id62" value="#{msgs.createNewDocket}"/>
                                         </h:commandLink>
-                                        <table width="100%" border="0">
-                                            <tr valign="top">
-                                                <td align="left">
-
-                                                </td>
-                                                <td align="center">
-                                                    <!-- ===================== Datascroller für die Ergebnisse ====================== -->
-                                                    <t:aliasBean alias="#{mypage}"
-                                                                 value="#{DocketForm.page}">
-                                                        <ui:include src="/pages/inc/datascroller.xhtml"/>
-                                                    </t:aliasBean>
-                                                    <!-- ===================== // Datascroller für die Ergebnisse ====================== -->
-                                                </td>
-                                            </tr>
-                                        </table>
                                     </td>
                                 </tr>
                             </table>

--- a/Kitodo/src/main/webapp/pages/ProjekteAlle.xhtml
+++ b/Kitodo/src/main/webapp/pages/ProjekteAlle.xhtml
@@ -24,6 +24,7 @@
     xmlns:h="http://xmlns.jcp.org/jsf/html"
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
     xmlns:t="http://myfaces.apache.org/tomahawk"
+    xmlns:p="http://primefaces.org/ui"
     >
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
@@ -72,21 +73,16 @@
                                                     infoClass="text_blue" showDetail="true" showSummary="true"
                                                     tooltip="true"/>
 
-                                        <!-- Datentabelle -->
-                                        <t:dataTable id="id8" styleClass="standardTable" width="100%"
-                                                     cellspacing="1px" cellpadding="1px"
-                                                     headerClass="standardTable_Header"
-                                                     rowClasses="standardTable_Row1,standardTable_Row2"
-                                                     columnClasses="standardTable_Column,standardTable_ColumnCentered"
-                                                     var="item" value="#{ProjekteForm.page.listReload}"
-                                                     style="margin-top: 10px;">
+                                        <!-- List of projects -->
+                                        <p:dataTable id="id8" tableStyleClass="standardTable"
+                                                     var="item" value="#{ProjekteForm.lazyDTOModel}"
+                                                     lazy="true" paginator="true"
+                                                     rows="#{LoginForm.myBenutzer.tableSize}"
+                                                     style="margin-top: 10px; width: 100%">
 
-                                            <h:column id="id9">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id10" value="#{msgs.projekt}"/>
-                                                </f:facet>
+                                            <p:column id="id9" headerText="#{msgs.projekt}">
                                                 <h:outputText id="id11" value="#{item.title}"/>
-                                            </h:column>
+                                            </p:column>
 
                                             <!-- +++++++++++++++++  Mets ++++++++++++++++++++++++
                                             <t:column id="id12" style="text-align:center">
@@ -109,24 +105,13 @@
                                             </t:column>-->
 
                                             <!-- +++++++++++++++++  FileFormats ++++++++++++++++++++++++ -->
-                                            <t:column id="id20" style="text-align:center">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id21"
-                                                                  value="#{msgs.internesSpeicherformat}"/>
-                                                </f:facet>
+                                            <p:column id="id20" style="text-align:center" headerText="#{msgs.internesSpeicherformat}">
                                                 <h:outputText id="id22" value="#{item.fileFormatInternal}"/>
-                                            </t:column>
-                                            <t:column id="id23" style="text-align:center">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id24" value="#{msgs.dmsExportformat}"/>
-                                                </f:facet>
+                                            </p:column>
+                                            <p:column id="id23" style="text-align:center" headerText="#{msgs.dmsExportformat}">
                                                 <h:outputText id="id25" value="#{item.fileFormatDmsExport}"/>
-                                            </t:column>
-                                            <t:column id="id234" style="text-align:center">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id2440" value="#{msgs.projectIsArchived}"/>
-                                                </f:facet>
-
+                                            </p:column>
+                                            <p:column id="id234" style="text-align:center" headerText="#{msgs.projectIsArchived}">
                                                 <h:graphicImage id="id2341"
                                                                 value="/pages/images/check_true.gif"
                                                                 rendered="#{item.projectIsArchived}"
@@ -135,21 +120,18 @@
                                                                 value="/pages/images/check_false.gif"
                                                                 rendered="#{!item.projectIsArchived}"
                                                                 alt="not archived"/>
-                                            </t:column>
-                                            <t:column id="id26" style="text-align:center"
+                                            </p:column>
+                                            <p:column id="id26" style="text-align:center" headerText="#{msgs.auswahl}"
                                                       rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                                                <f:facet name="header">
-                                                    <h:outputText id="id27" value="#{msgs.auswahl}"/>
-                                                </f:facet>
-                                                <!-- Bearbeiten-Schaltknopf -->
+                                                <!-- Edit button -->
                                                 <h:link id="id28" outcome="/pages/ProjekteBearbeiten"
                                                                title="#{msgs.projektBearbeiten}">
                                                     <f:param name="id" value="#{item.id}"/>
                                                     <h:graphicImage alt="edit" id="id29"
                                                                     value="/pages/images/buttons/edit.gif"/>
                                                 </h:link>
-                                            </t:column>
-                                        </t:dataTable>
+                                            </p:column>
+                                        </p:dataTable>
 
                                         <!-- newUser-Schaltknopf -->
                                         <h:commandLink id="id52" action="#{ProjekteForm.newProject}"
@@ -157,21 +139,6 @@
                                                        rendered="#{((LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)) and (ProjekteForm.page.totalResults > LoginForm.myBenutzer.tableSize)}">
                                             <h:outputText id="id62" value="#{msgs.neuesProjektAnlegen}"/>
                                         </h:commandLink>
-
-                                        <table width="100%" border="0">
-                                            <tr valign="top">
-                                                <td align="left">
-
-                                                </td>
-                                                <td align="center">
-                                                    <!-- ===================== Datascroller für die Ergebnisse ====================== -->
-                                                    <t:aliasBean alias="#{mypage}" value="#{ProjekteForm.page}">
-                                                        <ui:include src="/pages/inc/datascroller.xhtml"/>
-                                                    </t:aliasBean>
-                                                    <!-- ===================== // Datascroller für die Ergebnisse ====================== -->
-                                                </td>
-                                            </tr>
-                                        </table>
                                     </td>
                                 </tr>
                             </table>

--- a/Kitodo/src/main/webapp/pages/RegelsaetzeAlle.xhtml
+++ b/Kitodo/src/main/webapp/pages/RegelsaetzeAlle.xhtml
@@ -24,7 +24,7 @@
     xmlns:f="http://xmlns.jcp.org/jsf/core"
     xmlns:h="http://xmlns.jcp.org/jsf/html"
     xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-    xmlns:t="http://myfaces.apache.org/tomahawk"
+    xmlns:p="http://primefaces.org/ui"
     >
     <f:view locale="#{SpracheForm.locale}">
         <ui:include src="inc/head.xhtml" />
@@ -72,34 +72,22 @@
                                                 infoClass="text_blue" showDetail="true" showSummary="true"
                                                 tooltip="true"/>
 
-                                    <!-- Datentabelle -->
-                                    <t:dataTable id="id8" styleClass="standardTable" width="100%"
-                                                 cellspacing="1px" cellpadding="1px"
-                                                 headerClass="standardTable_Header"
-                                                 rowClasses="standardTable_Row1,standardTable_Row2"
-                                                 columnClasses="standardTable_Column,standardTable_Column,standardTable_ColumnCentered,standardTable_ColumnCentered"
-                                                 style="margin-top: 10px;"
-                                                 var="item" value="#{RulesetForm.page.listReload}">
+                                    <!-- List of rulesets -->
+                                    <p:dataTable id="id8" tableStyleClass="standardTable"
+                                                 var="item" value="#{RulesetForm.lazyDTOModel}" lazy="true"
+                                                 paginator="true" rows="#{LoginForm.myBenutzer.tableSize}"
+                                                 style="margin-top: 10px; width: 100%;">
 
-                                        <h:column id="id9">
-                                            <f:facet name="header">
-                                                <h:outputText id="id10" value="#{msgs.titel}"/>
-                                            </f:facet>
+                                        <p:column id="id9" headerText="#{msgs.titel}">
                                             <h:outputText id="id11" value="#{item.title}"/>
-                                        </h:column>
+                                        </p:column>
 
-                                        <h:column id="id12">
-                                            <f:facet name="header">
-                                                <h:outputText id="id13" value="#{msgs.datei}"/>
-                                            </f:facet>
+                                        <p:column id="id12" headerText="#{msgs.datei}">
                                             <h:outputText id="id14" value="#{item.file}"/>
-                                        </h:column>
+                                        </p:column>
 
-                                        <t:column id="id15" style="text-align:center">
-                                            <f:facet name="header">
-                                                <h:outputText id="id16"
-                                                              value="#{msgs.metadatenSortierungNachRegelsatz}"/>
-                                            </f:facet>
+                                        <p:column id="id15" style="text-align:center"
+                                                  headerText="#{msgs.metadatenSortierungNachRegelsatz}">
                                             <h:graphicImage id="id17"
                                                             value="/pages/images/check_true.gif"
                                                             rendered="#{item.orderMetadataByRuleset}"
@@ -108,42 +96,24 @@
                                                             value="/pages/images/check_false.gif"
                                                             rendered="#{!item.orderMetadataByRuleset}"
                                                             alt="do not order metadata by ruleset"/>
-                                        </t:column>
+                                        </p:column>
 
-                                        <h:column id="id19"
+                                        <p:column id="id19" headerText="#{msgs.auswahl}"
                                                   rendered="#{(LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)}">
-                                            <f:facet name="header">
-                                                <h:outputText id="id20" value="#{msgs.auswahl}"/>
-                                            </f:facet>
-                                            <!-- Bearbeiten-Schaltknopf -->
+                                            <!-- Edit button -->
                                             <h:link id="id21" outcome="/pages/RegelsaetzeBearbeiten"
                                                            title="#{msgs.regelsatzBearbeiten}">
                                                 <h:graphicImage id="id22" alt="edit ruleset"
-							value="/pages/images/buttons/edit.gif"/>
+                                                                value="/pages/images/buttons/edit.gif"/>
                                                 <f:param name="id" value="#{item.id}"/>
                                             </h:link>
-                                        </h:column>
+                                        </p:column>
 
-                                    </t:dataTable>
+                                    </p:dataTable>
                                     <h:commandLink id="id52" action="#{RulesetForm.createNewRuleset}"
                                                    rendered="#{((LoginForm.maximaleBerechtigung == 1) || (LoginForm.maximaleBerechtigung == 2)) and (RulesetForm.page.totalResults > LoginForm.myBenutzer.tableSize)}">
                                         <h:outputText id="id62" value="#{msgs.neuenRegelsatzAnlegen}"/>
                                     </h:commandLink>
-                                    <table width="100%" border="0">
-                                        <tr valign="top">
-                                            <td align="left">
-
-                                            </td>
-                                            <td align="center">
-                                                <!-- ===================== Datascroller für die Ergebnisse ====================== -->
-                                                <t:aliasBean alias="#{mypage}"
-                                                             value="#{RulesetForm.page}">
-                                                    <ui:include src="/pages/inc/datascroller.xhtml"/>
-                                                </t:aliasBean>
-                                                <!-- ===================== // Datascroller für die Ergebnisse ====================== -->
-                                            </td>
-                                        </tr>
-                                    </table>
                                 </td>
                             </tr>
                         </table>

--- a/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
+++ b/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
@@ -58,7 +58,7 @@
 
     <!-- List of processes -->
     <p:dataTable id="auflistung" tableStyleClass="standardTable" width="100%" cellspacing="1px" cellpadding="1px"
-                 var="item" value="#{ProzessverwaltungForm.lazyDataModel}" rows="#{LoginForm.myBenutzer.tableSize}"
+                 var="item" value="#{ProzessverwaltungForm.lazyDTOModel}" rows="#{LoginForm.myBenutzer.tableSize}"
                  lazy="true" paginator="true">
 
         <!-- +++++++++++++++++  SelectionBoxes ++++++++++++++++++++++++ -->

--- a/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
+++ b/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
@@ -57,18 +57,19 @@
     </t:aliasBeansScope>
 
     <!-- Datentabelle -->
-    <t:dataTable id="auflistung" styleClass="standardTable" width="100%" cellspacing="1px" cellpadding="1px"
-                 headerClass="standardTable_Header"
-                 rowClasses="standardTable_Row1,standardTable_Row2,standardTable_Row1,standardTable_Row2" var="item"
-                 value="#{ProzessverwaltungForm.page.listReload}">
+    <!--<t:dataTable id="auflistung" styleClass="standardTable" width="100%" cellspacing="1px" cellpadding="1px"-->
+                 <!--headerClass="standardTable_Header"-->
+                 <!--rowClasses="standardTable_Row1,standardTable_Row2,standardTable_Row1,standardTable_Row2" var="item"-->
+                 <!--value="#{ProzessverwaltungForm.page.listReload}">-->
+    <p:dataTable id="auflistung" tableStyleClass="standardTable" width="100%" cellspacing="1px" cellpadding="1px"
+                 rowStyleClass="standardTable_Row1,standardTable_Row2,standardTable_Row1,standardTable_Row2" var="item"
+                 value="#{ProzessverwaltungForm.lazyDataModel}" rows="10" lazy="true" paginator="true">
 
         <!-- +++++++++++++++++  SelectionBoxes ++++++++++++++++++++++++ -->
-        <t:column style="text-align:center"
+        <p:column style="text-align:center" headerText="#{msgs.auswahl2}"
                   rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and ProzessverwaltungForm.anzeigeAnpassen['selectionBoxes']}">
             <f:facet name="header">
                 <t:div>
-                    <!-- Header -->
-                    <h:outputText value="#{msgs.auswahl2}"/>
                     <h:commandLink action="#{ProzessverwaltungForm.selectAll}" id="selectall"
                                    title="#{msgs.alleAuswaehlen}" style="margin-left:10px">
                         <h:graphicImage value="/pages/images/check_true.gif" alt="select all"/>
@@ -87,50 +88,20 @@
                 <t:updateActionListener value="#{item.selected?false:true}" property="#{item.selected}"/>
                 <f:ajax render="myself1"/>
             </h:commandLink>
-        </t:column>
+        </p:column>
 
         <!-- +++++++++++++++++  ProzessID ++++++++++++++++++++++++ -->
-        <t:column style="text-align:center" rendered="#{ProzessverwaltungForm.anzeigeAnpassen['processId']}">
-            <f:facet name="header">
-                <h:outputText value="#{msgs.id}"/>
-            </f:facet>
+        <p:column style="text-align:center" rendered="#{ProzessverwaltungForm.anzeigeAnpassen['processId']}" headerText="#{msgs.id}">
             <h:outputText value="#{item.id}"/>
-        </t:column>
+        </p:column>
 
         <!-- +++++++++++++++++  BatchID ++++++++++++++++++++++++ -->
-        <t:column style="text-align:center" rendered="#{ProzessverwaltungForm.anzeigeAnpassen['batchId']}">
-            <f:facet name="header">
-                <t:div>
-                    <!-- Header -->
-                    <h:outputText value="#{msgs.batch}"/>
-                    <!-- Sortierung Asc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort13a"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='batchAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/asc.gif" alt="sort ascending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="batchDesc"/>
-                    </h:commandLink>
-                    <!-- Sortierung Desc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort14a"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='batchDesc'}">
-                        <h:graphicImage value="/pages/images/sorting/desc.gif" alt="sort descending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="batchAsc"/>
-                    </h:commandLink>
-                    <!-- Sortierung none -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort15a"
-                                   rendered="#{ProzessverwaltungForm.sortierung!='batchDesc' and ProzessverwaltungForm.sortierung!='batchAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/none.gif" alt="no sorting"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="batchAsc"/>
-                    </h:commandLink>
-                </t:div>
-            </f:facet>
+        <p:column style="text-align:center" rendered="#{ProzessverwaltungForm.anzeigeAnpassen['batchId']}" headerText="#{msgs.batch}">
             <h:outputText value="#{item.batchID}" rendered="#{item.batchID != null}"/>
-        </t:column>
+        </p:column>
 
         <!-- +++++++++++++++++  alle Schritte auflisten mit Ajax ++++++++++++++++++++++++ -->
-        <t:column rendered="true" id="ajaxcolumn" style="text-align:left">
+        <p:column rendered="true" id="ajaxcolumn" style="text-align:left" sortBy="#{item.title}">
             <f:facet name="header">
                 <t:div>
                     <!-- Header -->
@@ -140,28 +111,6 @@
                         <h:outputText value="#{msgs.prozessTitel}"
                                       rendered="#{ProzessverwaltungForm.modusAnzeige=='aktuell'}"/>
                     </h:panelGroup>
-
-                    <!-- Sortierung Asc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort1"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='titelAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/asc.gif" alt="sort ascending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="titelDesc"/>
-                    </h:commandLink>
-                    <!-- Sortierung Desc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort2"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='titelDesc'}">
-                        <h:graphicImage value="/pages/images/sorting/desc.gif" alt="sort descending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="titelAsc"/>
-                    </h:commandLink>
-                    <!-- Sortierung none -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort3"
-                                   rendered="#{ProzessverwaltungForm.sortierung!='titelDesc' and ProzessverwaltungForm.sortierung!='titelAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/none.gif" alt="no sorting"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="titelAsc"/>
-                    </h:commandLink>
                 </t:div>
             </f:facet>
 
@@ -213,74 +162,16 @@
 
                 </p:dataTable>
             </h:panelGroup>
-        </t:column>
+        </p:column>
         <!-- +++++++++++++++++  // alle Schritte auflisten mit Ajax ++++++++++++++++++++++++ -->
 
         <!-- +++++++++++++++++  Vorgangsdatum ++++++++++++++++++++++++ -->
-        <t:column style="text-align:center" rendered="#{ProzessverwaltungForm.anzeigeAnpassen['processDate']}">
-            <f:facet name="header">
-                <t:div>
-                    <!-- Header -->
-                    <h:outputText value="#{msgs.vorgangsdatum}"/>
-                    <!-- Sortierung Asc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort4"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='vorgangsdatumAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/asc.gif" alt="sort ascending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}"
-                                                value="vorgangsdatumDesc"/>
-                    </h:commandLink>
-                    <!-- Sortierung Desc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort5"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='vorgangsdatumDesc'}">
-                        <h:graphicImage value="/pages/images/sorting/desc.gif" alt="sort descending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}"
-                                                value="vorgangsdatumAsc"/>
-                    </h:commandLink>
-                    <!-- Sortierung none -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort6"
-                                   rendered="#{ProzessverwaltungForm.sortierung!='vorgangsdatumDesc' and ProzessverwaltungForm.sortierung!='vorgangsdatumAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/none.gif" alt="no sorting"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}"
-                                                value="vorgangsdatumAsc"/>
-                    </h:commandLink>
-                </t:div>
-
-            </f:facet>
+        <p:column style="text-align:center" rendered="#{ProzessverwaltungForm.anzeigeAnpassen['processDate']}" headerText="#{msgs.vorgangsdatum}">
             <h:outputText value="#{item.creationDate}"/>
-        </t:column>
+        </p:column>
 
         <!-- +++++++++++++++++  Status ++++++++++++++++++++++++ -->
-        <t:column style="text-align:center; width:120px">
-            <f:facet name="header">
-                <t:div>
-                    <!-- Header -->
-                    <h:outputText value="#{msgs.status}"/>
-                    <!-- Sortierung Asc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort7"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='fortschrittAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/asc.gif" alt="sort ascending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="fortschrittDesc"/>
-                    </h:commandLink>
-                    <!-- Sortierung Desc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort8"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='fortschrittDesc'}">
-                        <h:graphicImage value="/pages/images/sorting/desc.gif" alt="sort descending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="fortschrittAsc"/>
-                    </h:commandLink>
-                    <!-- Sortierung none -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort9"
-                                   rendered="#{ProzessverwaltungForm.sortierung!='fortschrittDesc' and ProzessverwaltungForm.sortierung!='fortschrittAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/none.gif" alt="no sorting"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="fortschrittAsc"/>
-                    </h:commandLink>
-                </t:div>
-            </f:facet>
+        <p:column style="text-align:center; width:120px" headerText="#{msgs.status}">
             <h:graphicImage value="/pages/images/fortschritt/ende_links.gif" alt="" rendered="true"/>
             <h:graphicImage value="/pages/images/fortschritt/gr.gif" alt="closed"
                             style="width:#{item.progressClosed * 0.8}px;height:10px"/>
@@ -291,75 +182,18 @@
             <h:graphicImage value="/pages/images/fortschritt/rt.gif" alt="locked"
                             style="width:#{item.progressLocked * 0.8}px;height:10px"/>
             <h:graphicImage value="/pages/images/fortschritt/ende_rechts.gif" rendered="true" alt=""/>
-        </t:column>
+        </p:column>
 
-        <t:column style="text-align:center; width:20%">
-            <f:facet name="header">
-                <t:div>
-                    <!-- Header -->
-                    <h:outputText value="#{msgs.projekt}"/>
-                    <!-- Sortierung Asc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort10"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='projektAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/asc.gif" alt="sort ascending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="projektDesc"/>
-                    </h:commandLink>
-                    <!-- Sortierung Desc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort11"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='projektDesc'}">
-                        <h:graphicImage value="/pages/images/sorting/desc.gif" alt="sort descending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="projektAsc"/>
-                    </h:commandLink>
-                    <!-- Sortierung none -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort12"
-                                   rendered="#{ProzessverwaltungForm.sortierung!='projektDesc' and ProzessverwaltungForm.sortierung!='projektAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/none.gif" alt="no sorting"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="projektAsc"/>
-                    </h:commandLink>
-                </t:div>
-            </f:facet>
+        <p:column style="text-align:center; width:20%" headerText="#{msgs.projekt}">
             <h:outputText value="#{item.project.title}"/>
-        </t:column>
+        </p:column>
 
-        <t:column style="text-align:center"
+        <p:column style="text-align:center" headerText="#{msgs.sperrungen}"
                   rendered="#{ProzessverwaltungForm.modusAnzeige!='vorlagen' and ProzessverwaltungForm.anzeigeAnpassen['lockings']}">
-            <f:facet name="header">
-                <t:div>
-                    <!-- Header -->
-                    <h:outputText value="#{msgs.sperrungen}"/>
-                    <!-- Sortierung Asc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort13"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='sperrungenAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/asc.gif" alt="sort ascending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="sperrungenDesc"/>
-                    </h:commandLink>
-                    <!-- Sortierung Desc -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort14"
-                                   rendered="#{ProzessverwaltungForm.sortierung=='sperrungenDesc'}">
-                        <h:graphicImage value="/pages/images/sorting/desc.gif" alt="sort descending"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="sperrungenAsc"/>
-                    </h:commandLink>
-                    <!-- Sortierung none -->
-                    <h:commandLink action="#{ProzessverwaltungForm.filterAll}" id="sort15"
-                                   rendered="#{ProzessverwaltungForm.sortierung!='sperrungenDesc' and ProzessverwaltungForm.sortierung!='sperrungenAsc'}">
-                        <h:graphicImage value="/pages/images/sorting/none.gif" alt="no sorting"
-                                        style="vertical-align:middle;margin-left:5px"/>
-                        <t:updateActionListener property="#{ProzessverwaltungForm.sortierung}" value="sperrungenAsc"/>
-                    </h:commandLink>
-                </t:div>
-            </f:facet>
             <h:outputText value="#{item.blockedUsers.fullName}" rendered="#{item.blockedUsers != null}"/>
-        </t:column>
+        </p:column>
 
-        <t:column style="text-align:center" width="223px" styleClass="action">
-            <f:facet name="header">
-                <h:outputText value="#{msgs.auswahl}" styleClass="action"/>
-            </f:facet>
+        <p:column style="text-align:center" width="223px" styleClass="action" headerText="#{msgs.auswahl}">
 
             <!-- Bearbeiten-Schaltknopf: konkrete Prozesse -->
             <h:link outcome="/pages/ProzessverwaltungBearbeiten"
@@ -524,9 +358,9 @@
                 </h:commandLink>
 
             </h:panelGroup>
-        </t:column>
+        </p:column>
 
-    </t:dataTable>
+    </p:dataTable>
 
     <!-- new process -->
     <h:link outcome="/pages/ProzessverwaltungBearbeiten"
@@ -540,17 +374,4 @@
         <h:outputText value="#{msgs.eineNeueProzessvorlageAnlegen}"/>
     </h:commandLink>
 
-    <table width="100%" border="0">
-        <tr valign="top">
-
-            <td align="center">
-                <!-- ===================== Datascroller für die Ergebnisse ====================== -->
-                <t:aliasBean alias="#{mypage}" value="#{ProzessverwaltungForm.page}">
-                    <ui:include src="/pages/inc/datascroller.xhtml"/>
-                </t:aliasBean>
-                <!-- ===================== // Datascroller für die Ergebnisse ====================== -->
-
-            </td>
-        </tr>
-    </table>
 </ui:composition>

--- a/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
+++ b/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/Prozesse_Liste.xhtml
@@ -56,14 +56,10 @@
         </f:subview>
     </t:aliasBeansScope>
 
-    <!-- Datentabelle -->
-    <!--<t:dataTable id="auflistung" styleClass="standardTable" width="100%" cellspacing="1px" cellpadding="1px"-->
-                 <!--headerClass="standardTable_Header"-->
-                 <!--rowClasses="standardTable_Row1,standardTable_Row2,standardTable_Row1,standardTable_Row2" var="item"-->
-                 <!--value="#{ProzessverwaltungForm.page.listReload}">-->
+    <!-- List of processes -->
     <p:dataTable id="auflistung" tableStyleClass="standardTable" width="100%" cellspacing="1px" cellpadding="1px"
-                 rowStyleClass="standardTable_Row1,standardTable_Row2,standardTable_Row1,standardTable_Row2" var="item"
-                 value="#{ProzessverwaltungForm.lazyDataModel}" rows="10" lazy="true" paginator="true">
+                 var="item" value="#{ProzessverwaltungForm.lazyDataModel}" rows="#{LoginForm.myBenutzer.tableSize}"
+                 lazy="true" paginator="true">
 
         <!-- +++++++++++++++++  SelectionBoxes ++++++++++++++++++++++++ -->
         <p:column style="text-align:center" headerText="#{msgs.auswahl2}"

--- a/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/schritt_box_BenutzerPopup.xhtml
+++ b/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/schritt_box_BenutzerPopup.xhtml
@@ -34,7 +34,8 @@
                                     tooltip="true"/>
 
                         <!-- Data table for user groups -->
-                        <p:dataTable var="user" value="#{ProzessverwaltungForm.activeUsers}" rows="10" paginator="true">
+                        <p:dataTable var="user" value="#{BenutzerverwaltungForm.lazyDTOModel}"
+                                     lazy="true" rows="#{LoginForm.myBenutzer.tableSize}" paginator="true">
                             <p:column headerText="#{msgs.benutzergruppe}">
                                 <h:outputText value="#{user.surname}, #{user.name}"/>
                             </p:column>

--- a/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/schritt_box_BenutzergruppenPopup.xhtml
+++ b/Kitodo/src/main/webapp/pages/inc_Prozessverwaltung/schritt_box_BenutzergruppenPopup.xhtml
@@ -34,7 +34,8 @@
                                     tooltip="true"/>
 
                         <!-- Data table for user groups -->
-                        <p:dataTable var="group" value="#{ProzessverwaltungForm.userGroups}" rows="10" paginator="true">
+                        <p:dataTable var="group" value="#{BenutzergruppenForm.lazyDTOModel}"
+                                     lazy="true" rows="#{LoginForm.myBenutzer.tableSize}" paginator="true">
                             <p:column headerText="#{msgs.benutzergruppe}">
                                 <h:outputText value="#{group.title}"/>
                             </p:column>

--- a/Kitodo/src/test/java/de/sub/goobi/model/LazyDTOModelTest.java
+++ b/Kitodo/src/test/java/de/sub/goobi/model/LazyDTOModelTest.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package de.sub.goobi.model;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.dto.UserDTO;
+import org.kitodo.services.ServiceManager;
+import org.primefaces.model.SortOrder;
+
+public class LazyDTOModelTest {
+
+    private ServiceManager serviceManager = new ServiceManager();
+    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserService());
+
+    @Before
+    public void setUp() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertUserGroupsFull();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldLoad() throws Exception {
+        List users = lazyDTOModel.load(0, 2, "login", SortOrder.ASCENDING, null);
+        UserDTO user = (UserDTO) users.get(0);
+        Assert.assertEquals(user.getLogin(), "dora");
+    }
+
+}

--- a/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
+++ b/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
@@ -13,9 +13,9 @@ package org.kitodo.model;
 
 import java.util.List;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.dto.UserDTO;
@@ -24,16 +24,13 @@ import org.primefaces.model.SortOrder;
 
 public class LazyDTOModelIT {
 
-    private ServiceManager serviceManager = new ServiceManager();
-    private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserService());
-
-    @Before
+    @BeforeClass
     public void setUp() throws Exception {
         MockDatabase.startNode();
         MockDatabase.insertUserGroupsFull();
     }
 
-    @After
+    @AfterClass
     public void tearDown() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
@@ -41,9 +38,10 @@ public class LazyDTOModelIT {
 
     @Test
     public void shouldLoad() throws Exception {
+        ServiceManager serviceManager = new ServiceManager();
+        LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserService());
         List users = lazyDTOModel.load(0, 2, "login", SortOrder.ASCENDING, null);
         UserDTO user = (UserDTO) users.get(0);
         Assert.assertEquals(user.getLogin(), "dora");
     }
-
 }

--- a/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
+++ b/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package de.sub.goobi.model;
+package org.kitodo.model;
 
 import java.util.List;
 
@@ -22,7 +22,7 @@ import org.kitodo.dto.UserDTO;
 import org.kitodo.services.ServiceManager;
 import org.primefaces.model.SortOrder;
 
-public class LazyDTOModelTest {
+public class LazyDTOModelIT {
 
     private ServiceManager serviceManager = new ServiceManager();
     private LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserService());

--- a/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
+++ b/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
@@ -20,28 +20,40 @@ import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.dto.UserDTO;
 import org.kitodo.services.ServiceManager;
+import org.kitodo.services.data.UserService;
 import org.primefaces.model.SortOrder;
 
 public class LazyDTOModelIT {
 
+    private static final ServiceManager serviceManager = new ServiceManager();
+    private static UserService userService = serviceManager.getUserService();
+    private static LazyDTOModel lazyDTOModel = null;
+
     @BeforeClass
-    public void setUp() throws Exception {
+    public static void setUp() throws Exception {
         MockDatabase.startNode();
         MockDatabase.insertUserGroupsFull();
+        lazyDTOModel = new LazyDTOModel(userService);
     }
 
     @AfterClass
-    public void tearDown() throws Exception {
+    public static void tearDown() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
     }
 
     @Test
+    public void shouldGetRowData() throws Exception {
+        List users = userService.findAll();
+        UserDTO firstUser = (UserDTO) users.get(0);
+        UserDTO lazyUser = (UserDTO) lazyDTOModel.getRowData(String.valueOf(firstUser.getId()));
+        Assert.assertEquals(firstUser.getLogin(), lazyUser.getLogin());
+    }
+
+    @Test
     public void shouldLoad() throws Exception {
-        ServiceManager serviceManager = new ServiceManager();
-        LazyDTOModel lazyDTOModel = new LazyDTOModel(serviceManager.getUserService());
         List users = lazyDTOModel.load(0, 2, "login", SortOrder.ASCENDING, null);
         UserDTO user = (UserDTO) users.get(0);
-        Assert.assertEquals(user.getLogin(), "dora");
+        Assert.assertEquals("dora", user.getLogin());
     }
 }


### PR DESCRIPTION
Replace the old Tomahawk datatables with new Primefaces datatables. The Primefaces tables use a lazy data model that only load the number of datasets that is displayed on the current page.

**Note**: in order to work effectively, the changes in https://github.com/kitodo/kitodo-production/pull/1063 are required.