### PR TITLE
Add possibility to set amount of maximum records for a query

### DIFF
--- a/Goobi/config/kitodo_mods_opac.xml
+++ b/Goobi/config/kitodo_mods_opac.xml
@@ -29,6 +29,7 @@
         <identifierElement xpath="//goobi:metadata[@name='CatalogIDDigital']" />
         <parentElement xpath="//mods:mods/mods:relatedItem/mods:identifier[@type='localparentid']" />
         <recordElement xpath="//srw:searchRetrieveResponse/srw:records/srw:record" />
+        <maximumChildRecords>50</maximumChildRecords>
         <searchFields>
             <searchField label="Title" value="ead.title" />
             <searchField label="Creator" value="ead.creator" />

--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/Query.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/Query.java
@@ -30,6 +30,8 @@ class Query {
     private static final String OR = "%2B"; // URL-encoded +
     private static final String NOT = "-";
 
+    private int maximumRecords = 0;
+
     // Example: Kalliope-URL returning the mods data for a given ead.id
     // http://kalliope-verbund.info/sru?version=1.2&operation=searchRetrieve&query=ead.id=DE-611-HS-2256337&recordSchema=mods
 
@@ -160,7 +162,22 @@ class Query {
         }
     }
 
+    /**
+     * Set maximum records to retrieve for a query.
+     * Value is added to getQueryUrl() call if value is greater then 0.
+     *
+     * @param maximumRecords
+     *                  number of maximum records for retrieving
+     */
+    void setMaximumRecords(int maximumRecords) {
+        this.maximumRecords = maximumRecords;
+    }
+
     String getQueryUrl() {
-        return this.queryUrl;
+        if (this.maximumRecords > 0) {
+            return this.queryUrl + "&maximumRecords=" + this.maximumRecords;
+        } else {
+            return this.queryUrl;
+        }
     }
 }


### PR DESCRIPTION
Querying Kalliope catalogue works fine until child elements are created. The querying of children returns only 50 elements. The reason behind is that Kalliope SRU returns on default only 50 records. You must add a not well known URL parameter `maximumRecords` with number to get more then 50 or the specific defined number of records back.

This changes allow it to retrieve a self-defined number of children records. Default value is 50 to reflect default behaviour.