### PR TITLE
Remove redundant methods with wildcards from BatchService

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/forms/BatchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/BatchForm.java
@@ -85,10 +85,6 @@ public class BatchForm extends BaseForm {
         return this.currentProcesses;
     }
 
-    public void setCurrentProcesses(List<Process> currentProcesses) {
-        this.currentProcesses = currentProcesses;
-    }
-
     /**
      * Load Batch data.
      */
@@ -314,7 +310,7 @@ public class BatchForm extends BaseForm {
         }
         try {
             for (Batch selectedBatch : this.selectedBatches) {
-                serviceManager.getBatchService().addAll(selectedBatch, this.selectedProcesses);
+                selectedBatch.getProcesses().addAll(this.selectedProcesses);
                 serviceManager.getBatchService().save(selectedBatch);
                 if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.BATCHES_LOG_CHANGES)) {
                     for (Process p : this.selectedProcesses) {
@@ -346,7 +342,7 @@ public class BatchForm extends BaseForm {
         }
 
         for (Batch selectedBatch : this.selectedBatches) {
-            serviceManager.getBatchService().removeAll(selectedBatch, this.selectedProcesses);
+            selectedBatch.getProcesses().removeAll(this.selectedProcesses);
             serviceManager.getBatchService().save(selectedBatch);
             if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.BATCHES_LOG_CHANGES)) {
                 for (Process p : this.selectedProcesses) {

--- a/Kitodo/src/main/java/org/kitodo/helper/tasks/CreateNewspaperProcessesTask.java
+++ b/Kitodo/src/main/java/org/kitodo/helper/tasks/CreateNewspaperProcessesTask.java
@@ -410,10 +410,10 @@ public class CreateNewspaperProcessesTask extends EmptyTask {
             if (batchLabel == null) {
                 batchLabel = createBatches.format(issues.get(lastIndex).getDate());
             }
-            serviceManager.getBatchService().add(logisticsBatch, process);
+            logisticsBatch.getProcesses().add(process);
             currentBreakMark = breakMark;
         }
-        serviceManager.getBatchService().add(fullBatch, process);
+        fullBatch.getProcesses().add(process);
     }
 
     /**
@@ -437,7 +437,7 @@ public class CreateNewspaperProcessesTask extends EmptyTask {
     /**
      * Returns the display name of the task to show to the user.
      *
-     * @see de.sub.goobi.helper.tasks.INameableTask#getDisplayName()
+     * @see org.kitodo.helper.tasks.INameableTask#getDisplayName()
      */
     @Override
     public String getDisplayName() {
@@ -483,7 +483,7 @@ public class CreateNewspaperProcessesTask extends EmptyTask {
      * order to render possible to restart them.
      *
      * @return a not-yet-executed replacement of this thread
-     * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
+     * @see org.kitodo.helper.tasks.EmptyTask#replace()
      */
     @Override
     public CreateNewspaperProcessesTask replace() {

--- a/Kitodo/src/main/java/org/kitodo/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/BatchService.java
@@ -12,7 +12,6 @@
 package org.kitodo.services.data;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -103,18 +102,6 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
     }
 
     /**
-     * The function removeAll() removes all elements that are contained in the given
-     * collection from this batch. TODO: Not sure if this method is needed, check it
-     *
-     * @param processes
-     *            collection containing elements to be removed from this set
-     * @return true if the set of processes was changed as a result of the call
-     */
-    public boolean removeAll(Batch batch, Collection<?> processes) {
-        return batch.getProcesses().removeAll(processes);
-    }
-
-    /**
      * Find batches with exact type. Necessary to assure that user pickup type from
      * the list which contains enums.
      *
@@ -200,31 +187,6 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
     private void convertRelatedJSONObjects(JsonObject jsonObject, BatchDTO batchDTO) throws DataException {
         batchDTO.setProcesses(convertRelatedJSONObjectToDTO(jsonObject, BatchTypeField.PROCESSES.getKey(),
             serviceManager.getProcessService()));
-    }
-
-    /**
-     * The function add() adds the given process to this batch if it is not
-     * already present. TODO: Not sure if this method is needed, check it
-     *
-     * @param process
-     *            to add
-     * @return true if this batch did not already contain the specified process
-     */
-    public boolean add(Batch batch, Process process) {
-        return batch.getProcesses().add(process);
-    }
-
-    /**
-     * The function addAll() adds all of the elements in the given collection to
-     * this batch if they're not already present. TODO: Not sure if this method
-     * is needed, check it
-     *
-     * @param processes
-     *            collection containing elements to be added to this set
-     * @return true if this set changed as a result of the call
-     */
-    public boolean addAll(Batch batch, Collection<? extends Process> processes) {
-        return batch.getProcesses().addAll(processes);
     }
 
     /**


### PR DESCRIPTION
- remove unnecessary layer for operations on batch and its processes
- remove not needed method: setCurrentProcesses
- fix JavaDocs