### PR TITLE
Fix dead code issue in Active MQ connector

### DIFF
--- a/Kitodo/src/main/java/org/goobi/mq/MapMessageObjectReader.java
+++ b/Kitodo/src/main/java/org/goobi/mq/MapMessageObjectReader.java
@@ -16,10 +16,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -139,11 +137,10 @@ public class MapMessageObjectReader {
      *             can be thrown by MapMessage.getString(String)
      */
     public Integer getMandatoryInteger(String key) throws IllegalArgumentException, JMSException {
-        Integer result = ticket.getInt(key);
-        if (result == null) {
+        if (!ticket.itemExists(key)) {
             throw new IllegalArgumentException("Missing mandatory argument: \"" + key + "\"");
         }
-        return result;
+        return ticket.getInt(key);
     }
 
     /**


### PR DESCRIPTION
This fix will put code that has become dead code back to work. I found this little bug due to a dead code warning. Maybe the underlying library changed slightly during a version upgrade.