### PR TITLE
Remove docket and ruleset from workflow

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/workflow/model/Reader.java
+++ b/Kitodo/src/main/java/org/kitodo/workflow/model/Reader.java
@@ -35,7 +35,6 @@ import org.camunda.bpm.model.bpmn.instance.StartEvent;
 import org.camunda.bpm.model.bpmn.instance.Task;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.beans.Workflow;
-import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.file.FileService;
@@ -73,7 +72,7 @@ public class Reader {
      *
      * @return Template bean
      */
-    public Template convertWorkflowToTemplate() throws DAOException, DataException {
+    public Template convertWorkflowToTemplate() throws DataException {
         this.tasks = new HashMap<>();
         this.followingFlowNodes = new ArrayList<>();
 
@@ -81,16 +80,6 @@ public class Reader {
         template.setWorkflow(determineWorkflow(this.workflow.getId(), this.diagramName));
         template.setTitle(this.workflow.getTitle());
         template.setOutputName(this.workflow.getOutputName());
-
-        Integer docketId = this.workflow.getDocket();
-        if (docketId > 0) {
-            template.setDocket(serviceManager.getDocketService().getById(docketId));
-        }
-
-        Integer rulesetId = this.workflow.getRuleset();
-        if (rulesetId > 0) {
-            template.setRuleset(serviceManager.getRulesetService().getById(rulesetId));
-        }
 
         getWorkflowTasks();
 

--- a/Kitodo/src/main/java/org/kitodo/workflow/model/Updater.java
+++ b/Kitodo/src/main/java/org/kitodo/workflow/model/Updater.java
@@ -40,9 +40,6 @@ public class Updater {
         List<Process> processes = this.template.getProcesses();
 
         for (Process process : processes) {
-            process.setDocket(this.template.getDocket());
-            process.setRuleset(this.template.getRuleset());
-
             serviceManager.getProcessService().save(process);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/workflow/model/beans/Diagram.java
+++ b/Kitodo/src/main/java/org/kitodo/workflow/model/beans/Diagram.java
@@ -11,8 +11,6 @@
 
 package org.kitodo.workflow.model.beans;
 
-import java.util.Objects;
-
 import org.camunda.bpm.model.bpmn.instance.Process;
 
 public class Diagram {
@@ -20,8 +18,6 @@ public class Diagram {
     private String id;
     private String title;
     private String outputName;
-    private Integer docket;
-    private Integer ruleset;
     private static final String NAMESPACE = "http://www.kitodo.org/template";
 
     /**
@@ -33,15 +29,6 @@ public class Diagram {
         this.id = process.getId();
         this.title = process.getName();
         this.outputName = process.getAttributeValueNs(NAMESPACE, "outputName");
-        this.docket = getIntegerValue(process.getAttributeValueNs(NAMESPACE, "docket"));
-        this.ruleset = getIntegerValue(process.getAttributeValueNs(NAMESPACE, "ruleset"));
-    }
-
-    private Integer getIntegerValue(String value) {
-        if (Objects.nonNull(value)) {
-            return Integer.valueOf(value);
-        }
-        return -1;
     }
 
     /**
@@ -96,41 +83,5 @@ public class Diagram {
      */
     public void setOutputName(String outputName) {
         this.outputName = outputName;
-    }
-
-    /**
-     * Get docket.
-     *
-     * @return value of docket
-     */
-    public Integer getDocket() {
-        return docket;
-    }
-
-    /**
-     * Set docket.
-     *
-     * @param docket as java.lang.Integer
-     */
-    public void setDocket(Integer docket) {
-        this.docket = docket;
-    }
-
-    /**
-     * Get ruleset.
-     *
-     * @return value of ruleset
-     */
-    public Integer getRuleset() {
-        return ruleset;
-    }
-
-    /**
-     * Set ruleset.
-     *
-     * @param ruleset as java.lang.Integer
-     */
-    public void setRuleset(Integer ruleset) {
-        this.ruleset = ruleset;
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/FileLoader.java
+++ b/Kitodo/src/test/java/org/kitodo/FileLoader.java
@@ -87,7 +87,7 @@ public class FileLoader {
         List<String> content = new ArrayList<>();
         content.add("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         content.add("<bpmn2:definitions xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:bpmn2=\"http://www.omg.org/spec/BPMN/20100524/MODEL\" xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\" xmlns:dc=\"http://www.omg.org/spec/DD/20100524/DC\" xmlns:di=\"http://www.omg.org/spec/DD/20100524/DI\" xmlns:template=\"http://www.kitodo.org/template\" id=\"sample-diagram\" targetNamespace=\"http://bpmn.io/schema/bpmn\" xsi:schemaLocation=\"http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd\">");
-        content.add("<bpmn2:process id=\"Process_1\" name=\"test-gateway\" template:docket=\"1\" template:outputName=\"Test Gateway\" isExecutable=\"false\">");
+        content.add("<bpmn2:process id=\"Process_1\" name=\"test-gateway\" template:outputName=\"Test Gateway\" isExecutable=\"false\">");
         content.add("<bpmn2:startEvent id=\"StartEvent_1\">");
         content.add("<bpmn2:outgoing>SequenceFlow_0651lvf</bpmn2:outgoing>");
         content.add("</bpmn2:startEvent>");

--- a/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceIT.java
@@ -80,9 +80,6 @@ public class WorkflowControllerServiceIT {
         assertEquals("Tasks of template were not saved correctly!", "Test Gateway", template.getOutputName());
         assertEquals("Tasks of template were not saved correctly!", 5, template.getTasks().size());
 
-        Docket docket = serviceManager.getDocketService().getById(1);
-        assertEquals("Tasks of template were not saved correctly!", docket, template.getDocket());
-
         List<Workflow> workflows = serviceManager.getWorkflowService().getByQuery("FROM Workflow WHERE title = 'Process_1'");
         assertEquals("Workflow of template was not saved correctly!", 1, workflows.size());
 

--- a/Kitodo/src/test/java/org/kitodo/workflow/model/UpdaterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/workflow/model/UpdaterIT.java
@@ -11,14 +11,10 @@
 
 package org.kitodo.workflow.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
-import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.services.ServiceManager;
 
@@ -40,17 +36,7 @@ public class UpdaterIT {
     public void shouldUpdateProcessesAssignedToTemplate() throws Exception {
         Template template = new ServiceManager().getTemplateService().getById(1);
 
-        for (Process process : template.getProcesses()) {
-            assertNotEquals("Template and Process have assigned the same docket!", template.getDocket(), process.getDocket());
-            assertNotEquals("Template and Process have assigned the same ruleset!", template.getRuleset(), process.getRuleset());
-        }
-
         Updater updater = new Updater(template);
         updater.updateProcessesAssignedToTemplate();
-
-        for (Process process : template.getProcesses()) {
-            assertEquals("Template and Process have assigned different docket!", template.getDocket(), process.getDocket());
-            assertEquals("Template and Process have assigned different ruleset!", template.getRuleset(), process.getRuleset());
-        }
     }
 }


### PR DESCRIPTION
Docket and ruleset are assigned to template later. Workflow doesn't store this information.