### PR TITLE
List of available docket and ruleset files

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -15,10 +15,15 @@ import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -160,6 +165,24 @@ public class DocketForm extends BasisForm {
             return serviceManager.getClientService().getAll();
         } catch (DAOException e) {
             Helper.setErrorMessage("errorLoadingMany", new Object[] {Helper.getTranslation("clients") }, logger, e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Get list of docket filenames.
+     *
+     * @return list of docket filenames
+     */
+    public List getDocketFiles() {
+        try {
+            return Files.walk(Paths.get(ConfigCore.getParameter("xsltFolder")))
+                    .filter(s -> s.toString().endsWith(".xsl"))
+                    .map(Path::getFileName)
+                    .sorted()
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            Helper.setErrorMessage("errorLoadingMany", new Object[] {Helper.getTranslation("dockets")}, logger, e);
             return new ArrayList<>();
         }
     }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/DocketForm.java
@@ -176,7 +176,7 @@ public class DocketForm extends BasisForm {
      */
     public List getDocketFiles() {
         try {
-            return Files.walk(Paths.get(ConfigCore.getParameter("xsltFolder")))
+            return Files.walk(Paths.get(ConfigCore.getParameter(Parameters.DIR_XSLT)))
                     .filter(s -> s.toString().endsWith(".xsl"))
                     .map(Path::getFileName)
                     .sorted()

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
@@ -15,10 +15,15 @@ import de.sub.goobi.config.ConfigCore;
 import de.sub.goobi.helper.Helper;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -169,6 +174,24 @@ public class RulesetForm extends BasisForm {
         } catch (DAOException e) {
             Helper.setErrorMessage("errorLoadingMany", new Object[] {Helper.getTranslation("clients") }, logger, e);
             return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Get list of ruleset filenames.
+     *
+     * @return list of ruleset filenames
+     */
+    public List getRulesetFilenames() {
+        try {
+            return Files.walk(Paths.get(ConfigCore.getParameter("RegelsaetzeVerzeichnis")))
+                    .filter(f -> f.toString().endsWith(".xml"))
+                    .map(Path::getFileName)
+                    .sorted()
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            Helper.setErrorMessage("errorLoadingMany", new Object[] {Helper.getTranslation("rulesets")}, logger, e);
+            return new ArrayList();
         }
     }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/RulesetForm.java
@@ -184,7 +184,7 @@ public class RulesetForm extends BasisForm {
      */
     public List getRulesetFilenames() {
         try {
-            return Files.walk(Paths.get(ConfigCore.getParameter("RegelsaetzeVerzeichnis")))
+            return Files.walk(Paths.get(ConfigCore.getParameter(Parameters.DIR_RULESETS)))
                     .filter(f -> f.toString().endsWith(".xml"))
                     .map(Path::getFileName)
                     .sorted()

--- a/Kitodo/src/main/webapp/pages/docketEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/docketEdit.xhtml
@@ -69,9 +69,11 @@
                         </div>
                         <div>
                             <p:outputLabel for="file" value="#{msgs.file}"/>
-                            <p:inputText id="file" value="#{DocketForm.myDocket.file}"
-                                         class="input"
-                                         required="#{empty param['editForm:saveButtonToggler']}"/>
+                            <p:selectOneMenu id="file" value="#{DocketForm.myDocket.file}">
+                                <f:selectItems value="#{DocketForm.docketFiles}" var="docketFile" itemValue="#{docketFile}"
+                                               itemLabel="#{docketFile}"/>
+                                <p:ajax event="change" oncomplete="toggleSave()"/>
+                            </p:selectOneMenu>
                         </div>
                     </p:row>
                     <p:row>

--- a/Kitodo/src/main/webapp/pages/rulesetEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/rulesetEdit.xhtml
@@ -66,11 +66,11 @@
                         </div>
                         <div>
                             <p:outputLabel for="file" value="#{msgs.file}"/>
-                            <p:inputText id="file"
-                                         class="input"
-                                         placeholder="#{msgs.file}"
-                                         value="#{RulesetForm.ruleset.file}"
-                                         required="#{empty param['editForm:saveButtonToggler']}"/>
+                            <p:selectOneMenu id="file" value="#{RulesetForm.ruleset.file}">
+                                <f:selectItems value="#{RulesetForm.rulesetFilenames}" var="rulesetFile" itemValue="#{rulesetFile}"
+                                               itemLabel="#{rulesetFile}"/>
+                                <p:ajax event="change" oncomplete="toggleSave()"/>
+                            </p:selectOneMenu>
                         </div>
                     </p:row>
                     <p:row>

--- a/Kitodo/src/test/java/org/kitodo/selenium/AddingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/AddingST.java
@@ -47,8 +47,7 @@ public class AddingST extends BaseTestSelenium {
     public void addDocketTest() throws Exception {
         Docket docket = new Docket();
         docket.setTitle("MockDocket");
-        docket.setFile("MetsModsGoobi_to_MetsKitodo.xsl");
-        Pages.getProjectsPage().createNewDocket().insertDocketData(docket).save();
+        Pages.getProjectsPage().goTo().createNewDocket().insertDocketData(docket).save();
         Assert.assertTrue("Redirection after save was not successful", Pages.getProjectsPage().isAt());
         List<String> docketTitles = Pages.getProjectsPage().switchToTabByIndex(TabIndex.DOCKETS.getIndex()).getDocketTitles();
         boolean docketAvailable = docketTitles.contains(docket.getTitle());
@@ -59,8 +58,7 @@ public class AddingST extends BaseTestSelenium {
     public void addRulesetTest() throws Exception {
         Ruleset ruleset = new Ruleset();
         ruleset.setTitle("MockRuleset");
-        ruleset.setFile("ruleset_test.xml");
-        Pages.getProjectsPage().createNewRuleset().insertRulesetData(ruleset).save();
+        Pages.getProjectsPage().goTo().createNewRuleset().insertRulesetData(ruleset).save();
         Assert.assertTrue("Redirection after save was not successful", Pages.getProjectsPage().isAt());
         List<String> rulesetTitles = Pages.getProjectsPage().switchToTabByIndex(TabIndex.RULESETS.getIndex()).getRulesetTitles();
         boolean rulesetAvailable = rulesetTitles.contains(ruleset.getTitle());

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/DocketEditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/DocketEditPage.java
@@ -14,6 +14,7 @@ package org.kitodo.selenium.testframework.pages;
 import org.kitodo.data.database.beans.Docket;
 import org.kitodo.selenium.testframework.Browser;
 import org.kitodo.selenium.testframework.Pages;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -30,8 +31,8 @@ public class DocketEditPage extends Page {
     private WebElement titleInput;
 
     @SuppressWarnings("unused")
-    @FindBy(id = "editForm:docketTabView:file")
-    private WebElement fileInput;
+    @FindBy(className = "ui-selectonemenu-trigger")
+    private WebElement selectTrigger;
 
     @SuppressWarnings("unused")
     @FindBy(className = "ui-messages-error-summary")
@@ -43,7 +44,8 @@ public class DocketEditPage extends Page {
 
     public DocketEditPage insertDocketData(Docket docket) {
         titleInput.sendKeys(docket.getTitle());
-        fileInput.sendKeys(docket.getFile());
+        selectTrigger.click();
+        Browser.getDriver().findElement(By.id("editForm:docketTabView:file_0")).click();
         return this;
     }
 

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/RulesetEditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/RulesetEditPage.java
@@ -14,6 +14,7 @@ package org.kitodo.selenium.testframework.pages;
 import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.selenium.testframework.Browser;
 import org.kitodo.selenium.testframework.Pages;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -30,8 +31,8 @@ public class RulesetEditPage extends Page {
     private WebElement titleInput;
 
     @SuppressWarnings("unused")
-    @FindBy(id = "editForm:rulesetTabView:file")
-    private WebElement fileInput;
+    @FindBy(className = "ui-selectonemenu-trigger")
+    private WebElement selectTrigger;
 
     @SuppressWarnings("unused")
     @FindBy(className = "ui-messages-error-summary")
@@ -43,7 +44,8 @@ public class RulesetEditPage extends Page {
 
     public RulesetEditPage insertRulesetData(Ruleset ruleset) {
         titleInput.sendKeys(ruleset.getTitle());
-        fileInput.sendKeys(ruleset.getFile());
+        selectTrigger.click();
+        Browser.getDriver().findElement(By.id("editForm:rulesetTabView:file_0")).click();
         return this;
     }
 


### PR DESCRIPTION
Replaced the input text fields for files in the docket and ruleset edit forms with select menus listing all available files in the corresponding directories.
