### PR TITLE
Hibernate without ssl

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
+++ b/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
@@ -1,4 +1,4 @@
 flyway.user=kitodo
 flyway.password=kitodo
-flyway.url=jdbc:mysql://localhost/kitodo
+flyway.url=jdbc:mysql://localhost/kitodo?useSSL=false
 flyway.locations=filesystem:../Kitodo-DataManagement/src/main/resources/db/migration

--- a/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.travis
+++ b/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.travis
@@ -1,4 +1,4 @@
 flyway.user=kitodo
 flyway.password=kitodo
-flyway.url=jdbc:mysql://localhost/kitodo
+flyway.url=jdbc:mysql://localhost/kitodo?useSSL=false
 flyway.locations=filesystem:Kitodo-DataManagement/src/main/resources/db/migration

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -24,12 +24,17 @@
         <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
 
         <property name="hibernate.connection.url">
-            jdbc:mysql://localhost/kitodo
+            jdbc:mysql://localhost/kitodo?useSSL=false
         </property>
         <property name="hibernate.connection.username">kitodo</property>
         <property name="hibernate.connection.password">kitodo</property>
         <property name="hibernate.connection.autoReconnect">true</property>
         <property name="hibernate.connection.autoReconnectForPools">true</property>
+
+        <!-- SSL connection properties -->
+        <property name="hibernate.connection.requireSSL">false</property>
+        <property name="hibernate.connection.verifyServerCertificate">false</property>
+        <property name="hibernate.connection.useSSL">false</property>
 
         <!-- connection pool -->
         <property name="hibernate.c3p0.max_size">5000</property>

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -24,10 +24,12 @@
         <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
 
         <property name="hibernate.connection.url">
-            jdbc:mysql://localhost/kitodo?autoReconnect=true&amp;autoReconnectForPools=true
+            jdbc:mysql://localhost/kitodo
         </property>
         <property name="hibernate.connection.username">kitodo</property>
         <property name="hibernate.connection.password">kitodo</property>
+        <property name="hibernate.connection.autoReconnect">true</property>
+        <property name="hibernate.connection.autoReconnectForPools">true</property>
 
         <!-- connection pool -->
         <property name="hibernate.c3p0.max_size">5000</property>


### PR DESCRIPTION
Flyway on Travis throws ugly messages

```
Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.
```
on every run. For now I'm disabling SSL access for flyway and normal database access. Changing this values from `false` to `true` re-enable it on established secure connections.