### PR TITLE
Fix back links

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/forms/BaseForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/BaseForm.java
@@ -44,6 +44,7 @@ public class BaseForm implements Serializable {
     protected static final String ERROR_SAVING = "errorSaving";
 
     protected static final String REDIRECT_PATH = TEMPLATE_ROOT + "{0}?" + REDIRECT_PARAMETER;
+    protected static final String DEFAULT_LINK = "desktop";
 
     /**
      * Getter: return lazyDTOModel.

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProjekteForm.java
@@ -80,6 +80,8 @@ public class ProjekteForm extends BaseForm {
     private String projectListPath = MessageFormat.format(REDIRECT_PATH, "projects");
     private String projectEditPath = MessageFormat.format(REDIRECT_PATH, "projectEdit");
 
+    private String projectEditReferer = DEFAULT_LINK;
+
     /**
      * Cash for the list of possible MIME types. So that the list does not have
      * to be read from file several times for one page load.
@@ -563,5 +565,28 @@ public class ProjekteForm extends BaseForm {
      */
     public List<SelectItem> getClients() {
         return SelectItemList.getClients();
+    }
+
+    /**
+     * Set referring view which will be returned when the user clicks "save" or "cancel" on the project edit page.
+     *
+     * @param referer the referring view
+     */
+    public void setProjectEditReferer(String referer) {
+        if (!referer.isEmpty()) {
+            if (referer.equals("projects")) {
+                this.projectEditReferer = referer;
+            } else {
+                this.projectEditReferer = DEFAULT_LINK;
+            }
+        }
+    }
+
+    /**
+     * Get project edit page referring view.
+     * @return project edit page referring view
+     */
+    public String getProjectEditReferer() {
+        return this.projectEditReferer;
     }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Kitodo/src/main/java/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -125,6 +125,9 @@ public class ProzessverwaltungForm extends TemplateBaseForm {
     private String processEditPath = MessageFormat.format(REDIRECT_PATH, "processEdit");
     private String taskEditPath = MessageFormat.format(REDIRECT_PATH, "taskEdit");
 
+    private String processEditReferer = DEFAULT_LINK;
+    private String taskEditReferer = DEFAULT_LINK;
+
     /**
      * Constructor.
      */
@@ -1694,5 +1697,51 @@ public class ProzessverwaltungForm extends TemplateBaseForm {
      */
     public void setSelectedProcesses(List<ProcessDTO> selectedProcesses) {
         this.selectedProcesses = selectedProcesses;
+    }
+
+    /**
+     * Set referring view which will be returned when the user clicks "save" or "cancel" on the task edit page.
+     *
+     * @param referer the referring view
+     */
+    public void setTaskEditReferer(String referer) {
+        if (referer.equals("processEdit?id=" + this.task.getProcess().getId())) {
+            this.taskEditReferer = referer;
+        } else {
+            this.taskEditReferer = DEFAULT_LINK;
+        }
+    }
+
+    /**
+     * Get task edit page referring view.
+     *
+     * @return task eit page referring view
+     */
+    public String getTaskEditReferer() {
+        return this.taskEditReferer;
+    }
+
+    /**
+     * Set referring view which will be returned when the user clicks "save" or "cancel" on the process edit page.
+     *
+     * @param referer the referring view
+     */
+    public void setProcessEditReferer(String referer) {
+        if (!referer.isEmpty()) {
+            if (referer.equals("processes")) {
+                this.processEditReferer = referer;
+            } else if (!referer.contains("taskEdit") || this.processEditReferer.isEmpty()) {
+                this.processEditReferer = DEFAULT_LINK;
+            }
+        }
+    }
+
+    /**
+     * Get process edit page referring view.
+     *
+     * @return process edit page referring view
+     */
+    public String getProcessEditReferer() {
+        return this.processEditReferer;
     }
 }

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
@@ -246,7 +246,7 @@ public class Metadaten {
             "metadataWrapperPanel",
             "commentWrapperPanel",
             "galleryWrapperPanel");
-    private String referringView = "processes";
+    private String referringView = "desktop";
 
 
 

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
@@ -324,7 +324,7 @@ public class Metadaten {
         calculateMetadataAndImages();
         cleanupMetadata();
         if (storeMetadata()) {
-            return "/pages/processes?faces-redirect=true";
+            return referringView;
         } else {
             Helper.setMessage("XML could not be saved");
             return "";

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
@@ -36,6 +36,7 @@
                         title="#{msgs.processEdit}">
                     <i class="fa fa-pencil-square-o fa-lg"/>
                     <f:param name="id" value="#{process.id}"/>
+                    <f:param name="referer" value="desktop"/>
                 </h:link>
                 <h:commandLink id="readXML" action="#{Metadaten.readXml}" title="#{msgs.metadataEdit}">
                     <f:setPropertyActionListener value="desktop" target="#{Metadaten.referringView}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
@@ -32,6 +32,7 @@
                         onclick="#{ProjekteForm.setLockedDetail(true)} #{ProjekteForm.setLockedMets(true)} #{ProjekteForm.setLockedTechnical(true)}" outcome="projectEdit"
                         title="#{msgs.projectEdit}">
                     <f:param name="id" value="#{project.id}" />
+                    <f:param name="referer" value="desktop"/>
                     <i class="fa fa-pencil-square-o fa-lg"/>
                 </h:link>
                 <h:commandLink rendered="#{SecurityAccessController.isAdminOrHasAuthorityGlobalOrForClient('addProject', project.client.id)}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/tasksWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/tasksWidget.xhtml
@@ -34,6 +34,7 @@
                 <h:link outcome="taskEdit" id="editTask"
                         rendered="#{SecurityAccessController.isAdminOrHasAuthorityGlobalOrForClientOrForProject('editTask',task.process.project.client.id, task.process.project.id)}"
                         title="#{msgs.detailsDesSchritts}">
+                    <f:param name="referer" value="desktop"/>
                     <f:param name="id" value="#{task.id}"/>
                     <i class="fa fa-pencil-square-o fa-lg"/>
                 </h:link>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
@@ -74,6 +74,7 @@
                     rendered="#{SecurityAccessController.isAdminOrHasAuthorityGlobalOrForClientOrForProject('editTask',item.process.project.client.id,item.process.project.id)}"
                     title="#{msgs.detailsDesSchritts}">
                 <f:param name="id" value="#{item.id}"/>
+                <f:param name="referer" value="processEdit?id=#{item.process.id}"/>
                 <i class="fa fa-pencil-square-o fa-lg"/>
             </h:link>
             <p:commandLink id="deleteTask"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -39,6 +39,7 @@
                         outcome="/pages/processEdit"
                         title="#{msgs.processEdit}">
                     <i class="fa fa-pencil-square-o fa-lg"/>
+                    <f:param name="referer" value="processes"/>
                     <f:param name="id" value="#{process.id}"/>
                 </h:link>
                 <h:commandLink id="readXML" action="#{Metadaten.readXml}" title="#{msgs.metadataEdit}">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -56,6 +56,7 @@
                         onclick="#{ProjekteForm.setLockedDetail(true)} #{ProjekteForm.setLockedMets(true)} #{ProjekteForm.setLockedTechnical(true)}" outcome="projectEdit"
                         title="#{msgs.projectEdit}">
                     <f:param name="id" value="#{item.id}" />
+                    <f:param name="referer" value="projects"/>
                     <i class="fa fa-pencil-square-o fa-lg"/>
                 </h:link>
                 <h:commandLink rendered="#{SecurityAccessController.isAdminOrHasAuthorityGlobalOrForClient('addProject',item.client.id)}"

--- a/Kitodo/src/main/webapp/pages/processEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/processEdit.xhtml
@@ -20,6 +20,7 @@
     <f:metadata>
         <f:viewParam name="id"/>
         <f:viewAction action="#{ProzessverwaltungForm.loadProcess(id)}" />
+        <f:viewAction action="#{ProzessverwaltungForm.setProcessEditReferer(request.getParameter('referer'))}"/>
     </f:metadata>
 
     <ui:define name="contentHeader">
@@ -46,7 +47,7 @@
                          style="display:none;"/>
         <p:button id="cancel"
                   value="#{msgs.cancel}"
-                  outcome="#{'processes'}"
+                  outcome="#{ProzessverwaltungForm.processEditReferer}"
                   onclick="setConfirmUnload(false);"
                   icon="fa fa-times fa-lg"
                   iconPos="right"

--- a/Kitodo/src/main/webapp/pages/projectEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/projectEdit.xhtml
@@ -20,6 +20,7 @@
     <f:metadata>
         <f:viewParam name="id"/>
         <f:viewAction action="#{ProjekteForm.loadProject(id)}"/>
+        <f:viewAction action="#{ProjekteForm.setProjectEditReferer(request.getParameter('referer'))}"/>
     </f:metadata>
 
     <ui:define name="contentHeader">
@@ -47,7 +48,7 @@
                          style="display:none;"/>
         <p:button value="#{msgs.cancel}"
                   onclick="setConfirmUnload(false);"
-                  outcome="projects"
+                  outcome="#{ProjekteForm.projectEditReferer}"
                   icon="fa fa-times fa-lg"
                   iconPos="right"
                   styleClass="secondary"/>

--- a/Kitodo/src/main/webapp/pages/taskEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/taskEdit.xhtml
@@ -20,6 +20,7 @@
     <f:metadata>
         <f:viewParam name="id"/>
         <f:viewAction action="#{ProzessverwaltungForm.loadTask(id)}" />
+        <f:viewAction action="#{ProzessverwaltungForm.setTaskEditReferer(request.getParameter('referer'))}"/>
     </f:metadata>
 
     <ui:define name="contentHeader">
@@ -44,7 +45,7 @@
                          update="save"
                          style="display:none;"/>
         <p:button id="cancel" value="#{msgs.cancel}"
-                  outcome="processEdit?id=#{ProzessverwaltungForm.task.process.id}"
+                  outcome="#{ProzessverwaltungForm.taskEditReferer}"
                   onclick="setConfirmUnload(false);"
                   icon="fa fa-times fa-lg"
                   iconPos="right"

--- a/Kitodo/src/main/webapp/pages/taskEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/taskEdit.xhtml
@@ -44,7 +44,7 @@
                          update="save"
                          style="display:none;"/>
         <p:button id="cancel" value="#{msgs.cancel}"
-                  outcome="processEdit?id=#{ProzessverwaltungForm.process.id}"
+                  outcome="processEdit?id=#{ProzessverwaltungForm.task.process.id}"
                   onclick="setConfirmUnload(false);"
                   icon="fa fa-times fa-lg"
                   iconPos="right"


### PR DESCRIPTION
PR fixes the navigation outcome of the 'cancel' button on the `taskEdit` view and adds "referer" parameters to links to `processEdit`, `taskEdit` and `projectEdit` pages, in order to return to the correct view when canceling or saving on those pages.