### PR TITLE
Fix Random objects should be reused pointed out by SonarCloud

### DIFF
--- a/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/CommandService.java
+++ b/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/CommandService.java
@@ -22,6 +22,8 @@ import org.kitodo.serviceloader.KitodoServiceLoader;
 
 class CommandService {
 
+    private Random random = new Random(1000000);
+
     /**
      * Method executes a script string.
      *
@@ -37,7 +39,7 @@ class CommandService {
         KitodoServiceLoader<CommandInterface> serviceLoader = new KitodoServiceLoader<>(CommandInterface.class);
         CommandInterface command = serviceLoader.loadModule();
 
-        CommandResult commandResult = command.runCommand(generateId(), script);
+        CommandResult commandResult = command.runCommand(random.nextInt(), script);
         List<String> commandResultMessages = commandResult.getMessages();
         if (commandResultMessages.size() > 0 && commandResultMessages.get(0).contains("IOException")) {
             throw new IOException(commandResultMessages.get(1));
@@ -79,15 +81,5 @@ class CommandService {
             scriptString = scriptString + " " + String.join(" ", parameter);
         }
         return scriptString;
-    }
-
-    /**
-     * Generates a random integer in the range of 0-1000000.
-     *
-     * @return The integer value.
-     */
-    private int generateId() {
-        Random random = new Random();
-        return random.nextInt(1000000);
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/command/CommandService.java
@@ -27,6 +27,7 @@ import org.kitodo.serviceloader.KitodoServiceLoader;
 public class CommandService {
 
     private ArrayList<CommandResult> finishedCommandResults = new ArrayList<>();
+    private Random random = new Random(1000000);
 
     /**
      * Method executes a script string.
@@ -47,7 +48,7 @@ public class CommandService {
         KitodoServiceLoader<CommandInterface> serviceLoader = new KitodoServiceLoader<>(CommandInterface.class);
         CommandInterface command = serviceLoader.loadModule();
 
-        CommandResult commandResult = command.runCommand(generateId(), script);
+        CommandResult commandResult = command.runCommand(random.nextInt(), script);
         List<String> commandResultMessages = commandResult.getMessages();
         if (!commandResultMessages.isEmpty() && commandResultMessages.get(0).contains("IOException")) {
             throw new IOException(commandResultMessages.get(1));
@@ -106,7 +107,7 @@ public class CommandService {
             CommandInterface commandInterface = serviceLoader.loadModule();
 
             Flowable<CommandResult> source = Flowable.fromCallable(() ->
-                commandInterface.runCommand(generateId(), script)
+                commandInterface.runCommand(random.nextInt(), script)
             );
 
             Flowable<CommandResult> commandBackgroundWorker = source.subscribeOn(Schedulers.io());
@@ -172,16 +173,6 @@ public class CommandService {
             scriptString = scriptString + " " + String.join(" ", parameter);
         }
         return scriptString;
-    }
-
-    /**
-     * Generates a random integer in the range of 0-1000000.
-     *
-     * @return The integer value.
-     */
-    private int generateId() {
-        Random random = new Random();
-        return random.nextInt(1000000);
     }
 
     /**


### PR DESCRIPTION
> Creating a new Random object each time a random value is needed is inefficient and may produce numbers which are not random depending on the JDK. For better efficiency and randomness, create a single Random, then store, and reuse it.

> The Random() constructor tries to set the seed with a distinct value every time. However there is no guarantee that the seed will be random or even uniformly distributed. Some JDK will use the current time as seed, which makes the generated numbers not random at all.

> This rule finds cases where a new Random is created each time a method is invoked and assigned to a local random variable.