### PR TITLE
Fix filter not being applied

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
@@ -26,4 +26,9 @@ window.onload = function () {
     document.getElementById('filterMenu:filterfield').addEventListener('change', function () {
         applyFilter(this.value);
     });
+
+    var filterString = document.getElementById('filterMenu:filterfield').value;
+    if (filterString.length > 0) {
+        applyFilter(filterString);
+    }
 }


### PR DESCRIPTION
The filter is now applied to the list of processes as soon as page is loaded when a filter has been passed.