### PR TITLE
Legal texts

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/editor/LegalTextEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/editor/LegalTextEditor.java
@@ -1,0 +1,165 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.editor;
+
+import de.sub.goobi.helper.Helper;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import javax.faces.context.FacesContext;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import org.kitodo.config.Config;
+import org.kitodo.helper.LegalTexts;
+
+@Named("LegalTextEditor")
+@ViewScoped
+public class LegalTextEditor implements Serializable {
+
+    private static List<String> legalTextTitles;
+    private String currentLegalTextTitle;
+    private String currentLegalTextContent;
+    private List<Locale> availableLocales = new ArrayList<>();
+    private String currentLanguage;
+
+    /**
+     * Default constructor.
+     */
+    public LegalTextEditor() {
+        legalTextTitles = new LinkedList<>();
+
+        legalTextTitles.add(LegalTexts.TERMS_OF_USE);
+        legalTextTitles.add(LegalTexts.DATA_PRIVACY);
+        legalTextTitles.add(LegalTexts.IMPRINT);
+
+        currentLegalTextTitle = legalTextTitles.get(0);
+
+        FacesContext.getCurrentInstance().getApplication().getSupportedLocales()
+                .forEachRemaining(availableLocales::add);
+        if (!availableLocales.isEmpty()) {
+            currentLanguage = availableLocales.get(0).getLanguage();
+        }
+        loadText();
+    }
+
+    /**
+     * Load currently selected legal file and set it's text content to
+     * 'currentLegalTextContent'.
+     */
+    private void loadText() {
+        currentLegalTextContent = LegalTexts.loadText(this.currentLegalTextTitle, this.currentLanguage);
+    }
+
+    /**
+     * Save text of currently selected legal text to file.
+     */
+    public void saveText() {
+        String filePath = Config.getKitodoConfigDirectory() + "legal_" + this.currentLegalTextTitle + "_"
+                + this.currentLanguage + ".html";
+        try {
+            Files.write(Paths.get(filePath), this.currentLegalTextContent.getBytes());
+            LegalTexts.updateTexts(this.currentLanguage);
+        } catch (IOException e) {
+            Helper.setErrorMessage("ERROR: unable to save file '" + filePath + "'!");
+        }
+    }
+
+    /**
+     * Return list of legal texts.
+     *
+     * @return list of legal texts
+     */
+    public List<String> getLegalTextTitles() {
+        return legalTextTitles;
+    }
+
+    /**
+     * Return current legal text.
+     *
+     * @return current legal text
+     */
+    public String getCurrentLegalTextTitle() {
+        return this.currentLegalTextTitle;
+    }
+
+    /**
+     * Set current legal text.
+     *
+     * @param text
+     *            current legal text
+     */
+    public void setCurrentLegalTextTitle(String text) {
+        if (!Objects.equals(text, this.currentLegalTextTitle)) {
+            this.currentLegalTextTitle = text;
+            loadText();
+        }
+    }
+
+    /**
+     * Return current legal text content as String.
+     *
+     * @return current legal text content as String
+     */
+    public String getCurrentLegalTextContent() {
+        return currentLegalTextContent;
+    }
+
+    /**
+     * Set current legal text content to given String 'textString'.
+     *
+     * @param textString
+     *            current legal text String
+     */
+    public void setCurrentLegalTextContent(String textString) {
+        this.currentLegalTextContent = textString;
+    }
+
+    /**
+     * Get list of available locales.
+     *
+     * @return list of available locales
+     */
+    public List<Locale> getAvailableLocales() {
+        return availableLocales;
+    }
+
+    /**
+     * Get language currently selected in the editor.
+     *
+     * @return language currently selected in the editor
+     */
+    public String getCurrentLanguage() {
+        return currentLanguage;
+    }
+
+    /**
+     * Set current language.
+     *
+     * @param language
+     *            new current language
+     */
+    public void setCurrentLanguage(String language) {
+        if (!Objects.equals(language, this.currentLanguage)) {
+            this.currentLanguage = language;
+            loadText();
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/forms/SpracheForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/SpracheForm.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
@@ -39,6 +40,7 @@ import org.kitodo.config.Parameters;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.helper.LegalTexts;
 import org.kitodo.services.ServiceManager;
 
 /**
@@ -59,6 +61,11 @@ public class SpracheForm implements Serializable {
      */
     public SpracheForm() {
         setSessionLocaleFieldId();
+    }
+
+    @PostConstruct
+    private void updateLegalTexts() {
+        LegalTexts.updateTexts(getLanguage());
     }
 
     /**
@@ -236,6 +243,7 @@ public class SpracheForm implements Serializable {
     public void setLanguage(String language) {
         try {
             switchLanguage(language);
+            LegalTexts.updateTexts(language);
         } catch (IOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }

--- a/Kitodo/src/main/java/org/kitodo/helper/LegalTexts.java
+++ b/Kitodo/src/main/java/org/kitodo/helper/LegalTexts.java
@@ -33,26 +33,59 @@ public class LegalTexts implements Serializable {
 
     private static final String DEFAULT_LANGUAGE = Locale.GERMAN.getLanguage();
 
+    /**
+     * Get terms of use text.
+     *
+     * @return terms of use text
+     */
     public String getTermsOfUseText() {
         return termsOfUseText;
     }
 
+    /**
+     * Set terms of use texts.
+     *
+     * @param newText
+     *            new terms of use text
+     */
     public void setTermsOfUseText(String newText) {
         termsOfUseText = newText;
     }
 
+    /**
+     * Get data privacy text.
+     *
+     * @return data privacy text
+     */
     public String getDataPrivacyText() {
         return dataPrivacyText;
     }
 
+    /**
+     * Set data privacy text.
+     *
+     * @param newText
+     *            new data privacy text
+     */
     public void setDataPrivacyText(String newText) {
         dataPrivacyText = newText;
     }
 
+    /**
+     * Get imprint text.
+     *
+     * @return imprint text
+     */
     public String getImprintText() {
         return imprintText;
     }
 
+    /**
+     * Set imprint text.
+     *
+     * @param newText
+     *            new imprint text
+     */
     public void setImprintText(String newText) {
         imprintText = newText;
     }

--- a/Kitodo/src/main/java/org/kitodo/helper/LegalTexts.java
+++ b/Kitodo/src/main/java/org/kitodo/helper/LegalTexts.java
@@ -1,0 +1,110 @@
+package org.kitodo.helper;
+
+import de.sub.goobi.helper.Helper;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.Objects;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import org.kitodo.config.Config;
+import org.omnifaces.cdi.Eager;
+import org.omnifaces.util.Ajax;
+import org.omnifaces.util.Faces;
+
+@Named("LegalTexts")
+@ApplicationScoped
+@Eager
+public class LegalTexts implements Serializable {
+
+    public static final String TERMS_OF_USE = "termsOfUse";
+    public static final String DATA_PRIVACY = "dataPrivacy";
+    public static final String IMPRINT = "imprint";
+
+    private static String termsOfUseText = "";
+    private static String dataPrivacyText = "";
+    private static String imprintText = "";
+
+    private static final String DEFAULT_LANGUAGE = Locale.GERMAN.getLanguage();
+
+    public String getTermsOfUseText() {
+        return termsOfUseText;
+    }
+
+    public void setTermsOfUseText(String newText) {
+        termsOfUseText = newText;
+    }
+
+    public String getDataPrivacyText() {
+        return dataPrivacyText;
+    }
+
+    public void setDataPrivacyText(String newText) {
+        dataPrivacyText = newText;
+    }
+
+    public String getImprintText() {
+        return imprintText;
+    }
+
+    public void setImprintText(String newText) {
+        imprintText = newText;
+    }
+
+    /**
+     * Initialize legal texts.
+     */
+    @PostConstruct
+    public static void initializeTexts() {
+        updateTexts(DEFAULT_LANGUAGE);
+    }
+
+    /**
+     * Reload all legal texts in the given language.
+     *
+     * @param language
+     *            language in which legal texts are loaded
+     */
+    public static void updateTexts(String language) {
+        termsOfUseText = loadText(TERMS_OF_USE, language);
+        dataPrivacyText = loadText(DATA_PRIVACY, language);
+        imprintText = loadText(IMPRINT, language);
+        if (Objects.nonNull(Faces.getContext())) {
+            Ajax.update("imprintDialog", "dataPrivacyDialog", "termsOfUseDialog");
+        }
+    }
+
+    /**
+     * Load legal text file identified by given String 'legalTextName' and in the
+     * given language and return its text content. If no file for the given
+     * parameters can be found, a corresponding default text from the message
+     * properties files will be used.
+     *
+     * @param legalTextName
+     *            String identifying the legal text file to load
+     * @param language
+     *            String specifying in which language the legal text is to be loaded
+     * @return the text content of the legal text
+     */
+    public static String loadText(String legalTextName, String language) {
+        String filePath = Config.getKitodoConfigDirectory() + "legal_" + legalTextName + "_" + language + ".html";
+        try {
+            return new String(Files.readAllBytes(Paths.get(filePath)));
+        } catch (IOException e) {
+            return getDefaultText(legalTextName, language);
+        }
+    }
+
+    private static String getDefaultText(String legalText, String language) {
+        return "<h1>" + Helper.getString(Locale.forLanguageTag(language), legalText) + "</h1><br/><p>"
+                + Helper.getString(Locale.forLanguageTag(language), legalText + "DefaultText") + "</p><br/><p>"
+                + Helper.getString(Locale.forLanguageTag(language), "adjustSettingText") + "</p>";
+
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/helper/LegalTexts.java
+++ b/Kitodo/src/main/java/org/kitodo/helper/LegalTexts.java
@@ -1,3 +1,14 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
 package org.kitodo.helper;
 
 import de.sub.goobi.helper.Helper;

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -37,6 +37,7 @@ addToBatch=Vorgang wurde zur Gruppe {0} hinzugef\u00FCgt.
 addToProcessLog=Zu Vorgangslog hinzuf\u00FCgen
 addToSelectedBatch=Selektierte Vorg\u00E4nge zu ausgew\u00E4hltem Batch hinzuf\u00FCgen
 additionalDetails=Zus\u00E4tzliche Details
+adjustSettingText=Ihr Administrator kann diese Einstellung unter System => Rechtliches konfigurieren!
 administration=Administration
 # administrativ is supposedly use for translation of TaskEditType
 administrativ=administrativ
@@ -219,6 +220,8 @@ dataCopier.runtimeException=Fehler beim Kopieren der Daten\:
 file=Datei
 dashboard=Dashboard
 dataPrivacy=Datenschutz
+# used in "LegalTexts.java"
+dataPrivacyDefaultText=Datenschutzinformationen f\u00FCr dieses System wurden noch nicht hinterlegt.
 databaseStatistic=Datenbankstatistik
 day=Tag
 days=Tage
@@ -401,6 +404,8 @@ importFiles=Dateien importieren
 importMittelsFileUpload=Import mittels Dateiupload
 importPlugin=Plugin f\u00FCr den Import
 imprint=Impressum
+# used in "LegalTexts.java"
+imprintDefaultText=Das Impressum f\u00FCr dieses System wurde noch nicht hinterlegt.
 inBearbeitungDurch=In Bearbeitung durch
 indexedEntries=Indexierte Eintr\u00E4ge
 indexing=Indexierung
@@ -435,6 +440,7 @@ ldapServerView=LDAP-Server anzeigen
 ldapServerSaving=LDAP-Server wird gespeichert...
 newLdapServer=Neuer LDAP-Server
 ldaplogin=LDAP login
+legal=Rechtliches
 link=Verkn\u00FCpfung
 linkImage=Bild verlinken
 loadAllProcesses=Alle Vorg\u00E4nge laden
@@ -715,6 +721,8 @@ templateProperties=Vorlageneigenschaften
 templateTitle=Produktionsvorlagentitel
 templates=Produktionsvorlagen
 termsOfUse=Nutzungsbedingungen
+# used in "LegalTexts.java"
+termsOfUseDefaultText=Die Nutzungsbedingungen f\u00FCr dieses System wurden noch nicht hinterlegt.
 tifHeaderDocumentName=Tif-Header Documentname
 tifHeaderImageDescription=Tif-Header Image-Beschreibung
 timeZone.+01\:00=MEZ

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -38,6 +38,7 @@ addToBatch=Added process to batch {0}.
 addToProcessLog=add to process log
 addToSelectedBatch=add selected processes to selected batch
 additionalDetails=Additional details
+adjustSettingText=Your administrator can adjust the corresponding settings under System => Legal!
 administration=Administration
 # administrativ is supposedly use for translation of TaskEditType
 administrativ=administrative
@@ -221,6 +222,8 @@ dataCopier.runtimeException=Copying the data failed\:
 file=File
 dashboard=Dashboard
 dataPrivacy=Data privacy
+# used in "LegalTexts.java"
+dataPrivacyDefaultText=Data privacy information have not been configured for this system.
 databaseStatistic=Database statistics
 day=day
 days=days
@@ -402,6 +405,8 @@ importedBatchLabel=Imported from {0}, {1}
 importingData=Importing data...
 importPlugin=import Plugin
 imprint=Imprint
+# used in "LegalTexts.java"
+imprintDefaultText=Imprint information have not been configured for this system.
 inBearbeitungDurch=In edition by
 indexedEntries=Indexed entries
 indexing=Indexing
@@ -436,6 +441,7 @@ ldapServerEdit=Edit LDAP-server
 ldapServerView=View LDAP-server
 ldapServerSaving=Saving LDAP-Server...
 ldapServerNew=Add new LDAP server
+legal=Legal
 link=Link
 linkImage=Link image
 loadAllProcesses=Load all processes
@@ -714,6 +720,8 @@ templateProperties=Template properties
 templates=Process templates
 templateTitle=Template title
 termsOfUse=Terms of use
+# used in "LegalTexts.java"
+termsOfUseDefaultText=Terms of use have not been configured for this system.
 tifHeaderDocumentName=Tiff header document name
 tifHeaderImageDescription=Tiff header image description
 timeZone.+01\:00=CET

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -868,6 +868,16 @@ main i.fa {
     line-height: 22px;
 }
 
+.legal-dialog {
+    width: 640px;
+    min-height: 480px;
+}
+
+.legal-texts-select-menu {
+    margin: 0 10px 10px 0;
+    width: 250px;
+}
+
 .select-client-note {
     background: #F94A15;
     padding: 16px 32px 16px 32px;
@@ -1216,7 +1226,8 @@ footer {
     display: inline;
     }
 
-#footer-meta-menu li a {
+#footer-meta-menu li a,
+#footer-meta-menu li input {
     background: #999;
     color: #fff;
     text-decoration: none;
@@ -1226,7 +1237,8 @@ footer {
     margin-bottom: 5px;
     }
 
-#footer-meta-menu li a:hover {
+#footer-meta-menu li a:hover,
+#footer-meta-menu li input:hover{
     background: #005182;
     }
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -67,6 +67,7 @@
                 <p:commandButton id="yesButton" value="#{msgs.yes}" type="button" styleClass="ui-confirmdialog-yes" icon="ui-icon-check" immediate="true" update="@(.ui-datatable)"/>
                 <p:commandButton id="noButton" value="#{msgs.no}" type="button" styleClass="ui-confirmdialog-no" icon="ui-icon-close" />
             </p:confirmDialog>
+            <ui:include src="/WEB-INF/templates/includes/legal.xhtml"/>
             <ui:insert name="dialog"/>
             <o:highlight styleClass="ui-state-error" />
         </h:body>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/footer.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/footer.xhtml
@@ -11,15 +11,34 @@
  *
 -->
 
-<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui">
     <div class="wrapper">
         <section id="footer-content">
-            <ul id="footer-meta-menu">
-                <li><a href="">#{msgs.imprint}</a></li>
-                <li><a href="">#{msgs.dataPrivacy}</a></li>
-                <li><a href="">#{msgs.termsOfUse}</a></li>
-            </ul>
-            <p>KITODO.PRODUCTION <span>Version #{HelperForm.version}</span></p>
+            <h:form id="legal-menu">
+                <ul id="footer-meta-menu">
+                    <li>
+                        <p:commandLink type="button"
+                                       value="#{msgs.imprint}"
+                                       update=":imprintDialog"
+                                       oncomplete="PF('imprintDialog').show()"/>
+                    </li>
+                    <li>
+                        <p:commandLink type="button"
+                                       value="#{msgs.dataPrivacy}"
+                                       update=":dataPrivacyDialog"
+                                       oncomplete="PF('dataPrivacyDialog').show()"/>
+                    </li>
+                    <li>
+                        <p:commandLink type="button"
+                                       value="#{msgs.termsOfUse}"
+                                       update=":termsOfUseDialog"
+                                       oncomplete="PF('termsOfUseDialog').show()"/>
+                    </li>
+                </ul>
+                <p>KITODO.PRODUCTION <span>Version #{HelperForm.version}</span></p>
+            </h:form>
         </section>
     </div>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/legal.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/legal.xhtml
@@ -1,0 +1,52 @@
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+    <f:view locale="#{SpracheForm.locale}">
+        <p:dialog id="imprintDialog"
+                  styleClass="legal-dialog"
+                  widgetVar="imprintDialog"
+                  header="#{msgs.imprint}"
+                  modal="true">
+            <h:outputText id="imprintText"
+                          value="#{LegalTexts.imprintText}"
+                          escape="false"
+                          style="padding: 30px;"/>
+        </p:dialog>
+        <p:dialog id="dataPrivacyDialog"
+                  styleClass="legal-dialog"
+                  widgetVar="dataPrivacyDialog"
+                  header="#{msgs.dataPrivacy}"
+                  modal="true">
+            <h:outputText id="dataPrivacyText"
+                          value="#{LegalTexts.dataPrivacyText}"
+                          escape="false"
+                          style="padding: 30px;"/>
+        </p:dialog>
+        <p:dialog id="termsOfUseDialog"
+                  styleClass="legal-dialog"
+                  widgetVar="termsOfUseDialog"
+                  header="#{msgs.termsOfUse}"
+                  modal="true">
+            <h:outputText id="termsOfUseText"
+                          value="#{LegalTexts.termsOfUseText}"
+                          escape="false"
+                          style="padding: 30px;"/>
+        </p:dialog>
+    </f:view>
+</ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/legalTextEditor.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/legalTextEditor.xhtml
@@ -1,0 +1,58 @@
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<ui:composition
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:pe="http://primefaces.org/ui/extensions">
+    <p:panel id="legalTextWrapper">
+        <h:form id="legalTextForm">
+            <p:selectOneMenu id="legalTexts"
+                             immediate="true"
+                             styleClass="legal-texts-select-menu"
+                             value="#{LegalTextEditor.currentLegalTextTitle}">
+                <f:selectItems value="#{LegalTextEditor.legalTextTitles}"
+                               var="currentLegalText"
+                               itemLabel="#{msgs[currentLegalText]}"/>
+                <p:ajax event="change"
+                        update="systemTabView:legalTextForm:legalTextEditor"/>
+            </p:selectOneMenu>
+            <p:selectOneMenu id="languageMenu"
+                             styleClass="legal-texts-select-menu"
+                             value="#{LegalTextEditor.currentLanguage}"
+                             immediate="true">
+                <f:selectItems value="#{LegalTextEditor.availableLocales}" var="entry"
+                               itemLabel="#{entry.displayLanguage}"
+                               itemValue="#{entry.language}"/>
+                <p:ajax event="change"
+                        update="systemTabView:legalTextForm:legalTextEditor"/>
+            </p:selectOneMenu>
+            <p:commandButton id="saveButton"
+                             widgetVar="saveButton"
+                             value="#{msgs.save}"
+                             action="#{LegalTextEditor.saveText()}"/>
+            <pe:codeMirror id="legalTextEditor"
+                           theme="blackboard"
+                           matchBrackets="true"
+                           widgetVar="legalTextEditor"
+                           indentUnit="4"
+                           lineNumbers="true"
+                           lineWrapping="true"
+                           mode="htmlembedded"
+                           keyMap="default"
+                           value="#{LegalTextEditor.currentLegalTextContent}"/>
+        </h:form>
+    </p:panel>
+</ui:composition>

--- a/Kitodo/src/main/webapp/pages/login.xhtml
+++ b/Kitodo/src/main/webapp/pages/login.xhtml
@@ -12,11 +12,11 @@
 -->
 
 <ui:composition template="/WEB-INF/templates/base.xhtml"
-      xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:sec="http://www.springframework.org/security/tags"
-      >
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:sec="http://www.springframework.org/security/tags">
+
     <ui:define name="header">
         <div class="wrapper">
             <section id="portal-logo" class="login-screen">

--- a/Kitodo/src/main/webapp/pages/system.xhtml
+++ b/Kitodo/src/main/webapp/pages/system.xhtml
@@ -33,6 +33,9 @@
             <p:tab id="taskManagerTab" title="#{msgs.taskManager}">
                 <ui:include src="/WEB-INF/templates/includes/system/taskmanager.xhtml" />
             </p:tab>
+            <p:tab id="termsTab" title="#{msgs.legal}">
+                <ui:include src="/WEB-INF/templates/includes/system/legalTextEditor.xhtml" />
+            </p:tab>
         </p:tabView>
     </ui:define>
 


### PR DESCRIPTION
This Pull Request adds an frontend editor for adjusting legal texts for imprint, data privacy and terms of use. These texts are now displayed in a modal dialog when clicking the corresponding buttons in the footer. If no custom texts have been saved, a default dialog will be displayed instead. 

The frontend editor can be found under "Settings" => "Legal" in the header menu / dashboard.