### PR TITLE
Repair the appearance of the folder editing dialog

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
@@ -137,7 +137,7 @@
             </p:column>
             <p:column>
                 <!-- edit button -->
-                <p:commandLink oncomplete="PF('editFileGroupDialog').show()"
+                <p:commandLink oncomplete="PF('editFolderDialog').show()"
                                id="edit"
                                styleClass="buttonset plain"
                                update="@(.editDialog)"


### PR DESCRIPTION
The folder editing dialog has been renamed quite some time ago, but that has probably been lost in one place. This patch will fix that.