### PR TITLE
Increase length of tasks' column scriptPath

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_46__Increase_length_of_scriptPath.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_46__Increase_length_of_scriptPath.sql
@@ -1,0 +1,17 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+--
+-- Migration: Increasing the maximum length of column scriptPath in table task.
+--            This allows longer paths and parameters to be saved.
+--
+
+ALTER TABLE task MODIFY COLUMN scriptPath VARCHAR(500);


### PR DESCRIPTION
Increases the length of the column "scriptPath" in the "tasks" table.
This creates more space for additional parameters to be saved with the script path. It helps to execute scripts of automatic tasks with parameters without the need for additional java code to pass the parameters.