### PR TITLE
Make SessionForm seralizable

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/SessionForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/SessionForm.java
@@ -11,6 +11,7 @@
 
 package de.sub.goobi.forms;
 
+import java.io.Serializable;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -21,8 +22,9 @@ import org.kitodo.services.ServiceManager;
 
 @Named
 @ApplicationScoped
-public class SessionForm {
+public class SessionForm implements Serializable {
 
+    private static final long serialVersionUID = -7449236123765282059L;
     private transient ServiceManager serviceManager = new ServiceManager();
 
     /**


### PR DESCRIPTION
@ApplicationScoped beans

- These really should be serializable but under certain circumstances, your app will work even when they are not
- These circumstances being when you can avoid serialization, e.g. running on a single node application server
- As soon as you need to replicate such bean into several nodes, you need it to be serializable too
- Another case when serializability can be omitted is in SE
- Your IDE is therefore smart and does not mandate the Serializable presence

Source: https://stackoverflow.com/a/44283328/2701807