### PR TITLE
Remove jdk15on to avoid cyclic dependencies

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -401,11 +401,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.56</version>
-        </dependency>
-        <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
             <version>${elasticsearch.version}</version>


### PR DESCRIPTION
Kitodo includes two bouncycastles jdk - jdk15on included by project directly and jdk14 included indirectly by itext. Increasing the version of itext is not possible yet. Reason is that higher versions has changed package name from com.lowagie to com.itextpdf (https://mvnrepository.com/artifact/com.itextpdf/itextpdf) and as it is included also by UGH package name change is hard to perform. After UGH is removed we should upgrade bouncycastle (https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on/1.60) and itext. 