### PR TITLE
Include metadata order when converting JSON rulesets to DTOs

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/RulesetService.java
@@ -131,6 +131,7 @@ public class RulesetService extends TitleSearchService<Ruleset, RulesetDTO, Rule
         JSONObject rulesetJSONObject = getSource(jsonObject);
         rulesetDTO.setTitle(getStringPropertyForDTO(rulesetJSONObject, "title"));
         rulesetDTO.setFile(getStringPropertyForDTO(rulesetJSONObject, "file"));
+        rulesetDTO.setOrderMetadataByRuleset(getBooleanPropertyForDTO(rulesetJSONObject, "orderMetadataByRuleset"));
         return rulesetDTO;
     }
 


### PR DESCRIPTION
This information is needed since it is displayed in the "rulesets" tab of the "projects" page.