### PR TITLE
Duplicate project

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -169,45 +169,10 @@ public class ProjekteForm extends BasisForm {
      * @return page address
      */
     public String duplicateProject(Integer itemId) {
-        this.myProjekt = new Project();
         this.itemId = 0;
         try {
-            Project baseProject = serviceManager.getProjectService().getById(itemId);
-
-            // Project _title_ should explicitly _not_ be duplicated!
-            this.myProjekt.setStartDate(baseProject.getStartDate());
-            this.myProjekt.setEndDate(baseProject.getEndDate());
-            this.myProjekt.setNumberOfPages(baseProject.getNumberOfPages());
-            this.myProjekt.setNumberOfVolumes(baseProject.getNumberOfVolumes());
-
-            this.myProjekt.setFileFormatInternal(baseProject.getFileFormatInternal());
-            this.myProjekt.setFileFormatDmsExport(baseProject.getFileFormatDmsExport());
-            this.myProjekt.setDmsImportErrorPath(baseProject.getDmsImportErrorPath());
-            this.myProjekt.setDmsImportSuccessPath(baseProject.getDmsImportSuccessPath());
-
-            this.myProjekt.setDmsImportTimeOut(baseProject.getDmsImportTimeOut());
-            this.myProjekt.setUseDmsImport(baseProject.isUseDmsImport());
-            this.myProjekt.setDmsImportCreateProcessFolder(baseProject.isDmsImportCreateProcessFolder());
-
-            this.myProjekt.setMetsRightsOwner(baseProject.getMetsRightsOwner());
-            this.myProjekt.setMetsRightsOwnerLogo(baseProject.getMetsRightsOwnerLogo());
-            this.myProjekt.setMetsRightsOwnerSite(baseProject.getMetsRightsOwnerSite());
-            this.myProjekt.setMetsRightsOwnerMail(baseProject.getMetsRightsOwnerMail());
-
-            this.myProjekt.setMetsDigiprovPresentation(baseProject.getMetsDigiprovPresentation());
-            this.myProjekt.setMetsDigiprovPresentationAnchor(baseProject.getMetsDigiprovPresentationAnchor());
-            this.myProjekt.setMetsDigiprovReference(baseProject.getMetsDigiprovReference());
-            this.myProjekt.setMetsDigiprovReferenceAnchor(baseProject.getMetsDigiprovReferenceAnchor());
-
-            this.myProjekt.setMetsPointerPath(baseProject.getMetsPointerPath());
-            this.myProjekt.setMetsPointerPathAnchor(baseProject.getMetsPointerPathAnchor());
-            this.myProjekt.setMetsPurl(baseProject.getMetsPurl());
-            this.myProjekt.setMetsContentIDs(baseProject.getMetsContentIDs());
-
-            this.myProjekt.setProcesses(new ArrayList<>(baseProject.getProcesses()));
-
+            this.myProjekt = serviceManager.getProjectService().duplicateProject(itemId);
             return redirectToEdit("?faces-redirect=true");
-
         } catch (DAOException e) {
             logger.error(e.getMessage());
             FacesContext facesContext = FacesContext.getCurrentInstance();

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -49,6 +49,7 @@ import org.goobi.production.flow.statistics.StatisticsRenderingElement;
 import org.goobi.production.flow.statistics.enums.CalculationUnit;
 import org.goobi.production.flow.statistics.enums.StatisticsMode;
 import org.goobi.production.flow.statistics.hibernate.StatQuestProjectProgressData;
+import org.hibernate.Session;
 import org.joda.time.DateTime;
 import org.joda.time.Months;
 import org.joda.time.Weeks;
@@ -180,7 +181,7 @@ public class ProjekteForm extends BasisForm {
         } catch (DAOException e) {
             logger.error(e.getMessage());
             FacesContext facesContext = FacesContext.getCurrentInstance();
-            FacesMessage facesMessage = new FacesMessage("ERROR: " + Helper.getTranslation("unableToDuplicateProject"));
+            FacesMessage facesMessage = new FacesMessage(Helper.getTranslation("unableToDuplicateProject"));
             facesContext.addMessage(null, facesMessage);
             return null;
         }
@@ -192,6 +193,8 @@ public class ProjekteForm extends BasisForm {
      * @return page or empty String
      */
     public String save() {
+        Session session = Helper.getHibernateSession();
+        session.evict(this.myProjekt);
         // call this to make saving and deleting permanent
         this.commitFileGroups();
         if (this.myProjekt.getTitle().equals("") || this.myProjekt.getTitle() == null) {
@@ -847,8 +850,7 @@ public class ProjekteForm extends BasisForm {
         } catch (DAOException e) {
             logger.error(e.getMessage());
             FacesContext facesContext = FacesContext.getCurrentInstance();
-            FacesMessage facesMessage = new FacesMessage(
-                    "ERROR: " + Helper.getTranslation("unableToRetrieveTemplates"));
+            FacesMessage facesMessage = new FacesMessage(Helper.getTranslation("unableToRetrieveTemplates"));
             facesContext.addMessage(null, facesMessage);
             return null;
         }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -829,6 +829,26 @@ public class ProjekteForm extends BasisForm {
         }
     }
 
+    /**
+     * Return the template titles of the project with the given ID "id".
+     *
+     * @param id
+     *            ID of the project for which the template titles are returned.
+     * @return String containing the templates titles of the project with the given
+     *         ID
+     */
+    public String getProjectTemplateTitles(int id) {
+        try {
+            return serviceManager.getProjectService().getProjectTemplatesTitlesAsString(id);
+        } catch (DAOException e) {
+            logger.error(e.getMessage());
+            FacesContext facesContext = FacesContext.getCurrentInstance();
+            FacesMessage facesMessage = new FacesMessage("ERROR: Unable to retrieve templates for project!");
+            facesContext.addMessage(null, facesMessage);
+            return null;
+        }
+    }
+
     // TODO:
     // replace calls to this function with "/pages/projectEdit" once we have
     // completely switched to the new frontend pages

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -166,7 +166,11 @@ public class ProjekteForm extends BasisForm {
     /**
      * Duplicate the selected project.
      *
-     * @return page address
+     * @param itemId
+     *            ID of the project to duplicate
+     * @return page address; either redirect to the edit project page or return
+     *         'null' if the project could not be retrieved, which will prompt JSF
+     *         to remain on the same page and reuse the bean.
      */
     public String duplicateProject(Integer itemId) {
         this.itemId = 0;

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -15,7 +15,6 @@ import de.intranda.commons.chart.renderer.ChartRenderer;
 import de.intranda.commons.chart.results.ChartDraw.ChartType;
 import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
-import de.sub.goobi.helper.Page;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -28,8 +27,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.SessionScoped;
+import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 import javax.imageio.ImageIO;
 import javax.inject.Named;
@@ -162,6 +161,60 @@ public class ProjekteForm extends BasisForm {
         this.myProjekt = new Project();
         this.itemId = 0;
         return redirectToEdit("?faces-redirect=true");
+    }
+
+    /**
+     * Duplicate the selected project.
+     *
+     * @return page address
+     */
+    public String duplicateProject(Integer itemId) {
+        this.myProjekt = new Project();
+        this.itemId = 0;
+        try {
+            Project baseProject = serviceManager.getProjectService().getById(itemId);
+
+            // Project _title_ should explicitly _not_ be duplicated!
+            this.myProjekt.setStartDate(baseProject.getStartDate());
+            this.myProjekt.setEndDate(baseProject.getEndDate());
+            this.myProjekt.setNumberOfPages(baseProject.getNumberOfPages());
+            this.myProjekt.setNumberOfVolumes(baseProject.getNumberOfVolumes());
+
+            this.myProjekt.setFileFormatInternal(baseProject.getFileFormatInternal());
+            this.myProjekt.setFileFormatDmsExport(baseProject.getFileFormatDmsExport());
+            this.myProjekt.setDmsImportErrorPath(baseProject.getDmsImportErrorPath());
+            this.myProjekt.setDmsImportSuccessPath(baseProject.getDmsImportSuccessPath());
+
+            this.myProjekt.setDmsImportTimeOut(baseProject.getDmsImportTimeOut());
+            this.myProjekt.setUseDmsImport(baseProject.isUseDmsImport());
+            this.myProjekt.setDmsImportCreateProcessFolder(baseProject.isDmsImportCreateProcessFolder());
+
+            this.myProjekt.setMetsRightsOwner(baseProject.getMetsRightsOwner());
+            this.myProjekt.setMetsRightsOwnerLogo(baseProject.getMetsRightsOwnerLogo());
+            this.myProjekt.setMetsRightsOwnerSite(baseProject.getMetsRightsOwnerSite());
+            this.myProjekt.setMetsRightsOwnerMail(baseProject.getMetsRightsOwnerMail());
+
+            this.myProjekt.setMetsDigiprovPresentation(baseProject.getMetsDigiprovPresentation());
+            this.myProjekt.setMetsDigiprovPresentationAnchor(baseProject.getMetsDigiprovPresentationAnchor());
+            this.myProjekt.setMetsDigiprovReference(baseProject.getMetsDigiprovReference());
+            this.myProjekt.setMetsDigiprovReferenceAnchor(baseProject.getMetsDigiprovReferenceAnchor());
+
+            this.myProjekt.setMetsPointerPath(baseProject.getMetsPointerPath());
+            this.myProjekt.setMetsPointerPathAnchor(baseProject.getMetsPointerPathAnchor());
+            this.myProjekt.setMetsPurl(baseProject.getMetsPurl());
+            this.myProjekt.setMetsContentIDs(baseProject.getMetsContentIDs());
+
+            this.myProjekt.setProcesses(new ArrayList<>(baseProject.getProcesses()));
+
+            return redirectToEdit("?faces-redirect=true");
+
+        } catch (DAOException e) {
+            logger.error(e.getMessage());
+            FacesContext facesContext = FacesContext.getCurrentInstance();
+            FacesMessage facesMessage = new FacesMessage("ERROR: Unable to duplicate selected project!");
+            facesContext.addMessage(null, facesMessage);
+            return null;
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -174,6 +174,7 @@ public class ProjekteForm extends BasisForm {
      *         to remain on the same page and reuse the bean.
      */
     public String duplicateProject(Integer itemId) {
+        setLocked(false);
         this.itemId = 0;
         try {
             this.myProjekt = serviceManager.getProjectService().duplicateProject(itemId);

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -180,7 +180,7 @@ public class ProjekteForm extends BasisForm {
         } catch (DAOException e) {
             logger.error(e.getMessage());
             FacesContext facesContext = FacesContext.getCurrentInstance();
-            FacesMessage facesMessage = new FacesMessage("ERROR: Unable to duplicate selected project!");
+            FacesMessage facesMessage = new FacesMessage("ERROR: " + Helper.getTranslation("unableToDuplicateProject"));
             facesContext.addMessage(null, facesMessage);
             return null;
         }
@@ -847,7 +847,8 @@ public class ProjekteForm extends BasisForm {
         } catch (DAOException e) {
             logger.error(e.getMessage());
             FacesContext facesContext = FacesContext.getCurrentInstance();
-            FacesMessage facesMessage = new FacesMessage("ERROR: Unable to retrieve templates for project!");
+            FacesMessage facesMessage = new FacesMessage(
+                    "ERROR: " + Helper.getTranslation("unableToRetrieveTemplates"));
             facesContext.addMessage(null, facesMessage);
             return null;
         }

--- a/Kitodo/src/main/java/org/kitodo/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/dto/ProjectDTO.java
@@ -12,7 +12,6 @@
 package org.kitodo.dto;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Project DTO object.
@@ -238,15 +237,5 @@ public class ProjectDTO extends BaseDTO {
      */
     public void setUsers(List<UserDTO> users) {
         this.users = users;
-    }
-
-    /**
-     * Return a string containing a comma separated list of process templates
-     * associated with this project.
-     *
-     * @return process templates associated with this project
-     */
-    public String getProcessTitles() {
-        return String.join(", ", this.processes.stream().map(ProcessDTO::getTitle).collect(Collectors.toList()));
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
@@ -340,9 +340,6 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO, Proj
         }
         duplicatedProject.setProjectFileGroups(duplicatedFileGroups);
 
-        // only duplicate templates, not all processes, of given base project
-        duplicatedProject.setProcesses(new ArrayList<>(
-                baseProject.getProcesses().stream().filter(Process::isTemplate).collect(Collectors.toList())));
         return duplicatedProject;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
@@ -31,6 +31,7 @@ import org.goobi.production.flow.statistics.StepInformation;
 import org.json.simple.JSONObject;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
+import org.kitodo.data.database.beans.ProjectFileGroup;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.helper.enums.IndexAction;
@@ -323,6 +324,21 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO, Proj
         duplicatedProject.setMetsPointerPathAnchor(baseProject.getMetsPointerPathAnchor());
         duplicatedProject.setMetsPurl(baseProject.getMetsPurl());
         duplicatedProject.setMetsContentIDs(baseProject.getMetsContentIDs());
+
+        ArrayList<ProjectFileGroup> duplicatedFileGroups = new ArrayList<>();
+        for (ProjectFileGroup projectFileGroup : baseProject.getProjectFileGroups()) {
+            ProjectFileGroup duplicatedGroup = new ProjectFileGroup();
+            duplicatedGroup.setMimeType(projectFileGroup.getMimeType());
+            duplicatedGroup.setName(projectFileGroup.getName());
+            duplicatedGroup.setPath(projectFileGroup.getPath());
+            duplicatedGroup.setPreviewImage(projectFileGroup.isPreviewImage());
+            duplicatedGroup.setSuffix(projectFileGroup.getSuffix());
+            duplicatedGroup.setFolder(projectFileGroup.getFolder());
+
+            duplicatedGroup.setProject(duplicatedProject);
+            duplicatedFileGroups.add(duplicatedGroup);
+        }
+        duplicatedProject.setProjectFileGroups(duplicatedFileGroups);
 
         // only duplicate templates, not all processes, of given base project
         duplicatedProject.setProcesses(new ArrayList<>(

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,7 +88,7 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO, Proj
 
     /**
      * Management od processes for project object.
-     * 
+     *
      * @param project
      *            object
      */
@@ -129,13 +130,13 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO, Proj
 
     /**
      * Find archived or not archived projects.
-     * 
+     *
      * @param archived
      *            if true - find archived projects, if false - find not archived
      *            projects
      * @param related
-     *            if true - found project is related to some other DTO object,
-     *            if false - not and it collects all related objects
+     *            if true - found project is related to some other DTO object, if
+     *            false - not and it collects all related objects
      * @return list of ProjectDTO objects
      */
     List<ProjectDTO> findByArchived(Boolean archived, boolean related) throws DataException {
@@ -281,5 +282,51 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO, Proj
 
         return project.getTitle() != null && project.template != null && project.getFileFormatDmsExport() != null
                 && project.getFileFormatInternal() != null && digitalCollectionsXmlExists && projectsXmlExists;
+    }
+
+    /**
+     * Duplicate the project with the given ID 'itemId'.
+     *
+     * @return the duplicated Project
+     */
+    public Project duplicateProject(Integer itemId) throws DAOException {
+        Project duplicatedProject = new Project();
+
+        Project baseProject = getById(itemId);
+
+        // Project _title_ should explicitly _not_ be duplicated!
+        duplicatedProject.setStartDate(baseProject.getStartDate());
+        duplicatedProject.setEndDate(baseProject.getEndDate());
+        duplicatedProject.setNumberOfPages(baseProject.getNumberOfPages());
+        duplicatedProject.setNumberOfVolumes(baseProject.getNumberOfVolumes());
+
+        duplicatedProject.setFileFormatInternal(baseProject.getFileFormatInternal());
+        duplicatedProject.setFileFormatDmsExport(baseProject.getFileFormatDmsExport());
+        duplicatedProject.setDmsImportErrorPath(baseProject.getDmsImportErrorPath());
+        duplicatedProject.setDmsImportSuccessPath(baseProject.getDmsImportSuccessPath());
+
+        duplicatedProject.setDmsImportTimeOut(baseProject.getDmsImportTimeOut());
+        duplicatedProject.setUseDmsImport(baseProject.isUseDmsImport());
+        duplicatedProject.setDmsImportCreateProcessFolder(baseProject.isDmsImportCreateProcessFolder());
+
+        duplicatedProject.setMetsRightsOwner(baseProject.getMetsRightsOwner());
+        duplicatedProject.setMetsRightsOwnerLogo(baseProject.getMetsRightsOwnerLogo());
+        duplicatedProject.setMetsRightsOwnerSite(baseProject.getMetsRightsOwnerSite());
+        duplicatedProject.setMetsRightsOwnerMail(baseProject.getMetsRightsOwnerMail());
+
+        duplicatedProject.setMetsDigiprovPresentation(baseProject.getMetsDigiprovPresentation());
+        duplicatedProject.setMetsDigiprovPresentationAnchor(baseProject.getMetsDigiprovPresentationAnchor());
+        duplicatedProject.setMetsDigiprovReference(baseProject.getMetsDigiprovReference());
+        duplicatedProject.setMetsDigiprovReferenceAnchor(baseProject.getMetsDigiprovReferenceAnchor());
+
+        duplicatedProject.setMetsPointerPath(baseProject.getMetsPointerPath());
+        duplicatedProject.setMetsPointerPathAnchor(baseProject.getMetsPointerPathAnchor());
+        duplicatedProject.setMetsPurl(baseProject.getMetsPurl());
+        duplicatedProject.setMetsContentIDs(baseProject.getMetsContentIDs());
+
+        // only duplicate templates, not all processes, of given base project
+        duplicatedProject.setProcesses(new ArrayList<>(
+                baseProject.getProcesses().stream().filter(Process::isTemplate).collect(Collectors.toList())));
+        return duplicatedProject;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
@@ -329,4 +329,16 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO, Proj
                 baseProject.getProcesses().stream().filter(Process::isTemplate).collect(Collectors.toList())));
         return duplicatedProject;
     }
+
+    /**
+     * Return a string containing a comma separated list of process templates
+     * associated with this project.
+     *
+     * @return process templates associated with this project
+     */
+    public String getProjectTemplatesTitlesAsString(int id) throws DAOException {
+        Project project = serviceManager.getProjectService().getById(id);
+        return String.join(", ", project.getProcesses().stream().filter(Process::isTemplate).map(Process::getTitle)
+                .collect(Collectors.toList()));
+    }
 }

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -427,6 +427,7 @@ download=Images herunterladen
 downloadInMeinHomeverzeichnis=Download in mein Homeverzeichnis
 duplicate=Duplizieren
 duplicateName=Dieser Name wird in dieser Kollektion bereits verwendet
+duplicateProject=Projekt duplizieren
 duration=Laufzeit
 durationInMonth=Laufzeit in Monaten
 editDocket=Laufzettel bearbeiten

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -1081,8 +1081,10 @@ typeSetNewspaper=Zeitung
 typeSetSerial=fortlaufendes Sammelwerk
 uebernehmen=\u00DCbernehmen
 uebersicht=\u00DCbersicht
+unableToDuplicateProject=Projekt konnte nicht dupliziert werden!
 unableToRegisterObject=Objekt konnte nicht registriert werden
 unableToRetrieveTask=Aufgabe konnte nicht geladen werden!
+unableToRetrieveTemplates=Templates konnten nicht geladen werden!
 unbekannt=Unbekannt
 unbekannterFehler=Unbekannter Fehler
 unknownErrorMsgWithLinkToStartPage=Ein unerwarteter Fehler ist aufgetreten. Eventuell m\u00FCssen Sie von vorne anfangen. Um fortzufahren klicken Sie bitte <a href\='../pages/Main.jsf'>hier</a>.<p>Sie k\u00F6nnen die  Fehlermeldung ignorieren oder eine <a href\='replaceThisForErrorEmail'><b><b><b> email an die Entwickler </b></b></b></a>  schicken.</p>

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -1081,10 +1081,10 @@ typeSetNewspaper=Zeitung
 typeSetSerial=fortlaufendes Sammelwerk
 uebernehmen=\u00DCbernehmen
 uebersicht=\u00DCbersicht
-unableToDuplicateProject=Projekt konnte nicht dupliziert werden!
+unableToDuplicateProject=Fehler: Projekt konnte nicht dupliziert werden!
 unableToRegisterObject=Objekt konnte nicht registriert werden
 unableToRetrieveTask=Aufgabe konnte nicht geladen werden!
-unableToRetrieveTemplates=Templates konnten nicht geladen werden!
+unableToRetrieveTemplates=Fehler: Templates konnten nicht geladen werden!
 unbekannt=Unbekannt
 unbekannterFehler=Unbekannter Fehler
 unknownErrorMsgWithLinkToStartPage=Ein unerwarteter Fehler ist aufgetreten. Eventuell m\u00FCssen Sie von vorne anfangen. Um fortzufahren klicken Sie bitte <a href\='../pages/Main.jsf'>hier</a>.<p>Sie k\u00F6nnen die  Fehlermeldung ignorieren oder eine <a href\='replaceThisForErrorEmail'><b><b><b> email an die Entwickler </b></b></b></a>  schicken.</p>

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -1088,10 +1088,10 @@ typeSetNewspaper=newspaper
 typeSetSerial=serial publications
 uebernehmen=Apply
 uebersicht=Overview
-unableToDuplicateProject=Unable to duplicate project!
+unableToDuplicateProject=Error: Unable to duplicate project!
 unableToRegisterObject=Couldn't register object
 unableToRetrieveTask=Unable to retrieve the requested task!
-unableToRetrieveTemplates=Unable to retrieve templates!
+unableToRetrieveTemplates=Error: Unable to retrieve templates!
 unbekannt=Unknown
 unbekannterFehler=error
 unknownErrorMsgWithLinkToStartPage=An unexpected Error occurred. You may have to restart. To continue please klick <a href\='../pages/Main.jsf'>here</a>.<p>You may ignore the Stack Trace or send an <a href\='replaceThisForErrorEmail'><b><b><b>email to the developers</b></b></b></a>.</p>

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -430,6 +430,7 @@ download=Download images
 downloadInMeinHomeverzeichnis=Download to my home directory
 duplicate=duplicate
 duplicateName=This name has already been used in this collection.
+duplicateProject=Duplicate project
 duration=Duration
 durationInMonth=Duration in month
 editDocket=edit docket

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -1088,8 +1088,10 @@ typeSetNewspaper=newspaper
 typeSetSerial=serial publications
 uebernehmen=Apply
 uebersicht=Overview
+unableToDuplicateProject=Unable to duplicate project!
 unableToRegisterObject=Couldn't register object
 unableToRetrieveTask=Unable to retrieve the requested task!
+unableToRetrieveTemplates=Unable to retrieve templates!
 unbekannt=Unknown
 unbekannterFehler=error
 unknownErrorMsgWithLinkToStartPage=An unexpected Error occurred. You may have to restart. To continue please klick <a href\='../pages/Main.jsf'>here</a>.<p>You may ignore the Stack Trace or send an <a href\='replaceThisForErrorEmail'><b><b><b>email to the developers</b></b></b></a>.</p>

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -674,7 +674,8 @@ footer {
     width: 150px;
 }
 
-.ui-datatable tr td.actionsColumn > a {
+.ui-datatable tr td.actionsColumn > a,
+.ui-datatable tr td.actionsColumn > form > a  {
     color: #2B6FB6;
     margin-right: 10px;
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/header.xhtml
@@ -61,7 +61,7 @@
                             <li><h3>#{msgs.dashboard}<h:outputText rendered="#{LoginForm.maximaleBerechtigung == 1}"> <i>(Admin)</i></h:outputText></h3></li>
                             <li class="nav-pic-text"><h:link value="#{msgs.schritte}" outcome="tasks"><i class="fa fa-bell fa-lg"/></h:link></li>
                             <li class="nav-pic-text"><h:link value="#{msgs.prozesse}" outcome="processes"><i class="fa fa-hourglass-3 fa-lg"/></h:link></li>
-                            <li class="nav-pic-text"><h:link value="#{msgs.projekte}" outcome="projects" onclick="#{ProjekteForm.setLocked(true)}"><i class="fa fa-folder-open fa-lg"/></h:link></li>
+                            <li class="nav-pic-text"><h:link value="#{msgs.projekte}" outcome="projects"><i class="fa fa-folder-open fa-lg"/></h:link></li>
                             <li class="nav-pic-text"><h:link value="#{msgs.benutzer}" outcome="users"><i class="fa fa-user fa-lg"/></h:link></li>
                             <li class="nav-pic-text"><h:link value="#{msgs.modules}" outcome="newTaskManager"><i class="fa fa-puzzle-piece fa-lg"/></h:link></li>
                             <li class="nav-pic-text"><h:link value="#{msgs.help}" outcome="userInstructions"><i class="fa fa-life-ring fa-lg"/></h:link></li>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -70,7 +70,7 @@
                 <h:outputText value="#{item.fileFormatDmsExport}"/>
 
                 <h:outputText value="#{msgs.prozessvorlagen}:"/>
-                <h:outputText value="#{item.processTitles}"/>
+                <h:outputText value="#{ProjekteForm.getProjectTemplateTitles(item.id)}"/>
             </p:panelGrid>
         </p:rowExpansion>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -48,13 +48,17 @@
         </p:column>
 
         <p:column headerText="#{msgs.auswahl}" styleClass="actionsColumn">
-            <h:link outcome="projectEdit"
-                    title="#{msgs.projektBearbeiten}">
-                <f:param name="id" value="#{item.id}" />
-                <i class="fa fa-pencil-square-o fa-lg"/>
-            </h:link>
-            <h:link><i class="fa fa-clone fa-lg"/></h:link>
-            <h:link><i class="fa fa-bar-chart fa-lg"/></h:link>
+            <h:form id="projectActionForm">
+                <h:link outcome="projectEdit"
+                        title="#{msgs.projektBearbeiten}">
+                    <f:param name="id" value="#{item.id}" />
+                    <i class="fa fa-pencil-square-o fa-lg"/>
+                </h:link>
+                <h:commandLink action="#{ProjekteForm.duplicateProject(item.id)}" immediate="true">
+                    <i class="fa fa-clone fa-lg"/>
+                </h:commandLink>
+                <h:link><i class="fa fa-bar-chart fa-lg"/></h:link>
+            </h:form>
         </p:column>
 
         <p:rowExpansion styleClass="expansion-class">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -54,9 +54,7 @@
                     <f:param name="id" value="#{item.id}" />
                     <i class="fa fa-pencil-square-o fa-lg"/>
                 </h:link>
-                <h:commandLink action="#{ProjekteForm.duplicateProject(item.id)}" immediate="true">
-                    <i class="fa fa-clone fa-lg"/>
-                </h:commandLink>
+                <h:commandLink action="#{ProjekteForm.duplicateProject(item.id)}" immediate="true" title="#{msgs.duplicateProject}"><i class="fa fa-clone fa-lg"/></h:commandLink>
                 <h:link><i class="fa fa-bar-chart fa-lg"/></h:link>
             </h:form>
         </p:column>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -49,12 +49,13 @@
 
         <p:column headerText="#{msgs.auswahl}" styleClass="actionsColumn">
             <h:form id="projectActionForm">
-                <h:link outcome="projectEdit"
+                <h:link onclick="#{ProjekteForm.setLocked(true)}" outcome="projectEdit"
                         title="#{msgs.projektBearbeiten}">
                     <f:param name="id" value="#{item.id}" />
                     <i class="fa fa-pencil-square-o fa-lg"/>
                 </h:link>
-                <h:commandLink action="#{ProjekteForm.duplicateProject(item.id)}" immediate="true" title="#{msgs.duplicateProject}"><i class="fa fa-clone fa-lg"/></h:commandLink>
+                <h:commandLink action="#{ProjekteForm.duplicateProject(item.id)}" immediate="true"
+                               title="#{msgs.duplicateProject}"><i class="fa fa-clone fa-lg"/></h:commandLink>
                 <h:link><i class="fa fa-bar-chart fa-lg"/></h:link>
             </h:form>
         </p:column>

--- a/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
+++ b/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
@@ -19,6 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.data.ProjectService;
@@ -83,6 +84,16 @@ public class ProjekteFormIT {
 
         projekteForm.duplicateProject(initialProject.getId());
 
-        assertEquals(projekteForm.getMyProjekt().getFileFormatDmsExport(), initialProject.getFileFormatDmsExport());
+        long templateCountOriginal = initialProject.getProcesses().stream().filter(Process::isTemplate).count();
+        long templateCountDuplicate = projekteForm.getMyProjekt().getProcesses().stream().filter(Process::isTemplate)
+                .count();
+
+        assertEquals(
+            "DMS export file format of duplicated project does not match DMS export file format of original project!",
+            projekteForm.getMyProjekt().getFileFormatDmsExport(), initialProject.getFileFormatDmsExport());
+
+        assertEquals(
+            "Number of process templates in duplicated project does not match number of process templates in original project!",
+            templateCountDuplicate, templateCountOriginal);
     }
 }

--- a/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
+++ b/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
@@ -13,7 +13,6 @@ package de.sub.goobi.forms;
 
 import static org.junit.Assert.assertEquals;
 
-import org.goobi.production.flow.statistics.StatisticsManager;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -73,5 +72,17 @@ public class ProjekteFormIT {
 
         //assertEquals("Statistics Manager was not counted correctly!", Integer.valueOf(50), statisticsManager.getNumberOfPages());
         //assertEquals("Statistics Manager was not counted correctly!", Integer.valueOf(3), statisticsManager.getNumberOfVolumes());
+    }
+
+    @Test
+    public void shouldDuplicateProject() throws Exception {
+        ProjekteForm projekteForm = new ProjekteForm();
+        ProjectService projectService = new ServiceManager().getProjectService();
+
+        Project initialProject = projectService.getById(1);
+
+        projekteForm.duplicateProject(initialProject.getId());
+
+        assertEquals(projekteForm.getMyProjekt().getFileFormatDmsExport(), initialProject.getFileFormatDmsExport());
     }
 }

--- a/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
+++ b/Kitodo/src/test/java/de/sub/goobi/forms/ProjekteFormIT.java
@@ -19,7 +19,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
-import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.data.ProjectService;
@@ -73,27 +72,5 @@ public class ProjekteFormIT {
 
         //assertEquals("Statistics Manager was not counted correctly!", Integer.valueOf(50), statisticsManager.getNumberOfPages());
         //assertEquals("Statistics Manager was not counted correctly!", Integer.valueOf(3), statisticsManager.getNumberOfVolumes());
-    }
-
-    @Test
-    public void shouldDuplicateProject() throws Exception {
-        ProjekteForm projekteForm = new ProjekteForm();
-        ProjectService projectService = new ServiceManager().getProjectService();
-
-        Project initialProject = projectService.getById(1);
-
-        projekteForm.duplicateProject(initialProject.getId());
-
-        long templateCountOriginal = initialProject.getProcesses().stream().filter(Process::isTemplate).count();
-        long templateCountDuplicate = projekteForm.getMyProjekt().getProcesses().stream().filter(Process::isTemplate)
-                .count();
-
-        assertEquals(
-            "DMS export file format of duplicated project does not match DMS export file format of original project!",
-            projekteForm.getMyProjekt().getFileFormatDmsExport(), initialProject.getFileFormatDmsExport());
-
-        assertEquals(
-            "Number of process templates in duplicated project does not match number of process templates in original project!",
-            templateCountDuplicate, templateCountOriginal);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
@@ -239,5 +240,25 @@ public class ProjectServiceIT {
         project.setTitle("First project");
         exception.expect(DataException.class);
         projectService.save(project);
+    }
+
+    @Test
+    public void shouldDuplicateProject() throws DAOException {
+        ProjectService projectService = new ServiceManager().getProjectService();
+
+        Project initialProject = projectService.getById(1);
+
+        Project duplicatedProject = projectService.duplicateProject(1);
+
+        long templateCountOriginal = initialProject.getProcesses().stream().filter(Process::isTemplate).count();
+        long templateCountDuplicate = duplicatedProject.getProcesses().stream().filter(Process::isTemplate).count();
+
+        assertEquals(
+            "DMS export file format of duplicated project does not match DMS export file format of original project!",
+            duplicatedProject.getFileFormatDmsExport(), initialProject.getFileFormatDmsExport());
+
+        assertEquals(
+            "Number of process templates in duplicated project does not match number of process templates in original project!",
+            templateCountDuplicate, templateCountOriginal);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/ProjectServiceIT.java
@@ -29,7 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.kitodo.MockDatabase;
-import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
@@ -250,15 +249,8 @@ public class ProjectServiceIT {
 
         Project duplicatedProject = projectService.duplicateProject(1);
 
-        long templateCountOriginal = initialProject.getProcesses().stream().filter(Process::isTemplate).count();
-        long templateCountDuplicate = duplicatedProject.getProcesses().stream().filter(Process::isTemplate).count();
-
         assertEquals(
             "DMS export file format of duplicated project does not match DMS export file format of original project!",
             duplicatedProject.getFileFormatDmsExport(), initialProject.getFileFormatDmsExport());
-
-        assertEquals(
-            "Number of process templates in duplicated project does not match number of process templates in original project!",
-            templateCountDuplicate, templateCountOriginal);
     }
 }


### PR DESCRIPTION
Lets the user duplicate existing projects from the project list view using a "duplicate project" button. The user is redirected to the project edit view of the new, duplicated project, with all fields apart from the title pre-populated with the values retrieved from the original project.