### PR TITLE
Simplified filtering

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -144,7 +144,7 @@ public class ProzessverwaltungForm extends BasisForm {
         this.anzeigeAnpassen.put("processId", false);
         this.anzeigeAnpassen.put("batchId", false);
         this.sortierung = "titelAsc";
-        super.setLazyDTOModel(new LazyDTOModel(true, serviceManager.getProcessService()));
+        super.setLazyDTOModel(new LazyDTOModel(serviceManager.getProcessService()));
         /*
          * Vorgangsdatum generell anzeigen?
          */

--- a/Kitodo/src/main/java/de/sub/goobi/forms/SearchForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/SearchForm.java
@@ -33,7 +33,6 @@ import org.kitodo.data.database.helper.enums.TaskStatus;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.enums.FilterString;
 import org.kitodo.enums.ObjectMode;
-import org.kitodo.model.LazyDTOModel;
 import org.kitodo.services.ServiceManager;
 
 @Named("SearchForm")
@@ -410,7 +409,6 @@ public class SearchForm {
         if (form != null) {
             form.filter = search;
             form.setDisplayMode(ObjectMode.PROCESS);
-            form.setLazyDTOModel(new LazyDTOModel(true, serviceManager.getProcessService()));
             return form.filterAll();
         }
         return null;

--- a/Kitodo/src/main/java/org/kitodo/model/LazyDTOModel.java
+++ b/Kitodo/src/main/java/org/kitodo/model/LazyDTOModel.java
@@ -13,9 +13,6 @@ package org.kitodo.model;
 
 import static java.lang.Math.toIntExact;
 
-import de.sub.goobi.forms.ProzessverwaltungForm;
-import de.sub.goobi.helper.Helper;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +29,6 @@ import org.primefaces.model.SortOrder;
 public class LazyDTOModel extends LazyDataModel<Object> {
 
     private static final long serialVersionUID = 8782111495680176505L;
-    private boolean additionalFiltering = false;
     private SearchService searchService;
     private static final Logger logger = LogManager.getLogger(LazyDTOModel.class);
 
@@ -48,27 +44,6 @@ public class LazyDTOModel extends LazyDataModel<Object> {
     public LazyDTOModel(SearchService searchService) {
         this.searchService = searchService;
 
-        try {
-            this.setRowCount(toIntExact(searchService.count()));
-        } catch (DataException e) {
-            logger.error(e.getMessage());
-            this.setRowCount(0);
-        }
-    }
-
-    /**
-     * Creates a LazyDTOModel instance that allows fetching data from the data
-     * source lazily, e.g. only the number of datasets that will be displayed in the
-     * frontend.
-     *
-     * @param additionalFiltering true, set up only in ProzessverwaltungForm or SearchForm
-     * @param searchService
-     *            the searchService which is used to retrieve data from the data
-     *            source
-     */
-    public LazyDTOModel(boolean additionalFiltering, SearchService searchService) {
-        this.additionalFiltering = additionalFiltering;
-        this.searchService = searchService;
         try {
             this.setRowCount(toIntExact(searchService.count()));
         } catch (DataException e) {
@@ -97,42 +72,17 @@ public class LazyDTOModel extends LazyDataModel<Object> {
     public List load(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) {
         try {
             List entities;
-            if (additionalFiltering) {
-                ProzessverwaltungForm form = (ProzessverwaltungForm) Helper.getManagedBeanValue("#{ProzessverwaltungForm}");
-                Map<String, String> filterMap = (Map<String, String>) filters;
-                String filterString = null;
-                if (filters.isEmpty()) {
-                    form.setFilter("");
-                } else {
-                    for (Map.Entry<String, String> entry : filterMap.entrySet()) {
-                        form.setFilter(entry.getValue());
-                    }
-                }
-                form.filterAll();
-                entities = form.getProcessDTOS();
+            if (!Objects.equals(sortField, null)
+                    && Objects.equals(sortOrder, SortOrder.ASCENDING)) {
+                entities = searchService.findAll("{\"" + sortField + "\":\"asc\" }", first, pageSize, filters);
+            } else if (!Objects.equals(sortField, null)
+                    && Objects.equals(sortOrder, SortOrder.DESCENDING)) {
+                entities = searchService.findAll("{\"" + sortField + "\":\"desc\" }", first, pageSize, filters);
             } else {
-                if (!Objects.equals(sortField, null)
-                        && Objects.equals(sortOrder, SortOrder.ASCENDING)) {
-                    entities = searchService.findAll("{\"" + sortField + "\":\"asc\" }", first, pageSize);
-                } else if (!Objects.equals(sortField, null)
-                        && Objects.equals(sortOrder, SortOrder.DESCENDING)) {
-                    entities = searchService.findAll("{\"" + sortField + "\":\"desc\" }", first, pageSize);
-                } else {
-                    entities = searchService.findAll(null, first, pageSize);
-                }
+                entities = searchService.findAll(null, first, pageSize, filters);
             }
             logger.info(entities.size() + " entities loaded!");
-            int dataSize = entities.size();
-            // pagination
-            if (dataSize > pageSize) {
-                try {
-                    return entities.subList(first, first + pageSize);
-                } catch (IndexOutOfBoundsException e) {
-                    return entities.subList(first, first + (dataSize % pageSize));
-                }
-            } else {
-                return entities;
-            }
+            return entities;
         } catch (DataException e) {
             logger.error(e.getMessage());
             return new LinkedList();

--- a/Kitodo/src/main/java/org/kitodo/model/LazyDTOModel.java
+++ b/Kitodo/src/main/java/org/kitodo/model/LazyDTOModel.java
@@ -71,6 +71,8 @@ public class LazyDTOModel extends LazyDataModel<Object> {
     @Override
     public List load(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) {
         try {
+            setRowCount(toIntExact(searchService.count(searchService.createCountQuery(filters))));
+
             List entities;
             if (!Objects.equals(sortField, null)
                     && Objects.equals(sortOrder, SortOrder.ASCENDING)) {

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
@@ -156,6 +156,9 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
 
         // TODO: find other way than retrieving the form bean to access "modusAnzeige" e.g. whether templates or processes should be returned!
         ProzessverwaltungForm form = (ProzessverwaltungForm) Helper.getManagedBeanValue("#{ProzessverwaltungForm}");
+        if (Objects.equals(form, null)) {
+            form = new ProzessverwaltungForm();
+        }
         boolean isTemplate = form.getModusAnzeige().equals("vorlagen");
         Map<String, String> filterMap = (Map<String, String>) filters;
 
@@ -174,7 +177,12 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
                 query.must(serviceManager.getProcessService().getQueryProjectArchived(false));
             }
         }
-        return convertJSONObjectsToDTOs(searcher.findDocuments(query.toString(), sort, offset, size), false);
+
+        String queryString = "";
+        if (!Objects.equals(query, null)) {
+            queryString = query.toString();
+        }
+        return convertJSONObjectsToDTOs(searcher.findDocuments(queryString, sort, offset, size), false);
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
@@ -92,6 +92,7 @@ import org.kitodo.dto.ProjectDTO;
 import org.kitodo.dto.PropertyDTO;
 import org.kitodo.dto.TaskDTO;
 import org.kitodo.dto.UserDTO;
+import org.kitodo.enums.ObjectMode;
 import org.kitodo.enums.ObjectType;
 import org.kitodo.serviceloader.KitodoServiceLoader;
 import org.kitodo.services.ServiceManager;
@@ -154,12 +155,13 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
     @Override
     public List<ProcessDTO> findAll(String sort, Integer offset, Integer size, Map filters) throws DataException {
 
-        // TODO: find other way than retrieving the form bean to access "modusAnzeige" e.g. whether templates or processes should be returned!
+        // TODO: find other way than retrieving the form bean to access "displayMode"
+        // e.g. whether templates or processes should be returned!
         ProzessverwaltungForm form = (ProzessverwaltungForm) Helper.getManagedBeanValue("#{ProzessverwaltungForm}");
         if (Objects.equals(form, null)) {
             form = new ProzessverwaltungForm();
         }
-        boolean isTemplate = form.getModusAnzeige().equals("vorlagen");
+        boolean isTemplate = Objects.equals(form.getDisplayMode(), ObjectMode.TEMPLATE);
         Map<String, String> filterMap = (Map<String, String>) filters;
 
         BoolQueryBuilder query = null;
@@ -187,9 +189,10 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
 
     @Override
     public String createCountQuery(Map filters) throws DataException {
-        // TODO: find other way than retrieving the form bean to access "modusAnzeige" e.g. whether templates or processes should be returned!
+        // TODO: find other way than retrieving the form bean to access "displayMode"
+        // e.g. whether templates or processes should be returned!
         ProzessverwaltungForm form = (ProzessverwaltungForm) Helper.getManagedBeanValue("#{ProzessverwaltungForm}");
-        boolean isTemplate = form.getModusAnzeige().equals("vorlagen");
+        boolean isTemplate = Objects.equals(form.getDisplayMode(), ObjectMode.TEMPLATE);
         Map<String, String> filterMap = (Map<String, String>) filters;
 
         BoolQueryBuilder query = null;

--- a/Kitodo/src/main/java/org/kitodo/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/base/SearchService.java
@@ -169,7 +169,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      *
      * @param filters Map of parameters used for filtering
      * @return null
-     * @throws DataException
+     * @throws DataException that can be caused by ElasticSearch
      */
     public String createCountQuery(Map filters) throws DataException {
         return null;

--- a/Kitodo/src/main/java/org/kitodo/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/base/SearchService.java
@@ -163,6 +163,19 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     }
 
     /**
+     * This function can be overriden to implement specific filters e.g. in ProcessService.
+     * Since there are no general filters at the moment this function just returns null,
+     * but a query for general filters can be implemented here in the future.
+     *
+     * @param filters Map of parameters used for filtering
+     * @return null
+     * @throws DataException
+     */
+    public String createCountQuery(Map filters) throws DataException {
+        return null;
+    }
+
+    /**
      * Method saves object to database.
      *
      * @param baseIndexedBean

--- a/Kitodo/src/main/java/org/kitodo/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/base/SearchService.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -126,6 +127,21 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      * @return list of all objects from ES
      */
     public List<S> findAll(String sort, Integer offset, Integer size) throws DataException {
+        return convertJSONObjectsToDTOs(findAllDocuments(sort, offset, size), false);
+    }
+
+    /**
+     * Find list of all objects from ES.
+     *
+     * @param sort
+     *            possible sort query according to which results will be sorted
+     * @param offset
+     *            start point for get results
+     * @param size
+     *            amount of requested results
+     * @return list of all objects from ES
+     */
+    public List<S> findAll(String sort, Integer offset, Integer size, Map filters) throws DataException {
         return convertJSONObjectsToDTOs(findAllDocuments(sort, offset, size), false);
     }
 


### PR DESCRIPTION
Since PrimeFaces handles the loading for all data in a single place, loading/filtering methods inside the beans were unpractical.
Loading is now handled by a general method "findAll" in SearchService and can be overwritten in specific Services (e.g. ProcessService). This simplifies the LazyDTOModel and removes the necessity to import specific beans like ProzessverwaltungForm.