### PR TITLE
Remove not used method editProcess from ProzessverwaltungForm

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -161,16 +161,6 @@ public class ProzessverwaltungForm extends TemplateBaseForm {
     }
 
     /**
-     * Edit process.
-     *
-     * @return page
-     */
-    public String editProcess() {
-        reload();
-        return processEditPath + "&id=" + (Objects.isNull(this.process.getId()) ? 0 : this.process.getId());
-    }
-
-    /**
      * Save process.
      *
      * @return null


### PR DESCRIPTION
This functionality is replace with link.