### PR TITLE
Fix users directory for UserServiceIT and WorkflowControllerServiceIT

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/services/data/LdapServerService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/LdapServerService.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.security.InvalidKeyException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -292,10 +293,10 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
      */
     public URI getUserHomeDirectory(User user) {
 
-        URI userFolderBasePath = URI.create("file:///" + ConfigCore.getParameter(ParameterCore.DIR_USERS));
+        String userFolderBasePath = ConfigCore.getParameter(ParameterCore.DIR_USERS);
 
         if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.LDAP_USE_LOCAL_DIRECTORY)) {
-            return userFolderBasePath.resolve(user.getLogin());
+            return Paths.get(userFolderBasePath, user.getLogin()).toUri();
         }
         Hashtable<String, String> env = initializeWithLdapConnectionSettings(user.getLdapGroup().getLdapServer());
         if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.LDAP_USE_TLS)) {
@@ -322,12 +323,12 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
             } catch (IOException e) {
                 logger.error("TLS negotiation error:", e);
 
-                return userFolderBasePath.resolve(user.getLogin());
+                return Paths.get(userFolderBasePath, user.getLogin()).toUri();
             } catch (NamingException e) {
 
                 logger.error("JNDI error:", e);
 
-                return userFolderBasePath.resolve(user.getLogin());
+                return Paths.get(userFolderBasePath, user.getLogin()).toUri();
             } finally {
                 if (tls != null) {
                     try {
@@ -366,7 +367,7 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
             if (userFolderPath.getPath().startsWith("/")) {
                 userFolderPath = serviceManager.getFileService().deleteFirstSlashFromPath(userFolderPath);
             }
-            return userFolderBasePath.resolve(userFolderPath);
+            return Paths.get(userFolderBasePath, userFolderPath.getRawPath()).toUri();
         } else {
             return userFolderPath;
         }

--- a/Kitodo/src/main/java/org/kitodo/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/file/FileService.java
@@ -114,9 +114,9 @@ public class FileService {
      */
     public void createDirectoryForUser(URI dirName, String userName) throws IOException {
         if (!serviceManager.getFileService().fileExist(dirName)) {
-
             CommandService commandService = serviceManager.getCommandService();
-            List<String> commandParameter = Arrays.asList(userName, new File(dirName).getPath());
+            List<String> commandParameter = Arrays.asList(userName, new File(dirName).getAbsolutePath());
+            System.out.println(commandParameter);
             commandService.runCommand(new File(ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_DIR_USER_HOME)),
                 commandParameter);
         }

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
@@ -44,12 +44,14 @@ import org.kitodo.data.database.beans.UserGroup;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.services.ServiceManager;
+import org.kitodo.services.file.FileService;
 
 /**
  * Tests for UserService class.
  */
 public class UserServiceIT {
 
+    private static final FileService fileService = new ServiceManager().getFileService();
     private static final UserService userService = new ServiceManager().getUserService();
 
     @BeforeClass
@@ -57,12 +59,16 @@ public class UserServiceIT {
         MockDatabase.startNode();
         MockDatabase.insertProcessesFull();
         MockDatabase.setUpAwaitility();
+
+        fileService.createDirectory(URI.create(""), "users");
     }
 
     @AfterClass
     public static void cleanDatabase() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
+
+        fileService.delete(URI.create("users"));
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceIT.java
@@ -54,6 +54,8 @@ public class WorkflowControllerServiceIT {
         MockDatabase.insertProcessesForWorkflowFull();
         SecurityTestUtils.addUserDataToSecurityContext(new ServiceManager().getUserService().getById(1));
 
+        fileService.createDirectory(URI.create(""), "users");
+
         if (!SystemUtils.IS_OS_WINDOWS) {
             ExecutionPermission.setExecutePermission(scriptCreateDirUserHome);
             ExecutionPermission.setExecutePermission(scriptCreateSymLink);
@@ -70,6 +72,8 @@ public class WorkflowControllerServiceIT {
             ExecutionPermission.setNoExecutePermission(scriptCreateDirUserHome);
             ExecutionPermission.setNoExecutePermission(scriptCreateSymLink);
         }
+
+        fileService.delete(URI.create("users"));
     }
 
     @Test

--- a/Kitodo/src/test/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/kitodo_config.properties
@@ -42,7 +42,7 @@ elasticsearch.port=9205
 elasticsearch.index=testindex
 elasticsearch.useAuthentication=false
 directory.config=src/test/resources/
-directory.users=src/test/resources/userdata/
+directory.users=src/test/resources/users/
 
 metsEditor.lockingTime=2
 


### PR DESCRIPTION
- use Paths.get in getUserHomeDirectory - created URI was not absolute
- use getAbsolutePath in createDirectoryForUser

Previous log:
`[INFO] Running org.kitodo.services.workflow.WorkflowControllerServiceIT
09:23:52.866 [main] ERROR org.kitodo.command.Command - Execution of Command 1187715285 /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/scripts/script_createDirUserHome.sh kowal /src/test/resources/userdata/kowal failed!: [/bin/mkdir: cannot create directory ‘/src/test/resources/userdata/kowal’: No such file or directory, /bin/chmod: cannot access ‘/src/test/resources/userdata/kowal’: No such file or directory]
09:23:52.891 [main] ERROR org.kitodo.command.Command - Execution of Command 1608240105 /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/scripts/script_createSymLink.sh /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/1/images /src/test/resources/userdata/kowal/First process__[1] kowal failed!: [/bin/ln: failed to create symbolic link ‘/src/test/resources/userdata/kowal/First’: No such file or directory, /bin/chown: invalid user: ‘process__[1]’]
09:23:52.935 [main] ERROR org.kitodo.command.Command - Execution of Command 289855413 /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/scripts/script_createDirUserHome.sh kowal /src/test/resources/userdata/kowal failed!: [/bin/mkdir: cannot create directory ‘/src/test/resources/userdata/kowal’: No such file or directory, /bin/chmod: cannot access ‘/src/test/resources/userdata/kowal’: No such file or directory]
09:23:53.546 [main] ERROR org.kitodo.command.Command - Execution of Command -82649717 /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/scripts/script_createDirUserHome.sh kowal /src/test/resources/userdata/kowal failed!: [/bin/mkdir: cannot create directory ‘/src/test/resources/userdata/kowal’: No such file or directory, /bin/chmod: cannot access ‘/src/test/resources/userdata/kowal’: No such file or directory]
09:24:00.182 [main] ERROR org.kitodo.command.Command - Execution of Command -51485231 /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/scripts/script_createDirUserHome.sh kowal /src/test/resources/userdata/kowal failed!: [/bin/mkdir: cannot create directory ‘/src/test/resources/userdata/kowal’: No such file or directory, /bin/chmod: cannot access ‘/src/test/resources/userdata/kowal’: No such file or directory]
09:24:00.486 [main] ERROR org.kitodo.command.Command - Execution of Command 1803040961 /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/scripts/script_createDirUserHome.sh kowal /src/test/resources/userdata/kowal failed!: [/bin/mkdir: cannot create directory ‘/src/test/resources/userdata/kowal’: No such file or directory, /bin/chmod: cannot access ‘/src/test/resources/userdata/kowal’: No such file or directory]`

Current log:

`[INFO] Running org.kitodo.services.workflow.WorkflowControllerServiceIT
[kowal, /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/users/kowal]
11:16:35.412 [main] ERROR org.kitodo.command.Command - Execution of Command 1608240105 /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/scripts/script_createSymLink.sh /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/1/images /home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/users/kowal/First process__[1] kowal failed!: [‘/home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/users/kowal/First’ -> ‘/home/travis/build/Beacze/kitodo-production/Kitodo/src/test/resources/1/images’, /bin/chown: invalid user: ‘process__[1]’]`