### PR TITLE
Fix count display of indexed objects on indexing page when page loads

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/IndexingForm.java
@@ -46,6 +46,7 @@ import org.kitodo.services.ServiceManager;
 import org.kitodo.services.data.base.SearchService;
 import org.omnifaces.cdi.Push;
 import org.omnifaces.cdi.PushContext;
+import org.omnifaces.util.Ajax;
 
 @Named
 @ApplicationScoped
@@ -204,14 +205,7 @@ public class IndexingForm {
         if (currentIndexState == objectType) {
             indexedObjects.put(objectType, indexWorkers.get(objectType).getIndexedObjects());
         } else if (!indexedObjects.containsKey(objectType)) {
-            try {
-                SearchService searchService = getService(objectType);
-                if (searchService != null) {
-                    indexedObjects.put(objectType, toIntExact(searchService.count()));
-                }
-            } catch (DataException e) {
-                Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
-            }
+            updateCount(objectType);
         }
         return indexedObjects.get(objectType);
     }
@@ -585,4 +579,24 @@ public class IndexingForm {
         return ObjectType.NONE;
     }
 
+    /**
+     * Update the view.
+     */
+    public void updateView() {
+        for (ObjectType objectType : ObjectType.values()) {
+            updateCount(objectType);
+        }
+        Ajax.update("@all");
+    }
+
+    private void updateCount(ObjectType objectType) {
+        SearchService searchService = getService(objectType);
+        if (searchService != null) {
+            try {
+                indexedObjects.put(objectType, toIntExact(searchService.count()));
+            } catch (DataException e) {
+                Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
+            }
+        }
+    }
 }

--- a/Kitodo/src/main/webapp/pages/indexingPage.xhtml
+++ b/Kitodo/src/main/webapp/pages/indexingPage.xhtml
@@ -14,9 +14,13 @@
 <ui:composition
         template="/WEB-INF/templates/baseListView.xhtml"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:p="http://primefaces.org/ui"
         xmlns:o="http://omnifaces.org/ui">
+    <f:metadata>
+        <f:viewAction action="#{indexingForm.updateView()}"/>
+    </f:metadata>
     <ui:define name="contentHeader">
         <h3>#{msgs.indexing}</h3>
     </ui:define>


### PR DESCRIPTION
Since `IndexingForm` is an application scoped bean, the variables indicating the number of indexed objects aren't updated automatically when adding or deleting objects while Kitodo is running and the displayed numbers are not correct. Therefor the variables must be updated manually when the indexing page loads.