### PR TITLE
FIX often failing TemplateAdd selenium test

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/Page.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/Page.java
@@ -103,7 +103,7 @@ public abstract class Page<T> {
     /**
      * Find row matching to give table, click toggle row and return index of found
      * row.
-     * 
+     *
      * @param dataTable
      *            table for search
      * @param objectTitle
@@ -164,6 +164,11 @@ public abstract class Page<T> {
             }
         }
         throw new TimeoutException("Could not access save button!" + button.getAttribute("id"));
+    }
+
+    protected void clickElement(WebElement element) {
+        await("Wait for element clicked").pollDelay(500, TimeUnit.MILLISECONDS).atMost(20, TimeUnit.SECONDS)
+                                        .ignoreExceptions().until(() -> isButtonClicked.matches(element));
     }
 
     Predicate<WebElement> isButtonClicked = (webElement) -> {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/TemplateEditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/TemplateEditPage.java
@@ -54,14 +54,14 @@ public class TemplateEditPage extends Page<TemplateEditPage> {
     public TemplateEditPage insertTemplateData(Template template) {
         titleInput.sendKeys(template.getTitle());
         Browser.getDriver().findElements(By.className("ui-selectlistbox-item")).get(0).click();
-        workflowSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)).click();
-        Browser.getDriver().findElement(By.id(workflowSelect.getAttribute("id") + "_0")).click();
+        clickElement(workflowSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
+        clickElement(Browser.getDriver().findElement(By.id(workflowSelect.getAttribute("id") + "_0")));
 
-        rulesetSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)).click();
-        Browser.getDriver().findElement(By.id(rulesetSelect.getAttribute("id") + "_1")).click();
+        clickElement(rulesetSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
+        clickElement(Browser.getDriver().findElement(By.id(rulesetSelect.getAttribute("id") + "_1")));
 
-        docketSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)).click();
-        Browser.getDriver().findElement(By.id(docketSelect.getAttribute("id") + "_1")).click();
+        clickElement(docketSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
+        clickElement(Browser.getDriver().findElement(By.id(docketSelect.getAttribute("id") + "_1")));
         return this;
     }
 


### PR DESCRIPTION
Adding new template selenium test was failing very often because clicking the dropdown lists without waiting caused that a dropdown trigger can be still overlapped by the previous dropdown list.

This PR adds waitings to prevent this.
