### PR TITLE
Remove links from items in header popup lists for tasks and active users

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -247,7 +247,7 @@ body.first-visit #portal-header {
     background-color: #f3f3f3;
     }
 
-#header-nav li ul li a {
+#header-nav li ul li a, #header-nav li ul li div {
     padding: 12px 15px;
     color: #1b2b36;
     text-decoration: none !important;
@@ -893,7 +893,7 @@ min 700px
         padding: 30px;
         }
 
-    #header-nav li ul li a {
+    #header-nav li ul li a, #header-nav li ul li div {
        padding: 12px 30px;
         }
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/header.xhtml
@@ -44,9 +44,9 @@
                         <ul>
                             <li><h3>#{msgs.aktuelleSchritte}</h3></li>
                             <ui:repeat value="#{tasks}" var="task" size="#{tasks.size() gt 3 ? 3 : tasks.size()}">
-                                <li><a href=""><span class="nav-item-col">#{task.title}</span><span
+                                <li><div><span class="nav-item-col">#{task.title}</span><span
                                     class="nav-item-col">#{task.process.title}</span><span class="nav-item-col"><i
-                                    class="fa fa-check-square-o fa-lg nc-info"/></span></a></li>
+                                    class="fa fa-check-square-o fa-lg nc-info"/></span></div></li>
                             </ui:repeat>
                             <li><h:link outcome="tasks" value="#{msgs.allMyTasks} (#{tasks.size()})"/></li>
                         </ul>
@@ -61,7 +61,7 @@
                             <ui:repeat
                                 value="#{SessionForm.activeSessions.subList(0, (SessionForm.activeSessions.size() gt 3) ? 3 : SessionForm.activeSessions.size())}"
                                 var="activeSession">
-                                <li><a href=""><span class="nav-item-col">#{activeSession['userName']}</span></a></li>
+                                <li><div><span class="nav-item-col">#{activeSession['userName']}</span></div></li>
                             </ui:repeat>
                             <li><h:link outcome="activeUsers"
                                         value="#{msgs.allActiveUsers} (#{SessionForm.activeSessions.size()})"/></li>


### PR DESCRIPTION
Since we do not have detail views for individual users or tasks (apart from their "edit" pages), the  entries in the corresponding header popup lists should not be links.