### PR TITLE
Fix duplication of workflows

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/forms/WorkflowForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/WorkflowForm.java
@@ -20,7 +20,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URI;
-import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Objects;
@@ -135,7 +134,7 @@ public class WorkflowForm extends BaseForm {
                 .getRequestParameterMap();
 
         if (isWorkflowAlreadyInUse(this.workflow)) {
-            this.workflow.setFileName(decodeXMLDiagramName(this.workflow.getFileName()) + "_" + randomString(3));
+            this.workflow.setFileName(decodeXMLDiagramName(this.workflow.getFileName()) + "_" + Helper.generateRandomString(3));
         }
         URI svgDiagramURI = new File(diagramsFolder + decodeXMLDiagramName(this.workflow.getFileName()) + ".svg")
                 .toURI();
@@ -152,6 +151,7 @@ public class WorkflowForm extends BaseForm {
 
         return fileService.fileExist(xmlDiagramURI) && fileService.fileExist(svgDiagramURI);
     }
+
 
     void saveFile(URI fileURI, String fileContent) {
         try (OutputStream outputStream = fileService.write(fileURI);
@@ -198,17 +198,6 @@ public class WorkflowForm extends BaseForm {
 
     private boolean isWorkflowAlreadyInUse(Workflow workflow) {
         return !workflow.getTemplates().isEmpty();
-    }
-
-    private static String randomString(int length) {
-        final String AB = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-        SecureRandom rnd = new SecureRandom();
-
-        StringBuilder sb = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
-            sb.append(AB.charAt(rnd.nextInt(AB.length())));
-        }
-        return sb.toString();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/helper/Helper.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.SecureRandom;
 import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
@@ -583,5 +584,23 @@ public class Helper implements Observer, Serializable {
      */
     public static void setActiveMQReporting(Map<String, String> activeMQReporting) {
         Helper.activeMQReporting = activeMQReporting;
+    }
+
+    /**
+     * Generate random string.
+     * 
+     * @param length
+     *            of random string to be created
+     * @return random string
+     */
+    public static String generateRandomString(int length) {
+        final String AB = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        SecureRandom random = new SecureRandom();
+
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(AB.charAt(random.nextInt(AB.length())));
+        }
+        return sb.toString();
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/WorkflowService.java
@@ -25,6 +25,7 @@ import org.kitodo.data.elasticsearch.index.type.enums.WorkflowTypeField;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.dto.WorkflowDTO;
+import org.kitodo.helper.Helper;
 import org.kitodo.services.data.base.SearchService;
 
 public class WorkflowService extends SearchService<Workflow, WorkflowDTO, WorkflowDAO> {
@@ -82,7 +83,7 @@ public class WorkflowService extends SearchService<Workflow, WorkflowDTO, Workfl
         Workflow duplicatedWorkflow = new Workflow();
 
         // Workflow _title_ should explicitly _not_ be duplicated!
-        duplicatedWorkflow.setFileName(baseWorkflow.getFileName() + "_Copy");
+        duplicatedWorkflow.setFileName(baseWorkflow.getFileName() + "_" + Helper.generateRandomString(3));
         duplicatedWorkflow.setActive(baseWorkflow.isActive());
         duplicatedWorkflow.setReady(false);
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
@@ -49,8 +49,9 @@
                         <f:param name="id" value="#{item.id}"/>
                     </h:link>
 
-                    <h:commandLink action="#{WorkflowForm.duplicate(item.id)}" immediate="true"
-                                   title="#{msgs.duplicateWorkflow}"><i class="fa fa-clone fa-lg"/></h:commandLink>
+                    <h:commandLink action="#{WorkflowForm.duplicate(item.id)}" title="#{msgs.duplicateWorkflow}">
+                        <i class="fa fa-clone fa-lg"/>
+                    </h:commandLink>
 
                     <p:commandLink id="deleteWorkflow" action="#{WorkflowForm.delete}"
                                    title="#{msgs.delete}" update="projectsTabView:workflowTable">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/workflowEdit/workflowEditDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/workflowEdit/workflowEditDetails.xhtml
@@ -32,7 +32,7 @@
             <div>
                 <p:commandButton id="btnReadXmlDiagram" value="Read XML diagram"
                                  action="#{WorkflowForm.readXMLDiagram}"
-                                 rendered="#{WorkflowForm.workflow.id ne null}"
+                                 rendered="#{WorkflowForm.workflow.fileName ne null}"
                                  immediate="true"/>
             </div>
 

--- a/Kitodo/src/main/webapp/pages/workflowEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/workflowEdit.xhtml
@@ -32,10 +32,11 @@
         </script>
         <h3>
             <h:outputText value="#{msgs.editWorkflow} (#{WorkflowForm.workflow.title})"
-                          rendered="#{not empty WorkflowForm.workflow.title}"/>
-            <h:outputText value="#{msgs.createNewWorkflow}" rendered="#{empty WorkflowForm.workflow.title}"/>
+                          rendered="#{WorkflowForm.workflow.id ne null}"/>
+            <h:outputText value="#{msgs.createNewWorkflow}"
+                          rendered="#{WorkflowForm.workflow.id eq null and WorkflowForm.workflow.fileName eq null}"/>
             <h:outputText value="#{msgs.duplicateWorkflow}"
-                          rendered="#{empty WorkflowForm.workflow.title and not empty WorkflowForm.workflow.fileName}"/>
+                          rendered="#{WorkflowForm.workflow.title eq null and WorkflowForm.workflow.fileName ne null}"/>
         </h3>
         <p:commandButton id="save"
                          widgetVar="save"
@@ -74,6 +75,8 @@
             <a href="">
                 <h:outputText value="#{msgs.editWorkflow}" rendered="#{WorkflowForm.workflow.id ne null}"/>
                 <h:outputText value="#{msgs.createNewWorkflow}" rendered="#{WorkflowForm.workflow.id eq null}"/>
+                <h:outputText value="#{msgs.duplicateWorkflow}"
+                              rendered="#{empty WorkflowForm.workflow.title and not empty WorkflowForm.workflow.fileName}"/>
             </a>
         </li>
     </ui:define>

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.security.SecureRandom;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -78,6 +77,7 @@ import org.kitodo.data.database.persistence.HibernateUtil;
 import org.kitodo.data.elasticsearch.index.IndexRestClient;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.enums.ObjectType;
+import org.kitodo.helper.Helper;
 import org.kitodo.security.SecurityPasswordEncoder;
 import org.kitodo.services.ServiceManager;
 
@@ -113,7 +113,7 @@ public class MockDatabase {
 
     @SuppressWarnings("unchecked")
     public static void startNodeWithoutMapping() throws Exception {
-        String nodeName = randomString(6);
+        String nodeName = Helper.generateRandomString(6);
         final String port = ConfigMain.getParameter("elasticsearch.port", "9205");
 
         testIndexName = ConfigMain.getParameter("elasticsearch.index", "testindex");
@@ -205,17 +205,6 @@ public class MockDatabase {
         public ExtendedNode(Settings preparedSettings, Collection<Class<? extends Plugin>> classpathPlugins) {
             super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null), classpathPlugins);
         }
-    }
-
-    private static String randomString(int lenght) {
-        final String AB = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-        SecureRandom rnd = new SecureRandom();
-
-        StringBuilder sb = new StringBuilder(lenght);
-        for (int i = 0; i < lenght; i++) {
-            sb.append(AB.charAt(rnd.nextInt(AB.length())));
-        }
-        return sb.toString();
     }
 
     private static IndexRestClient initializeIndexRestClient() {


### PR DESCRIPTION
- use random generator for names
- save duplicated files (missing removing in case user abort copying)
- remove overwrite of copied workflow in load method