### PR TITLE
Bring back linespacing to kitodo_config.properties

### DIFF
--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -8,12 +8,14 @@
 # For the full copyright and license information, please read the
 # GPL3-License.txt file that was distributed with this source code.
 #
+
 # =============================================================================
 #      FILE AND DIRECTORY MANAGEMENT
 # =============================================================================
 # -----------------------------------
 # Directories
 # -----------------------------------
+
 # Absolute path to the directory that the configuration files are stored in,
 # terminated by a directory separator ("/").
 # Note: Several, but not all configuration files are read from that directory.
@@ -21,22 +23,27 @@
 #       the servlet container will extract the configuration files to (like
 #       webapps/kitodo/WEB-INF/classes) in order to make sure they are found.
 KonfigurationVerzeichnis=/usr/local/kitodo/config/
+
 # Absolute path to the directory that the rule set definition files will be
 # read from. It must be terminated by a directory separator ("/").
 RegelsaetzeVerzeichnis=/usr/local/kitodo/rulesets/
+
 # Absolute path to the directory that XSLT files are stored in which are used
 # to transform the "XML log" (as visible from the XML button in the processes
 # list) to a downloadable PDF docket which can be enclosed with the physical
 # binding units to digitise.
 # The path must be terminated by a directory separator ("/").
 xsltFolder=/usr/local/kitodo/xslt/
+
 # Filename of the XSLT file for transforming old metadata files which need to
 # be in the xslt folder above
 xsltFilenameMetadataTransformation=MetsModsGoobi_to_MetsKitodo.xsl
+
 # Absolute path to the directory that process directories will be created in,
 # terminated by a directory separator ("/").
 # The servlet container must have write permission to that directory.
 MetadatenVerzeichnis=/usr/local/kitodo/metadata/
+
 # Absolute path to the base directory of the users' home directories,
 # terminated by a directory separator ("/").
 # If a user accepts a task to work on which
@@ -45,21 +52,37 @@ MetadatenVerzeichnis=/usr/local/kitodo/metadata/
 # or her home directory that will be removed again after finishing the task.
 # Note: If LDAP is used, the users' home dirs will instead be read from LDAP
 dir_Users=/usr/local/kitodo/users/
+
 # Absolute path to a folder the application can temporarily create files in,
 # terminated by a directory separator ("/").
 tempfolder=/usr/local/kitodo/temp/
+
 # Path to directory in which BPMN diagrams are stored
 diagramsFolder=/usr/local/kitodo/diagrams/
+
+
 # -----------------------------------
 # Directory management
 # -----------------------------------
+
 # OrigOrdner anlegen, wenn nicht vorhanden
 createOrigFolderIfNotExists=true
+
 # indicates whether the source folder should be created automatically or not, default is false
 createSourceFolder=false
+
+# following parameters DIRECTORY_PREFIX and DIRECTORY_SUFFIX are used on creating image directory
+# when a process is created.
+# Resulting image directory name is <DIRECTORY_PREFIX>_<ProcessTitle>_<DIRECTORY_SUFFIX>
+#
+# prefix of image directory name created on process creation
 DIRECTORY_PREFIX=master
+#
+# directory suffix for created image directory on process creation
 DIRECTORY_SUFFIX=media
+
 importUseOldConfiguration=false
+
 # creation and export of process sub-directories
 # e.g. images/(processtitle)_tif&ocr/(processtitle)_pdf
 # (processtitle) is a placeholder for the process title
@@ -71,11 +94,15 @@ importUseOldConfiguration=false
 # Using the processDirs parameter is always an addition
 # to the existing folder creating and exporting functions of Kitodo.Production.
 # processDirs=
+
 # set if Master-Images-Folder 'orig_' should be used at all
 useOrigFolder=true
+
+
 # -----------------------------------
 # Directory and symbolic link management
 # -----------------------------------
+
 # For each process, a process directory will be created to store the associated
 # files in them. If a user accepts a task to work on which will require him
 # or her to have access permission to the data of a process, a symbolic link
@@ -88,59 +115,79 @@ useOrigFolder=true
 # For examples of these scripts, see the *.sh files in subdirectory `script`
 # of your Kitodo installation.
 # You will have to set execute permission before using those script files.
+
 # Script to create the user's home directory when adding a new user
 script_createDirUserHome=/usr/local/kitodo/scripts/script_createDirUserHome.sh
+
 # Script to create the directory for a new process
 script_createDirMeta=/usr/local/kitodo/scripts/script_createDirMeta.sh
+
 # Script to create a symbolic link in the user home direcory and set
 # permissions for the user
 script_createSymLink=/usr/local/kitodo/scripts/script_createSymLink.sh
+
 # Script to remove the symbolic link from the user home directory
 script_deleteSymLink=/usr/local/kitodo/scripts/script_deleteSymLink.sh
+
+
 # -----------------------------------
 # Images
 # -----------------------------------
+
 # Prefix for image names as regex. Default is 8 digits \\d{8} and gets
 # validated
 ImagePrefix=\\d{8}
+
 # Sorting of images. At this time implemented sorting options:
 # - number (default): 1 is lesser then 002, compares the number of image names,
 #       characters other than digits are not supported
 # - alphanumeric: 1 is greater then 002, compares character by character of
 #       image names, all characters are supported
 ImageSorting=number
+
+
 # =============================================================================
 #      VISUAL APPEARANCE
 # =============================================================================
 # -----------------------------------
 # Internationalization
 # -----------------------------------
+
 # Absolute path to the directory that the resource bundle files are stored in,
 # terminated by a directory separator ("/").
 # Note: If this directory DOESN'T EXIST, the internal resource bundles will be
 #       used. If this directory exists BUT DOES NOT CONTAIN suitable resources,
 #       the screens will not work as expected.
 localMessages=/usr/local/kitodo/messages/
+
 # Start-up language: If not set, Kitodo.Production will start up with the
 # language best matching the user's Accept-Languages HTTP Request header. You
 # can override this behaviour by setting a default language here:
 # language.force-default=de
+
 # Default language: If no Accept-Language Http Request header is present, use the following language:
 language.default=de
+
+
 # -----------------------------------
 # Data protection
 # -----------------------------------
+
 # The General Data Protection Regulation or local law might require to set this value to true.
 # anonymized statistics, displaying user on steps, etc
 # possible values: true/false
 anonymize=true
+
 # show statistics box on startpage, default is true
 showStatisticsOnStartPage=true
+
 # enable / disable search for steps done by user
 withUserStepDoneSearch=false
+
 # -----------------------------------
 # Error page
 # -----------------------------------
+
 # page the user will be directed to continue
 err_linkToPage=../pages/statischTechnischerHintergrund.jsf
 # =============================================================================
@@ -149,28 +196,38 @@ err_linkToPage=../pages/statischTechnischerHintergrund.jsf
 # -----------------------------------
 # Catalogue search
 # -----------------------------------
+
 # How many hits per page do you want to have displayed?
 catalogue.hitlist.pageSize=12
+
 # You may specify a timeout for database catalogue responses in milliseconds
 # after that the network interaction can be considered as failed. Note that in
 # large database-driven systems the search for a frequent term may take more
 # than a quarter of an hour (> 900.000 ms).
 catalogue.timeout=1800000
+
+
 # -----------------------------------
 # Metadata editor behaviour
 # -----------------------------------
 # use special image folder for METS editor if exists (define suffix here)
 MetsEditorDefaultSuffix=jpeg
+
 # use automatic default pagination
 MetsEditorWithAutomaticPagination=true
+
 # use special pagination type for automatic default pagination (uncounted, roman, arabic)
 MetsEditorDefaultPagination=uncounted
+
 # use a maximum of characters to display titles in the left part of mets editor, the default value is 0 (everything is displayed)
 MetsEditorMaxTitleLength=0
+
 # initialise all sub elements in Mets editor to assign default values, default value is true
 MetsEditorEnableDefaultInitialisation=true
+
 # display the file manipulation dialog within the mets editor
 MetsEditorDisplayFileManipulation=true
+
 # Comma-separated list of separators available for pagination modes where two
 # pages are on one image. Enclose in double quotes if contains white space or
 # comma. Example:
@@ -179,21 +236,29 @@ MetsEditorDisplayFileManipulation=true
 #
 # Defaults to one single white space:
 pageSeparators=" "
+
+
 # -----------------------------------
 # backup of metadata configuration
 # -----------------------------------
 numberOfMetaBackups=8
+
+
 # -----------------------------------
 # Metadata enrichment
 # -----------------------------------
+
 # Feature of automatic meta data inheritance and enrichment. If this is
 # enabled, all meta data elements from a higher level of the logical document
 # structure are automatically inherited and lower levels are enriched with them
 # upon process creation, given they have the same meta data type addable.
 #useMetadataEnrichment=false
+
+
 # -----------------------------------
 # Data copy rules
 # -----------------------------------
+
 # Data copy rules may be used to copy Kitodo internal data and metadata.
 # Copying can be done either on catalogue query or on DMS export.
 # A copy rule consists of a location to assign the data to, an assignment
@@ -272,107 +337,145 @@ numberOfMetaBackups=8
 # combining into it the metadata from its respective ancestors:
 #
 # /PublicationYear[0]/PublicationMonth[*]/PublicationDay[*]/Issue@DatePublished =format "%1$04d-%2$02d-%3$02d" #1@TitleDocMain #2@TitleDocMainShort #3@TitleDocMainShort
+
 #copyData.onCatalogueQuery=/@CurrentNoSorting ""\= /*[0]@CurrentNoSorting;/*[0]@TitleDocMain ""\= /@TitleDocMain
 #copyData.onExport=/@GoobiIdentifier \= $process.id;/PublicationYear[0]/PublicationMonth[*]/PublicationDay[*]/Issue@DatePublished \=format "%1$04d-%2$02d-%3$02d" #1@TitleDocMain #2@TitleDocMainShort #3@TitleDocMainShort
+
+
 # -----------------------------------
 # Metadata validation
 # -----------------------------------
+
 # grundsaetzliche Metadatenvalidierung durchfuehren oder nicht
 useMetadatenvalidierung=true
+
 # Validierung der Vorgangstitel ueber regulaeren Ausdruck
 validateProzessTitelRegex=[\\w-]*
+
 # Validierung des Identifiers ueber regulaeren Ausdruck
 # Regular Expression for validating the identifier
 validateIdentifierRegex=[\\w\\|-]
+
+
 # =============================================================================
 #      AUTOMATION
 # =============================================================================
 # -----------------------------------
 # Mass process generation
 # -----------------------------------
+
 # Colours used to represent the issues in the calendar editor
 issue.colours=#CC0000;#0000AA;#33FF00;#FF9900;#5555FF;#006600;#AAAAFF;#000055;#0000FF;#FFFF00;#000000
+
 # Minimal average number of pages per process in newspaper process creation
 numberOfPages.minimum=1
+
+
 # -----------------------------------
 # Batch processing
 # -----------------------------------
+
 # number of maximal items per batch, if not configured the default is 100
 batchMaxSize=500
+
 # Turn on or off whether each assignment of processes to or removal from
 # batches shall result in rewriting each processes' wiki field in order to
 # leave a note there. Enabling this function may slow down operations in the
 # batches dialogue.
 batches.logChangesToWikiField=false
+
+
 # -----------------------------------
 # GoobiContentServer for pdf generation
 # -----------------------------------
+
 pdfAsDownload=true
+
 # If empty, internal GoobiContentServer will be used, make sure
 # to configure it in goobiContentServerConfig.xml
 # Example: http://localhost:8080/kitodo/gcs/gcs?action=pdf\&metsFile=
 kitodoContentServerUrl=
+
 # TimeOut for GoobiContentServlet-Request via HTTP in ms (default value, if
 # nothing defined here: 60000)
 kitodoContentServerTimeOut=30000
+
+
 # -----------------------------------
 # Task manager
 # -----------------------------------
+
 # Overrides the limit of tasks run in parallel. Defaults to the number of
 # available cores.
 #taskManager.autoRunLimit=1
+
 # Sets the time interval between two inspections of the task list. Defaults to
 # 2000 ms.
 #taskManager.inspectionIntervalMillis=2000
+
 # Sets the maximum number of failed threads to keep around in RAM. Defaults to
 # 10. Keep in mind that zombie processes still occupy all their ressources and
 # aren't available for garbage collection, so choose these values as
 # restrictive as possible.
 #taskManager.keepThreads.failed.count=10
+
 # Sets the maximum time to keep failed threads around in RAM. Defaults to
 # 250 minutes (4 hours, 10 minutes). Keep in mind that zombie processes still
 # occupy all their ressources and aren't available for garbage collection, so
 # choose these values as restrictive as possible.
 #taskManager.keepThreads.failed.minutes=250
+
 # Sets the maximum number of successfully finished threads to keep around in
 # RAM. Defaults to 3. Keep in mind that zombie processes still occupy all
 # their ressources and aren't available for garbage collection, so choose
 # these values as restrictive as possible.
 #taskManager.keepThreads.successful.count=3
+
 # Sets the maximum time to keep successfully finished threads around in RAM.
 # Defaults to 20 minutes. Keep in mind that zombie processes still occupy all
 # their ressources and aren't available for garbage collection, so choose
 # these values as restrictive as possible.
 #taskManager.keepThreads.successful.minutes=20
+
 # Sets whether or not to show the task manager entry in the navigation sidebar.
 # Defaults to true. Setting this property doesn't have any influence on the
 # operativeness of the task manager.
 # Hint: This is a replacement for the former property "show_taskmanager"
 #taskManager.showInSidebar=true
+
 # Sets whether or not to show an option to "add a sample task" in the task
 # manager. This is---if for anything at all---useful for debugging or
 # demonstration purposes only. Defaults to false.
 #taskManager.showSampleTask=false
+
+
 # -----------------------------------
 # Export to presentation module
 # -----------------------------------
+
 # If you set this to true the exports will be done asynchronously (in the
 # background). This requires that the automatic export was set up in the
 # project settings.
 asynchronousAutomaticExport=true
+
 automaticExportWithImages=true
 automaticExportWithOcr=true
+
 # if this parameter is missing or 'false' the old export mechanism is used,
 # otherwise there is no timelimit for export
 exportWithoutTimeLimit=true
+
+
 # =============================================================================
 #      REMOTE SERVICES
 # =============================================================================
 # -----------------------------------
 # LDAP Configuration
 # -----------------------------------
+
 # Logins ueber LDAP verwenden
 ldap_use=false
+
 # -----------------------------------
 # Authority control configuration
 # -----------------------------------
@@ -389,72 +492,102 @@ ldap_use=false
 # Authority File (GND) is published, to the abstract name "gnd", use:
 # authority.http\://d-nb.info/gnd/.id=gnd
 authority.http\://d-nb.info/gnd/.id=gnd
+
 # You may want to specify the base URL of your preferred authority records
 # database once here to have it pre-filled-in automatically in authority
 # record input elements. For example, to use the Integrated Authority File
 # (GND) as your preferred authority records database, use:
 # authority.default=http\://d-nb.info/gnd/
+
 authority.default=http\://d-nb.info/gnd/
+
+
 # =============================================================================
 #      STATISTICS
 # =============================================================================
+
 # time in milliseconds, when to start automatic storage calculation each day
 # if no automatic storage calculation should be started, set to -1 here
 # sample: 0 means midnight
 storageCalculationSchedule=-1
+
+
 # =============================================================================
 #      DEVELOPER TOOLS
 # =============================================================================
 # -----------------------------------
 # interactive error management
 # -----------------------------------
+
 # use this to turn this feature on or off
 err_userHandling=true
+
 # use this to turn the email feature on or off
 err_emailEnabled=false
+
 # An indefinite number of e-mail addresses can be entered here. Create one
 # enumerated configuration entry line per address, like:
 # err_emailAddress1=(...), err_emailAddress2=(...), err_emailAddress3=(...), ..
 err_emailAddress1=
+
+
 # -----------------------------------
 # Debug folder
 # -----------------------------------
+
 # Falls Dateien zum Debuggen / Tracen geschrieben werden sollen, hier ein Verzeichnis angeben
 debugFolder=/usr/local/kitodo/debug/
+
+
 # =============================================================================
 #      FUNCTIONAL EXTENSIONS
 # =============================================================================
 # -----------------------------------
 # Module configuration
 # -----------------------------------
+
 moduleFolder=/usr/local/kitodo/modules/
+
+
 # -----------------------------------
 # OCR service access
 # -----------------------------------
+
 # Show OCR button for selected structural element
 showOcrButton=false
+
 # Base path to OCR, without parameters
 ocrUrl=
+
+
 # -----------------------------------
 # Plug-in interface
 # -----------------------------------
+
 # Absolute path to the plugins directory,
 # terminated by a directory separator ("/").
 # The plugins directory must contain a subfolder for each plugin type, which
 # must be named "command", "import", "opac", "step" and "validation", resp.
 # In each folder .jar files containing plugin implementations can be placed.
 pluginFolder=/usr/local/kitodo/plugins/
+
 massImportAllowed=true
+
 useWebApi=true
+
+
 # -----------------------------------
 # ActiveMQ web services
 # -----------------------------------
+
 # If you want to use Kitodo's ActiveMQ web servic interface, set the host here
 #activeMQ.hostURL=failover:(tcp://localhost:61616?closeAsync=false)
+
 # You can provide a topic that Kitodo reports results and status messages to
 #activeMQ.results.topic=KitodoProduction.ResultMessages.Topic
+
 # By default, Kitodo instructs the server to keep status messages for a
-# equivalent of 7 days. You can change this value in (milliseconds to) meet
+# equivalent of 7 days. You can change this value (in milliseconds) to meet
 # your needs. 0 will disable the deletion of messages completely. (However,
 # the messages will only available on the Active MQ server if your
 # TopicSubscriber is online with the Active MQ server before the message is
@@ -470,11 +603,18 @@ useWebApi=true
 # block inside the <policyEntries>-Element. "recoverDuration" has to be given
 # in milliseconds here, too.)
 #activeMQ.results.timeToLive=604800000
+
 # You can provide a queue from which messages are read to create new processes
 #activeMQ.createNewProcess.queue=KitodoProduction.CreateNewProcesses.Queue
+
 # You can provide a queue from which messages are read to finalise steps
 #activeMQ.finaliseStep.queue=KitodoProduction.FinaliseStep.Queue
+
+
+# -----------------------------------
 # Elasticsearch properties
+# -----------------------------------
+
 elasticsearch.host=localhost
 elasticsearch.port=9200
 elasticsearch.protocol=http


### PR DESCRIPTION
This returns the spacing lines to kitodo_config.properties and a little bit of comments/typo fixes found when diff’ing to 2.x version. I hope I did it right.