### PR TITLE
Hide underscore character

### DIFF
--- a/Kitodo/src/main/webapp/pages/projectEditMets.xhtml
+++ b/Kitodo/src/main/webapp/pages/projectEditMets.xhtml
@@ -135,7 +135,7 @@
                                onclick="if (!confirm('#{msgs.sollDieserEintragWirklichGeloeschtWerden}')) return"
                                oncomplete="jQuery('#editForm\\:saveButtonToggler').click()"
                                styleClass="buttonset button-blue" disabled="#{ProjekteForm.locked}">
-                    <i class="fa fa-trash fa-lg"/>
+                    <h:outputText><i class="fa fa-trash fa-lg"/></h:outputText>
                     <f:setPropertyActionListener target="#{ProjekteForm.myFilegroup}"
                                                  value="#{filegroup}"/>
                 </p:commandLink>


### PR DESCRIPTION
Since the `p:commandLink` does not contain any text but only a _Font Awesome_ symbol (using a CSS class in the contained `<i>` tag), JSF adds an underscore to the seemingly empty text of the link to ensure it is clickable. This can be prevented by wrapping an `h:outputText` tag around the `<i>`.