### PR TITLE
Encapsulate UGH in Interface (1/3): Add Interface

### DIFF
--- a/Kitodo-UGH-API/pom.xml
+++ b/Kitodo-UGH-API/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kitodo-production</artifactId>
+        <groupId>org.kitodo</groupId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <maxAllowedViolations>3</maxAllowedViolations>
+    </properties>
+
+    <artifactId>kitodo-ugh-api</artifactId>
+    <name>Kitodo - UGH-API</name>
+
+</project>

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/ContentFileInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/ContentFileInterface.java
@@ -1,0 +1,21 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface ContentFileInterface {
+    String getLocation();
+
+    /**
+     * @return always {@code true}. Return value is never used.
+     */
+    boolean setLocation(String fileName);
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DigitalDocumentInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DigitalDocumentInterface.java
@@ -18,7 +18,8 @@ public interface DigitalDocumentInterface {
 
     void addAllContentFiles();
 
-    DocStructInterface createDocStruct(DocStructTypeInterface docStructTypeInterface) throws TypeNotAllowedForParentException;
+    DocStructInterface createDocStruct(DocStructTypeInterface docStructTypeInterface)
+            throws TypeNotAllowedForParentException;
 
     FileSetInterface getFileSet();
 
@@ -28,10 +29,14 @@ public interface DigitalDocumentInterface {
 
     void overrideContentFiles(List<String> images);
 
-    /** @return always {@code true}. The result is never used. */
+    /**
+     * @return always {@code true}. The result is never used.
+     */
     boolean setLogicalDocStruct(DocStructInterface docStructInterface);
 
-    /** @return always {@code true}. The result is never used. */
+    /**
+     * @return always {@code true}. The result is never used.
+     */
     boolean setPhysicalDocStruct(DocStructInterface docStructInterface);
 
 }

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DigitalDocumentInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DigitalDocumentInterface.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import java.util.List;
+import org.kitodo.api.ugh.exceptions.TypeNotAllowedForParentException;
+
+public interface DigitalDocumentInterface {
+
+    void addAllContentFiles();
+
+    DocStructInterface createDocStruct(DocStructTypeInterface docStructTypeInterface) throws TypeNotAllowedForParentException;
+
+    FileSetInterface getFileSet();
+
+    DocStructInterface getLogicalDocStruct();
+
+    DocStructInterface getPhysicalDocStruct();
+
+    void overrideContentFiles(List<String> images);
+
+    /** @return always {@code true}. The result is never used. */
+    boolean setLogicalDocStruct(DocStructInterface docStructInterface);
+
+    /** @return always {@code true}. The result is never used. */
+    boolean setPhysicalDocStruct(DocStructInterface docStructInterface);
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DocStructInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DocStructInterface.java
@@ -1,0 +1,184 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import java.util.Collection;
+import java.util.List;
+import org.kitodo.api.ugh.exceptions.ContentFileNotLinkedException;
+import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
+import org.kitodo.api.ugh.exceptions.TypeNotAllowedAsChildException;
+import org.kitodo.api.ugh.exceptions.TypeNotAllowedForParentException;
+
+public interface DocStructInterface {
+
+    /**
+     * @return wether inchild isn’t null and its type isn’t null. The return
+     *         value is never used.
+     */
+    boolean addChild(DocStructInterface dsvolume) throws TypeNotAllowedAsChildException;
+
+    /**
+     * @param index
+     *            {@code int} would be sufficient. Throws NullPointerException
+     *            if {@code null}.
+     * @return {@code false} if {@code child} is {@code null} or does not have a
+     *         type, true otherwise. The return value is never used.
+     */
+    boolean addChild(Integer index, DocStructInterface child) throws TypeNotAllowedAsChildException;
+
+    void addContentFile(ContentFileInterface cf);
+
+    /**
+     * @return always {@true}. The return value is never used.
+     */
+    boolean addMetadata(MetadataInterface newMetadata) throws MetadataTypeNotAllowedException;
+
+    /**
+     * @return {@code this}. The return value is never used.
+     */
+    DocStructInterface addMetadata(String fieldName, String value) throws MetadataTypeNotAllowedException;
+
+    /**
+     * @return always {@true}. The return value is never used.
+     */
+    boolean addMetadataGroup(MetadataGroupInterface metadataGroupInterface) throws MetadataTypeNotAllowedException;
+
+    /**
+     * @return always {@true}. The return value is never used.
+     */
+    boolean addPerson(PersonInterface p) throws MetadataTypeNotAllowedException;
+
+    /**
+     * @return a newly created References object containing information about
+     *         linking both DocStructs. The return value is never used.
+     */
+    ReferenceInterface addReferenceTo(DocStructInterface newPage, String string);
+
+    DocStructInterface copy(boolean b, Boolean c);
+
+    /**
+     * FIXME: Why is this function still here? It should have been removed. Is
+     * there something not yet merged?
+     */
+    DocStructInterface createChild(String docStructType, DigitalDocumentInterface digitalDocumentInterface,
+            PrefsInterface ruleset) throws TypeNotAllowedAsChildException, TypeNotAllowedForParentException;
+
+    void deleteUnusedPersonsAndMetadata();
+
+    List<MetadataGroupTypeInterface> getAddableMetadataGroupTypes();
+
+    List<MetadataTypeInterface> getAddableMetadataTypes();
+
+    List<DocStructInterface> getAllChildren();
+
+    List<DocStructInterface> getAllChildrenByTypeAndMetadataType(String string, String string2);
+
+    List<ContentFileInterface> getAllContentFiles();
+
+    List<ReferenceInterface> getAllFromReferences();
+
+    List<MetadataInterface> getAllIdentifierMetadata();
+
+    List<MetadataInterface> getAllMetadata(); /*
+                                               * return type collection would be
+                                               * sufficient
+                                               */
+
+    List<? extends MetadataInterface> getAllMetadataByType(MetadataTypeInterface mdt);
+
+    List<MetadataGroupInterface> getAllMetadataGroups();
+
+    List<PersonInterface> getAllPersons();
+
+    List<PersonInterface> getAllPersonsByType(MetadataTypeInterface authorType);
+
+    List<ReferenceInterface> getAllReferences(String string); // string seems to
+                                                              // be
+    // always "to"
+
+    Collection<ReferenceInterface> getAllToReferences();
+
+    Collection<ReferenceInterface> getAllToReferences(String string); // string
+                                                                      // alway
+    // "logical_physical"
+    // ?
+    // return type would be sufficient to be iterable, but there is a check for
+    // size()=0?
+
+    Object getAllVisibleMetadata(); // is null/is non-null -check only
+
+    String getAnchorClass();
+
+    DocStructInterface getChild(String type, String identifierField, String identifier);
+
+    List<MetadataTypeInterface> getDisplayMetadataTypes();
+
+    String getImageName();
+
+    /**
+     * @throws IndexOutOfBoundsException
+     */
+    DocStructInterface getNextChild(DocStructInterface tempDS);
+
+    DocStructInterface getParent();
+
+    /**
+     * @return type of {@code Collection<>} would be sufficient
+     */
+    List<MetadataTypeInterface> getPossibleMetadataTypes();
+
+    DocStructTypeInterface getType();
+
+    boolean isDocStructTypeAllowedAsChild(DocStructTypeInterface type);
+
+    /**
+     * @return whether the list contained that child. The return value is never
+     *         used.
+     */
+    boolean removeChild(DocStructInterface docStructInterface);
+
+    /**
+     * @return whether the content file references list was initialized with an
+     *         list instance before the function call. The return value is never
+     *         used.
+     */
+    boolean removeContentFile(ContentFileInterface contentFileInterface) throws ContentFileNotLinkedException;
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean removeMetadata(MetadataInterface md);
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean removeMetadataGroup(MetadataGroupInterface metadataGroupInterface);
+
+    /**
+     * @return whether the persons list was initialized with an list instance
+     *         before the function call. The return value is never used.
+     */
+    boolean removePerson(PersonInterface p);
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean removeReferenceTo(DocStructInterface docStructInterface);
+
+    void setImageName(String otherFile);
+
+    /**
+     * @return aways {@code true}. The return value is never used.
+     */
+    boolean setType(DocStructTypeInterface dst);
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DocStructInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DocStructInterface.java
@@ -38,7 +38,7 @@ public interface DocStructInterface {
     void addContentFile(ContentFileInterface cf);
 
     /**
-     * @return always {@true}. The return value is never used.
+     * @return always {@code true}. The return value is never used.
      */
     boolean addMetadata(MetadataInterface newMetadata) throws MetadataTypeNotAllowedException;
 
@@ -48,12 +48,12 @@ public interface DocStructInterface {
     DocStructInterface addMetadata(String fieldName, String value) throws MetadataTypeNotAllowedException;
 
     /**
-     * @return always {@true}. The return value is never used.
+     * @return always {@code true}. The return value is never used.
      */
     boolean addMetadataGroup(MetadataGroupInterface metadataGroupInterface) throws MetadataTypeNotAllowedException;
 
     /**
-     * @return always {@true}. The return value is never used.
+     * @return always {@code true}. The return value is never used.
      */
     boolean addPerson(PersonInterface p) throws MetadataTypeNotAllowedException;
 
@@ -80,7 +80,7 @@ public interface DocStructInterface {
 
     List<DocStructInterface> getAllChildren();
 
-    List<DocStructInterface> getAllChildrenByTypeAndMetadataType(String string, String string2);
+    List<DocStructInterface> getAllChildrenByTypeAndMetadataType(String type, String metadataType);
 
     List<ContentFileInterface> getAllContentFiles();
 
@@ -88,10 +88,10 @@ public interface DocStructInterface {
 
     List<MetadataInterface> getAllIdentifierMetadata();
 
-    List<MetadataInterface> getAllMetadata(); /*
-                                               * return type collection would be
-                                               * sufficient
-                                               */
+    /**
+     * @return type {@code Collection<>} would be sufficient.
+     */
+    List<MetadataInterface> getAllMetadata();
 
     List<? extends MetadataInterface> getAllMetadataByType(MetadataTypeInterface mdt);
 
@@ -101,20 +101,25 @@ public interface DocStructInterface {
 
     List<PersonInterface> getAllPersonsByType(MetadataTypeInterface authorType);
 
-    List<ReferenceInterface> getAllReferences(String string); // string seems to
-                                                              // be
-    // always "to"
+    /*
+     * @param string seems to be always "to"
+     */
+    List<ReferenceInterface> getAllReferences(String string);
 
     Collection<ReferenceInterface> getAllToReferences();
 
-    Collection<ReferenceInterface> getAllToReferences(String string); // string
-                                                                      // alway
-    // "logical_physical"
-    // ?
-    // return type would be sufficient to be iterable, but there is a check for
-    // size()=0?
+    /*
+     * @param string always "logical_physical" ?
+     * 
+     * @return type would be sufficient to be iterable, but there is a check for
+     * size()=0?
+     */
+    Collection<ReferenceInterface> getAllToReferences(String string);
 
-    Object getAllVisibleMetadata(); // is null/is non-null -check only
+    /*
+     * Is null/is non-null -check only.
+     */
+    Object getAllVisibleMetadata();
 
     String getAnchorClass();
 
@@ -124,7 +129,7 @@ public interface DocStructInterface {
 
     String getImageName();
 
-    /**
+    /*
      * @throws IndexOutOfBoundsException
      */
     DocStructInterface getNextChild(DocStructInterface tempDS);

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DocStructTypeInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/DocStructTypeInterface.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import java.util.List;
+
+public interface DocStructTypeInterface {
+
+    List<String> getAllAllowedDocStructTypes(); /*
+                                                 * note: list<String>! not
+                                                 * list<DocStructType>
+                                                 */
+
+    List<MetadataTypeInterface> getAllMetadataTypes(); // iterable would be sufficient
+
+    String getAnchorClass();
+
+    String getName(); /* internal name, ID */
+
+    String getNameByLanguage(String language);
+
+    String getNumberOfMetadataType(MetadataTypeInterface metadataTypeInterface);
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/FactoryInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/FactoryInterface.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
+import org.kitodo.api.ugh.exceptions.PreferencesException;
+
+public interface FactoryInterface {
+    ContentFileInterface createContentFile();
+
+    DigitalDocumentInterface createDigitalDocument();
+
+    MetadataInterface createMetadata(MetadataTypeInterface metadataTypeInterface)
+            throws MetadataTypeNotAllowedException;
+
+    MetadataGroupInterface createMetadataGroup(MetadataGroupTypeInterface metadataGroupTypeInterface)
+            throws MetadataTypeNotAllowedException;
+
+    MetadataGroupTypeInterface createMetadataGroupType();
+
+    MetadataTypeInterface createMetadataType();
+
+    MetsModsInterface createMetsMods(PrefsInterface prefsInterface) throws PreferencesException;
+
+    MetsModsImportExportInterface createMetsModsImportExport(PrefsInterface prefsInterface) throws PreferencesException;
+
+    PersonInterface createPerson(MetadataTypeInterface metadataTypeInterface) throws MetadataTypeNotAllowedException;
+
+    PicaPlusInterface createPicaPlus(PrefsInterface prefsInterface);
+
+    PrefsInterface createPrefs();
+
+    FileformatInterface createRDFFile(PrefsInterface prefsInterface) throws PreferencesException;
+
+    RomanNumeralInterface createRomanNumeral();
+
+    VirtualFileGroupInterface createVirtualFileGroup();
+
+    FileformatInterface createXStream(PrefsInterface prefsInterface) throws PreferencesException;
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/FileSetInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/FileSetInterface.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface FileSetInterface {
+    /**
+     * @return always {@code true}. The result value is never used.
+     */
+    boolean addFile(ContentFileInterface contentFileInterface);
+
+    void addVirtualFileGroup(VirtualFileGroupInterface v);
+
+    Iterable<ContentFileInterface> getAllFiles();
+
+    /**
+     * @return always {@code true}. The result value is never used.
+     */
+    boolean removeFile(ContentFileInterface contentFileInterface);
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/FileformatInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/FileformatInterface.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import org.kitodo.api.ugh.exceptions.PreferencesException;
+import org.kitodo.api.ugh.exceptions.ReadException;
+import org.kitodo.api.ugh.exceptions.WriteException;
+
+public interface FileformatInterface {
+
+    DigitalDocumentInterface getDigitalDocument()
+            throws PreferencesException /* Error on creating process */;
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean read(String path) throws PreferencesException, ReadException;
+
+    /**
+     * @return constantly {@code true} or {@code false}, depending on the
+     *         implementing class. The return value is never used.
+     */
+    boolean setDigitalDocument(DigitalDocumentInterface newFile);
+
+    boolean write(String string) throws PreferencesException, WriteException;
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataGroupInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataGroupInterface.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface MetadataGroupInterface {
+
+    void addMetadata(MetadataInterface metadataInterface);
+
+    void addPerson(PersonInterface personInterface);
+
+    List<MetadataInterface> getMetadataByType(String type);
+
+    public List<MetadataInterface> getMetadataList();
+
+    public Iterable<PersonInterface> getPersonByType(String personType);
+
+    public Collection<PersonInterface> getPersonList();
+
+    public MetadataGroupTypeInterface getType();
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataGroupTypeInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataGroupTypeInterface.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MetadataGroupTypeInterface {
+
+    void addMetadataType(MetadataTypeInterface metadataTypeInterface);
+
+    Map<String, String> getAllLanguages();
+
+    String getLanguage(String language);
+
+    List<MetadataTypeInterface> getMetadataTypeList();
+
+    String getName();
+
+    void setAllLanguages(Map<String, String> allLanguages);
+
+    void setName(String name);
+
+    /**
+     * @param num
+     *            one of "1m", "1o", "+", or "*"
+     * @return {@code false}, if the string argument is not one of these four
+     *         string; true otherwise. The return value is never used.
+     */
+    boolean setNum(String num);
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataInterface.java
@@ -21,9 +21,13 @@ public interface MetadataInterface {
 
     public void setDocStruct(DocStructInterface docStructInterface);
 
-    /** @return always {@code true}. The result is never used. */
+    /**
+     * @return always {@code true}. The result is never used.
+     */
     public boolean setType(MetadataTypeInterface metadataTypeInterface);
 
-    /** @return always {@code true}. The result is never used. */
+    /**
+     * @return always {@code true}. The result is never used.
+     */
     public boolean setValue(String value);
 }

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataInterface.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface MetadataInterface {
+
+    public DocStructInterface getDocStruct();
+
+    public MetadataTypeInterface getType();
+
+    public String getValue();
+
+    public void setDocStruct(DocStructInterface docStructInterface);
+
+    /** @return always {@code true}. The result is never used. */
+    public boolean setType(MetadataTypeInterface metadataTypeInterface);
+
+    /** @return always {@code true}. The result is never used. */
+    public boolean setValue(String value);
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataTypeInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetadataTypeInterface.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public interface MetadataTypeInterface {
+
+    Map<String, String> getAllLanguages();
+
+    boolean getIsPerson();
+
+    public String getLanguage(String language);
+
+    public String getName();
+
+    public String getNameByLanguage(String language);
+
+    public String getNum();
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean setAllLanguages(HashMap<String, String> labels);
+
+    public void setIdentifier(boolean identifier);
+
+    public void setIsPerson(boolean person);
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean setName(String string);
+
+    /**
+     * @param num
+     *            one of "1m", "1o", "+", or "*"
+     * @return {@code false}, if the string argument is not one of these four
+     *         string; true otherwise. The return value is never used.
+     */
+    boolean setNum(String quantityRestriction);
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetsModsImportExportInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetsModsImportExportInterface.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface MetsModsImportExportInterface extends FileformatInterface {
+
+    static final String CREATE_LABEL_ATTRIBUTE_TYPE = "...";
+    static final String CREATE_MPTR_ELEMENT_TYPE = "...";
+    static final String CREATE_ORDERLABEL_ATTRIBUTE_TYPE = "...";
+
+    void setContentIDs(String replace);
+
+    void setDigiprovPresentation(String replace);
+
+    void setDigiprovPresentationAnchor(String replace);
+
+    void setDigiprovReference(String replace);
+
+    void setDigiprovReferenceAnchor(String replace);
+
+    void setMptrAnchorUrl(String pointer);
+
+    void setMptrUrl(String object);
+
+    void setPurlUrl(String replace);
+
+    void setRightsOwner(String replace);
+
+    void setRightsOwnerContact(String replace);
+
+    void setRightsOwnerLogo(String replace);
+
+    void setRightsOwnerSiteURL(String replace);
+
+    void setWriteLocal(boolean writeLocalFileGroup);
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetsModsInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/MetsModsInterface.java
@@ -1,0 +1,16 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface MetsModsInterface extends FileformatInterface {
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/PersonInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/PersonInterface.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface PersonInterface extends MetadataInterface {
+
+    String getAuthorityURI();
+
+    String getAuthorityValue();
+
+    String getDisplayname();
+
+    String getFirstname();
+
+    String getLastname();
+
+    String getRole();
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean setAutorityFile(String authority, String authorityURI, String valueURI);
+
+    void setDisplayname(String displayname);
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean setFirstname(String firstname);
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean setLastname(String lastname);
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean setRole(String role);
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/PicaPlusInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/PicaPlusInterface.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import org.kitodo.api.ugh.exceptions.ReadException;
+import org.w3c.dom.Node;
+
+public interface PicaPlusInterface extends FileformatInterface {
+
+    /**
+     * @return always {@code true}. The result value is never used.
+     */
+    boolean read(Node node) throws ReadException;
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/PrefsInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/PrefsInterface.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+import java.util.List;
+import org.kitodo.api.ugh.exceptions.PreferencesException;
+
+public interface PrefsInterface {
+    List<DocStructTypeInterface> getAllDocStructTypes();
+
+    DocStructTypeInterface getDocStrctTypeByName(String identifier);
+
+    MetadataTypeInterface getMetadataTypeByName(String identifier);
+
+    /**
+     * @return always {@code true}. The return value is never used.
+     */
+    boolean loadPrefs(String string) throws PreferencesException;
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/RDFFileInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/RDFFileInterface.java
@@ -1,0 +1,16 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface RDFFileInterface extends FileformatInterface {
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/ReferenceInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/ReferenceInterface.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface ReferenceInterface {
+
+    DocStructInterface getSource();
+
+    DocStructInterface getTarget();
+
+    String getType();
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/RomanNumeralInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/RomanNumeralInterface.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface RomanNumeralInterface {
+
+    String getNumber();
+
+    int intValue();
+
+    void setValue(int currentPhysicalOrder);
+
+    void setValue(String paginationStartValue);
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/UghImplementation.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/UghImplementation.java
@@ -1,0 +1,17 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public class UghImplementation {
+    public static final FactoryInterface INSTANCE = null; // FIXME: Set UGH
+                                                    // implementation
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/VirtualFileGroupInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/VirtualFileGroupInterface.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface VirtualFileGroupInterface {
+
+    public void setFileSuffix(String suffix);
+
+    public void setMimetype(String mimeType);
+
+    public void setName(String name);
+
+    public void setOrdinary(boolean ordinary);
+
+    public void setPathToFiles(String replace);
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/XStreamInterface.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/XStreamInterface.java
@@ -1,0 +1,16 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh;
+
+public interface XStreamInterface extends FileformatInterface {
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/ContentFileNotLinkedException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/ContentFileNotLinkedException.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class ContentFileNotLinkedException extends UGHException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ContentFileNotLinkedException() {
+    }
+
+    public ContentFileNotLinkedException(String message) {
+        super(message);
+    }
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/DocStructHasNoTypeException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/DocStructHasNoTypeException.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class DocStructHasNoTypeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DocStructHasNoTypeException() {
+    }
+
+    public DocStructHasNoTypeException(String message) {
+        super(message);
+    }
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/IncompletePersonObjectException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/IncompletePersonObjectException.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class IncompletePersonObjectException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public IncompletePersonObjectException() {
+    }
+
+    public IncompletePersonObjectException(String message) {
+        super(message);
+    }
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/MetadataTypeNotAllowedException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/MetadataTypeNotAllowedException.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class MetadataTypeNotAllowedException extends UGHException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MetadataTypeNotAllowedException() {
+    }
+
+    public MetadataTypeNotAllowedException(String message) {
+        super(message);
+    }
+
+    public MetadataTypeNotAllowedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/PreferencesException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/PreferencesException.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class PreferencesException extends UGHException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PreferencesException() {
+    }
+
+    public PreferencesException(String message) {
+        super(message);
+    }
+
+    public PreferencesException(String message, Throwable t) {
+        super(message, t);
+    }
+
+    public PreferencesException(Throwable t) {
+        super(t);
+    }
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/ReadException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/ReadException.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class ReadException extends UGHException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ReadException(String message) {
+        super(message);
+    }
+
+    public ReadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/TypeNotAllowedAsChildException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/TypeNotAllowedAsChildException.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class TypeNotAllowedAsChildException extends UGHException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TypeNotAllowedAsChildException(String message) {
+        super(message);
+    }
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/TypeNotAllowedForParentException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/TypeNotAllowedForParentException.java
@@ -1,0 +1,18 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class TypeNotAllowedForParentException extends UGHException {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/UGHException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/UGHException.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class UGHException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public UGHException() {
+    }
+
+    public UGHException(String message) {
+        super(message);
+    }
+
+    public UGHException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UGHException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/WriteException.java
+++ b/Kitodo-UGH-API/src/main/java/org/kitodo/api/ugh/exceptions/WriteException.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.ugh.exceptions;
+
+public class WriteException extends UGHException {
+
+    private static final long serialVersionUID = 1L;
+
+    public WriteException() {
+    }
+
+    public WriteException(String message) {
+        super(message);
+    }
+
+    public WriteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <module>Kitodo-Docket</module>
         <module>Kitodo-Command</module>
         <module>Kitodo-SchemaConverter</module>
+        <module>Kitodo-UGH-API</module>
         <module>Kitodo-Validation</module>
         <module>Kitodo</module>
     </modules>


### PR DESCRIPTION
Adds an interface for the UGH classes.

The interface has to be implemented as a separate maven module, to allow to compile the UGH against it while avoiding cyclomatic module dependencies.

The interface will be removed, as soon as the UGH classes have been replaced.