### PR TITLE
Exclude SVG images from RequestControlFilter

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/helper/servletfilter/RequestControlFilter.java
+++ b/Kitodo/src/main/java/de/sub/goobi/helper/servletfilter/RequestControlFilter.java
@@ -57,11 +57,11 @@ import org.hibernate.LazyInitializationException;
  * <li>Requests wait a maximum of 5 seconds, which can be overridden per URI
  * pattern in the filter's configuration.</li>
  * </ul>
- * 
+ *
  * @author Kevin Chipalowsky and Ivelin Ivanov
  */
 @WebFilter(filterName = "RequestControlFilter", urlPatterns = "*.jsf", initParams = {
-        @WebInitParam(name = "excludePattern", value = ".*\\.(js|css)\\.jsf") })
+        @WebInitParam(name = "excludePattern", value = ".*\\.(js|css|svg)\\.jsf") })
 public class RequestControlFilter implements Filter {
 
     /**


### PR DESCRIPTION
The `RequestControlFilter` blocks repeated access to the same resource when the requests come within a certain small time window. In the new frontend pages this leads to image resources like the header background not being loaded when the user navigates between pages very fast, which completely breaks the layout. To prevent this, this commit adds the `svg` file extension to the exclude pattern of the RequestControlFilter. 