### PR TITLE
Fix XML parser problem in Eclipse

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -13,7 +13,7 @@
 -->
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/j2ee/web-app_3_0.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/web-app_3_0.xsd">
 
     <display-name>Kitodo</display-name>
 


### PR DESCRIPTION
Eclipse tries to download the XSD file from sun.com which is badly redirected. This updates the URL correctly.

See: https://stackoverflow.com/a/48871273/1503237