### PR TITLE
Use hibernate-ehcache as 2nd level hibernate cache

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -172,6 +172,11 @@
             <version>5.2.10.Final</version>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-ehcache</artifactId>
+            <version>5.2.10.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.kitodo</groupId>
             <artifactId>kitodo-ugh</artifactId>
             <version>3.0-SNAPSHOT</version>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -248,17 +248,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache</artifactId>
-            <version>1.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>opensymphony</groupId>
             <artifactId>oscache</artifactId>
             <version>2.3</version>

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -38,6 +38,11 @@
         <property name="hibernate.c3p0.acquire_increment">1</property>
         <property name="hibernate.c3p0.validate">true</property>
 
+        <!-- hibernate caching -->
+        <property name="hibernate.cache.use_second_level_cache">true</property>
+        <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
+
         <!-- Enable Hibernate's automatic session context management -->
         <property name="current_session_context_class">managed</property>
 


### PR DESCRIPTION
Add a 2nd level cache for Hibernate usage. The usage of this cache can be deactivated through property options in `hibernate.cfg.xml` file. If you use a local `hibernate.cfg.xml` file you should add this properties to this file.