### PR TITLE
Fix overlying menus

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -234,6 +234,10 @@ body.first-visit #portal-header {
     color: #1b2b36;
     }
 
+#header-nav li.disabled:hover > a {
+    color: #fff;
+}
+
 #header-nav li ul {
     position: fixed;
     list-style: none;

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/menu.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/menu.js
@@ -114,6 +114,7 @@ var activationDelay = function() {
 menu.mouseleave(mouseleaveMenu)
     .find("> li")
     .mouseenter(mouseenterMenu)
+    .click(mouseenterMenu);
 
 $(document).mousemove(mousemoveDocument);
 
@@ -129,9 +130,13 @@ var callback = function () {
         }
     });
     if (disableMenu) {
-        menu.find('> li').off('mouseenter');
+        var list = menu.find('> li');
+        list.off('mouseenter');
+        list.addClass('disabled');
     } else {
-        menu.find('> li').mouseenter(mouseenterMenu);
+        var list = menu.find('> li');
+        list.mouseenter(mouseenterMenu);
+        list.removeClass('disabled');
     }
 };
 // observe for changes in DOM, eg. opening or closing popups

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/menu.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/menu.js
@@ -116,3 +116,24 @@ menu.mouseleave(mouseleaveMenu)
     .mouseenter(mouseenterMenu)
 
 $(document).mousemove(mousemoveDocument);
+
+// disable menu if a another popup is open
+var node = document.getElementsByTagName('body')[0];
+var config = { attributes: true, childList: true, subtree: true };
+var callback = function () {
+    var elements = $('.ui-menu, .ui-selectonemenu-panel, .ui-datepicker');
+    var disableMenu = false;
+    elements.each(function () {
+        if ($(this).css('display') === 'block') {
+            disableMenu = true;
+        }
+    });
+    if (disableMenu) {
+        menu.find('> li').off('mouseenter');
+    } else {
+        menu.find('> li').mouseenter(mouseenterMenu);
+    }
+};
+// observe for changes in DOM, eg. opening or closing popups
+var observer = new MutationObserver(callback);
+observer.observe(node, config);


### PR DESCRIPTION
Fixes the main menu interfering with opened popup, e.g. "New" button on several pages.
When a popup is already opened the main menu now only opens on click.