### PR TITLE
Fix layout of select menus in a panelGrid

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -763,6 +763,8 @@ footer {
 .ui-panelgrid-cell .ui-selectonemenu {
     width: 100%;
     box-sizing: border-box;
+    margin-bottom: 0;
+    display: block;
 }
 
 .ui-picklist.ui-picklist-responsive .ui-picklist-list-wrapper {


### PR DESCRIPTION
Fixes the layout of selectOneMenu elements when rendered in a panelGrid along other input elements. They are now vertically centered in the grid cell like all other elements.