### PR TITLE
Remove c3p0 library

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -59,11 +59,6 @@
             <version>2.1.5</version>
         </dependency>
         <dependency>
-            <groupId>com.mchange</groupId>
-            <artifactId>c3p0</artifactId>
-            <version>0.9.5.2</version>
-        </dependency>
-        <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${jersey.version}</version>

--- a/Kitodo/src/main/resources/c3p0.properties
+++ b/Kitodo/src/main/resources/c3p0.properties
@@ -7,6 +7,14 @@
 #
 # For the full copyright and license information, please read the
 # GPL3-License.txt file that was distributed with this source code.
+
+# This configuration is not direct used inside the application but will
+# be used on usage. This both mentioned properties are for connection
+# testing and is used for unstable or bad programmed connections from
+# application to database.
+#
+# Link: https://www.mchange.com/projects/c3p0/#configuring_connection_testing
+
 # c3p0.properties
 c3p0.testConnectionOnCheckout=false
 c3p0.preferredTestQuery=SELECT 1;


### PR DESCRIPTION
It looks this one is not used anymore. Configuration in hibernate mapping uses hibernate c3p0.