### PR TITLE
Standard tables hover for rows

### DIFF
--- a/Goobi/css/default.css
+++ b/Goobi/css/default.css
@@ -804,3 +804,12 @@ span.jscalendar-DB-title-control-normal-style:hover{
 .sundayNoBlock {
     background-color: #B68A8A;
 }
+
+/*
+   ------------------------------------------------------------
+   standard tables hover for rows
+   ------------------------------------------------------------
+*/
+table.standardtable tr:hover {
+    background-color: lightcyan;
+}


### PR DESCRIPTION
The active row in the standard tables is highlighted. Improves orientation in a table row. The current color is just a suggestion. This color is currently used in the University Library Mannheim.