### PR TITLE
Add link to create new process template

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -184,7 +184,7 @@ public class ProzessverwaltungForm extends BasisForm {
         this.newProcessTitle = "";
         this.process.setTemplate(true);
         this.editMode = ObjectMode.PROCESS;
-        return PROCESS_EDIT_PATH_OLD;
+        return redirectToEdit();
     }
 
     /**
@@ -2214,7 +2214,11 @@ public class ProzessverwaltungForm extends BasisForm {
             if (id != 0) {
                 setProcess(this.serviceManager.getProcessService().getById(id));
             } else {
-                newProcess();
+                if (Objects.nonNull(this.process) && this.process.isTemplate()) {
+                    newTemplate();
+                } else {
+                    newProcess();
+                }
             }
             setSaveDisabled(true);
         } catch (DAOException e) {
@@ -2297,7 +2301,7 @@ public class ProzessverwaltungForm extends BasisForm {
             String callerViewId = referrer.substring(referrer.lastIndexOf('/') + 1);
             if (!callerViewId.isEmpty()
                     && (callerViewId.contains("processes.jsf") || callerViewId.contains("taskEdit.jsf")
-                            || callerViewId.contains("processEdit.jsf"))) {
+                            || callerViewId.contains("processEdit.jsf") || callerViewId.contains("projects.jsf"))) {
                 return PROCESS_EDIT_PATH + urlParameters;
             } else {
                 return PROCESS_EDIT_PATH_OLD + urlParameters;

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/details.xhtml
@@ -61,12 +61,13 @@
                 </p:selectOneMenu>
             </div>
 
-            <div>
-                <p:outputLabel for="isTemplate" value="#{msgs.istTemplate}"/>
-                <p:selectBooleanCheckbox id="isTemplate" value="#{ProzessverwaltungForm.process.template}">
-                    <p:ajax event="change" oncomplete="jQuery('#editForm\\:saveButtonToggler').click()"/>
-                </p:selectBooleanCheckbox>
-            </div>
+            <!-- TODO: decide whether the following switch is required -->
+            <!--<div>-->
+                <!--<p:outputLabel for="isTemplate" value="#{msgs.istTemplate}"/>-->
+                <!--<p:selectBooleanCheckbox id="isTemplate" value="#{ProzessverwaltungForm.process.template}">-->
+                    <!--<p:ajax event="change" oncomplete="jQuery('#editForm\\:saveButtonToggler').click()"/>-->
+                <!--</p:selectBooleanCheckbox>-->
+            <!--</div>-->
         </p:row>
     </p:panelGrid>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/details.xhtml
@@ -61,13 +61,12 @@
                 </p:selectOneMenu>
             </div>
 
-            <!-- TODO: decide whether the following switch is required -->
-            <!--<div>-->
-                <!--<p:outputLabel for="isTemplate" value="#{msgs.istTemplate}"/>-->
-                <!--<p:selectBooleanCheckbox id="isTemplate" value="#{ProzessverwaltungForm.process.template}">-->
-                    <!--<p:ajax event="change" oncomplete="jQuery('#editForm\\:saveButtonToggler').click()"/>-->
-                <!--</p:selectBooleanCheckbox>-->
-            <!--</div>-->
+            <div>
+                <p:outputLabel for="isTemplate" value="#{msgs.istTemplate}"/>
+                <p:selectBooleanCheckbox id="isTemplate" value="#{ProzessverwaltungForm.process.template}">
+                    <p:ajax event="change" oncomplete="jQuery('#editForm\\:saveButtonToggler').click()"/>
+                </p:selectBooleanCheckbox>
+            </div>
         </p:row>
     </p:panelGrid>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
@@ -33,14 +33,14 @@
             <h:outputText>
                 <h:form>
                     <h:link id="editProcess" outcome="/pages/processEdit"
-                            title="#{msgs.prozessBearbeiten}">
+                            title="#{msgs.editTemplate}">
                         <i class="fa fa-pencil-square-o fa-lg"/>
                         <f:param name="id" value="#{item.id}"/>
                     </h:link>
 
                     <h:commandLink action="#{ProzesskopieForm.prepare(item.id)}" id="action22"
                                    title="#{item.containsUnreachableSteps?msgs.prozessvorlageMitUnvollstaendigenSchrittdetails:msgs.eineKopieDieserProzessvorlageAnlegen}">
-                        <i class="fa fa-inbox fa-lg"/>
+                        <h:outputText><i class="fa fa-inbox fa-lg"/></h:outputText>
                     </h:commandLink>
 
                     <h:link><i class="fa fa-clipboard fa-lg"/></h:link>

--- a/Kitodo/src/main/webapp/pages/processEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/processEdit.xhtml
@@ -28,8 +28,10 @@
             window.onload = function () {checkForm('editForm')};
         </script>
         <h3>
-            <h:outputText value="#{msgs.prozessBearbeiten} (#{ProzessverwaltungForm.process.title})" rendered="#{not empty ProzessverwaltungForm.process.title}"/>
-            <h:outputText value="#{msgs.einenNeuenProzessAnlegen}" rendered="#{empty ProzessverwaltungForm.process.title}"/>
+            <h:outputText value="#{msgs.prozessBearbeiten} (#{ProzessverwaltungForm.process.title})" rendered="#{not empty ProzessverwaltungForm.process.title and not ProzessverwaltungForm.process.template}"/>
+            <h:outputText value="#{msgs.editTemplate} (#{ProzessverwaltungForm.process.title})" rendered="#{not empty ProzessverwaltungForm.process.title and ProzessverwaltungForm.process.template}"/>
+            <h:outputText value="#{msgs.einenNeuenProzessAnlegen}" rendered="#{empty ProzessverwaltungForm.process.title and not ProzessverwaltungForm.process.template}"/>
+            <h:outputText value="#{msgs.newProcessTemplate}" rendered="#{empty ProzessverwaltungForm.process.title and ProzessverwaltungForm.process.template}"/>
         </h3>
         <p:commandButton id="save"
                          widgetVar="save"

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -22,8 +22,9 @@
             <h3>#{msgs.prozessverwaltung}</h3>
             <h:form id="addForm">
                 <p:menuButton value="#{msgs.newElement}" icon="fa fa-plus-circle fa-lg" iconPos="right" styleClass="button-filled-green">
-                    <!-- TODO: decide whether creating processes from scratch - without template - is required (than we need the next line) -->
-                    <!--<p:menuitem value="#{msgs.newProcess}" outcome="/pages/processEdit" icon="ui-icon-plusthick" />-->
+                    <p:menuitem value="#{msgs.newProcess}" action="#{ProzessverwaltungForm.newProcess}"
+                                immediate="true" style="width: inherit;"
+                                icon="ui-icon-plusthick"/>
                     <p:menuitem value="#{msgs.newBatch}" icon="ui-icon-plusthick" />
                 </p:menuButton>
             </h:form>

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -22,7 +22,8 @@
             <h3>#{msgs.prozessverwaltung}</h3>
             <h:form id="addForm">
                 <p:menuButton value="#{msgs.newElement}" icon="fa fa-plus-circle fa-lg" iconPos="right" styleClass="button-filled-green">
-                    <p:menuitem value="#{msgs.newProcess}" outcome="/pages/processEdit" icon="ui-icon-plusthick" />
+                    <!-- TODO: decide whether creating processes from scratch - without template - is required (than we need the next line) -->
+                    <!--<p:menuitem value="#{msgs.newProcess}" outcome="/pages/processEdit" icon="ui-icon-plusthick" />-->
                     <p:menuitem value="#{msgs.newBatch}" icon="ui-icon-plusthick" />
                 </p:menuButton>
             </h:form>


### PR DESCRIPTION
~~… processes without template~~

This pull request slightly changes the way how ~~processes and~~ process templates are created in the new frontend :

- the "New process template" sub-button under the "New" button on the `projects` page now leads to the `processEdit` page with corresponding "process template" labels instead of "process" labels in the header and breadcrumb menu (this link still led to a page in the old design until now).
- ~~the "New process" sub-button under the "New" button on the `processes` page and the "is template" switch on the "Create new process (template)" page have been removed until we decide whether this way to create new processes without templates is really required or not~~
- ~~instead, new processes now always have to be created using the "Create process from template" button in the template list of "Process templates" tab on the `projects` page.~~

**Note:** I restored the controversial part (creating processes without process templates) so that this PR only contains clear fixes.