### PR TITLE
Fix gallery layout

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1166,6 +1166,19 @@ Column content
     margin-left: 5px;
 }
 
+#galleryWrapperPanel,
+#galleryWrapperPanel_content {
+    height: 100%;
+}
+
+#thumbnailStripe > div {
+    text-align: center;
+}
+
+#thumbnailStripe a {
+    display: inline-block;
+}
+
 .thumbnail {
     height: 60px;
     border: 1px solid black;

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/ol_custom.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/ol_custom.js
@@ -12,6 +12,7 @@
 // Kitodo namespace
 window.kitodo = {};
 var kitodo = window.kitodo;
+var map;
 
 /**
  * @param {Object=} opt_options Custom control options for Kitodo in OpenLayers
@@ -87,38 +88,50 @@ kitodo.RotateRightControl = function(opt_options) {
 ol.inherits(kitodo.RotateLeftControl, ol.control.Rotate);
 ol.inherits(kitodo.RotateRightControl, ol.control.Rotate);
 
-// Map image coordinates to map coordinates to be able to use image extent in pixels.
-var extent = [0, 0, 800, 1280];
-var projection = new ol.proj.Projection({
-    code: 'kitodo-image',
-    units: 'pixels',
-    extent: extent
-});
+// load image to get correct dimensions
+var image = new Image();
+var imagePath = document.getElementById("imageData").dataset.image;
+var imageDimensions;
+image.onload = function () {
+    imageDimensions = [image.width, image.height];
+    initializeMap(imageDimensions);
+};
+image.src = imagePath;
 
-var map = new ol.Map({
-    controls: ol.control.defaults({
-        attributionOptions: {
-            collapsible: false
-        }
-    }).extend([
-        new kitodo.RotateLeftControl()
-    ]).extend([
-        new kitodo.RotateRightControl()
-    ]),
-    layers: [
-        new ol.layer.Image({
-            source: new ol.source.ImageStatic({
-                url: document.getElementById("imageData").dataset.image,
-                projection: projection,
-                imageExtent: extent
+function initializeMap(imageDimensions) {
+    // Map image coordinates to map coordinates to be able to use image extent in pixels.
+    var extent = [0, 0, imageDimensions[0], imageDimensions[1]];
+    var projection = new ol.proj.Projection({
+        code: 'kitodo-image',
+        units: 'pixels',
+        extent: extent
+    });
+
+    map = new ol.Map({
+        controls: ol.control.defaults({
+            attributionOptions: {
+                collapsible: false
+            }
+        }).extend([
+            new kitodo.RotateLeftControl()
+        ]).extend([
+            new kitodo.RotateRightControl()
+        ]),
+        layers: [
+            new ol.layer.Image({
+                source: new ol.source.ImageStatic({
+                    url: imagePath,
+                    projection: projection,
+                    imageExtent: extent
+                })
             })
+        ],
+        target: 'map',
+        view: new ol.View({
+            projection: projection,
+            center: ol.extent.getCenter(extent),
+            zoom: 1,
+            maxZoom: 8
         })
-    ],
-    target: 'map',
-    view: new ol.View({
-        projection: projection,
-        center: ol.extent.getCenter(extent),
-        zoom: 1,
-        maxZoom: 8
-    })
-});
+    });
+}

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/ol_custom.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/ol_custom.js
@@ -135,3 +135,8 @@ function initializeMap(imageDimensions) {
         })
     });
 }
+
+// reload map if container was resized
+$('#thirdColumnWrapper').on('resize', function () {
+    map.updateSize();
+});

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/resize.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/resize.js
@@ -98,6 +98,7 @@ function resizeFirstAndThird(e) {
         thirdColumn.width(wrapperPositionX + wrapper.width() - 2 * SEPARATOR_WIDTH - secondColumn.width() - e.pageX);
         firstColumnWidth = firstColumn.width();
         thirdColumnWidth = thirdColumn.width();
+        thirdColumn[0].dispatchEvent(new Event('resize'));
     }
 }
 
@@ -108,6 +109,7 @@ function resizeSecondAndThird(e) {
         thirdColumn.width(wrapperPositionX + wrapper.width() - SEPARATOR_WIDTH - e.pageX);
         secondColumnWidth = secondColumn.width();
         thirdColumnWidth = thirdColumn.width();
+        thirdColumn[0].dispatchEvent(new Event('resize'));
     }
 }
 
@@ -141,6 +143,7 @@ function setSizes() {
     thirdColumn.width(wrapper.width() - firstColumn.data('min-width') - secondColumn.data('min-width') - 2 * SEPARATOR_WIDTH);
     firstSection.height(wrapper.height() / 2 - HEADING_HEIGHT - (parseInt(secondColumn.css('padding-top')) / 2));
     secondSection.height(wrapper.height() / 2 - HEADING_HEIGHT - (parseInt(secondColumn.css('padding-top')) / 2) - SEPARATOR_HEIGHT);
+    thirdColumn[0].dispatchEvent(new Event('resize'));
 }
 
 function toggleResizers() {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -114,13 +114,15 @@
             <ui:fragment rendered="#{Metadaten.viewMode eq 'preview' and Metadaten.imageListExistent}">
                 <!-- OpenLayers Kitodo custom controls -->
                 <div id="olWrapper" style="overflow-x: auto; height: 100%">
-                    <div id="thumbnailStripe" style="width: 10%; display: inline-block; float: right">
+                    <div id="thumbnailStripe" style="width: 100px; display: inline-block; float: right">
                         <ui:repeat value="#{Metadaten.images}" var="image">
-                            <p:commandLink update="imagePreviewForm, galleryHeadingWrapper" rendered="#{Metadaten.isAccessGranted(image)}">
-                                <!-- outputText is needed to remove whitespace produced by correct code indent -->
-                                <h:outputText><img style="display: inline;" class="thumbnail #{Metadaten.currentImage eq image ? 'active' : ''}" src="#{request.contextPath}#{Metadaten.getThumbnail(image)}"/></h:outputText>
-                                <f:setPropertyActionListener value="#{image}" target="#{Metadaten.currentImage}"/>
-                            </p:commandLink>
+                            <div>
+                                <p:commandLink update="imagePreviewForm, galleryHeadingWrapper" rendered="#{Metadaten.isAccessGranted(image)}">
+                                    <!-- outputText is needed to remove whitespace produced by correct code indent -->
+                                    <h:outputText><img style="display: inline;" class="thumbnail #{Metadaten.currentImage eq image ? 'active' : ''}" src="#{request.contextPath}#{Metadaten.getThumbnail(image)}"/></h:outputText>
+                                    <f:setPropertyActionListener value="#{image}" target="#{Metadaten.currentImage}"/>
+                                </p:commandLink>
+                            </div>
                             <!-- FIXME: primefaces does not find the image, need to prefix the path with 'window.location.host'! -->
                             <!--<p:graphicImage styleClass="thumbnail" name="#{image}" alt="#{image}" title="#{image}"/>-->
                         </ui:repeat>
@@ -128,7 +130,7 @@
                     <ui:fragment rendered="#{Metadaten.isAccessGranted(Metadaten.currentImage)}">
                         <h:outputStylesheet name="webjars/openlayers/4.5.0/ol.css"/>
                         <h:outputScript name="js/ol_custom.js"/>
-                        <div id="map" class="map" style="width: 85%; height: 100%; display: inline-block; float: left"/>
+                        <div id="map" class="map" style="width: calc(100% - 100px); height: 100%; display: inline-block; float: left"/>
                     </ui:fragment>
                 </div>
             </ui:fragment>


### PR DESCRIPTION
The OpenLayers gallery now uses all the available space in the third column (removed top and bottom bars). The image's aspect ratio is now maintained also on images with horizontal aspect ratio.