### PR TITLE
Add logging settings for log4j2 - fix error missing file

### DIFF
--- a/Kitodo/src/test/resources/selenium/resources/log4j2.xml
+++ b/Kitodo/src/test/resources/selenium/resources/log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+<Configuration monitorInterval="60">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Fix for: 

`[INFO] [talledLocalContainer] 2018-06-15 11:41:50,649 localhost-startStop-1 ERROR FileManager (/usr/local/kitodo/logs/kitodo.log) java.io.FileNotFoundException: /usr/local/kitodo/logs/kitodo.log (No such file or directory) java.io.FileNotFoundException: /usr/local/kitodo/logs/kitodo.log (No such file or directory)
.....
[INFO] [talledLocalContainer] 2018-06-15 11:41:50,659 localhost-startStop-1 ERROR Unable to invoke factory method in class class org.apache.logging.log4j.core.appender.FileAppender for element File. java.lang.reflect.InvocationTargetException`