### PR TITLE
Fix method indexCheck in MetadataPathSelector

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/MetadataPathSelector.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/MetadataPathSelector.java
@@ -363,11 +363,8 @@ public class MetadataPathSelector extends MetadataSelector {
         if (index == null && lastChildIndex == 0 || ALL_CHILDREN_SYMBOL.equals(index)) {
             return true;
         }
-        int comparee = ((Integer) index).intValue();
-        if (childIndex == comparee || (comparee == Integer.MAX_VALUE && childIndex == lastChildIndex)) {
-            return true;
-        }
-        throw new RuntimeException("Could not resolve metadata path: Path selector is ambiguous for " + docStructType);
+        int compare = ((Integer) index).intValue();
+        return (childIndex == compare || (compare == Integer.MAX_VALUE && childIndex == lastChildIndex));
     }
 
     /**


### PR DESCRIPTION
Method indexCheck is used for check condition. Return false when condition is not fulfilled is better solution than throwing RuntimeException.