### PR TITLE
Fix checkstyle rule for sorting of static imports

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <parent.basedir>${basedir}/../</parent.basedir>
-        <maxAllowedViolations>92</maxAllowedViolations>
+        <maxAllowedViolations>88</maxAllowedViolations>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
         <selenium.version>3.9.1</selenium.version>
         <cargo.plugin.version>1.6.8</cargo.plugin.version>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -211,7 +211,7 @@
             <property name="groups" value="com,de,edu,gov,io,/^java\./,javax,junit,net,org,sun,ugh"/>
             <property name="ordered" value="true"/>
             <property name="separated" value="true"/>
-            <property name="option" value="above"/>
+            <property name="option" value="top"/>
             <property name="sortStaticImportsAlphabetically" value="true"/>
         </module>
 


### PR DESCRIPTION
Change 'above' to 'top'.