### PR TITLE
Add exclusion for conflicting poi library

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -493,6 +493,10 @@
                     <artifactId>itext</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>poi</groupId>
+                    <artifactId>poi</artifactId>
+                </exclusion>
+                <exclusion>
                     <artifactId>spring</artifactId>
                     <groupId>org.springframework</groupId>
                 </exclusion>


### PR DESCRIPTION
It fixes conflict in poi library (tomahawk included 2.x - we use 3.x) which is used for generating search results (list of processes) to excel file.

Method generate was dying silently with error NoSuchMethodError.