### PR TITLE
Fix and simplification for StructMap getters in MetsKitodoWrapper

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
@@ -70,18 +70,18 @@ public class MetsKitodoObjectFactory extends ObjectFactory {
     }
 
     /**
-     * Creates a StructMap object of type "PHYSICAL".
+     * Creates a PhysicalStructMapType object.
      *
-     * @return The StructMap object.
+     * @return The PhysicalStructMapType object.
      */
     public PhysicalStructMapType createPhysicalStructMapType() {
         return new PhysicalStructMapType(createStructMapTypeOfType("PHYSICAL"));
     }
 
     /**
-     * Creates a StructMap object of type "LOGICAL".
+     * Creates a LogicalStructMapType object.
      *
-     * @return The StructMap object.
+     * @return The LogicalStructMapType object.
      */
     public LogicalStructMapType createLogicalStructMapType() {
         return new LogicalStructMapType(createStructMapTypeOfType("LOGICAL"));

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 
+import org.kitodo.dataeditor.entities.LogicalStructMapType;
+import org.kitodo.dataeditor.entities.PhysicalStructMapType;
 import org.kitodo.dataformat.metskitodo.DivType;
 import org.kitodo.dataformat.metskitodo.KitodoType;
 import org.kitodo.dataformat.metskitodo.MdSecType;
@@ -70,8 +72,8 @@ public class MetsKitodoObjectFactory extends ObjectFactory {
      *
      * @return The StructMap object.
      */
-    public StructMapType createPhysicalStructMapType() {
-        return createStructMapTypeOfType("PHYSICAL");
+    public PhysicalStructMapType createPhysicalStructMapType() {
+        return new PhysicalStructMapType(createStructMapTypeOfType("PHYSICAL"));
     }
 
     /**
@@ -79,8 +81,8 @@ public class MetsKitodoObjectFactory extends ObjectFactory {
      *
      * @return The StructMap object.
      */
-    public StructMapType createLogicalStructMapType() {
-        return createStructMapTypeOfType("LOGICAL");
+    public LogicalStructMapType createLogicalStructMapType() {
+        return new LogicalStructMapType(createStructMapTypeOfType("LOGICAL"));
     }
 
     private StructMapType createStructMapTypeOfType(String type) {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
@@ -15,8 +15,10 @@ import java.io.IOException;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 
+import org.kitodo.dataeditor.entities.FileSec;
 import org.kitodo.dataeditor.entities.LogicalStructMapType;
 import org.kitodo.dataeditor.entities.PhysicalStructMapType;
+import org.kitodo.dataeditor.entities.StructLink;
 import org.kitodo.dataformat.metskitodo.DivType;
 import org.kitodo.dataformat.metskitodo.KitodoType;
 import org.kitodo.dataformat.metskitodo.MdSecType;
@@ -125,6 +127,24 @@ public class MetsKitodoObjectFactory extends ObjectFactory {
         divType.setTYPE(type);
         divType.getDMDID().add(dmdSecOfLogicalRootDiv);
         return divType;
+    }
+
+    /**
+     * Creates a StructLink object.
+     * 
+     * @return The StructLink object.
+     */
+    public StructLink createStructLink() {
+        return new StructLink(super.createMetsTypeStructLink());
+    }
+
+    /**
+     * Creates a FileSec object.
+     * 
+     * @return The FileSec object.
+     */
+    public FileSec createFileSec() {
+        return new FileSec(super.createMetsTypeFileSec());
     }
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoWrapper.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoWrapper.java
@@ -162,7 +162,7 @@ public class MetsKitodoWrapper {
     /**
      * Returns the physical StructMap of the wrapped mets document.
      *
-     * @return The StructMapType object.
+     * @return The PhysicalStructMapType object.
      */
     public PhysicalStructMapType getPhysicalStructMap() {
         return this.physicalStructMapType;

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoWrapper.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoWrapper.java
@@ -33,7 +33,6 @@ import org.kitodo.dataformat.metskitodo.KitodoType;
 import org.kitodo.dataformat.metskitodo.MdSecType;
 import org.kitodo.dataformat.metskitodo.Mets;
 import org.kitodo.dataformat.metskitodo.MetsType;
-import org.kitodo.dataformat.metskitodo.StructMapType;
 
 /**
  * This is a wrapper class for holding and manipulating the content of a
@@ -85,11 +84,13 @@ public class MetsKitodoWrapper {
             mets.setMetsHdr(objectFactory.createKitodoMetsHeader());
         }
         if (mets.getStructMap().isEmpty()) {
-            StructMapType logicalStructMapType = objectFactory.createLogicalStructMapType();
+            LogicalStructMapType logicalStructMapType = objectFactory.createLogicalStructMapType();
             mets.getStructMap().add(logicalStructMapType);
+            this.logicalStructMapType = logicalStructMapType;
 
-            StructMapType physicalStructMapType = objectFactory.createPhysicalStructMapType();
+            PhysicalStructMapType physicalStructMapType = objectFactory.createPhysicalStructMapType();
             mets.getStructMap().add(physicalStructMapType);
+            this.physicalStructMapType = physicalStructMapType;
         }
     }
 
@@ -147,6 +148,7 @@ public class MetsKitodoWrapper {
         if (Objects.isNull(this.physicalStructMapType)) {
             this.physicalStructMapType = new PhysicalStructMapType(
                     MetsKitodoStructMapHandler.getMetsStructMapByType(mets, "PHYSICAL"));
+            this.mets.getStructMap().add(this.physicalStructMapType);
         }
         return this.physicalStructMapType;
     }
@@ -160,6 +162,7 @@ public class MetsKitodoWrapper {
         if (Objects.isNull(this.logicalStructMapType)) {
             this.logicalStructMapType = new LogicalStructMapType(
                     MetsKitodoStructMapHandler.getMetsStructMapByType(mets, "LOGICAL"));
+            this.mets.getStructMap().add(this.logicalStructMapType);
         }
         return this.logicalStructMapType;
     }
@@ -172,6 +175,7 @@ public class MetsKitodoWrapper {
     public FileSec getFileSec() {
         if (Objects.isNull(this.fileSec)) {
             this.fileSec = new FileSec(getMets().getFileSec());
+            this.mets.setFileSec(this.fileSec);
         }
         return this.fileSec;
     }
@@ -184,6 +188,7 @@ public class MetsKitodoWrapper {
     public StructLink getStructLink() {
         if (Objects.isNull(this.structLink)) {
             this.structLink = new StructLink(getMets().getStructLink());
+            this.mets.setStructLink(structLink);
         }
         return this.structLink;
     }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
@@ -481,8 +481,6 @@ public class MetsKitodoWrapperTest {
         MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper(xmlfile, xsltFile);
         DivType rootDiv = metsKitodoWrapper.getLogicalStructMap().getDiv();
         DivType rootDivFromMets = metsKitodoWrapper.getMets().getStructMap().get(1).getDiv();
-        MetsKitodoWriter writer = new MetsKitodoWriter();
-        System.out.println(writer.writeSerializedToString(metsKitodoWrapper.getMets()));
         Assert.assertEquals("Div elements from getter and directly from mets objects were not the same", rootDiv,
             rootDivFromMets);
     }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
@@ -442,7 +442,6 @@ public class MetsKitodoWrapperTest {
     public void shouldRemoveSmLink()
             throws JAXBException, TransformerException, IOException, DatatypeConfigurationException {
         MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper(xmlfile, xsltFile);
-
         DivType firstChapterDiv = metsKitodoWrapper.getLogicalStructMap().getDiv().getDiv().get(1).getDiv().get(2);
         List<DivType> physicalDivs = metsKitodoWrapper.getPhysicalDivsByLinkingLogicalDiv(firstChapterDiv);
 
@@ -456,7 +455,7 @@ public class MetsKitodoWrapperTest {
 
     @Test
     public void shouldPaginateDivs()
-        throws JAXBException, TransformerException, IOException, DatatypeConfigurationException {
+            throws JAXBException, TransformerException, IOException, DatatypeConfigurationException {
         MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper(xmlfile, xsltFile);
 
         List<DivType> physicalDivs = metsKitodoWrapper.getPhysicalStructMap().getDiv().getDiv();
@@ -465,6 +464,24 @@ public class MetsKitodoWrapperTest {
         paginator.writeToOrderLabelsOfDiyTypes(physicalDivs);
 
         DivType divType = metsKitodoWrapper.getPhysicalStructMap().getDiv().getDiv().get(9);
-        Assert.assertEquals("","XII",divType.getORDERLABEL());
+        Assert.assertEquals("", "XII", divType.getORDERLABEL());
+    }
+
+    @Test
+    public void shouldGetDivOfLogicalStructMap() throws DatatypeConfigurationException, IOException {
+        MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper("Manuscript");
+        DivType rootDiv = metsKitodoWrapper.getLogicalStructMap().getDiv();
+        DivType rootDivFromMets = metsKitodoWrapper.getMets().getStructMap().get(0).getDiv();
+        Assert.assertEquals("Div elements from getter and directly from mets objects were not the same", rootDiv,
+            rootDivFromMets);
+    }
+
+    @Test
+    public void shouldGetDivOfLogicalStructMapFromExistingFile() throws DatatypeConfigurationException, IOException, JAXBException, TransformerException {
+        MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper(xmlfile, xsltFile);
+        DivType rootDiv = metsKitodoWrapper.getLogicalStructMap().getDiv();
+        DivType rootDivFromMets = metsKitodoWrapper.getMets().getStructMap().get(0).getDiv();
+        Assert.assertEquals("Div elements from getter and directly from mets objects were not the same", rootDiv,
+            rootDivFromMets);
     }
 }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
@@ -480,7 +480,9 @@ public class MetsKitodoWrapperTest {
     public void shouldGetDivOfLogicalStructMapFromExistingFile() throws DatatypeConfigurationException, IOException, JAXBException, TransformerException {
         MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper(xmlfile, xsltFile);
         DivType rootDiv = metsKitodoWrapper.getLogicalStructMap().getDiv();
-        DivType rootDivFromMets = metsKitodoWrapper.getMets().getStructMap().get(0).getDiv();
+        DivType rootDivFromMets = metsKitodoWrapper.getMets().getStructMap().get(1).getDiv();
+        MetsKitodoWriter writer = new MetsKitodoWriter();
+        System.out.println(writer.writeSerializedToString(metsKitodoWrapper.getMets()));
         Assert.assertEquals("Div elements from getter and directly from mets objects were not the same", rootDiv,
             rootDivFromMets);
     }


### PR DESCRIPTION
Fixing a bug that the structMap getters are not returning the actual structMap of current mets document of MetsKitodoWrapper but new instances.