### PR TITLE
Show background animation only on first visit

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/LoginForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/LoginForm.java
@@ -56,6 +56,7 @@ public class LoginForm implements Serializable {
     private SecurityPasswordEncoder passwordEncoder = new SecurityPasswordEncoder();
     private transient ServiceManager serviceManager = new ServiceManager();
     private static final Logger logger = LogManager.getLogger(LoginForm.class);
+    private boolean firstVisit = true;
 
     /**
      * Log out.
@@ -389,5 +390,13 @@ public class LoginForm implements Serializable {
             result = serviceManager.getUserService().getHomeDirectory(loginForm.getMyBenutzer());
         }
         return result;
+    }
+
+    public boolean isFirstVisit() {
+        boolean visit = firstVisit;
+        if (firstVisit) {
+            firstVisit = false;
+        }
+        return visit;
     }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/LoginForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/LoginForm.java
@@ -392,6 +392,14 @@ public class LoginForm implements Serializable {
         return result;
     }
 
+    /**
+     * Checks and returns whether this is the first time the user visits a Kitodo
+     * page in the current session or not. Makes use of the fact that "LoginForm" is
+     * a SessionScoped bean.
+     *
+     * @return whether this is the users first visit to Kitodo during the current
+     *         session or not
+     */
     public boolean isFirstVisit() {
         boolean visit = firstVisit;
         if (firstVisit) {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -23,9 +23,12 @@ body {
     line-height: 18px;
     background: url("#{resource['/images/background-top.svg']}") no-repeat #f3f3f3 center top fixed;
     background-size: auto 300px;
+    }
+
+body.first-visit {
     animation-duration: 1s;
     animation-name: slidein;
-    }
+}
 
 p, form, img, legend, ul, ol, li, h1, h2, h3, h4, h5, h6, dl, dt, dd {
     margin: 0;

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -28,7 +28,7 @@ body {
 body.first-visit {
     animation-duration: 1s;
     animation-name: slidein;
-}
+    }
 
 p, form, img, legend, ul, ol, li, h1, h2, h3, h4, h5, h6, dl, dt, dd {
     margin: 0;

--- a/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -24,7 +24,7 @@
                 <ui:include src="/WEB-INF/templates/includes/head.xhtml" />
             </ui:insert>
         </h:head>
-        <h:body>
+        <h:body styleClass="#{LoginForm.firstVisit ? 'first-visit' : ''}">
             <h:outputStylesheet name="css/kitodo.css"/>
             <h:outputStylesheet name="css/pattern-library.css"/>
             <p:growl id="notifications" widgetVar="notifications" severity="info"/>


### PR DESCRIPTION
The "slide-in" animation of the new layouts background graphic has been deemed obtrusive because it is shown for every page the user opens.
This change restricts the animation to the first page in new layout opened by the user per session. All following pages will show the background image without animation.