### PR TITLE
Move the mapping of the JHove result values to the global configuration

### DIFF
--- a/Kitodo-LongTimePreservationValidationModule/src/main/java/org/kitodo/longtimepreservationvalidationmodule/KitodoOutputHandler.java
+++ b/Kitodo-LongTimePreservationValidationModule/src/main/java/org/kitodo/longtimepreservationvalidationmodule/KitodoOutputHandler.java
@@ -113,8 +113,9 @@ public class KitodoOutputHandler extends HandlerBase {
 
     @Override
     public void show(RepInfo info) {
-        state = ValidationResultState.valueOf(info.getWellFormed(),
+        state = new ValidationResultState(info.getWellFormed(),
             super._je.getSignatureFlag() ? RepInfo.UNDETERMINED : info.getValid());
+        messages.add(state.getResultString());
         info.getMessage().forEach(this::addMessage);
     }
 

--- a/Kitodo-LongTimePreservationValidationModule/src/main/java/org/kitodo/longtimepreservationvalidationmodule/LongTermPreservationValidationConfigParameter.java
+++ b/Kitodo-LongTimePreservationValidationModule/src/main/java/org/kitodo/longtimepreservationvalidationmodule/LongTermPreservationValidationConfigParameter.java
@@ -1,0 +1,124 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.longtimepreservationvalidationmodule;
+
+import java.util.stream.Stream;
+
+import org.kitodo.config.enums.ParameterInterface;
+
+/**
+ * Implements the ParameterInterface to access the
+ * LongTermPreservationValidation mapping.
+ */
+enum LongTermPreservationValidationConfigParameter implements ParameterInterface {
+    /**
+     * Specifies the Kitodo validation result if a JHove file is rated neither
+     * well-formed nor valid.
+     */
+    VALIDATION_RESULT_NOT_WELL_FORMED_NOT_VALID("LongTermPreservationValidation.mapping.FALSE.FALSE"),
+
+    /**
+     * Specifies the Kitodo validation result if a JHove file is not well-formed
+     * but valid. Whatever that may be.
+     */
+    VALIDATION_RESULT_NOT_WELL_FORMED_VALID("LongTermPreservationValidation.mapping.FALSE.TRUE"),
+
+    /**
+     * Specifies the Kitodo validation result if a file was not well-formed by
+     * JHove and JHove was unable to determine if the file is valid.
+     */
+    VALIDATION_RESULT_NOT_WELL_FORMED_MAYBE_VALID("LongTermPreservationValidation.mapping.FALSE.UNDETERMINED"),
+
+    /**
+     * Specifies the Kitodo validation result if a file is judged by JHove to be
+     * well-formed but not valid.
+     */
+    VALIDATION_RESULT_WELL_FORMED_NOT_VALID("LongTermPreservationValidation.mapping.TRUE.FALSE"),
+
+    /**
+     * Specifies the Kitodo validation result if a file has been rated as
+     * well-formed and valid by JHove.
+     */
+    VALIDATION_RESULT_WELL_FORMED_VALID("LongTermPreservationValidation.mapping.TRUE.TRUE"),
+
+    /**
+     * Specifies the Kitodo validation result if a file was rated well by JHove,
+     * but JHove could not determine if the file is valid.
+     */
+    VALIDATION_RESULT_WELL_FORMED_MAYBE_VALID("LongTermPreservationValidation.mapping.TRUE.UNDETERMINED"),
+
+    /**
+     * Specifies the Kitodo validation result if it could not determine if a
+     * file is well-formed, but definitely not valid.
+     */
+    VALIDATION_RESULT_MAYBE_WELL_FORMED_NOT_VALID("LongTermPreservationValidation.mapping.UNDETERMINED.FALSE"),
+
+    /**
+     * Specifies the Kitodo validation result if JHove was unable to determine
+     * if a file is well-formed, but definitely valid.
+     */
+    VALIDATION_RESULT_MAYBE_WELL_FORMED_VALID("LongTermPreservationValidation.mapping.UNDETERMINED.TRUE"),
+
+    /**
+     * Specifies the Kitodo validation result if JHove is completely undecided
+     * about the contents in a file.
+     */
+    VALIDATION_RESULT_MAYBE_WELL_FORMED_MAYBE_VALID("LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED");
+
+    /**
+     * The constant for the indefinite state.
+     */
+    private static final String UNDETERMINED = "UNDETERMINED";
+
+    /**
+     * This is what we call the configuration parameter that is entered in the
+     * configuration file.
+     */
+    private String name;
+
+    /**
+     * Private constructor to hide the implicit public one.
+     *
+     * @param name
+     *            of parameter
+     */
+    LongTermPreservationValidationConfigParameter(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of the long term preservation validation config
+     * parameter.
+     * 
+     * @return the name
+     */
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    /**
+     * Retrieves the parameter interface element for a validation result state.
+     * 
+     * @param state
+     *            input status
+     * @return one of the above possibilities
+     */
+    public static ParameterInterface valueOf(ValidationResultState state) {
+        Stream<LongTermPreservationValidationConfigParameter> constants = Stream
+                .of(LongTermPreservationValidationConfigParameter.values()).parallel();
+        String result = state.toString().replace(TernaryValue.MAYBE.toString(), UNDETERMINED).replace('/', '.');
+        LongTermPreservationValidationConfigParameter constant = constants
+                .filter(member -> member.getName().endsWith(result)).findFirst().get();
+        return constant;
+    }
+}

--- a/Kitodo-LongTimePreservationValidationModule/src/main/java/org/kitodo/longtimepreservationvalidationmodule/TernaryValue.java
+++ b/Kitodo-LongTimePreservationValidationModule/src/main/java/org/kitodo/longtimepreservationvalidationmodule/TernaryValue.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.longtimepreservationvalidationmodule;
+
+import edu.harvard.hul.ois.jhove.RepInfo;
+
+/**
+ * Enumeration of possible values in ternary logic.
+ */
+enum TernaryValue {
+    /**
+     * A constant with the truth value true. Corresponds to the boolean value
+     * true.
+     */
+    TRUE {
+        @Override
+        String toModalAdverb() {
+            return "";
+        }
+    },
+
+    /**
+     * A constant with the truth value maybe. The use of this constant has the
+     * meaning of knowing that we know nothing, what is different from not
+     * knowing if we do not know something. This value has no equivalent in
+     * Boolean logic.
+     */
+    MAYBE {
+        @Override
+        String toModalAdverb() {
+            return " unclear if";
+        }
+    },
+
+    /**
+     * A constant with the truth value false. Corresponds to the boolean value
+     * false.
+     */
+    FALSE {
+        @Override
+        String toModalAdverb() {
+            return " not";
+        }
+    };
+
+    /**
+     * A modal adverb is a word that modifies the quality, manner, quantity, or
+     * intensity of an expression, such as "not" or "maybe." For the sake of
+     * simpler string building, returning a word returns a space before the
+     * word.
+     * 
+     * @return a modal adverb, can also be empty if the linguistic utterance
+     *         attains its correctness through non-alteration
+     */
+    abstract String toModalAdverb();
+
+    /**
+     * JHove returns the state of the result as int. This is converted into a
+     * Java value as optional of truth value.
+     * 
+     * @param repInfo
+     *            State of result as RepInfo (int) value
+     * @return an optional one of truth value
+     */
+    static TernaryValue valueOf(int repInfo) {
+        switch (repInfo) {
+            case RepInfo.UNDETERMINED: {
+                return TernaryValue.MAYBE;
+            }
+            case RepInfo.FALSE: {
+                return TernaryValue.FALSE;
+            }
+            case RepInfo.TRUE: {
+                return TernaryValue.TRUE;
+            }
+            default: {
+                throw new IllegalArgumentException(("The argument must be in the range " + RepInfo.UNDETERMINED + " to "
+                        + RepInfo.TRUE + ", but was " + repInfo) + '.');
+            }
+        }
+    }
+}

--- a/Kitodo-LongTimePreservationValidationModule/src/test/java/org/kitodo/longtimepreservationvalidationmodule/LongTimePreservationValidationModuleIT.java
+++ b/Kitodo-LongTimePreservationValidationModule/src/test/java/org/kitodo/longtimepreservationvalidationmodule/LongTimePreservationValidationModuleIT.java
@@ -19,6 +19,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 import org.kitodo.api.validation.State;
@@ -27,6 +28,8 @@ import org.kitodo.api.validation.longtimepreservation.FileType;
 import org.kitodo.api.validation.longtimepreservation.LongTimePreservationValidationInterface;
 
 public class LongTimePreservationValidationModuleIT {
+    private static final String NEITHER_WELL_FORMED_NOR_VALID = "Examination result: not well-formed, not valid";
+    private static final List<String> WELL_FORMED_AND_VALID = Arrays.asList("Examination result: well-formed, valid");
     private static final URI CORRUPTED_TIF_URI, GIF_URI, JAVA_URI, JP2_URI, JPG_URI, PDF_URI, PNG_URI, TIF_URI;
 
     static {
@@ -51,7 +54,7 @@ public class LongTimePreservationValidationModuleIT {
         ValidationResult validationResult = validator.validate(CORRUPTED_TIF_URI, FileType.TIFF);
         assertThat(validationResult.getState(), is(equalTo(State.ERROR)));
         assertThat(validationResult.getResultMessages(),
-            is(equalTo(Arrays.asList("IFD offset not word-aligned:  110423"))));
+            is(equalTo(Arrays.asList(NEITHER_WELL_FORMED_NOR_VALID, "IFD offset not word-aligned:  110423"))));
     }
 
     @Test
@@ -60,37 +63,55 @@ public class LongTimePreservationValidationModuleIT {
 
         ValidationResult validationResult = validator.validate(JAVA_URI, FileType.PDF);
         assertThat(validationResult.getState(), is(equalTo(State.ERROR)));
-        assertThat(validationResult.getResultMessages(), is(equalTo(Arrays.asList("No PDF header", "Offset: 0"))));
+        assertThat(validationResult.getResultMessages(),
+            is(equalTo(Arrays.asList(NEITHER_WELL_FORMED_NOR_VALID, "No PDF header", "Offset: 0"))));
 
         validationResult = validator.validate(PDF_URI, FileType.GIF);
         assertThat(validationResult.getState(), is(equalTo(State.ERROR)));
-        assertThat(validationResult.getResultMessages(), is(equalTo(Arrays.asList("Invalid GIF header", "Offset: 0"))));
+        assertThat(validationResult.getResultMessages(),
+            is(equalTo(Arrays.asList(NEITHER_WELL_FORMED_NOR_VALID, "Invalid GIF header", "Offset: 0"))));
 
         validationResult = validator.validate(JP2_URI, FileType.JPEG);
         assertThat(validationResult.getState(), is(equalTo(State.ERROR)));
         assertThat(validationResult.getResultMessages(),
-            is(equalTo(Arrays.asList("Invalid JPEG header", "Offset: 0"))));
+            is(equalTo(Arrays.asList(NEITHER_WELL_FORMED_NOR_VALID, "Invalid JPEG header", "Offset: 0"))));
 
         validationResult = validator.validate(PNG_URI, FileType.JPEG_2000);
         assertThat(validationResult.getState(), is(equalTo(State.ERROR)));
         assertThat(validationResult.getResultMessages(),
-            is(equalTo(Arrays.asList("No JPEG 2000 header", "Offset: 0"))));
+            is(equalTo(Arrays.asList(NEITHER_WELL_FORMED_NOR_VALID, "No JPEG 2000 header", "Offset: 0"))));
     }
 
     @Test
     public void testThatValidFilesValidateWithDefaultModules() {
         LongTimePreservationValidationInterface validator = new LongTimePreservationValidationModule();
-        assertThat(validator.validate(GIF_URI, FileType.GIF).getState(), is(equalTo(State.SUCCESS)));
-        assertThat(validator.validate(JP2_URI, FileType.JPEG_2000).getState(), is(equalTo(State.SUCCESS)));
-        assertThat(validator.validate(JPG_URI, FileType.JPEG).getState(), is(equalTo(State.SUCCESS)));
-        assertThat(validator.validate(PDF_URI, FileType.PDF).getState(), is(equalTo(State.SUCCESS)));
-        assertThat(validator.validate(TIF_URI, FileType.TIFF).getState(), is(equalTo(State.SUCCESS)));
+        ValidationResult validationResult = validator.validate(GIF_URI, FileType.GIF);
+        assertThat(validationResult.getState(), is(equalTo(State.SUCCESS)));
+        assertThat(validationResult.getResultMessages(), is(equalTo(WELL_FORMED_AND_VALID)));
+
+        validationResult = validator.validate(JP2_URI, FileType.JPEG_2000);
+        assertThat(validationResult.getState(), is(equalTo(State.SUCCESS)));
+        assertThat(validationResult.getResultMessages(), is(equalTo(WELL_FORMED_AND_VALID)));
+
+        validationResult = validator.validate(JPG_URI, FileType.JPEG);
+        assertThat(validationResult.getState(), is(equalTo(State.SUCCESS)));
+        assertThat(validationResult.getResultMessages(), is(equalTo(WELL_FORMED_AND_VALID)));
+
+        validationResult = validator.validate(PDF_URI, FileType.PDF);
+        assertThat(validationResult.getState(), is(equalTo(State.SUCCESS)));
+        assertThat(validationResult.getResultMessages(), is(equalTo(WELL_FORMED_AND_VALID)));
+
+        validationResult = validator.validate(TIF_URI, FileType.TIFF);
+        assertThat(validationResult.getState(), is(equalTo(State.SUCCESS)));
+        assertThat(validationResult.getResultMessages(), is(equalTo(WELL_FORMED_AND_VALID)));
     }
 
     @Test
     public void testThatValidFilesValidateWithExtendedModules() {
         LongTimePreservationValidationInterface validator = new LongTimePreservationValidationModule();
-        assertThat(validator.validate(PNG_URI, FileType.PNG).getState(), is(equalTo(State.SUCCESS)));
+        ValidationResult validationResult = validator.validate(PNG_URI, FileType.PNG);
+        assertThat(validationResult.getState(), is(equalTo(State.SUCCESS)));
+        assertThat(validationResult.getResultMessages(), is(equalTo(WELL_FORMED_AND_VALID)));
     }
 
 }

--- a/Kitodo-LongTimePreservationValidationModule/src/test/resources/kitodo_config.properties
+++ b/Kitodo-LongTimePreservationValidationModule/src/test/resources/kitodo_config.properties
@@ -1,0 +1,20 @@
+#
+# (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+#
+# This file is part of the Kitodo project.
+#
+# It is licensed under GNU General Public License version 3 or later.
+#
+# For the full copyright and license information, please read the
+# GPL3-License.txt file that was distributed with this source code.
+#
+
+LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
+LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
+LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR
+LongTermPreservationValidation.mapping.TRUE.FALSE=WARNING
+LongTermPreservationValidation.mapping.TRUE.TRUE=SUCCESS
+LongTermPreservationValidation.mapping.TRUE.UNDETERMINED=SUCCESS
+LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
+LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
+LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -627,3 +627,24 @@ elasticsearch.password=kitodo
 # File system paths must be (mounted) equally on the remote machine(s).
 
 #ImageManagementModule.sshHosts=user@rhost1.kitodo.org,user@rhost2.kitodo.org
+
+# -----------------------------------
+# LongTimePreservationValidatiuon
+# -----------------------------------
+
+# Maps the output parameter of the JHove process to the interface parameters of
+# Kitodo. JHove distinguishes between well-formedness (the first value) and
+# validity (the second value) of an image. Depending on the output state, the
+# process either runs through (SUCCESS), must be continued manually (WARNING)
+# or is locked (ERROR). With manual processing, the continuation is always
+# locked. The mapping can be changed as required.
+
+LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
+LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
+LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR
+LongTermPreservationValidation.mapping.TRUE.FALSE=WARNING
+LongTermPreservationValidation.mapping.TRUE.TRUE=SUCCESS
+LongTermPreservationValidation.mapping.TRUE.UNDETERMINED=SUCCESS
+LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
+LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
+LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING

--- a/Kitodo/src/test/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/kitodo_config.properties
@@ -47,3 +47,13 @@ directory.users=src/test/resources/users/
 metsEditor.lockingTime=2
 
 copyData.onExport=/@GoobiIdentifier \= $process.id;
+
+LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
+LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
+LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR
+LongTermPreservationValidation.mapping.TRUE.FALSE=WARNING
+LongTermPreservationValidation.mapping.TRUE.TRUE=SUCCESS
+LongTermPreservationValidation.mapping.TRUE.UNDETERMINED=SUCCESS
+LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
+LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
+LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING


### PR DESCRIPTION
How it works:
The bivalent mapping can be determined in the configuration file. An example was added.

Implementation:
The configuration parameter is generated from the two-valued result and looked up in the configuration file. From this the result is formed, which is returned to production. The original state is added to the messages.