### PR TITLE
Fix possible NPE while process title generation

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzesskopieForm.java
@@ -1890,7 +1890,10 @@ public class ProzesskopieForm {
             } else if (myString.equals("$Doctype")) {
                 /* wenn der Doctype angegeben werden soll */
                 try {
-                    this.tifHeader_imagedescription += ConfigOpac.getDoctypeByName(this.docType).getTifHeaderType();
+                    ConfigOpacDoctype cod = ConfigOpac.getDoctypeByName(this.docType);
+                    if (! Objects.equals(cod, null)) {
+                        this.tifHeader_imagedescription += cod.getTifHeaderType();
+                    }
                 } catch (Throwable t) {
                     logger.error("Error while reading von opac-config", t);
                     Helper.setFehlerMeldung("Error while reading von opac-config", t.getMessage());


### PR DESCRIPTION
Prevent a null pointer exception if document type could not be found. This can happen if document type is not defined in goobi_opac.xml and come from an other plugin like the mods plugin.