### PR TITLE
Remove duplicate global confirm dialog

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -62,7 +62,7 @@
                 </footer>
             </div>
             <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" styleClass="confirm-delete" id="deleteConfirmDialog">
-                <p:commandButton id="yesButton" value="#{msgs.yes}" type="button" styleClass="ui-confirmdialog-yes" icon="ui-icon-check" immediate="true" update="processesTabView:processesForm:processesTable"/>
+                <p:commandButton id="yesButton" value="#{msgs.yes}" type="button" styleClass="ui-confirmdialog-yes" icon="ui-icon-check" immediate="true" update="@(.ui-datatable)"/>
                 <p:commandButton id="noButton" value="#{msgs.no}" type="button" styleClass="ui-confirmdialog-no" icon="ui-icon-close" />
             </p:confirmDialog>
             <ui:insert name="dialog"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
@@ -142,11 +142,6 @@
 
     </p:dataTable>
 
-    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" styleClass="confirm-delete" id="deleteConfirmDialog">
-        <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" icon="ui-icon-check" />
-        <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no" icon="ui-icon-close" />
-    </p:confirmDialog>
-
     <p:commandButton action="#{ProzessverwaltungForm.newTask}"
                      value="#{msgs.taskAdd}"
                      rendered="#{SecurityAccessController.isAdminOrHasAuthorityGlobalOrForClientOrForProject('addTask',item.process.project.client.id,item.process.project.id)}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/taskList.xhtml
@@ -109,11 +109,6 @@
 
     <o:graphicImage rendered="#{item.template.workflow ne null}" value="#{TemplateForm.tasksDiagram}" dataURI="true" />
 
-    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" styleClass="confirm-delete" id="deleteConfirmDialog">
-        <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" icon="ui-icon-check" />
-        <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no" icon="ui-icon-close" />
-    </p:confirmDialog>
-
     <p:commandButton action="#{TemplateForm.newTask}"
                      value="#{msgs.taskAdd}"
                      rendered="#{SecurityAccessController.isAdminOrHasAuthorityGlobalOrForClientOrForProject('addTask',item.template.project.client.id,item.template.project.id)}"


### PR DESCRIPTION
The global confirm dialog is now located in the base.xhtml template, so it should not be defined again in the individual template clients using it.