### PR TITLE
Formulate the Javadoc comment more comprehensible

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/model/Subfolder.java
+++ b/Kitodo/src/main/java/org/kitodo/model/Subfolder.java
@@ -185,7 +185,8 @@ public class Subfolder {
     }
 
     /**
-     * Returns the settings of the subfolder configured in the project.
+     * Returns the folder database bean. The folder bean contains the settings
+     * for the subfolder.
      * 
      * @return the folder
      */


### PR DESCRIPTION
Renaming the database class would go beyond the scope here, at least for now. That would be a real change. That's why I just now just adapted the Javadoc comment so that it is consistent in itself.