### PR TITLE
Removed filterKein from DocketForm

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -13,14 +13,10 @@ package de.sub.goobi.forms;
 
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
-import de.sub.goobi.helper.Page;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 
@@ -29,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 import org.kitodo.data.database.beans.Docket;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.dto.DocketDTO;
 import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.data.ProcessService;
@@ -72,7 +67,7 @@ public class DocketForm extends BasisForm {
         try {
             if (hasValidRulesetFilePath(myDocket, ConfigCore.getParameter("xsltFolder"))) {
                 this.serviceManager.getDocketService().save(myDocket);
-                return filterKein();
+                return "/pages/DocketList";
             } else {
                 Helper.setFehlerMeldung("DocketNotFound");
                 return null;
@@ -106,38 +101,13 @@ public class DocketForm extends BasisForm {
             Helper.setFehlerMeldung("fehlerNichtLoeschbar", e.getMessage());
             return null;
         }
-        return filterKein();
+        return "/pages/DocketList";
     }
 
     private boolean hasAssignedProcesses(Docket d) throws DataException {
         ProcessService processService = serviceManager.getProcessService();
         Integer number = processService.findByDocket(d).size();
         return number > 0;
-    }
-
-    /**
-     * No filter.
-     *
-     * @return page or empty String
-     */
-    public String filterKein() {
-        List<DocketDTO> dockets = new ArrayList<>();
-        try {
-            dockets = serviceManager.getDocketService().findAll();
-        } catch (DataException e) {
-            logger.error(e);
-        }
-        this.page = new Page<>(0, dockets);
-        return "/pages/DocketList";
-    }
-
-    /**
-     * This method initializes the docket list without any filter whenever the
-     * bean is constructed.
-     */
-    @PostConstruct
-    public void initializeDocketList() {
-        filterKein();
     }
 
     /**


### PR DESCRIPTION
Due to the usage of PrimeFaces LazyDataModel the _filterKein_ method and _page_ object are no longer needed.