### PR TITLE
Fix hibernate dialect and switch to innodb

### DIFF
--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -21,6 +21,7 @@
     <session-factory>
         <!-- SQL - Settings -->
         <property name="hibernate.dialect">org.hibernate.dialect.MySQL5Dialect</property>
+        <property name="hibernate.dialect.storage_engine">innodb</property>
         <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
 
         <property name="hibernate.connection.url">

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -20,7 +20,7 @@
 
     <session-factory>
         <!-- SQL - Settings -->
-        <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
+        <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>
         <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
 
         <property name="hibernate.connection.url">

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -20,7 +20,7 @@
 
     <session-factory>
         <!-- SQL - Settings -->
-        <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>
+        <property name="hibernate.dialect">org.hibernate.dialect.MySQL5Dialect</property>
         <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
 
         <property name="hibernate.connection.url">


### PR DESCRIPTION
- fix usage of Hibernate `dialect` property
- raise used dialect level for MySQL 5 
- define storage engine to InnoDB as we now using transactions and relations between tables