### PR TITLE
Make SelectItemList more flexible + minor improvements caused by usage of getAllForSelectedClient

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkflowDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkflowDAO.java
@@ -11,6 +11,7 @@
 
 package org.kitodo.data.database.persistence;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,11 +77,16 @@ public class WorkflowDAO extends BaseDAO<Workflow> {
     }
 
     /**
-     * Get available workflows - available means that workflow is active and ready.
+     * Get available workflows - available means that workflow is active, ready and
+     * assigned to client with given id.
      * 
+     * @param clientId
+     *            id of client to which searched workflows should be assigned
      * @return list of available Workflow objects
      */
-    public List<Workflow> getAvailableWorkflows() {
-        return getByQuery("FROM Workflow WHERE active = 1 AND ready = 1 ORDER BY title");
+    public List<Workflow> getAvailableWorkflows(int clientId) {
+        return getByQuery(
+            "SELECT w FROM Workflow AS w INNER JOIN w.client AS c WITH c.id = :clientId WHERE w.active = 1 AND w.ready = 1",
+            Collections.singletonMap("clientId", clientId));
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/forms/DocketForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/DocketForm.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.enterprise.context.SessionScoped;
-import javax.faces.model.SelectItem;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -37,7 +36,6 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.enums.ObjectType;
 import org.kitodo.helper.Helper;
-import org.kitodo.helper.SelectItemList;
 import org.kitodo.model.LazyDTOModel;
 
 @Named("DocketForm")
@@ -189,15 +187,6 @@ public class DocketForm extends BaseForm {
 
     public void setMyDocket(Docket docket) {
         this.myDocket = docket;
-    }
-
-    /**
-     * Get all available clients.
-     *
-     * @return list of Client objects
-     */
-    public List<SelectItem> getClients() {
-        return SelectItemList.getClients();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/ProcessForm.java
@@ -1472,7 +1472,7 @@ public class ProcessForm extends TemplateBaseForm {
      * @return list of dockets as SelectItem objects
      */
     public List<SelectItem> getDockets() {
-        return SelectItemList.getDockets();
+        return SelectItemList.getDockets(serviceManager.getDocketService().getAllForSelectedClient());
     }
 
     /**
@@ -1481,7 +1481,7 @@ public class ProcessForm extends TemplateBaseForm {
      * @return list of projects as SelectItem objects
      */
     public List<SelectItem> getProjects() {
-        return SelectItemList.getProjects();
+        return SelectItemList.getProjects(serviceManager.getProjectService().getAllForSelectedClient());
     }
 
     /**
@@ -1490,7 +1490,7 @@ public class ProcessForm extends TemplateBaseForm {
      * @return list of rulesets as SelectItem objects
      */
     public List<SelectItem> getRulesets() {
-        return SelectItemList.getRulesets();
+        return SelectItemList.getRulesets(serviceManager.getRulesetService().getAllForSelectedClient());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/forms/ProjectForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/ProjectForm.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
-import javax.faces.model.SelectItem;
 import javax.inject.Named;
 import javax.xml.bind.JAXBException;
 
@@ -43,7 +42,6 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.dto.ProjectDTO;
 import org.kitodo.enums.ObjectType;
 import org.kitodo.helper.Helper;
-import org.kitodo.helper.SelectItemList;
 import org.kitodo.model.LazyDTOModel;
 
 @Named("ProjectForm")
@@ -468,15 +466,6 @@ public class ProjectForm extends BaseForm {
                 logger, e);
             return new LinkedList<>();
         }
-    }
-
-    /**
-     * Gets all available clients.
-     *
-     * @return The list of clients.
-     */
-    public List<SelectItem> getClients() {
-        return SelectItemList.getClients();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/forms/RoleForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/RoleForm.java
@@ -181,7 +181,11 @@ public class RoleForm extends BaseForm {
      * @return list of Client objects
      */
     public List<SelectItem> getClients() {
-        return SelectItemList.getClients();
+        try {
+            return SelectItemList.getClients(serviceManager.getClientService().getAll());
+        } catch (DAOException e) {
+            return SelectItemList.getClients(new ArrayList<>());
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/RulesetForm.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.enterprise.context.SessionScoped;
-import javax.faces.model.SelectItem;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -37,7 +36,6 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.enums.ObjectType;
 import org.kitodo.helper.Helper;
-import org.kitodo.helper.SelectItemList;
 import org.kitodo.model.LazyDTOModel;
 
 @Named("RulesetForm")
@@ -199,15 +197,6 @@ public class RulesetForm extends BaseForm {
             Helper.setErrorMessage(ERROR_LOADING_ONE,
                 new Object[] {ObjectType.RULESET.getTranslationSingular(), rulesetID }, logger, e);
         }
-    }
-
-    /**
-     * Get all available clients.
-     *
-     * @return list of Client objects
-     */
-    public List<SelectItem> getClients() {
-        return SelectItemList.getClients();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/forms/TemplateForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/TemplateForm.java
@@ -237,7 +237,7 @@ public class TemplateForm extends TemplateBaseForm {
      * @return list of SelectItem objects
      */
     public List<SelectItem> getDockets() {
-        return SelectItemList.getDockets();
+        return SelectItemList.getDockets(serviceManager.getDocketService().getAllForSelectedClient());
     }
 
     /**
@@ -246,7 +246,7 @@ public class TemplateForm extends TemplateBaseForm {
      * @return list of SelectItem objects
      */
     public List<SelectItem> getProjects() {
-        return SelectItemList.getProjects();
+        return SelectItemList.getProjects(serviceManager.getProjectService().getAllForSelectedClient());
     }
 
     /**
@@ -255,7 +255,7 @@ public class TemplateForm extends TemplateBaseForm {
      * @return list of SelectItem objects
      */
     public List<SelectItem> getRulesets() {
-        return SelectItemList.getRulesets();
+        return SelectItemList.getRulesets(serviceManager.getRulesetService().getAllForSelectedClient());
     }
 
     /**
@@ -264,7 +264,7 @@ public class TemplateForm extends TemplateBaseForm {
      * @return list of SelectItem objects
      */
     public List<SelectItem> getWorkflows() {
-        return SelectItemList.getWorkflows();
+        return SelectItemList.getWorkflows(serviceManager.getWorkflowService().getAvailableWorkflows());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/helper/SelectItemList.java
+++ b/Kitodo/src/main/java/org/kitodo/helper/SelectItemList.java
@@ -12,6 +12,7 @@
 package org.kitodo.helper;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -59,11 +60,13 @@ public class SelectItemList {
     /**
      * Get clients for select list.
      *
+     * @param clients
+     *            to convert to select list
      * @return list of clients as SelectItem list
      */
-    public static List<SelectItem> getClients() {
+    public static List<SelectItem> getClients(List<Client> clients) {
         List<SelectItem> selectItems = new ArrayList<>();
-        List<Client> clients = serviceManager.getClientService().getByQuery("from Client ORDER BY name");
+        clients.sort(Comparator.comparing(Client::getName));
         for (Client client : clients) {
             selectItems.add(new SelectItem(client, client.getName(), null));
         }
@@ -73,11 +76,13 @@ public class SelectItemList {
     /**
      * Get dockets for select list.
      *
+     * @param dockets
+     *            to convert to select list
      * @return list of dockets as SelectItem list
      */
-    public static List<SelectItem> getDockets() {
+    public static List<SelectItem> getDockets(List<Docket> dockets) {
         List<SelectItem> selectItems = new ArrayList<>();
-        List<Docket> dockets = serviceManager.getDocketService().getByQuery("from Docket ORDER BY title");
+        dockets.sort(Comparator.comparing(Docket::getTitle));
         for (Docket docket : dockets) {
             selectItems.add(new SelectItem(docket, docket.getTitle(), null));
         }
@@ -127,6 +132,7 @@ public class SelectItemList {
      */
     public static List<SelectItem> getProcesses(List<Process> processes) {
         List<SelectItem> selectItems = new ArrayList<>();
+        processes.sort(Comparator.comparing(Process::getTitle));
         for (Process process : processes) {
             selectItems.add(new SelectItem(process, process.getTitle(), null));
         }
@@ -136,12 +142,14 @@ public class SelectItemList {
     /**
      * Get list of projects for select list.
      *
+     * @param projects
+     *            to convert to select list
      * @return list of SelectItem objects
      */
-    public static List<SelectItem> getProjects() {
+    public static List<SelectItem> getProjects(List<Project> projects) {
         List<SelectItem> selectItems = new ArrayList<>();
-        List<Project> temp = serviceManager.getProjectService().getByQuery("from Project ORDER BY title");
-        for (Project project : temp) {
+        projects.sort(Comparator.comparing(Project::getTitle));
+        for (Project project : projects) {
             selectItems.add(new SelectItem(project, project.getTitle(), null));
         }
         return selectItems;
@@ -150,11 +158,13 @@ public class SelectItemList {
     /**
      * Get rulesets for select list.
      *
+     * @param rulesets
+     *            to convert to select list
      * @return list of rulesets as SelectItem list
      */
-    public static List<SelectItem> getRulesets() {
+    public static List<SelectItem> getRulesets(List<Ruleset> rulesets) {
         List<SelectItem> selectItems = new ArrayList<>();
-        List<Ruleset> rulesets = serviceManager.getRulesetService().getByQuery("from Ruleset ORDER BY title");
+        rulesets.sort(Comparator.comparing(Ruleset::getTitle));
         for (Ruleset ruleset : rulesets) {
             selectItems.add(new SelectItem(ruleset, ruleset.getTitle(), null));
         }
@@ -164,11 +174,13 @@ public class SelectItemList {
     /**
      * Get list of workflows for select list.
      *
+     * @param workflows
+     *            to convert to select list
      * @return list of SelectItem objects
      */
-    public static List<SelectItem> getWorkflows() {
+    public static List<SelectItem> getWorkflows(List<Workflow> workflows) {
         List<SelectItem> selectItems = new ArrayList<>();
-        List<Workflow> workflows = serviceManager.getWorkflowService().getAvailableWorkflows();
+        workflows.sort(Comparator.comparing(Workflow::getTitle));
         for (Workflow workflow : workflows) {
             selectItems.add(new SelectItem(workflow, workflow.getTitle(), null));
         }

--- a/Kitodo/src/main/java/org/kitodo/services/data/AuthorityService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/AuthorityService.java
@@ -141,7 +141,7 @@ public class AuthorityService extends TitleSearchService<Authority, AuthorityDTO
     }
 
     @Override
-    public List<Authority> getAllForSelectedClient(int clientId) {
+    public List<Authority> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/BatchService.java
@@ -100,7 +100,7 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
     }
 
     @Override
-    public List<Batch> getAllForSelectedClient(int clientId) {
+    public List<Batch> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/ClientService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ClientService.java
@@ -79,7 +79,7 @@ public class ClientService extends SearchService<Client, ClientDTO, ClientDAO> {
     }
 
     @Override
-    public List<Client> getAllForSelectedClient(int clientId) {
+    public List<Client> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/DocketService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/DocketService.java
@@ -86,9 +86,9 @@ public class DocketService extends TitleSearchService<Docket, DocketDTO, DocketD
     }
 
     @Override
-    public List<Docket> getAllForSelectedClient(int clientId) {
+    public List<Docket> getAllForSelectedClient() {
         return dao.getByQuery("SELECT d FROM Docket AS d INNER JOIN d.client AS c WITH c.id = :clientId",
-            Collections.singletonMap("clientId", clientId));
+            Collections.singletonMap("clientId", serviceManager.getUserService().getSessionClientId()));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/FilterService.java
@@ -101,7 +101,7 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
     }
 
     @Override
-    public List<Filter> getAllForSelectedClient(int clientId) {
+    public List<Filter> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/FolderService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/FolderService.java
@@ -33,7 +33,7 @@ public class FolderService extends SearchDatabaseService<Folder, FolderDAO> {
     }
 
     @Override
-    public List<Folder> getAllForSelectedClient(int clientId) {
+    public List<Folder> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/services/data/LdapGroupService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/LdapGroupService.java
@@ -30,7 +30,7 @@ public class LdapGroupService extends SearchDatabaseService<LdapGroup, LdapGroup
     }
 
     @Override
-    public List<LdapGroup> getAllForSelectedClient(int clientId) {
+    public List<LdapGroup> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/LdapServerService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/LdapServerService.java
@@ -100,7 +100,7 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
     }
 
     @Override
-    public List<LdapServer> getAllForSelectedClient(int clientId) {
+    public List<LdapServer> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
@@ -409,7 +409,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
     }
 
     @Override
-    public List<Process> getAllForSelectedClient(int clientId) {
+    public List<Process> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProjectService.java
@@ -160,9 +160,9 @@ public class ProjectService extends TitleSearchService<Project, ProjectDTO, Proj
     }
 
     @Override
-    public List<Project> getAllForSelectedClient(int clientId) {
+    public List<Project> getAllForSelectedClient() {
         return dao.getByQuery("SELECT p FROM Project AS p INNER JOIN p.client AS c WITH c.id = :clientId",
-                Collections.singletonMap("clientId", clientId));
+                Collections.singletonMap("clientId", serviceManager.getUserService().getSessionClientId()));
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/PropertyService.java
@@ -98,7 +98,7 @@ public class PropertyService extends TitleSearchService<Property, PropertyDTO, P
     }
 
     @Override
-    public List<Property> getAllForSelectedClient(int clientId) {
+    public List<Property> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/RoleService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/RoleService.java
@@ -144,9 +144,9 @@ public class RoleService extends TitleSearchService<Role, RoleDTO, RoleDAO> {
     }
 
     @Override
-    public List<Role> getAllForSelectedClient(int clientId) {
+    public List<Role> getAllForSelectedClient() {
         return dao.getByQuery("SELECT r FROM Role AS r INNER JOIN r.client AS c WITH c.id = :clientId",
-            Collections.singletonMap("clientId", clientId));
+            Collections.singletonMap("clientId", serviceManager.getUserService().getSessionClientId()));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/RulesetService.java
@@ -95,9 +95,9 @@ public class RulesetService extends TitleSearchService<Ruleset, RulesetDTO, Rule
     }
 
     @Override
-    public List<Ruleset> getAllForSelectedClient(int clientId) {
+    public List<Ruleset> getAllForSelectedClient() {
         return dao.getByQuery("SELECT r FROM Ruleset AS r INNER JOIN r.client AS c WITH c.id = :clientId",
-            Collections.singletonMap("clientId", clientId));
+            Collections.singletonMap("clientId", serviceManager.getUserService().getSessionClientId()));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/TaskService.java
@@ -302,7 +302,7 @@ public class TaskService extends TitleSearchService<Task, TaskDTO, TaskDAO> {
     }
 
     @Override
-    public List<Task> getAllForSelectedClient(int clientId) {
+    public List<Task> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/TemplateService.java
@@ -96,7 +96,7 @@ public class TemplateService extends TitleSearchService<Template, TemplateDTO, T
     }
 
     @Override
-    public List<Template> getAllForSelectedClient(int clientId) {
+    public List<Template> getAllForSelectedClient() {
         throw new UnsupportedOperationException();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/UserService.java
@@ -336,9 +336,9 @@ public class UserService extends SearchService<User, UserDTO, UserDAO> implement
     }
 
     @Override
-    public List<User> getAllForSelectedClient(int clientId) {
+    public List<User> getAllForSelectedClient() {
         return dao.getByQuery("SELECT u FROM User AS u INNER JOIN u.clients AS c WITH c.id = :clientId",
-            Collections.singletonMap("clientId", clientId));
+            Collections.singletonMap("clientId", serviceManager.getUserService().getSessionClientId()));
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/services/data/base/SearchDatabaseService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/base/SearchDatabaseService.java
@@ -34,11 +34,9 @@ public abstract class SearchDatabaseService<T extends BaseBean, S extends BaseDA
     /**
      * Get list of all objects for selected client from database.
      *
-     * @param clientId
-     *            id of selected client
      * @return list of all objects for selected client from database
      */
-    public abstract List<T> getAllForSelectedClient(int clientId);
+    public abstract List<T> getAllForSelectedClient();
 
     /**
      * Method saves object to database.

--- a/Kitodo/src/main/webapp/pages/docketEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/docketEdit.xhtml
@@ -77,16 +77,7 @@
                             </p:selectOneMenu>
                         </div>
                     </p:row>
-                    <p:row rendered="#{SessionClientController.currentSessionClient eq null}">
-                        <div>
-                            <p:outputLabel for="client" value="#{msgs.client}"/>
-                            <p:selectOneMenu id="client" converter="#{clientConverter}" value="#{DocketForm.myDocket.client}">
-                                <f:selectItems value="#{DocketForm.clients}"/>
-                                <p:ajax event="change" oncomplete="toggleSave()"/>
-                            </p:selectOneMenu>
-                        </div>
-                    </p:row>
-                    <p:row rendered="#{SessionClientController.currentSessionClient ne null}" />
+                    <p:row />
                 </p:panelGrid>
             </p:tab>
         </p:tabView>

--- a/Kitodo/src/main/webapp/pages/rulesetEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/rulesetEdit.xhtml
@@ -75,16 +75,7 @@
                             </p:selectOneMenu>
                         </div>
                     </p:row>
-                    <p:row rendered="#{SessionClientController.currentSessionClient eq null}">
-                        <ui:fragment rendered="#{SessionClientController.currentSessionClient eq null}">
-                            <div>
-                                <p:outputLabel for="client" value="#{msgs.client}"/>
-                                <p:selectOneMenu id="client" converter="#{clientConverter}" value="#{RulesetForm.ruleset.client}">
-                                    <f:selectItems value="#{RulesetForm.clients}"/>
-                                    <p:ajax event="change" oncomplete="toggleSave()"/>
-                                </p:selectOneMenu>
-                            </div>
-                        </ui:fragment>
+                    <p:row>
                         <div>
                             <p:outputLabel for="sortByRuleset" value="#{msgs.metadataSortByRuleset}"/>
                             <p:selectBooleanCheckbox id="sortByRuleset"

--- a/Kitodo/src/test/java/org/goobi/export/ExportMetsIT.java
+++ b/Kitodo/src/test/java/org/goobi/export/ExportMetsIT.java
@@ -62,7 +62,7 @@ public class ExportMetsIT {
         fileService.createDirectory(URI.create(""), metadataDirectory);
         fileService.copyFileToDirectory(URI.create("metadata/testmetaOldFormat.xml"), URI.create(metadataDirectory));
         fileService.renameFile(URI.create(metadataDirectory + "/testmetaOldFormat.xml"), "meta.xml");
-        SecurityTestUtils.addUserDataToSecurityContext(user);
+        SecurityTestUtils.addUserDataToSecurityContext(user, 1);
         FileLoader.createConfigProjectsFile();
 
         if (!SystemUtils.IS_OS_WINDOWS) {

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -1290,14 +1290,16 @@ public class MockDatabase {
         serviceManager.getProcessService().save(workpiece);
     }
 
-    public static void insertWorkflows() throws DataException {
+    public static void insertWorkflows() throws DAOException, DataException {
         Workflow firstWorkflow = new Workflow("say-hello", "test");
         firstWorkflow.setActive(true);
         firstWorkflow.setReady(true);
+        firstWorkflow.setClient(serviceManager.getClientService().getById(1));
         serviceManager.getWorkflowService().save(firstWorkflow);
 
         Workflow secondWorkflow = new Workflow("gateway", "gateway");
         secondWorkflow.setReady(false);
+        secondWorkflow.setClient(serviceManager.getClientService().getById(2));
         serviceManager.getWorkflowService().save(secondWorkflow);
     }
 

--- a/Kitodo/src/test/java/org/kitodo/SecurityTestUtils.java
+++ b/Kitodo/src/test/java/org/kitodo/SecurityTestUtils.java
@@ -22,17 +22,19 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class SecurityTestUtils {
 
     /**
-     * Adds a given user as SecurityUserDetails object to security context. Can be used for unit testing.
+     * Adds a given user as SecurityUserDetails object to security context. Can be
+     * used for unit testing.
      * 
      * @param user
      *            user object
+     * @param clientId
+     *            id of client dor session client
      */
-    public static void addUserDataToSecurityContext(User user) throws DAOException {
+    public static void addUserDataToSecurityContext(User user, int clientId) throws DAOException {
         SecurityUserDetails securityUserDetails = new SecurityUserDetails(user);
-        Authentication auth = new UsernamePasswordAuthenticationToken(securityUserDetails, null, securityUserDetails.getAuthorities());
-        if (!user.getClients().isEmpty()) {
-            securityUserDetails .setSessionClient(new ServiceManager().getClientService().getById(1));
-        }
+        Authentication auth = new UsernamePasswordAuthenticationToken(securityUserDetails, null,
+                securityUserDetails.getAuthorities());
+        securityUserDetails.setSessionClient(new ServiceManager().getClientService().getById(clientId));
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 

--- a/Kitodo/src/test/java/org/kitodo/helper/SelectItemListIT.java
+++ b/Kitodo/src/test/java/org/kitodo/helper/SelectItemListIT.java
@@ -29,14 +29,20 @@ import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.Workflow;
 import org.kitodo.services.ServiceManager;
 import org.kitodo.services.data.BatchService;
+import org.kitodo.services.data.ClientService;
+import org.kitodo.services.data.DocketService;
+import org.kitodo.services.data.ProjectService;
+import org.kitodo.services.data.RulesetService;
+import org.kitodo.services.data.WorkflowService;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class SelectItemListIT {
+
+    private static ServiceManager serviceManager = new ServiceManager();
 
     @BeforeClass
     public static void prepareDatabase() throws Exception {
@@ -44,7 +50,7 @@ public class SelectItemListIT {
         MockDatabase.insertProcessesFull();
         MockDatabase.setUpAwaitility();
 
-        SecurityTestUtils.addUserDataToSecurityContext(new ServiceManager().getUserService().getById(1));
+        SecurityTestUtils.addUserDataToSecurityContext(serviceManager.getUserService().getById(1), 1);
     }
 
     @AfterClass
@@ -57,7 +63,7 @@ public class SelectItemListIT {
 
     @Test
     public void shouldGetBatches() throws Exception {
-        BatchService batchService = new ServiceManager().getBatchService();
+        BatchService batchService = serviceManager.getBatchService();
 
         await().untilAsserted(() -> assertEquals("Incorrect amount of select items!", 4,
             SelectItemList.getBatches(batchService.getAll()).size()));
@@ -77,11 +83,13 @@ public class SelectItemListIT {
     }
 
     @Test
-    public void shouldGetClients() {
-        await().untilAsserted(
-            () -> assertEquals("Incorrect amount of select items!", 4, SelectItemList.getClients().size()));
+    public void shouldGetClients() throws Exception {
+        ClientService clientService = serviceManager.getClientService();
 
-        List<SelectItem> selectItems = SelectItemList.getClients();
+        await().untilAsserted(
+            () -> assertEquals("Incorrect amount of select items!", 4, SelectItemList.getClients(clientService.getAll()).size()));
+
+        List<SelectItem> selectItems = SelectItemList.getClients(clientService.getAll());
 
         assertEquals("Second item is not sorted correctly!", "First client", selectItems.get(0).getLabel());
         assertEquals("Third item is not sorted correctly!", "Not used client", selectItems.get(1).getLabel());
@@ -92,11 +100,13 @@ public class SelectItemListIT {
     }
 
     @Test
-    public void shouldGetDockets() {
-        await().untilAsserted(
-            () -> assertEquals("Incorrect amount of select items!", 5, SelectItemList.getDockets().size()));
+    public void shouldGetDockets() throws Exception {
+        DocketService docketService = serviceManager.getDocketService();
 
-        List<SelectItem> selectItems = SelectItemList.getDockets();
+        await().untilAsserted(
+            () -> assertEquals("Incorrect amount of select items!", 5, SelectItemList.getDockets(docketService.getAll()).size()));
+
+        List<SelectItem> selectItems = SelectItemList.getDockets(docketService.getAll());
 
         assertEquals("First item is not sorted correctly!", "Removable docket", selectItems.get(0).getLabel());
         assertEquals("Second item is not sorted correctly!", "default", selectItems.get(1).getLabel());
@@ -131,11 +141,13 @@ public class SelectItemListIT {
     }
 
     @Test
-    public void shouldGetProjects() {
-        await().untilAsserted(
-            () -> assertEquals("Incorrect amount of select items!", 3, SelectItemList.getProjects().size()));
+    public void shouldGetProjects() throws Exception {
+        ProjectService projectService = serviceManager.getProjectService();
 
-        List<SelectItem> selectItems = SelectItemList.getProjects();
+        await().untilAsserted(
+            () -> assertEquals("Incorrect amount of select items!", 3, SelectItemList.getProjects(projectService.getAll()).size()));
+
+        List<SelectItem> selectItems = SelectItemList.getProjects(projectService.getAll());
 
         assertEquals("First item is not sorted correctly!", "First project", selectItems.get(0).getLabel());
         assertEquals("Second item is not sorted correctly!", "Inactive project", selectItems.get(1).getLabel());
@@ -145,11 +157,13 @@ public class SelectItemListIT {
     }
 
     @Test
-    public void shouldGetRulesets() {
-        await().untilAsserted(
-            () -> assertEquals("Incorrect amount of select items!", 4, SelectItemList.getRulesets().size()));
+    public void shouldGetRulesets() throws Exception {
+        RulesetService rulesetService = serviceManager.getRulesetService();
 
-        List<SelectItem> selectItems = SelectItemList.getRulesets();
+        await().untilAsserted(
+            () -> assertEquals("Incorrect amount of select items!", 4, SelectItemList.getRulesets(rulesetService.getAll()).size()));
+
+        List<SelectItem> selectItems = SelectItemList.getRulesets(rulesetService.getAll());
 
         assertEquals("First item is not sorted correctly!", "Removable ruleset", selectItems.get(0).getLabel());
         assertEquals("Second item is not sorted correctly!", "SLUBBB", selectItems.get(1).getLabel());
@@ -160,13 +174,16 @@ public class SelectItemListIT {
     }
 
     @Test
-    public void shouldGetWorkflows() {
+    public void shouldGetWorkflows() throws Exception {
+        WorkflowService workflowService = serviceManager.getWorkflowService();
+
         await().untilAsserted(
-            () -> assertEquals("Incorrect amount of select items!", 1, SelectItemList.getWorkflows().size()));
+            () -> assertEquals("Incorrect amount of select items!", 2, SelectItemList.getWorkflows(workflowService.getAll()).size()));
 
-        List<SelectItem> selectItems = SelectItemList.getWorkflows();
+        List<SelectItem> selectItems = SelectItemList.getWorkflows(workflowService.getAll());
 
-        assertEquals("First item is not sorted correctly!", "say-hello", selectItems.get(0).getLabel());
+        assertEquals("First item is not sorted correctly!", "gateway", selectItems.get(0).getLabel());
+        assertEquals("Second item is not sorted correctly!", "say-hello", selectItems.get(1).getLabel());
 
         assertThat("First item is not a Workflow type!", selectItems.get(0).getValue(), instanceOf(Workflow.class));
     }

--- a/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
+++ b/Kitodo/src/test/java/org/kitodo/model/LazyDTOModelIT.java
@@ -18,22 +18,22 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
-import org.kitodo.dto.WorkflowDTO;
+import org.kitodo.dto.ClientDTO;
 import org.kitodo.services.ServiceManager;
-import org.kitodo.services.data.WorkflowService;
+import org.kitodo.services.data.ClientService;
 import org.primefaces.model.SortOrder;
 
 public class LazyDTOModelIT {
 
     private static final ServiceManager serviceManager = new ServiceManager();
-    private static WorkflowService workflowService = serviceManager.getWorkflowService();
+    private static ClientService clientService = serviceManager.getClientService();
     private static LazyDTOModel lazyDTOModel = null;
 
     @BeforeClass
     public static void setUp() throws Exception {
         MockDatabase.startNode();
-        MockDatabase.insertWorkflows();
-        lazyDTOModel = new LazyDTOModel(workflowService);
+        MockDatabase.insertClients();
+        lazyDTOModel = new LazyDTOModel(clientService);
     }
 
     @AfterClass
@@ -44,16 +44,16 @@ public class LazyDTOModelIT {
 
     @Test
     public void shouldGetRowData() throws Exception {
-        List dockets = workflowService.findAll();
-        WorkflowDTO firstWorkflow = (WorkflowDTO) dockets.get(0);
-        WorkflowDTO lazyWorkflow = (WorkflowDTO) lazyDTOModel.getRowData(String.valueOf(firstWorkflow.getId()));
-        Assert.assertEquals(firstWorkflow.getTitle(), lazyWorkflow.getTitle());
+        List clients = clientService.findAll();
+        ClientDTO firstClient = (ClientDTO) clients.get(0);
+        ClientDTO lazyClient = (ClientDTO) lazyDTOModel.getRowData(String.valueOf(firstClient.getId()));
+        Assert.assertEquals(firstClient.getName(), lazyClient.getName());
     }
 
     @Test
     public void shouldLoad() {
-        List workflows = lazyDTOModel.load(0, 2, "title", SortOrder.ASCENDING, null);
-        WorkflowDTO workflow = (WorkflowDTO) workflows.get(0);
-        Assert.assertEquals("gateway", workflow.getTitle());
+        List clients = lazyDTOModel.load(0, 2, "clientName", SortOrder.ASCENDING, null);
+        ClientDTO client = (ClientDTO) clients.get(0);
+        Assert.assertEquals("Second client", client.getName());
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/ListingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ListingST.java
@@ -16,8 +16,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.kitodo.SecurityTestUtils;
+import org.kitodo.data.database.beans.User;
 import org.kitodo.selenium.testframework.BaseTestSelenium;
 import org.kitodo.selenium.testframework.Pages;
 import org.kitodo.selenium.testframework.pages.ProcessesPage;
@@ -28,7 +31,7 @@ import org.kitodo.services.ServiceManager;
 
 public class ListingST extends BaseTestSelenium {
 
-    private ServiceManager serviceManager = new ServiceManager();
+    private static ServiceManager serviceManager = new ServiceManager();
 
     private static ProcessesPage processesPage;
     private static ProjectsPage projectsPage;
@@ -46,6 +49,14 @@ public class ListingST extends BaseTestSelenium {
     @BeforeClass
     public static void login() throws Exception {
         Pages.getLoginPage().goTo().performLoginAsAdmin();
+
+        User user = serviceManager.getUserService().getByLogin("kowal");
+        SecurityTestUtils.addUserDataToSecurityContext(user, 1);
+    }
+
+    @AfterClass
+    public static void cleanSecurityContext() {
+        SecurityTestUtils.cleanSecurityContext();
     }
 
     @Test
@@ -112,15 +123,15 @@ public class ListingST extends BaseTestSelenium {
         //assertEquals("Displayed wrong template's docket", "second", detailsTemplate.get(2));
         //assertEquals("Displayed wrong template's project", "First project", detailsTemplate.get(2));
 
-        int workflowsInDatabase = serviceManager.getWorkflowService().getAll().size();
+        int workflowsInDatabase = serviceManager.getWorkflowService().getAllForSelectedClient().size();
         int workflowsDisplayed = projectsPage.countListedWorkflows();
         assertEquals("Displayed wrong number of workflows", workflowsInDatabase, workflowsDisplayed);
 
-        int docketsInDatabase = serviceManager.getDocketService().getAllForSelectedClient(1).size();
+        int docketsInDatabase = serviceManager.getDocketService().getAllForSelectedClient().size();
         int docketsDisplayed = projectsPage.countListedDockets();
         assertEquals("Displayed wrong number of dockets", docketsInDatabase, docketsDisplayed);
 
-        int rulesetsInDatabase = serviceManager.getRulesetService().getAllForSelectedClient(1).size();
+        int rulesetsInDatabase = serviceManager.getRulesetService().getAllForSelectedClient().size();
         int rulesetsDisplayed = projectsPage.countListedRulesets();
         assertEquals("Displayed wrong number of rulesets", rulesetsInDatabase, rulesetsDisplayed);
     }

--- a/Kitodo/src/test/java/org/kitodo/selenium/ListingSessionClientST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ListingSessionClientST.java
@@ -19,6 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.kitodo.SecurityTestUtils;
+import org.kitodo.data.database.beans.User;
 import org.kitodo.selenium.testframework.BaseTestSelenium;
 import org.kitodo.selenium.testframework.Browser;
 import org.kitodo.selenium.testframework.Pages;
@@ -54,6 +56,9 @@ public class ListingSessionClientST extends BaseTestSelenium {
 
     @Test
     public void listProjectsForUserWithFirstSessionClientTest() throws Exception {
+        User user = serviceManager.getUserService().getById(2);
+        SecurityTestUtils.addUserDataToSecurityContext(user, 1);
+
         Pages.getTopNavigation().selectSessionClient(0);
 
         // user will see only projects page as this one right he has for First client
@@ -65,10 +70,15 @@ public class ListingSessionClientST extends BaseTestSelenium {
 
         exception.expect(IndexOutOfBoundsException.class);
         projectsPage.countListedTemplates();
+
+        SecurityTestUtils.cleanSecurityContext();
     }
 
     @Test
     public void listProjectsForUserWithSecondSessionClientTest() throws Exception {
+        User user = serviceManager.getUserService().getById(2);
+        SecurityTestUtils.addUserDataToSecurityContext(user, 2);
+
         Pages.getTopNavigation().selectSessionClient(1);
 
         // user will see first four tabs as this rights he has for Second client
@@ -82,15 +92,17 @@ public class ListingSessionClientST extends BaseTestSelenium {
         int templatesDisplayed = projectsPage.countListedTemplates();
         assertEquals("Displayed wrong number of templates", templatesInDatabase, templatesDisplayed);
 
-        int workflowsInDatabase = serviceManager.getWorkflowService().getAll().size();
+        int workflowsInDatabase = serviceManager.getWorkflowService().getAllForSelectedClient().size();
         int workflowsDisplayed = projectsPage.countListedWorkflows();
         assertEquals("Displayed wrong number of workflows", workflowsInDatabase, workflowsDisplayed);
 
-        int docketsInDatabase = serviceManager.getDocketService().getAllForSelectedClient(2).size();
+        int docketsInDatabase = serviceManager.getDocketService().getAllForSelectedClient().size();
         int docketsDisplayed = projectsPage.countListedDockets();
         assertEquals("Displayed wrong number of dockets", docketsInDatabase, docketsDisplayed);
 
         exception.expect(IndexOutOfBoundsException.class);
         projectsPage.countListedRulesets();
+
+        SecurityTestUtils.cleanSecurityContext();
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/services/data/FilterServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/FilterServiceIT.java
@@ -43,7 +43,7 @@ public class FilterServiceIT {
         MockDatabase.startNode();
         MockDatabase.insertProcessesFull();
         MockDatabase.setUpAwaitility();
-        SecurityTestUtils.addUserDataToSecurityContext(new ServiceManager().getUserService().getById(1));
+        SecurityTestUtils.addUserDataToSecurityContext(new ServiceManager().getUserService().getById(1), 1);
     }
 
     @AfterClass

--- a/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/UserServiceIT.java
@@ -457,7 +457,7 @@ public class UserServiceIT {
 
     @Test
     public void shouldGetAuthenticatedUser() throws DAOException {
-        SecurityTestUtils.addUserDataToSecurityContext(userService.getById(1));
+        SecurityTestUtils.addUserDataToSecurityContext(userService.getById(1), 1);
         User authenticatedUser = userService.getAuthenticatedUser();
         assertEquals("Returned authenticated user was wrong", "kowal", authenticatedUser.getLogin());
         SecurityTestUtils.cleanSecurityContext();

--- a/Kitodo/src/test/java/org/kitodo/services/data/WorkflowServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/data/WorkflowServiceIT.java
@@ -17,6 +17,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
+import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.Workflow;
 import org.kitodo.services.ServiceManager;
 
@@ -25,11 +26,13 @@ import static org.junit.Assert.assertTrue;
 
 public class WorkflowServiceIT {
 
-    private WorkflowService workflowService = new ServiceManager().getWorkflowService();
+    private ServiceManager serviceManager = new ServiceManager();
+    private WorkflowService workflowService = serviceManager.getWorkflowService();
 
     @BeforeClass
     public static void prepareDatabase() throws Exception {
         MockDatabase.startNode();
+        MockDatabase.insertRolesFull();
         MockDatabase.insertWorkflows();
     }
 
@@ -59,8 +62,12 @@ public class WorkflowServiceIT {
     }
 
     @Test
-    public void shouldGetAvailableWorkflows() {
+    public void shouldGetAvailableWorkflows() throws Exception {
+        SecurityTestUtils.addUserDataToSecurityContext(serviceManager.getUserService().getById(1), 1);
+
         List<Workflow> workflows = workflowService.getAvailableWorkflows();
         assertEquals("Workflows were not found in database!", 1, workflows.size());
+
+        SecurityTestUtils.cleanSecurityContext();
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/services/security/SecurityAccessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/security/SecurityAccessServiceIT.java
@@ -50,7 +50,7 @@ public class SecurityAccessServiceIT {
     @Test
     public void shouldGetAuthorities() throws DAOException {
         User user = serviceManager.getUserService().getByLogin("kowal");
-        SecurityTestUtils.addUserDataToSecurityContext(user);
+        SecurityTestUtils.addUserDataToSecurityContext(user, 1);
         Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext().getAuthentication()
                 .getAuthorities();
         Assert.assertEquals("Security context holder does not hold the corresponding authorities", 142,
@@ -60,7 +60,7 @@ public class SecurityAccessServiceIT {
     @Test
     public void hasAuthorityTest() throws DAOException {
         User user = serviceManager.getUserService().getByLogin("kowal");
-        SecurityTestUtils.addUserDataToSecurityContext(user);
+        SecurityTestUtils.addUserDataToSecurityContext(user, 1);
         Assert.assertTrue("The authority \"editClient\" was not found for authenticated user",
             serviceManager.getSecurityAccessService().hasAuthorityGlobal("editClient"));
     }
@@ -68,7 +68,7 @@ public class SecurityAccessServiceIT {
     @Test
     public void hasAuthorityForClientTest() throws DAOException {
         User user = serviceManager.getUserService().getByLogin("kowal");
-        SecurityTestUtils.addUserDataToSecurityContext(user);
+        SecurityTestUtils.addUserDataToSecurityContext(user,1);
         Assert.assertTrue("Checking if user has edit project authority for first client returned wrong value",
             serviceManager.getSecurityAccessService().hasAuthorityForClient("editProject"));
     }

--- a/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceIT.java
@@ -52,7 +52,7 @@ public class WorkflowControllerServiceIT {
     public static void prepareDatabase() throws Exception {
         MockDatabase.startNode();
         MockDatabase.insertProcessesForWorkflowFull();
-        SecurityTestUtils.addUserDataToSecurityContext(new ServiceManager().getUserService().getById(1));
+        SecurityTestUtils.addUserDataToSecurityContext(serviceManager.getUserService().getById(1), 1);
 
         fileService.createDirectory(URI.create(""), "users");
 

--- a/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/services/workflow/WorkflowControllerServiceTest.java
@@ -16,8 +16,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.Task;
-import org.kitodo.data.database.beans.User;
-import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.helper.enums.TaskStatus;
 import org.kitodo.services.ServiceManager;
 
@@ -28,9 +26,8 @@ public class WorkflowControllerServiceTest {
     private static WorkflowControllerService workflowControllerService;
 
     @BeforeClass
-    public static void setUp() throws DAOException {
+    public static void setUp() {
         workflowControllerService = new ServiceManager().getWorkflowControllerService();
-        SecurityTestUtils.addUserDataToSecurityContext(new User());
     }
 
     @AfterClass


### PR DESCRIPTION
- more flexible SelectItemList
- remove Client select items lists from docket, project and workflow forms
- remove param clientId form method getAllForSelectedClient() - use client id from security context
- adjust selenium tests to use SecurityContext