### PR TITLE
Remove checks for logger level

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/config/ConfigMain.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/config/ConfigMain.java
@@ -36,11 +36,8 @@ public class ConfigMain {
                     try {
                         initialized = new PropertiesConfiguration(CONFIG_FILE);
                     } catch (ConfigurationException e) {
-                        if (logger.isWarnEnabled()) {
-                            logger.warn(
-                                    "Loading of " + CONFIG_FILE + " failed. Trying to start with empty configuration.",
-                                    e);
-                        }
+                        logger.warn("Loading of {} failed. Trying to start with empty configuration. Exception: {}",
+                                CONFIG_FILE, e);
                         initialized = new PropertiesConfiguration();
                     }
                     initialized.setListDelimiter('&');

--- a/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
+++ b/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
@@ -153,9 +153,7 @@ public class FileManagement implements FileManagementInterface {
         boolean success;
 
         if (!fileExist(mappedFileURI)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("File " + uri.getPath() + " does not exist for renaming.");
-            }
+            logger.debug("File {} does not exist for renaming.", uri.getPath());
             throw new FileNotFoundException(uri + " does not exist for renaming.");
         }
 

--- a/Kitodo/src/main/java/de/sub/goobi/export/download/Multipage.java
+++ b/Kitodo/src/main/java/de/sub/goobi/export/download/Multipage.java
@@ -66,9 +66,7 @@ public class Multipage {
         // take all pictures into an array
         RenderedImage[] image = new PlanarImage[files.size()];
         for (int i = 0; i < files.size(); i++) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(path + files.get(i).toString());
-            }
+            logger.debug("Path: {}, file: {}", path, files.get(i).toString());
             image[i] = JAI.create("fileload", path + files.get(i).toString());
         }
         logger.debug("Bilder durchlaufen");

--- a/Kitodo/src/main/java/de/sub/goobi/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/de/sub/goobi/helper/VariableReplacer.java
@@ -304,13 +304,9 @@ public class VariableReplacer {
 
             switch (inLevel) {
                 case FIRSTCHILD:
-                    /*
-                     * ohne vorhandenes FirstChild, kann dieses nicht zurückgegeben werden
-                     */
+                    // without existing FirstChild, this can not be returned
                     if (resultFirst == null) {
-                        if (logger.isInfoEnabled()) {
-                            logger.info("Can not replace firstChild-variable for METS: " + metadata);
-                        }
+                        logger.info("Can not replace firstChild-variable for METS: {}", metadata);
                         result = "";
                     } else {
                         result = resultFirst;
@@ -320,9 +316,7 @@ public class VariableReplacer {
                 case TOPSTRUCT:
                     if (resultTop == null) {
                         result = "";
-                        if (logger.isWarnEnabled()) {
-                            logger.warn("Can not replace topStruct-variable for METS: " + metadata);
-                        }
+                        logger.warn("Can not replace topStruct-variable for METS: {}", metadata);
                     } else {
                         result = resultTop;
                     }
@@ -335,9 +329,7 @@ public class VariableReplacer {
                         result = resultTop;
                     } else {
                         result = "";
-                        if (logger.isWarnEnabled()) {
-                            logger.warn("Can not replace variable for METS: " + metadata);
-                        }
+                        logger.warn("Can not replace variable for METS: {}", metadata);
                     }
                     break;
 

--- a/Kitodo/src/main/java/de/sub/goobi/helper/ldap/LdapUser.java
+++ b/Kitodo/src/main/java/de/sub/goobi/helper/ldap/LdapUser.java
@@ -168,10 +168,8 @@ public class LdapUser implements DirContext {
             String.valueOf(Integer.parseInt(inUidNumber) * 2 + 1000));
         result = result.replaceAll("\\{uidnumber\\*2\\+1001\\}",
             String.valueOf(Integer.parseInt(inUidNumber) * 2 + 1001));
-        if (logger.isDebugEnabled()) {
-            logger.debug("Replace instring: " + inString + " - " + inUser + " - " + inUidNumber);
-            logger.debug("Replace outstring: " + result);
-        }
+        logger.debug("Replace instring: {} - {} - {}", inString, inUser);
+        logger.debug("Replace outstring: {}", result);
         return result;
     }
 

--- a/Kitodo/src/main/java/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
+++ b/Kitodo/src/main/java/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
@@ -134,23 +134,16 @@ public class CreatePdfFromServletThread extends LongRunningTask {
                 kitodoContentServerUrl = new URL(contentServerUrl + imageString + targetFileName);
             }
 
-            /*
-             * get pdf from servlet and forward response to file
-             */
-
+            // get pdf from servlet and forward response to file
             HttpClient httpclient = new HttpClient();
-            if (logger.isDebugEnabled()) {
-                logger.debug("Retrieving: " + kitodoContentServerUrl.toString());
-            }
+            logger.debug("Retrieving: {}", kitodoContentServerUrl.toString());
             method = new GetMethod(kitodoContentServerUrl.toString());
             try {
                 method.getParams().setParameter("http.socket.timeout", contentServerTimeOut);
                 int statusCode = httpclient.executeMethod(method);
                 if (statusCode != HttpStatus.SC_OK) {
                     logger.error("HttpStatus not ok");
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Response is:\n" + method.getResponseBodyAsString());
-                    }
+                    logger.debug("Response is:\n {}", method.getResponseBodyAsString());
                     return;
                 }
 
@@ -171,16 +164,10 @@ public class CreatePdfFromServletThread extends LongRunningTask {
             } finally {
                 method.releaseConnection();
             }
-            /*
-             * copy pdf from temp to final destination
-             */
-            if (logger.isDebugEnabled()) {
-                logger.debug("pdf file created: " + tempPdf + "; now copy it to " + finalPdf);
-            }
+            // copy pdf from temp to final destination
+            logger.debug("pdf file created: {}; now copy it to {}", tempPdf, finalPdf);
             fileService.copyFile(tempPdf, finalPdf);
-            if (logger.isDebugEnabled()) {
-                logger.debug("pdf copied to " + finalPdf + "; now start cleaning up");
-            }
+            logger.debug("pdf copied to {}; now start cleaning up", finalPdf);
             fileService.delete(tempPdf);
             if (this.metsURL != null) {
                 File tempMets = new File(this.metsURL.toString());

--- a/Kitodo/src/main/java/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
+++ b/Kitodo/src/main/java/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
@@ -552,20 +552,15 @@ public class ExportNewspaperBatchTask extends EmptyTask {
             try {
                 child.addMetadata(optionalField, identifier);
             } catch (MetadataTypeNotAllowedException e) {
-                if (logger.isInfoEnabled()) {
-                    logger.info(
-                            e.getMessage().replaceFirst("^Couldn’t add ([^:]+):", "Couldn’t add optional field $1."));
-                }
+                logger.info("Exception: {}",
+                        e.getMessage().replaceFirst("^Couldn’t add ([^:]+):", "Couldn’t add optional field $1."));
             }
 
             Integer rank = null;
             try {
                 rank = Integer.valueOf(identifier);
             } catch (NumberFormatException e) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("Cannot place " + type + " \"" + identifier
-                            + "\" correctly because its sorting criterion is not numeric.");
-                }
+                logger.warn("Cannot place {} \"{}\" correctly because its sorting criterion is not numeric.", type, identifier);
             }
             parent.addChild(positionByRank(parent.getAllChildren(), identifierField, rank), child);
 
@@ -608,15 +603,13 @@ public class ExportNewspaperBatchTask extends EmptyTask {
                                 return result;
                             }
                         } catch (NumberFormatException e) {
-                            if (logger.isWarnEnabled()) {
-                                String typeName = aforeborn.getDocStructType() != null
-                                        && aforeborn.getDocStructType().getName() != null
-                                                ? aforeborn.getDocStructType().getName()
-                                                : "cross-reference";
-                                logger.warn("Cannot determine position to place " + typeName
-                                        + " correctly because the sorting criterion of one of its siblings is \""
-                                        + metadataElement.getValue() + "\", but must be numeric.");
-                            }
+                            String typeName = aforeborn.getDocStructType() != null
+                                    && aforeborn.getDocStructType().getName() != null
+                                    ? aforeborn.getDocStructType().getName() : "cross-reference";
+                            logger.warn(
+                                    "Cannot determine position to place {} correctly because the sorting criterion "
+                                            + "of one of its siblings is \"{}\", but must be numeric.",
+                                    typeName, metadataElement.getValue());
                         }
                     }
                 }

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/FileManipulation.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/FileManipulation.java
@@ -109,15 +109,10 @@ public class FileManipulation {
                 baseName = uploadedFileName;
 
             }
-            if (logger.isTraceEnabled()) {
-                logger.trace("folder to import: " + currentFolder);
-            }
+            logger.trace("folder to import: {}", currentFolder);
             URI filename = serviceManager.getFileService().getProcessSubTypeURI(metadataBean.getProcess(),
                     ProcessSubType.IMAGE, currentFolder + File.separator + baseName);
-
-            if (logger.isTraceEnabled()) {
-                logger.trace("filename to import: " + filename);
-            }
+            logger.trace("filename to import: {}", filename);
 
             if (fileService.fileExist(filename)) {
                 List<String> parameterList = new ArrayList<>();
@@ -134,19 +129,14 @@ public class FileManipulation {
             while ((len = inputStream.read(buf)) > 0) {
                 outputStream.write(buf, 0, len);
             }
-            if (logger.isTraceEnabled()) {
-                logger.trace(filename + " was imported");
-            }
+            logger.trace("{} was imported", filename);
             // if file was uploaded into media folder, update pagination
             // sequence
             if (serviceManager.getProcessService().getImagesTifDirectory(false, metadataBean.getProcess())
                     .equals(serviceManager.getFileService().getProcessSubTypeURI(metadataBean.getProcess(),
                             ProcessSubType.IMAGE, currentFolder + File.separator))) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("update pagination for " + metadataBean.getProcess().getTitle());
-                }
+                logger.trace("update pagination for {}", metadataBean.getProcess().getTitle());
                 updatePagination(filename);
-
             }
 
             Helper.setMeldung(Helper.getTranslation("metsEditorFileUploadSuccessful"));

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
@@ -1072,9 +1072,7 @@ public class Metadaten {
         try {
             this.metaHelper.moveNodeUp(this.docStruct);
         } catch (TypeNotAllowedAsChildException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Fehler beim Verschieben des Knotens: " + e.getMessage());
-            }
+            logger.debug("Fehler beim Verschieben des Knotens: {}", e.getMessage());
         }
         readMetadataAsFirstTree();
     }
@@ -1086,9 +1084,7 @@ public class Metadaten {
         try {
             this.metaHelper.moveNodeDown(this.docStruct);
         } catch (TypeNotAllowedAsChildException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Fehler beim Verschieben des Knotens: " + e.getMessage());
-            }
+            logger.debug("Fehler beim Verschieben des Knotens: {}", e.getMessage());
         }
         readMetadataAsFirstTree();
     }
@@ -1661,9 +1657,7 @@ public class Metadaten {
                 this.image = dataList.get(0);
             }
             if (this.currentTifFolder != null) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("currentTifFolder: " + this.currentTifFolder);
-                }
+                logger.trace("currentTifFolder: {}", this.currentTifFolder);
                 dataList = this.imageHelper.getImageFiles(this.process, this.currentTifFolder);
                 if (dataList == null) {
                     return;
@@ -1699,9 +1693,7 @@ public class Metadaten {
             if (this.image != null) {
                 try {
                     URI tifFile = this.currentTifFolder.resolve(this.image);
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("tiffconverterpfad: " + tifFile);
-                    }
+                    logger.trace("tiffconverterpfad: {}", tifFile);
                     if (!fileService.fileExist(tifFile)) {
                         tifFile = serviceManager.getProcessService().getImagesTifDirectory(true, this.process)
                                 .resolve(this.image);

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadatenHelper.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadatenHelper.java
@@ -586,10 +586,8 @@ public class MetadatenHelper implements Comparator<Object> {
                 firstName = firstMetadataType.getNameByLanguage(this.language);
                 secondName = secondMetadataType.getNameByLanguage(this.language);
             } catch (java.lang.NullPointerException e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Language " + language + " for metadata " + firstMetadata.getMetadataType() + " or "
-                            + secondMetadata.getMetadataType() + " is missing in ruleset");
-                }
+                logger.debug("Language {} for metadata {} or {} is missing in ruleset",
+                        this.language, firstMetadata.getMetadataType(), secondMetadata.getMetadataType());
                 return 0;
             }
             if (firstName == null || firstName.length() == 0) {

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadatenImagesHelper.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadatenImagesHelper.java
@@ -351,9 +351,7 @@ public class MetadatenImagesHelper {
         if (tmpSize < 1) {
             tmpSize = 1;
         }
-        if (logger.isTraceEnabled()) {
-            logger.trace("tmpSize: " + tmpSize);
-        }
+        logger.trace("tmpSize: {}", tmpSize);
         if (ConfigCore.getParameter("kitodoContentServerUrl", "").equals("")) {
             logger.trace("api");
             // TODO source image files are locked under windows forever after
@@ -376,9 +374,7 @@ public class MetadatenImagesHelper {
             String cs = ConfigCore.getParameter("kitodoContentServerUrl") + inFileName + "&scale=" + tmpSize
                     + "&rotate=" + intRotation + "&format=jpg";
             cs = cs.replace("\\", "/");
-            if (logger.isTraceEnabled()) {
-                logger.trace("url: " + cs);
-            }
+            logger.trace("url: {}", cs);
             URL csUrl = new URL(cs);
             HttpClient httpclient = new HttpClient();
             GetMethod method = new GetMethod(csUrl.toString());
@@ -389,9 +385,7 @@ public class MetadatenImagesHelper {
             if (statusCode != HttpStatus.SC_OK) {
                 return;
             }
-            if (logger.isTraceEnabled()) {
-                logger.trace("statusCode: " + statusCode);
-            }
+            logger.trace("statusCode: {}", statusCode);
             InputStream inStream = method.getResponseBodyAsStream();
             logger.trace("inStream");
             try (BufferedInputStream bis = new BufferedInputStream(inStream);

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/DataCopier.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/DataCopier.java
@@ -63,9 +63,7 @@ public class DataCopier {
             try {
                 rule.apply(data);
             } catch (RuntimeException notApplicable) {
-                if (logger.isInfoEnabled()) {
-                    logger.info("Rule not applicable for \"" + data.getProcessTitle() + "\", skipped: " + rule);
-                }
+                logger.info("Rule not applicable for \"{}\", skipped: {}", data.getProcessTitle(), rule);
             }
         }
     }

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/LocalMetadataSelector.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/LocalMetadataSelector.java
@@ -191,19 +191,13 @@ public class LocalMetadataSelector extends MetadataSelector {
         } catch (MetadataTypeNotAllowedException e) {
             // copy rules aren’t related to the rule set but depend on it, so
             // copy rules that don’t work with the current rule set are ignored
-            if (logger.isDebugEnabled()) {
-                logger.debug("Cannot create metadata element " + selector.getName()
-                        + ": The type isn’t defined by the rule set used.");
-            }
+            logger.debug("Cannot create metadata element {}: The type isn’t defined by the rule set used.",
+                    selector.getName());
             return;
         } catch (Exception e) {
             // copy rule failed, skip it
-            if (logger.isDebugEnabled()) {
-                logger.debug("Cannot create metadata element " + selector.getName()
-                        + ": Accessing the rule set failed with exception: "
-                        + (e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()),
-                    e);
-            }
+            logger.debug("Cannot create metadata element {}: Accessing the rule set failed with exception: {}",
+                    selector.getName(), e.getMessage());
             return;
         }
         try {
@@ -212,13 +206,10 @@ public class LocalMetadataSelector extends MetadataSelector {
         } catch (MetadataTypeNotAllowedException e) {
             // copy rules aren’t related to the rule set but depend on it, so
             // copy rules that don’t work with the current rule set are ignored
-            if (logger.isDebugEnabled()) {
-                logger.debug("Cannot assign metadata element " + selector.getName() + " (\"" + value
-                        + "\") to structural element "
-                        + (logicalNode.getDocStructType() != null ? logicalNode.getDocStructType().getName()
-                                : "without type")
-                        + ": " + e.getMessage());
-            }
+            String nodeName = logicalNode.getDocStructType() != null ? logicalNode.getDocStructType().getName()
+                    : "without type";
+            logger.debug("Cannot assign metadata element {} (\"{}\") to structural element {}: {}",
+                    selector.getName(), value, nodeName, e.getMessage());
         }
     }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/MetadataPathSelector.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/copier/MetadataPathSelector.java
@@ -175,23 +175,18 @@ public class MetadataPathSelector extends MetadataSelector {
                 // copy rules aren’t related to the rule set but depend on it,
                 // so copy rules that don’t work with the current rule set are
                 // ignored
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Cannot create structural element " + docStructType + " as child of "
-                            + (logicalNode.getDocStructType() != null ? logicalNode.getDocStructType().getName() : "without type")
-                            + " because it isn’t allowed by the rule set.");
-                }
+                String nodeName = logicalNode.getDocStructType() != null ? logicalNode.getDocStructType().getName() : "without type";
+                logger.debug("Cannot create structural element {} as child of {} because it isn’t allowed by the rule set.",
+                        docStructType, nodeName);
                 return;
             } catch (TypeNotAllowedForParentException e) {
                 // see https://github.com/kitodo/kitodo-ugh/issues/2
                 throw new UnreachableCodeException("TypeNotAllowedForParentException is never thrown");
             } catch (Exception e) {
                 // copy rule failed, skip it
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Cannot create structural element " + docStructType + " as child of "
-                            + (logicalNode.getDocStructType() != null ? logicalNode.getDocStructType().getName() : "without type")
-                            + ": Accessing the rule set failed with exception: "
-                            + (e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()), e);
-                }
+                String nodeName = logicalNode.getDocStructType() != null ? logicalNode.getDocStructType().getName() : "without type";
+                logger.debug("Cannot create structural element {} as child of {}: Accessing the rule set failed with exception: {}",
+                        docStructType, nodeName, e.getMessage());
                 return;
             }
         }

--- a/Kitodo/src/main/java/org/goobi/io/BackupFileRotation.java
+++ b/Kitodo/src/main/java/org/goobi/io/BackupFileRotation.java
@@ -73,10 +73,8 @@ public class BackupFileRotation {
         metaFiles = generateBackupBaseNameFileList(format, process);
 
         if (metaFiles.size() < 1) {
-            if (logger.isInfoEnabled()) {
-                logger.info("No files matching format '" + format + "' in directory "
-                        + serviceManager.getProcessService().getProcessDataDirectory(process) + " found.");
-            }
+            logger.info("No files matching format '{}' in directory {} found.",
+                    this.format, serviceManager.getProcessService().getProcessDataDirectory(process));
             return;
         }
 
@@ -142,9 +140,7 @@ public class BackupFileRotation {
             try {
                 fileService.renameFile(oldName, newName);
             } catch (FileNotFoundException oldNameNotYetPresent) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(oldName + " does not yet exist >>> nothing to do");
-                }
+                logger.debug("{} does not yet exist >>> nothing to do", oldName);
             }
         }
     }

--- a/Kitodo/src/main/java/org/goobi/mq/processors/CreateNewProcessProcessor.java
+++ b/Kitodo/src/main/java/org/goobi/mq/processors/CreateNewProcessProcessor.java
@@ -137,9 +137,7 @@ public class CreateNewProcessProcessor extends ActiveMQProcessor {
             if (!state.equals("NewProcess/Page3")) {
                 throw new RuntimeException();
             }
-            if (logger.isInfoEnabled()) {
-                logger.info("Created new process: " + id);
-            }
+            logger.info("Created new process: {}", id);
         } catch (Exception exited) {
             logger.error("Failed to create new process: " + id, exited);
             throw exited;
@@ -151,7 +149,7 @@ public class CreateNewProcessProcessor extends ActiveMQProcessor {
      * from a given template.
      *
      * @param templateTitle
-     *            titel value of the template to look for
+     *            title value of the template to look for
      * @return a ProzesskopieForm object, prepared from a given template
      * @throws IllegalArgumentException
      *             if no suitable template is found

--- a/Kitodo/src/main/java/org/goobi/production/chart/ProjectStatusDraw.java
+++ b/Kitodo/src/main/java/org/goobi/production/chart/ProjectStatusDraw.java
@@ -179,9 +179,7 @@ public class ProjectStatusDraw {
         if (duration == 0) {
             duration = 1;
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(datePosition + " / " + duration);
-        }
+        logger.debug("{} / {}", datePosition, duration);
         float[] dash = {2.0f };
         BasicStroke dashed = new BasicStroke(1.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND, 1.0f, dash, 0.0f);
         g2d.setStroke(dashed);

--- a/Kitodo/src/main/java/org/goobi/production/cli/WebInterface.java
+++ b/Kitodo/src/main/java/org/goobi/production/cli/WebInterface.java
@@ -80,9 +80,7 @@ public class WebInterface extends HttpServlet {
                         "No command given. Use help as command to get more information.");
                 return;
             }
-            if (logger.isDebugEnabled()) {
-                logger.debug("command: " + command);
-            }
+            logger.debug("command: {}", command);
 
             // check if command is allowed for used IP
             List<String> allowedCommands = WebInterfaceConfig.getCredentials(ip, password);

--- a/Kitodo/src/main/java/org/goobi/production/cli/helper/WikiFieldHelper.java
+++ b/Kitodo/src/main/java/org/goobi/production/cli/helper/WikiFieldHelper.java
@@ -62,9 +62,7 @@ public class WikiFieldHelper {
         if (p != null) {
             processName = "processname: " + p.getTitle() + ", message: ";
         }
-        if (logger.isInfoEnabled()) {
-            logger.info(timestamp + " " + processName + " " + value);
-        }
+        logger.info("{} {} {}", timestamp, processName, value);
         message = message + timestamp + ": " + value + TAG_END;
         return message;
     }

--- a/Kitodo/src/main/java/org/goobi/production/flow/helper/JobCreation.java
+++ b/Kitodo/src/main/java/org/goobi/production/flow/helper/JobCreation.java
@@ -53,19 +53,13 @@ public class JobCreation {
     @SuppressWarnings("static-access")
     public static Process generateProcess(ImportObject io, Process vorlage) throws DataException, IOException {
         String processTitle = io.getProcessTitle();
-        if (logger.isTraceEnabled()) {
-            logger.trace("processtitle is " + processTitle);
-        }
+        logger.trace("processtitle is {}", processTitle);
         // TODO: what is differecene between metsfilename and basepath and
         // metsfile
         URI metsfilename = io.getMetsFilename();
-        if (logger.isTraceEnabled()) {
-            logger.trace("mets filename is " + metsfilename);
-        }
+        logger.trace("mets filename is {}", metsfilename);
         URI basepath = metsfilename;
-        if (logger.isTraceEnabled()) {
-            logger.trace("basepath is " + basepath);
-        }
+        logger.trace("basepath is {}", basepath);
         URI metsfile = metsfilename;
         Process p = null;
         if (!testTitle(processTitle)) {

--- a/Kitodo/src/main/java/org/goobi/production/flow/jobs/AbstractGoobiJob.java
+++ b/Kitodo/src/main/java/org/goobi/production/flow/jobs/AbstractGoobiJob.java
@@ -38,18 +38,14 @@ public abstract class AbstractGoobiJob implements Job, IGoobiJob {
     @Override
     public void execute(JobExecutionContext context) {
         if (!getIsRunning()) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("start scheduled Job: " + getJobName());
-            }
+            logger.trace("start scheduled Job: {}", getJobName());
             if (!isRunning) {
                 logger.trace("start history updating for all processes");
                 setIsRunning(true);
                 execute();
                 setIsRunning(false);
             }
-            if (logger.isTraceEnabled()) {
-                logger.trace("End scheduled Job: " + getJobName());
-            }
+            logger.trace("End scheduled Job: {}", getJobName());
         }
     }
 

--- a/Kitodo/src/main/java/org/goobi/production/flow/jobs/HotfolderJob.java
+++ b/Kitodo/src/main/java/org/goobi/production/flow/jobs/HotfolderJob.java
@@ -101,9 +101,7 @@ public class HotfolderJob extends AbstractGoobiJob {
                                 logger.trace("12");
 
                                 for (URI filename : metsfiles) {
-                                    if (logger.isDebugEnabled()) {
-                                        logger.debug("found file: " + filename);
-                                    }
+                                    logger.debug("found file: {}", filename);
                                     logger.trace("13");
 
                                     int returnValue = generateProcess(filename.toString(), template,
@@ -115,9 +113,7 @@ public class HotfolderJob extends AbstractGoobiJob {
                                         failedData.put(filename.toString(), returnValue);
                                         logger.trace("16");
                                     } else {
-                                        if (logger.isDebugEnabled()) {
-                                            logger.debug("finished file: " + filename);
-                                        }
+                                        logger.debug("finished file: {}", filename);
                                     }
                                 }
                                 if (!failedData.isEmpty()) {
@@ -326,17 +322,11 @@ public class HotfolderJob extends AbstractGoobiJob {
     @SuppressWarnings("static-access")
     public static Process generateProcess(ImportObject io, Process vorlage) throws IOException {
         String processTitle = io.getProcessTitle();
-        if (logger.isTraceEnabled()) {
-            logger.trace("processtitle is " + processTitle);
-        }
+        logger.trace("processtitle is {}", processTitle);
         URI metsfilename = io.getMetsFilename();
-        if (logger.isTraceEnabled()) {
-            logger.trace("mets filename is " + metsfilename);
-        }
+        logger.trace("mets filename is {}", metsfilename);
         URI basepath = URI.create(metsfilename.toString().substring(0, metsfilename.toString().length() - 4));
-        if (logger.isTraceEnabled()) {
-            logger.trace("basepath is " + basepath);
-        }
+        logger.trace("basepath is {}", basepath);
         Process p = null;
         if (!testTitle(processTitle)) {
             logger.trace("wrong title");

--- a/Kitodo/src/main/java/org/goobi/production/flow/statistics/StatisticsManager.java
+++ b/Kitodo/src/main/java/org/goobi/production/flow/statistics/StatisticsManager.java
@@ -144,14 +144,9 @@ public class StatisticsManager implements Serializable {
             return;
         }
 
-        /*
-         * some debugging here
-         */
-        if (logger.isDebugEnabled()) {
-            logger.debug(sourceDateFrom + " - " + sourceDateTo + " - " + sourceNumberOfTimeUnits + " - "
-                    + sourceTimeUnit + "\n" + targetTimeUnit + " - " + targetCalculationUnit + " - "
-                    + targetResultOutput + " - " + showAverage);
-        }
+        logger.debug("{} - {} - {} - {}\n{} - {} - {} - {}",
+                sourceDateFrom, sourceDateTo, sourceNumberOfTimeUnits, sourceTimeUnit, targetTimeUnit,
+                targetCalculationUnit, targetResultOutput, showAverage);
 
         /*
          * calculate the statistical results and save it as List of DataTables (because

--- a/Kitodo/src/main/java/org/goobi/production/importer/GoobiHotfolder.java
+++ b/Kitodo/src/main/java/org/goobi/production/importer/GoobiHotfolder.java
@@ -201,9 +201,7 @@ public class GoobiHotfolder implements IGoobiHotfolder {
             logger.trace("config 18");
 
         } catch (Exception e) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("config 19" + e.getMessage());
-            }
+            logger.trace("config 19 {}", e.getMessage());
             return new ArrayList<>();
         }
         logger.trace("config 20");

--- a/Kitodo/src/main/java/org/goobi/production/plugin/PluginLoader.java
+++ b/Kitodo/src/main/java/org/goobi/production/plugin/PluginLoader.java
@@ -180,10 +180,8 @@ public class PluginLoader {
                     plugin.configure(getPluginConfiguration());
                     result.add(plugin);
                 } catch (NoSuchMethodException | SecurityException e) {
-                    if (logger.isWarnEnabled()) {
-                        logger.warn("Bad implementation of " + type.getName() + " plugin "
-                                + implementation.getClass().getName(), e);
-                    }
+                    logger.warn("Bad implementation of {} plugin {}. Exception: {}",
+                            type.getName(), implementation.getClass().getName(), e);
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/PicaMassImport.java
+++ b/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/PicaMassImport.java
@@ -143,10 +143,7 @@ public class PicaMassImport implements IImportPlugin, IPlugin {
 
         currentIdentifier = data;
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                "retrieving pica record for " + currentIdentifier + " with server address: " + this.getOpacAddress());
-        }
+        logger.debug("retrieving pica record for {} with server address: {}", this.currentIdentifier, getOpacAddress());
         String search = SRUHelper.search(currentIdentifier, this.getOpacAddress());
         logger.trace(search);
         try {
@@ -434,9 +431,7 @@ public class PicaMassImport implements IImportPlugin, IPlugin {
                     MetsModsInterface mm = UghImplementation.INSTANCE.createMetsMods(this.prefs);
                     mm.setDigitalDocument(ff.getDigitalDocument());
                     String fileName = getImportFolder() + getProcessTitle() + ".xml";
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Writing '" + fileName + "' into given folder...");
-                    }
+                    logger.debug("Writing '{}' into given folder...", fileName);
                     mm.write(fileName);
                     io.setMetsFilename(new File(fileName).toURI());
                     io.setImportReturnValue(ImportReturnValue.ExportFinished);

--- a/Kitodo/src/main/java/org/kitodo/production/thread/TaskScriptThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/TaskScriptThread.java
@@ -14,8 +14,8 @@ package org.kitodo.production.thread;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.tasks.EmptyTask;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.services.ServiceManager;
@@ -49,9 +49,7 @@ public class TaskScriptThread extends EmptyTask {
     @Override
     public void run() {
         boolean automatic = this.task.isTypeAutomatic();
-        if (logger.isDebugEnabled()) {
-            logger.debug("task is automatic: " + automatic);
-        }
+        logger.debug("task is automatic: {}", automatic);
         String scriptPath = taskService.getScriptPath(this.task);
         if (!scriptPath.equals("")) {
             try {

--- a/Kitodo/src/main/java/org/kitodo/services/data/LdapServerService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/LdapServerService.java
@@ -273,10 +273,8 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
             logger.debug("ldap environment set");
 
             try {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("start classic ldap authentification");
-                    logger.debug("user DN is " + buildUserDN(user));
-                }
+                logger.debug("start classic ldap authentication");
+                logger.debug("user DN is {}", buildUserDN(user));
 
                 if (ConfigCore.getParameter("ldap_AttributeToTest") == null) {
                     logger.debug("ldap attribute to test is null");
@@ -302,9 +300,7 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
                     }
                 }
             } catch (NamingException e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("login not allowed for " + user.getLogin(), e);
-                }
+                logger.debug("login not allowed for {}. Exception: {}", user.getLogin(), e);
                 return false;
             }
         }
@@ -419,9 +415,7 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
 
             while (answer.hasMore()) {
                 SearchResult sr = answer.next();
-                if (logger.isDebugEnabled()) {
-                    logger.debug(">>>" + sr.getName());
-                }
+                logger.debug(">>>{}", sr.getName());
                 Attributes attrs = sr.getAttributes();
                 String givenName = getStringForAttribute(attrs, "givenName");
                 String surName = getStringForAttribute(attrs, "sn");

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
@@ -1335,11 +1335,9 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
             throw new IOException(Helper.getTranslation("metadataFileNotFound") + " " + metadataFileUri);
         }
 
-        /* prüfen, welches Format die Metadaten haben (Mets, xstream oder rdf */
+        // check the format of the metadata - METS, XStream or RDF
         String type = MetadatenHelper.getMetaFileType(metadataFileUri);
-        if (logger.isDebugEnabled()) {
-            logger.debug("current meta.xml file type for id " + process.getId() + ": " + type);
-        }
+        logger.debug("current meta.xml file type for id {}: {}", process.getId(), type);
 
         FileformatInterface ff = determineFileFormat(type, process);
         try {
@@ -1395,9 +1393,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
         URI processSubTypeURI = fileService.getProcessSubTypeURI(process, ProcessSubType.TEMPLATE, null);
         if (fileService.fileExist(processSubTypeURI)) {
             String type = MetadatenHelper.getMetaFileType(processSubTypeURI);
-            if (logger.isDebugEnabled()) {
-                logger.debug("current template.xml file type: " + type);
-            }
+            logger.debug("current template.xml file type: {}", type);
             FileformatInterface ff = determineFileFormat(type, process);
             ff.read(processSubTypeURI.toString());
             return ff;
@@ -1500,10 +1496,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
      *            object
      */
     public void downloadDocket(Process process) throws IOException {
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("generate docket for process " + process.getId());
-        }
+        logger.debug("generate docket for process with id {}", process.getId());
         URI rootPath = Paths.get(ConfigCore.getParameter("xsltFolder")).toUri();
         URI xsltFile;
         if (process.getDocket() != null) {
@@ -1535,9 +1528,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
      *             failed.
      */
     public void downloadDocket(List<Process> processes) throws IOException {
-        if (logger.isDebugEnabled()) {
-            logger.debug("generate docket for processes " + processes);
-        }
+        logger.debug("generate docket for processes {}", processes);
         URI rootPath = Paths.get(ConfigCore.getParameter("xsltFolder")).toUri();
         URI xsltFile = serviceManager.getFileService().createResource(rootPath, "docket_multipage.xsl");
         FacesContext facesContext = FacesContext.getCurrentInstance();

--- a/Kitodo/src/main/java/org/kitodo/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/TaskService.java
@@ -612,9 +612,7 @@ public class TaskService extends TitleSearchService<Task, TaskDTO, TaskDAO> {
         script = replacer.replace(script);
         boolean executedSuccessful = false;
         try {
-            if (logger.isInfoEnabled()) {
-                logger.info("Calling the shell: " + script);
-            }
+            logger.info("Calling the shell: {}", script);
 
             CommandService commandService = serviceManager.getCommandService();
             CommandResult commandResult = commandService.runCommand(script);
@@ -646,9 +644,7 @@ public class TaskService extends TitleSearchService<Task, TaskDTO, TaskDAO> {
     public void executeScript(Task task, boolean automatic) throws DataException {
         String script = task.getScriptPath();
         boolean scriptFinishedSuccessful = true;
-        if (logger.isDebugEnabled()) {
-            logger.debug("starting script " + script);
-        }
+        logger.debug("starting script {}", script);
         if (script != null && !script.equals(" ") && script.length() != 0) {
             scriptFinishedSuccessful = executeScript(task, script, automatic);
         }


### PR DESCRIPTION
Logger level checks are useful only in case of String concatenation. It can be replaced with passing arguments. This will only convert the passed in parameters to strings if debug is enabled.