### PR TITLE
Fix header layout on large screens

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -928,10 +928,6 @@ min 1900px
 
 @media only screen and (min-width: 1900px) {
 
-    .wrapper {
-        max-width: 1900px;
-        }
-
     #breadcrumb {
         max-width: 1900px;
         }


### PR DESCRIPTION
The header content now has the same margin like the main content on screens larger than 1900px.