### PR TITLE
Disable 'copyToClipboard' buttons next to empty input fields

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/clipboard.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/clipboard.js
@@ -12,7 +12,16 @@
 function copyToClipboard(inputFieldName) {
     try {
         var inputField = document.getElementById(inputFieldName);
-        inputField.select();
+
+        // Temporarily activate deactivated inputFields to enable selecting
+        if (inputField.getAttribute('disabled') && inputField.getAttribute('disabled').localeCompare('disabled') === 0) {
+            inputField.removeAttribute('disabled');
+            inputField.select();
+            inputField.setAttribute('disabled', 'disabled');
+        } else {
+            inputField.select();
+        }
+
         document.execCommand('copy');
 
         PF('notifications').renderMessage({

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
@@ -30,43 +30,49 @@
                 <p:outputLabel for="metsRightsOwner" value="#{msgs.metsRightsOwner}" />
                 <p:inputText id="metsRightsOwner" placeholder="#{msgs.metsRightsOwner}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsRightsOwner}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsRightsOwnerButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwner')"/>
+                <p:commandButton id="copyMetsRightsOwnerButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwner')" disabled="#{empty ProjekteForm.myProjekt.metsRightsOwner}"/>
             </div>
             <div>
                 <p:outputLabel for="metsRightsOwnerUrl" value="#{msgs.metsRightsOwnerSite}" />
                 <p:inputText id="metsRightsOwnerUrl" placeholder="#{msgs.metsRightsOwnerSite}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsRightsOwnerSite}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsRightsOwnerUrlButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwnerUrl')"/>
+                <p:commandButton id="copyMetsRightsOwnerUrlButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwnerUrl')" disabled="#{empty ProjekteForm.myProjekt.metsRightsOwnerSite}"/>
             </div>
             <div>
                 <p:outputLabel for="metsDigiprovReference" value="#{msgs.metsDigiprovReference}" />
                 <p:inputText id="metsDigiprovReference" placeholder="#{msgs.metsDigiprovReference}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsDigiprovReference}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsDigiprovReferenceButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsDigiprovReference')"/>
+                <p:commandButton id="copyMetsDigiprovReferenceButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsDigiprovReference')" disabled="#{empty ProjekteForm.myProjekt.metsDigiprovReference}"/>
             </div>
             <div>
                 <p:outputLabel for="metsDigiprovReferenceAnchor" value="#{msgs.metsDigiprovReferenceAnchor}" />
                 <p:inputText id="metsDigiprovReferenceAnchor" placeholder="#{msgs.metsDigiprovReferenceAnchor}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsDigiprovReferenceAnchor}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsDigiprovReferenceAnchorButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsDigiprovReferenceAnchor')"/>
+                <p:commandButton id="copyMetsDigiprovReferenceAnchorButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsDigiprovReferenceAnchor')" disabled="#{empty ProjekteForm.myProjekt.metsDigiprovReferenceAnchor}"/>
             </div>
             <div>
                 <p:outputLabel for="metsPointerPath" value="#{msgs.metsPointerPath}" />
                 <p:inputText id="metsPointerPath" placeholder="#{msgs.metsPointerPath}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsPointerPath}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsPointerPathButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPointerPath')"/>
+                <p:commandButton id="copyMetsPointerPathButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPointerPath')" disabled="#{empty ProjekteForm.myProjekt.metsPointerPath}"/>
             </div>
             <div>
                 <p:outputLabel for="metsPurl" value="#{msgs.metsPurl}" />
                 <p:inputText id="metsPurl" placeholder="#{msgs.metsPurl}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsPurl}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsPurlButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPurl')"/>
+                <p:commandButton id="copyMetsPurlButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPurl')" disabled="#{empty ProjekteForm.myProjekt.metsPurl}"/>
             </div>
         </p:row>
         <p:row>
@@ -74,43 +80,49 @@
                 <p:outputLabel for="metsRightsOwnerLogo" value="#{msgs.metsRightsOwnerLogo}" />
                 <p:inputText id="metsRightsOwnerLogo" placeholder="#{msgs.metsRightsOwnerLogo}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsRightsOwnerLogo}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsRightsOwnerLogoButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwnerLogo')"/>
+                <p:commandButton id="copyMetsRightsOwnerLogoButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwnerLogo')" disabled="#{empty ProjekteForm.myProjekt.metsRightsOwnerLogo}"/>
             </div>
             <div>
                 <p:outputLabel for="metsRightsOwnerContact" value="#{msgs.metsRightsOwnerMail}" />
                 <p:inputText id="metsRightsOwnerContact" placeholder="#{msgs.metsRightsOwnerMail}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsRightsOwnerMail}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsRightsOwnerContactButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwnerContact')"/>
+                <p:commandButton id="copyMetsRightsOwnerContactButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsRightsOwnerContact')" disabled="#{empty ProjekteForm.myProjekt.metsRightsOwnerMail}"/>
             </div>
             <div>
                 <p:outputLabel for="metsDigiprovPresentation" value="#{msgs.metsDigiprovPresentation}" />
                 <p:inputText id="metsDigiprovPresentation" placeholder="#{msgs.metsDigiprovPresentation}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsDigiprovPresentation}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsDigiprovPresentationButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsDigiprovPresentation')"/>
+                <p:commandButton id="copyMetsDigiprovPresentationButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsDigiprovPresentation')" disabled="#{empty ProjekteForm.myProjekt.metsDigiprovPresentation}"/>
             </div>
             <div>
                 <p:outputLabel for="metsPresentationAnchor" value="#{msgs.metsDigiprovPresentationAnchor}" />
                 <p:inputText id="metsPresentationAnchor" placeholder="#{msgs.metsDigiprovPresentationAnchor}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsDigiprovPresentationAnchor}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsPresentationAnchorButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPresentationAnchor')"/>
+                <p:commandButton id="copyMetsPresentationAnchorButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPresentationAnchor')" disabled="#{empty ProjekteForm.myProjekt.metsDigiprovPresentationAnchor}"/>
             </div>
             <div>
                 <p:outputLabel for="metsPointerPathAnchor" value="#{msgs.metsPointerPathAnchor}" />
                 <p:inputText id="metsPointerPathAnchor" placeholder="#{msgs.metsPointerPathAnchor}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsPointerPathAnchor}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsPointerPathAnchorButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPointerPathAnchor')"/>
+                <p:commandButton id="copyMetsPointerPathAnchorButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsPointerPathAnchor')" disabled="#{empty ProjekteForm.myProjekt.metsPointerPathAnchor}"/>
             </div>
             <div>
                 <p:outputLabel for="metsContentId" value="#{msgs.metsContentIDs}" />
                 <p:inputText id="metsContentId" placeholder="#{msgs.metsContentIDs}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.metsContentIDs}" disabled="#{ProjekteForm.lockedMets}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyMetsContentIdButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsContentId')"/>
+                <p:commandButton id="copyMetsContentIdButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:metsContentId')" disabled="#{empty ProjekteForm.myProjekt.metsContentIDs}"/>
             </div>
         </p:row>
     </p:panelGrid>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditSpecification.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditSpecification.xhtml
@@ -38,15 +38,17 @@
                 <p:outputLabel for="dmsExportImageDir" value="#{msgs.dmsImportImagesPfad}" />
                 <p:inputText id="dmsExportImageDir" placeholder="#{msgs.dmsImportImagesPfad}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.dmsImportImagesPath}" disabled="#{ProjekteForm.lockedTechnical}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyDmsExportImageDirButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportImageDir');"/>
+                <p:commandButton id="copyDmsExportImageDirButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportImageDir');" disabled="#{empty ProjekteForm.myProjekt.dmsImportImagesPath}"/>
             </div>
             <div>
                 <p:outputLabel for="dmsExportErrorDir" value="#{msgs.dmsImportErrorPfad}" />
                 <p:inputText id="dmsExportErrorDir" placeholder="#{msgs.dmsImportErrorPfad}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.dmsImportErrorPath}" disabled="#{ProjekteForm.lockedTechnical}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyDmsExportErrorDirButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportErrorDir')"/>
+                <p:commandButton id="copyDmsExportErrorDirButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportErrorDir')" disabled="#{empty ProjekteForm.myProjekt.dmsImportErrorPath}"/>
             </div>
             <div>
                 <p:outputLabel for="automaticExport" value="#{msgs.automaticDmsImport}" />
@@ -73,15 +75,17 @@
                 <p:outputLabel for="dmsExportDir" value="#{msgs.dmsImportPfadXmlDatei}" />
                 <p:inputText id="dmsExportDir" placeholder="#{msgs.dmsImportPfadXmlDatei}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.dmsImportRootPath}" disabled="#{ProjekteForm.lockedTechnical}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyDmsExportDirButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportDir');"/>
+                <p:commandButton id="copyDmsExportDirButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportDir');" disabled="#{empty ProjekteForm.myProjekt.dmsImportRootPath}"/>
             </div>
             <div>
                 <p:outputLabel for="dmsExportSuccessDir" value="#{msgs.dmsImportSuccessPfad}" />
                 <p:inputText id="dmsExportSuccessDir" placeholder="#{msgs.dmsImportSuccessPfad}" styleClass="input-with-button" value="#{ProjekteForm.myProjekt.dmsImportSuccessPath}" disabled="#{ProjekteForm.lockedTechnical}">
                     <p:ajax event="blur"/>
+                    <p:ajax event="keyup" update="editForm:tabs:copyDmsExportSuccessDirButton"/>
                 </p:inputText>
-                <p:commandButton type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportSuccessDir');"/>
+                <p:commandButton id="copyDmsExportSuccessDirButton" type="button" icon="fa fa-copy" onclick="copyToClipboard('editForm:tabs:dmsExportSuccessDir');" disabled="#{empty ProjekteForm.myProjekt.dmsImportSuccessPath}"/>
             </div>
             <div>
                 <p:outputLabel for="createDir" value="#{msgs.dmsImportCreateProcessFolder}" />


### PR DESCRIPTION
After #1544, there is another small change to the "copyToClipboard" buttons: they are now only disabled next to empty input fields, and the disabled state does not depend on the "locked" property of the form anymore.