### PR TITLE
Restrict ldap group update to prevent overwriting existing data.

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_54__update_LDAP_Group_table.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_54__update_LDAP_Group_table.sql
@@ -29,4 +29,4 @@ sambaPasswordMustChange = '2147483647',
 sambaPasswordHistory = '00000000000000000000000000000000000000',
 sambaLogonHours = 'FFFFFFFFFFFFFFFFFFFF',
 sambaKickoffTime = '0'
-WHERE id = 2 ;
+WHERE id = 2 AND homeDirectory IS NULL AND gidNumber IS NULL AND sambaSID IS NULL;

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_54__update_LDAP_Group_table.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_54__update_LDAP_Group_table.sql
@@ -11,7 +11,7 @@
 
 -- 1. Update the dummy LDAP group
 
-UPDATE ldapGroup SET homeDirectory = '/home/test/users/{login}',
+UPDATE ldapGroup SET homeDirectory = '/usr/local/kitodo/users/{login}',
 gidNumber = '242',
 userDN = 'cn={login},ou=user,o=TestOrg,dc=kitodo,dc=org',
 objectClasses = 'top,inetOrgPerson,posixAccount,shadowAccount,sambaSamAccount',

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_54__update_LDAP_Group_table.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_54__update_LDAP_Group_table.sql
@@ -11,6 +11,8 @@
 
 -- 1. Update the dummy LDAP group
 
+SET SQL_SAFE_UPDATES = 0;
+
 UPDATE ldapGroup SET homeDirectory = '/usr/local/kitodo/users/{login}',
 gidNumber = '242',
 userDN = 'cn={login},ou=user,o=TestOrg,dc=kitodo,dc=org',
@@ -29,4 +31,6 @@ sambaPasswordMustChange = '2147483647',
 sambaPasswordHistory = '00000000000000000000000000000000000000',
 sambaLogonHours = 'FFFFFFFFFFFFFFFFFFFF',
 sambaKickoffTime = '0'
-WHERE id = 2 AND homeDirectory IS NULL AND gidNumber IS NULL AND sambaSID IS NULL;
+WHERE title = 'test' AND homeDirectory IS NULL AND gidNumber IS NULL AND sambaSID IS NULL;
+
+SET SQL_SAFE_UPDATES = 1;


### PR DESCRIPTION
Prevent overwriting of existing data which was introduced by #1870 .