### PR TITLE
Enables you to enable validation for folders

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
@@ -144,6 +144,17 @@ public class Task extends BaseIndexedBean {
     )
     private List<Folder> contentFolders;
 
+    /**
+     * This field contains information about folders whose contents are to be
+     * validated in this task.
+     */
+    @ManyToMany(cascade = CascadeType.PERSIST)
+    @JoinTable(name = "validationFolders_task_x_folder",
+        joinColumns = @JoinColumn(name = "task_id", foreignKey = @ForeignKey(name = "FK_validationFolders_task_x_folder_task_id")),
+        inverseJoinColumns = @JoinColumn(name = "folder_id", foreignKey = @ForeignKey(name = "FK_task_x_folder_folder_id"))
+    )
+    private List<Folder> validationFolders;
+
     @Transient
     private String localizedTitle;
 
@@ -430,6 +441,28 @@ public class Task extends BaseIndexedBean {
      */
     public void setContentFolders(List<Folder> contentFolders) {
         this.contentFolders = contentFolders;
+    }
+
+    /**
+     * Get list of folders whose contents are to be validated.
+     *
+     * @return list of Folder objects or empty list
+     */
+    public List<Folder> getValidationFolders() {
+        if (this.validationFolders == null) {
+            this.validationFolders = new ArrayList<>();
+        }
+        return validationFolders;
+    }
+
+    /**
+     * Set list of folders whose contents are to be validated.
+     *
+     * @param validationFolders
+     *            as list
+     */
+    public void setValidationFolders(List<Folder> validationFolders) {
+        this.validationFolders = validationFolders;
     }
 
     public boolean isTypeImagesRead() {

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_55__Create_table_validationFolders_task_x_folder.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_55__Create_table_validationFolders_task_x_folder.sql
@@ -1,0 +1,29 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+--
+-- Migration: Create table validationFolders_task_x_folder
+
+-- 1. Create table validationFolders_task_x_folder
+
+CREATE TABLE validationFolders_task_x_folder (
+  task_id   int(11) NOT NULL
+     COMMENT 'Task that triggers the validation of the contents of the folder',
+  folder_id int(11) NOT NULL
+     COMMENT 'Folder whose contents are to be validated in that task',
+  PRIMARY KEY ( task_id, folder_id ),
+  KEY FK_task_id   ( task_id ),
+  KEY FK_folder_id ( folder_id ),
+  CONSTRAINT FK_validationFolders_task_x_folder_task_id
+    FOREIGN KEY ( task_id ) REFERENCES task ( id ),
+  CONSTRAINT FK_validationFolders_task_x_folder_folder_id
+    FOREIGN KEY ( folder_id ) REFERENCES folder ( id )
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/Kitodo/src/main/java/org/kitodo/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/CurrentTaskForm.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -58,6 +59,7 @@ import org.kitodo.helper.tasks.TaskManager;
 import org.kitodo.model.LazyDTOModel;
 import org.kitodo.model.Subfolder;
 import org.kitodo.production.thread.TaskImageGeneratorThread;
+import org.kitodo.services.data.TaskService;
 import org.kitodo.services.file.SubfolderFactoryService;
 import org.kitodo.services.image.ImageGenerator;
 import org.kitodo.workflow.Problem;
@@ -701,7 +703,8 @@ public class CurrentTaskForm extends BaseForm {
      * @return whether action links should be displayed
      */
     public boolean isShowingGenerationActions() {
-        return !serviceManager.getTaskService().getGenerators(currentTask).isEmpty();
+        return TaskService.generatableFoldersFromProjects(Arrays.asList(currentTask.getProcess().getProject()).stream())
+                .findAny().isPresent();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/forms/FolderProcessingSwitch.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/FolderProcessingSwitch.java
@@ -9,17 +9,11 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.util;
+package org.kitodo.forms;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.data.database.beans.Folder;
-import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Task;
 
 /**
@@ -36,7 +30,7 @@ import org.kitodo.data.database.beans.Task;
  * Conversely, the task knows nothing about which non-selected folders with
  * configured generator function there.
  */
-public class GeneratorSwitch {
+public class FolderProcessingSwitch {
     /**
      * Folder represented by this generator switch.
      */
@@ -49,50 +43,6 @@ public class GeneratorSwitch {
     private List<Folder> contentFolders;
 
     /**
-     * Returns a list of generator switches for all folders whose contents can
-     * be generated.
-     *
-     * @param projects
-     *            stream of projects this task is used in
-     * @param contentFolders
-     *            modifiable list of folders whose contents are to be generated
-     * @return list of GeneratorSwitch objects or empty list
-     */
-    public static List<GeneratorSwitch> getGeneratorSwitches(Stream<Project> projects, List<Folder> contentFolders) {
-
-        //TODO: find more meaningful name
-        // Ignore all projects that do not have a source folder configured.
-        Stream<Project> projectsWithSourceFolder = projects.filter(lambda -> Objects.nonNull(lambda.getGeneratorSource()));
-
-        Stream<Folder> allowedFolders = dropOwnSourceFolders(projectsWithSourceFolder);
-
-        // Remove all folders to generate which do not have anything to generate
-        // configured.
-        Stream<Folder> generatableFolders = allowedFolders.filter(lambda -> lambda.getDerivative().isPresent()
-                || lambda.getDpi().isPresent() || lambda.getImageScale().isPresent() || lambda.getImageSize().isPresent());
-
-        // For all remaining folders, create an encapsulation to access the
-        // generator properties of the folder.
-        Stream<GeneratorSwitch> taskGenerators = generatableFolders.map(lambda -> new GeneratorSwitch(lambda, contentFolders));
-
-        return taskGenerators.collect(Collectors.toCollection(LinkedList::new));
-    }
-
-    /**
-     * Drop all folders to generate if they are their own source folder.
-     *
-     * @param projects
-     *            projects whose folders allowed to be generated are to be
-     *            determined
-     * @return a stream of folders that are allowed to be generated
-     */
-    private static Stream<Folder> dropOwnSourceFolders(Stream<Project> projects) {
-        Stream<Pair<Folder, Folder>> foldersWithSources = projects
-                .flatMap(lambda -> lambda.getFolders().stream().map(mi -> Pair.of(mi, lambda.getGeneratorSource())));
-        return foldersWithSources.filter(lambda -> !lambda.getLeft().equals(lambda.getRight())).map(lambda -> lambda.getLeft());
-    }
-
-    /**
      * Creates a new generator for this task.
      *
      * @param folder
@@ -100,7 +50,7 @@ public class GeneratorSwitch {
      * @param contentFolders
      *            modifiable list of enabled toggle switches
      */
-    public GeneratorSwitch(Folder folder, List<Folder> contentFolders) {
+    public FolderProcessingSwitch(Folder folder, List<Folder> contentFolders) {
         this.folder = folder;
         this.contentFolders = contentFolders;
     }

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -798,6 +798,7 @@ userNotFound=Benutzer kann nicht ermittelt werden
 userSaving=Benutzer wird gespeichert...
 validatingData=Daten werden validiert...
 validate=Validieren
+validator={0}-Bilder validieren
 value=Wert
 verlinkungDesBildesMitStrukturelement=Verlinkung des Bildes mit dem gew\u00E4hlten Strukturelement
 volume=Band

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -797,6 +797,7 @@ userNotFound=User not found
 userSaving=Saving user...
 validatingData=Validating data...
 validate=Validate
+validator=Validate {0} images
 value=Value
 verlinkungDesBildesMitStrukturelement=Link the image with the selected structure element
 volume=volume

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskTemplateEdit/taskEditDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskTemplateEdit/taskEditDetails.xhtml
@@ -18,7 +18,7 @@
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
     <p:panelGrid columns="2" layout="grid">
         <p:row>
-            <p:repeat var="generator" value="#{TemplateForm.generatorSwitches}">
+            <p:repeat var="generator" value="#{TemplateForm.generatableFolderSwitches}">
                 <div>
                     <p:outputLabel for="generator">
                         <h:outputFormat value="#{msgs.generator}">
@@ -26,6 +26,18 @@
                         </h:outputFormat>
                     </p:outputLabel>
                     <p:selectBooleanCheckbox id="generator" value="#{generator.value}" class="input">
+                        <p:ajax event="change" oncomplete="toggleSave()"/>
+                    </p:selectBooleanCheckbox>
+                </div>
+            </p:repeat>
+            <p:repeat var="validators" value="#{TemplateForm.validatableFolderSwitches}">
+                <div>
+                    <p:outputLabel for="validator">
+                        <h:outputFormat value="#{msgs.validator}">
+                            <f:param value="#{validator.label}"/>
+                        </h:outputFormat>
+                    </p:outputLabel>
+                    <p:selectBooleanCheckbox id="validator" value="#{validator.value}" class="input">
                         <p:ajax event="change" oncomplete="toggleSave()"/>
                     </p:selectBooleanCheckbox>
                 </div>

--- a/Kitodo/src/test/java/org/kitodo/forms/FolderProcessingSwitchTest.java
+++ b/Kitodo/src/test/java/org/kitodo/forms/FolderProcessingSwitchTest.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.forms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.kitodo.data.database.beans.Folder;
+
+public class FolderProcessingSwitchTest {
+    @Test
+    public void getLabelTest() {
+        Folder folderToBeGenerated = new Folder();
+        folderToBeGenerated.setPath("folderToBeGenerated");
+        FolderProcessingSwitch folderProcessingSwitch = new FolderProcessingSwitch(folderToBeGenerated,
+                new ArrayList<>());
+        assertThat(folderProcessingSwitch.getLabel(), is(equalTo(("folderToBeGenerated"))));
+    }
+
+    @Test
+    public void isValueTest() {
+        Folder folder = new Folder();
+        List<Folder> activatedFolders = new ArrayList<>();
+        FolderProcessingSwitch folderProcessingSwitch = new FolderProcessingSwitch(folder, activatedFolders);
+        assertThat(folderProcessingSwitch.isValue(), is(equalTo((false))));
+        activatedFolders.add(folder);
+        assertThat(folderProcessingSwitch.isValue(), is(equalTo((true))));
+        activatedFolders.remove(folder);
+        assertThat(folderProcessingSwitch.isValue(), is(equalTo((false))));
+    }
+
+    @Test
+    public void setValueTest() {
+        Folder folder = new Folder();
+        List<Folder> activatedFolders = new ArrayList<>();
+        FolderProcessingSwitch folderProcessingSwitch = new FolderProcessingSwitch(folder, activatedFolders);
+        assertThat(activatedFolders, not(contains(folder)));
+        folderProcessingSwitch.setValue(true);
+        assertThat(activatedFolders, contains(folder));
+        folderProcessingSwitch.setValue(false);
+        assertThat(activatedFolders, not(contains(folder)));
+    }
+}


### PR DESCRIPTION
How it works:
To turn on validation for the contents of a folder, switches appear on the task property page. By clicking on a switch, the function can be switched on or off.

Implementation:
A new table `validationFolders` (`task` × `folder`) is created. This saves the variable `validationFolders` in the `task`. The `taskEditDetails.xhtml` page has been enhanced with switches to enable and disable the validation in a step. The functionality for this has been implemented in the class `TemplateForm`. The same functionality for generating images has also been moved here, and duplicate code has been summarized. The `GeneratorSwitch` class has been renamed to `FolderProcessingSwitch` because the switches are used equally for both types of processing. The tests were adapted or supplemented.