### PR TITLE
Fix saving process from template

### DIFF
--- a/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
+++ b/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
@@ -30,10 +30,15 @@
                          value="#{msgs.save}"
                          action="#{ProzesskopieForm.createNewProcess}"
                          icon="fa fa-floppy-o fa-lg" iconPos="right"
-                         onclick="PF('notifications').renderMessage({'summary':'#{msgs.validatingData}','detail':'','severity':'info'});"
+                         onclick="setConfirmUnload(false);PF('notifications').renderMessage({'summary':'#{msgs.validatingData}','detail':'','severity':'info'});"
                          oncomplete="if (args &amp;&amp; !args.validationFailed) PF('sticky-notifications').renderMessage({'summary':'#{msgs.processSaving}','detail':'#{msgs.youWillBeRedirected}','severity':'info'});"
                          update="notifications, sticky-notifications"/>
-        <p:button value="#{msgs.cancel}" outcome="projects" icon="fa fa-times fa-lg" iconPos="right" styleClass="secondary-button"/>
+        <p:button value="#{msgs.cancel}"
+                  onclick="setConfirmUnload(false);"
+                  outcome="projects"
+                  icon="fa fa-times fa-lg"
+                  iconPos="right"
+                  styleClass="secondary-button"/>
     </ui:define>
 
     <ui:define name="pageTabView">


### PR DESCRIPTION
Clicking the 'save' or 'cancel' buttons on the 'processFromTemplate' page shouldn't trigger the "Unsaved changes" warning, so this change adds the required calls to the 'setConfirmUnload' function.