### PR TITLE
Refactor ModsPlugin

### DIFF
--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
@@ -813,6 +813,17 @@ public class ModsPlugin implements Plugin {
 
                 String docID = extractDocumentIdentifier(doc, transformationScript);
 
+                // read "additionalDetails" from document via XPaths elements
+                // specified in plugin configuration file
+                Document transformedDocument = transformXML(doc, transformationScript);
+                for (Map.Entry<String, String> detailField : getAdditionalDetailsFields(configuration.getTitle()).entrySet()) {
+                    XPath detailPath = XPath.newInstance(detailField.getValue());
+                    Element detailElement = (Element) detailPath.selectSingleNode(transformedDocument);
+                    if (!Objects.equals(detailElement, null)) {
+                        result.put(detailField.getKey(), detailElement.getText());
+                    }
+                }
+
                 @SuppressWarnings("unchecked")
                 ArrayList<Element> recordNodes = (ArrayList<Element>) srwRecordXPath.selectNodes(doc);
 

--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
@@ -569,6 +569,8 @@ public class ModsPlugin implements Plugin {
 
                         // TODO: create new structure div and add it to anchor structmap
                         //  - create structure div and add it to the anchor structmap
+                        anchorStructureMapDiv = createMETSStructureMapDiv(metadataSection.getAttributeValue(METS_ID), lastStructureType);
+                        anchorStructureMap.addContent(anchorStructureMapDiv);
 
                         // save new mets document to current anchor file
                         xmlOutputter.output(anchorMetsDocument, new FileWriter(anchorFile.getAbsoluteFile()));

--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/ModsPlugin.java
@@ -687,10 +687,12 @@ public class ModsPlugin implements Plugin {
 
             metadatasection = addDocumentToFile(document, anchorFile, timeout);
 
+            metadataFile = anchorFile;
+
             // add CatalogueIDDigital of anchor metadatasection to last metadatasection _before_ anchor!
             // TODO: find better (e.g. more robust!) way to select metadatasections to which the anchor ID should be added!
             if (tempFiles.size() > 1) {
-                addAnchorIDToMetadatasections(tempFiles.get(tempFiles.size()-2), structureMap, metadatasection, anchorFilenameSuffix);
+                addAnchorIDToMetadatasections(tempFiles.get(tempFiles.size()-2), structureMap, metadatasection, anchorClass);
             }
         }
         // use metadata file if current docstruct has NO anchor class


### PR DESCRIPTION
Refactor ModsPlugin in order to successfully import Kalliope documents with structure elements for which the "anchor" attribute is defined in the ruleset.