### PR TITLE
Fix CSS rule for login masks username input field

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -781,7 +781,7 @@ main i.fa {
     margin-bottom: 1.3em;
 }
 
-#login-section input[type=text], #login-section input[type=password] {
+#login-section input[id=username], #login-section input[type=password] {
     border: 1px solid #0071bc;
     border-radius: 3px;
     padding: 10px;


### PR DESCRIPTION
Fixes the selector for the login screens username input field, which was broken in https://github.com/kitodo/kitodo-production/commit/f1a89d00b8313d93ef1a686bc85b09e9be348263