### PR TITLE
Automatically generate images in a task

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/thread/TaskScriptThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/TaskScriptThread.java
@@ -50,13 +50,22 @@ public class TaskScriptThread extends EmptyTask {
         boolean automatic = this.task.isTypeAutomatic();
         logger.debug("task is automatic: {}", automatic);
         String scriptPath = taskService.getScriptPath(this.task);
-        if (!scriptPath.equals("")) {
+        boolean noScriptToRun = scriptPath.isEmpty();
+        if (!noScriptToRun) {
             try {
                 this.taskService.executeScript(this.task, automatic);
             } catch (DataException e) {
                 logger.error("Data Error occurred", e);
             }
-        } else if (this.task.isTypeExportDMS()) {
+        }
+        if (!task.getContentFolders().isEmpty()) {
+            try {
+                taskService.generateImages(this, task, automatic);
+            } catch (DataException e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+        if (noScriptToRun && task.isTypeExportDMS()) {
             try {
                 serviceManager.getTaskService().executeDmsExport(this.task);
             } catch (DataException e) {


### PR DESCRIPTION
Functioning:
When a task that has content folder generation enabled is completed, or when an automatic task runs, the requested subfolders are generated.

Implementation:
The task script thread, which always runs when completing a task or during automatic tasks, has been expanded to cause the images to be generated as well. The corresponding method was installed in the `TaskService`.