### PR TITLE
Minor fixes in metadata classes

### DIFF
--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadata.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadata.java
@@ -18,7 +18,7 @@ import javax.faces.model.SelectItem;
 import org.goobi.api.display.Item;
 import org.kitodo.api.ugh.MetadataInterface;
 
-public interface Metadatum {
+public interface Metadata {
 
     String getTyp();
 

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadata.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadata.java
@@ -66,14 +66,6 @@ public interface Metadata {
 
     /**
      * New function for use of display configuration within xml files. This one gets
-     * output type.
-     * 
-     * @return output type as string
-     */
-    String getOutputType();
-
-    /**
-     * New function for use of display configuration within xml files. This one gets
      * items.
      *
      * @return items as List of SelectItem objects

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadata.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadata.java
@@ -15,42 +15,124 @@ import java.util.List;
 
 import javax.faces.model.SelectItem;
 
-import org.goobi.api.display.Item;
 import org.kitodo.api.ugh.MetadataInterface;
 
 public interface Metadata {
 
+    /**
+     * Get type.
+     * 
+     * @return type as String
+     */
     String getTyp();
 
+    /**
+     * Set type.
+     * 
+     * @param inTyp
+     *            as String
+     */
     void setTyp(String inTyp);
 
+    /**
+     * Get identifier.
+     * 
+     * @return identifier
+     */
     int getIdentifier();
 
+    /**
+     * Set identifier.
+     * 
+     * @param identifier
+     *            as int
+     */
     void setIdentifier(int identifier);
 
+    /**
+     * Get metadata.
+     * 
+     * @return metadata
+     */
     MetadataInterface getMd();
 
+    /**
+     * Set metadata.
+     * 
+     * @param md
+     *            as MetadataInterface object
+     */
     void setMd(MetadataInterface md);
 
     /**
-     * new functions for use of display configuration whithin xml files.
-     *
+     * New function for use of display configuration within xml files. This one gets
+     * output type.
+     * 
+     * @return output type as string
      */
     String getOutputType();
 
+    /**
+     * New function for use of display configuration within xml files. This one gets
+     * items.
+     *
+     * @return items as List of SelectItem objects
+     */
     List<SelectItem> getItems();
 
+    /**
+     * New function for use of display configuration within xml files. This one sets
+     * list of items.
+     *
+     * @param items as List of SelectItem objects
+     */
     void setItems(List<SelectItem> items);
 
+    /**
+     * New function for use of display configuration within xml files. This one gets
+     * list of selected items.
+     *
+     * @return selected item as List of SelectItem objects
+     */
     List<String> getSelectedItems();
 
+    /**
+     * New function for use of display configuration within xml files. This one sets
+     * list of selected items.
+     *
+     * @param selectedItems as List of String objects
+     */
     void setSelectedItems(List<String> selectedItems);
 
+    /**
+     * New function for use of display configuration within xml files. This one gets
+     * selected item.
+     *
+     * @return selected item as String
+     */
     String getSelectedItem();
 
+    /**
+     * New function for use of display configuration within xml files. This one sets
+     * selected item.
+     *
+     * @param selectedItem as String
+     */
     void setSelectedItem(String selectedItem);
 
+    /**
+     * New function for use of display configuration within xml files. This one sets
+     * value.
+     *
+     * @param value as String
+     */
     void setValue(String value);
 
+    /**
+     * New function for use of display configuration within xml files. This one gets
+     * value.
+     *
+     * @return value as String
+     */
     String getValue();
 }

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadataImpl.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadataImpl.java
@@ -34,7 +34,7 @@ import org.kitodo.services.ServiceManager;
  * @version 1.00 - 10.01.2005
  */
 
-public class MetadatumImpl implements Metadatum {
+public class MetadataImpl implements Metadata {
     private ServiceManager serviceManager = new ServiceManager();
     private MetadataInterface md;
     private int identifier;
@@ -46,7 +46,7 @@ public class MetadatumImpl implements Metadatum {
     /**
      * Allgemeiner Konstruktor().
      */
-    public MetadatumImpl(MetadataInterface m, int inID, PrefsInterface inPrefs, Process inProcess) {
+    public MetadataImpl(MetadataInterface m, int inID, PrefsInterface inPrefs, Process inProcess) {
         this.md = m;
         this.identifier = inID;
         this.myPrefs = inPrefs;

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadataImpl.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadataImpl.java
@@ -71,10 +71,6 @@ public class MetadataImpl implements Metadata {
         this.md.setType(mdt);
     }
 
-    /*
-     * Getter und Setter
-     */
-
     @Override
     public int getIdentifier() {
         return this.identifier;
@@ -94,10 +90,6 @@ public class MetadataImpl implements Metadata {
     public void setMd(MetadataInterface md) {
         this.md = md;
     }
-
-    /**
-     * new functions for use of display configuration whithin xml files.
-     */
 
     @Override
     public String getOutputType() {

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadataImpl.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadataImpl.java
@@ -92,11 +92,6 @@ public class MetadataImpl implements Metadata {
     }
 
     @Override
-    public String getOutputType() {
-        return this.myValues.get(Modes.getBindState().getTitle()).getDisplayType().getTitle();
-    }
-
-    @Override
     public List<SelectItem> getItems() {
         this.items = new ArrayList<>();
         this.selectedItems = new ArrayList<>();

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadaten.java
@@ -119,9 +119,9 @@ public class Metadaten {
     private MetadataHelper metaHelper;
     private FileformatInterface gdzfile;
     private DocStructInterface docStruct;
-    private List<MetadatumImpl> myMetadaten = new LinkedList<>();
+    private List<MetadataImpl> myMetadaten = new LinkedList<>();
     private List<MetaPerson> metaPersonList = new LinkedList<>();
-    private MetadatumImpl curMetadatum;
+    private MetadataImpl currentMetadata;
     private MetaPerson curPerson;
     private DigitalDocumentInterface digitalDocument;
     private Process process;
@@ -140,9 +140,9 @@ public class Metadaten {
     private String[] allPagesSelection;
     private String[] structSeitenAuswahl;
     private String[] allPages;
-    private MetadatumImpl[] allPagesNew;
-    private ArrayList<MetadatumImpl> tempMetadatumList = new ArrayList<>();
-    private MetadatumImpl selectedMetadatum;
+    private MetadataImpl[] allPagesNew;
+    private List<MetadataImpl> tempMetadataList = new ArrayList<>();
+    private MetadataImpl selectedMetadata;
     private String currentRepresentativePage = "";
     private boolean showPagination = false;
 
@@ -161,7 +161,7 @@ public class Metadaten {
     // Seitennummer
     private boolean fictitious = false;
     private SelectItem[] structSeiten;
-    private MetadatumImpl[] structSeitenNeu;
+    private MetadataImpl[] structurePageNew;
     private DocStructInterface logicalTopstruct;
     private TreeNodeStruct3 treeNodeStruct;
     private URI image;
@@ -171,7 +171,7 @@ public class Metadaten {
     private int imageRotation = 0;
     private boolean displayImage = true;
     private boolean imageToStructuralElement = false;
-    private final MetadataLock sperrung = new MetadataLock();
+    private final MetadataLock metadataLock = new MetadataLock();
     private String ajaxPageStart = "";
     private String ajaxPageEnd = "";
     private String pagesStart = "";
@@ -208,10 +208,8 @@ public class Metadaten {
             "galleryWrapperPanel");
     private String referringView = "desktop";
 
-
-
     /**
-     * Konstruktor.
+     * Public constructor.
      */
     public Metadaten() {
         this.treeProperties = new HashMap<>();
@@ -227,7 +225,7 @@ public class Metadaten {
      */
     public void add() {
         Modes.setBindState(BindState.CREATE);
-        getMetadatum().setValue("");
+        getMetadata().setValue("");
     }
 
     /**
@@ -244,7 +242,7 @@ public class Metadaten {
      */
     public void cancel() {
         Modes.setBindState(BindState.EDIT);
-        getMetadatum().setValue("");
+        getMetadata().setValue("");
     }
 
     /**
@@ -268,9 +266,9 @@ public class Metadaten {
     public void copy() {
         MetadataInterface md;
         try {
-            md = UghImplementation.INSTANCE.createMetadata(this.curMetadatum.getMd().getMetadataType());
+            md = UghImplementation.INSTANCE.createMetadata(this.currentMetadata.getMd().getMetadataType());
 
-            md.setStringValue(this.curMetadatum.getMd().getValue());
+            md.setStringValue(this.currentMetadata.getMd().getValue());
             this.docStruct.addMetadata(md);
         } catch (MetadataTypeNotAllowedException e) {
             Helper.setErrorMessage(e.getMessage());
@@ -308,7 +306,7 @@ public class Metadaten {
         try {
             MetadataInterface md = UghImplementation.INSTANCE
                     .createMetadata(this.myPrefs.getMetadataTypeByName(this.tempTyp));
-            md.setStringValue(this.selectedMetadatum.getValue());
+            md.setStringValue(this.selectedMetadata.getValue());
 
             this.docStruct.addMetadata(md);
         } catch (MetadataTypeNotAllowedException e) {
@@ -320,7 +318,7 @@ public class Metadaten {
             try {
                 MetadataInterface secondMetadata = UghImplementation.INSTANCE
                         .createMetadata(this.myPrefs.getMetadataTypeByName("TitleDocMainShort"));
-                secondMetadata.setStringValue(this.selectedMetadatum.getValue());
+                secondMetadata.setStringValue(this.selectedMetadata.getValue());
                 this.docStruct.addMetadata(secondMetadata);
             } catch (MetadataTypeNotAllowedException e) {
                 logger.error("Error while adding title (MetadataTypeNotAllowedException): " + e.getMessage());
@@ -328,7 +326,7 @@ public class Metadaten {
         }
 
         Modes.setBindState(BindState.EDIT);
-        this.selectedMetadatum.setValue("");
+        this.selectedMetadata.setValue("");
         saveMetadataAsBean(this.docStruct);
     }
 
@@ -394,7 +392,7 @@ public class Metadaten {
      *
      */
     public void delete() {
-        this.docStruct.removeMetadata(this.curMetadatum.getMd());
+        this.docStruct.removeMetadata(this.currentMetadata.getMd());
         saveMetadataAsBean(this.docStruct);
     }
 
@@ -422,11 +420,11 @@ public class Metadaten {
      * @return The metadata types.
      */
     public List<SelectItem> getAddableMetadataTypes() {
-        return getAddableMetadataTypes(docStruct, tempMetadatumList);
+        return getAddableMetadataTypes(docStruct, this.tempMetadataList);
     }
 
     private ArrayList<SelectItem> getAddableMetadataTypes(DocStructInterface myDocStruct,
-                                                          ArrayList<MetadatumImpl> tempMetadatumList) {
+                                                          List<MetadataImpl> tempMetadataList) {
         ArrayList<SelectItem> selectItems = new ArrayList<>();
 
         // determine all addable metadata types
@@ -454,10 +452,10 @@ public class Metadaten {
             selectItems.add(new SelectItem(mdt.getName(), this.metaHelper.getMetadatatypeLanguage(mdt)));
             try {
                 MetadataInterface md = UghImplementation.INSTANCE.createMetadata(mdt);
-                MetadatumImpl mdum = new MetadatumImpl(md, counter, this.myPrefs, this.process);
+                MetadataImpl mdum = new MetadataImpl(md, counter, this.myPrefs, this.process);
                 counter++;
-                if (tempMetadatumList != null) {
-                    tempMetadatumList.add(mdum);
+                if (tempMetadataList != null) {
+                    tempMetadataList.add(mdum);
                 }
 
             } catch (MetadataTypeNotAllowedException e) {
@@ -476,7 +474,7 @@ public class Metadaten {
         DocStructTypeInterface dst = this.myPrefs.getDocStrctTypeByName(this.tempTyp);
         DocStructInterface ds = this.digitalDocument.createDocStruct(dst);
 
-        return getAddableMetadataTypes(ds, this.tempMetadatumList);
+        return getAddableMetadataTypes(ds, this.tempMetadataList);
     }
 
     /**
@@ -525,7 +523,7 @@ public class Metadaten {
         }
 
         expandTree();
-        this.sperrung.setLocked(this.process.getId(), this.userId);
+        this.metadataLock.setLocked(this.process.getId(), this.userId);
     }
 
     /**
@@ -674,7 +672,7 @@ public class Metadaten {
      */
     private void saveMetadataAsBean(DocStructInterface inStrukturelement) {
         this.docStruct = inStrukturelement;
-        LinkedList<MetadatumImpl> lsMeta = new LinkedList<>();
+        LinkedList<MetadataImpl> lsMeta = new LinkedList<>();
         LinkedList<MetaPerson> lsPers = new LinkedList<>();
 
         /*
@@ -685,7 +683,7 @@ public class Metadaten {
             this.process);
         if (tempMetadata != null) {
             for (MetadataInterface metadata : tempMetadata) {
-                MetadatumImpl meta = new MetadatumImpl(metadata, 0, this.myPrefs, this.process);
+                MetadataImpl meta = new MetadataImpl(metadata, 0, this.myPrefs, this.process);
                 meta.getSelectedItem();
                 lsMeta.add(meta);
             }
@@ -1090,13 +1088,13 @@ public class Metadaten {
         }
         int zaehler = meineListe.size();
         this.allPages = new String[zaehler];
-        this.allPagesNew = new MetadatumImpl[zaehler];
+        this.allPagesNew = new MetadataImpl[zaehler];
         zaehler = 0;
         MetadataTypeInterface mdt = this.myPrefs.getMetadataTypeByName("logicalPageNumber");
         for (DocStructInterface mySeitenDocStruct : meineListe) {
             List<? extends MetadataInterface> mySeitenDocStructMetadaten = mySeitenDocStruct.getAllMetadataByType(mdt);
             for (MetadataInterface page : mySeitenDocStructMetadaten) {
-                this.allPagesNew[zaehler] = new MetadatumImpl(page, zaehler, this.myPrefs, this.process);
+                this.allPagesNew[zaehler] = new MetadataImpl(page, zaehler, this.myPrefs, this.process);
                 this.allPages[zaehler] = determineMetadata(page.getDocStruct(), "physPageNumber").trim() + ": "
                         + page.getValue();
             }
@@ -1135,7 +1133,7 @@ public class Metadaten {
 
             /* die Größe der Arrays festlegen */
             this.structSeiten = new SelectItem[references.size()];
-            this.structSeitenNeu = new MetadatumImpl[references.size()];
+            this.structurePageNew = new MetadataImpl[references.size()];
 
             /* alle Referenzen durchlaufen und deren Metadaten ermitteln */
             for (ReferenceInterface ref : references) {
@@ -1168,7 +1166,7 @@ public class Metadaten {
             return;
         }
         for (MetadataInterface meineSeite : listMetadaten) {
-            this.structSeitenNeu[inZaehler] = new MetadatumImpl(meineSeite, inZaehler, this.myPrefs, this.process);
+            this.structurePageNew[inZaehler] = new MetadataImpl(meineSeite, inZaehler, this.myPrefs, this.process);
             this.structSeiten[inZaehler] = new SelectItem(String.valueOf(inZaehler),
                     determineMetadata(meineSeite.getDocStruct(), "physPageNumber") + ": " + meineSeite.getValue());
         }
@@ -1409,8 +1407,8 @@ public class Metadaten {
          * gilt, Sperrung aktualisieren
          */
         if (MetadataLock.isLocked(this.process.getId())
-                && this.sperrung.getLockUser(this.process.getId()).equals(this.userId)) {
-            this.sperrung.setLocked(this.process.getId(), this.userId);
+                && this.metadataLock.getLockUser(this.process.getId()).equals(this.userId)) {
+            this.metadataLock.setLocked(this.process.getId(), this.userId);
             return true;
         } else {
             return false;
@@ -1596,7 +1594,7 @@ public class Metadaten {
     public String removePages() {
         for (String structurePage : this.structSeitenAuswahl) {
             int currentId = Integer.parseInt(structurePage);
-            this.docStruct.removeReferenceTo(this.structSeitenNeu[currentId].getMd().getDocStruct());
+            this.docStruct.removeReferenceTo(this.structurePageNew[currentId].getMd().getDocStruct());
         }
         determinePagesStructure(this.docStruct);
         this.structSeitenAuswahl = null;
@@ -1612,15 +1610,15 @@ public class Metadaten {
      * @return String
      */
     public String getTempTyp() {
-        if (this.selectedMetadatum == null) {
+        if (this.selectedMetadata == null) {
             getAddableMetadataTypes();
-            if (!this.tempMetadatumList.isEmpty()) {
-                this.selectedMetadatum = this.tempMetadatumList.get(0);
+            if (!this.tempMetadataList.isEmpty()) {
+                this.selectedMetadata = this.tempMetadataList.get(0);
             } else {
                 return "";
             }
         }
-        return this.selectedMetadatum.getMd().getMetadataType().getName();
+        return this.selectedMetadata.getMd().getMetadataType().getName();
     }
 
     /**
@@ -1636,21 +1634,21 @@ public class Metadaten {
     /**
      * Get metadata.
      *
-     * @return MetadatumImpl object
+     * @return MetadataImpl object
      */
-    public MetadatumImpl getMetadatum() {
+    public MetadataImpl getMetadata() {
 
-        if (this.selectedMetadatum == null) {
+        if (this.selectedMetadata == null) {
             getAddableMetadataTypes();
-            if (!this.tempMetadatumList.isEmpty()) {
-                this.selectedMetadatum = this.tempMetadatumList.get(0);
+            if (!this.tempMetadataList.isEmpty()) {
+                this.selectedMetadata = this.tempMetadataList.get(0);
             }
         }
-        return this.selectedMetadatum;
+        return this.selectedMetadata;
     }
 
-    public void setMetadatum(MetadatumImpl meta) {
-        this.selectedMetadatum = meta;
+    public void setMetadatum(MetadataImpl meta) {
+        this.selectedMetadata = meta;
     }
 
     public String getTempPersonNachname() {
@@ -1874,11 +1872,11 @@ public class Metadaten {
         }
     }
 
-    public List<MetadatumImpl> getMyMetadaten() {
+    public List<MetadataImpl> getMyMetadaten() {
         return this.myMetadaten;
     }
 
-    public void setMyMetadaten(List<MetadatumImpl> myMetadaten) {
+    public void setMyMetadaten(List<MetadataImpl> myMetadaten) {
         this.myMetadaten = myMetadaten;
     }
 
@@ -1890,12 +1888,12 @@ public class Metadaten {
         this.metaPersonList = metaPersonList;
     }
 
-    public MetadatumImpl getCurMetadatum() {
-        return this.curMetadatum;
+    public MetadataImpl getCurrentMetadata() {
+        return this.currentMetadata;
     }
 
-    public void setCurMetadatum(MetadatumImpl curMetadatum) {
-        this.curMetadatum = curMetadatum;
+    public void setCurrentMetadata(MetadataImpl currentMetadata) {
+        this.currentMetadata = currentMetadata;
     }
 
     public MetaPerson getCurPerson() {

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadatum.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/Metadatum.java
@@ -20,10 +20,6 @@ import org.kitodo.api.ugh.MetadataInterface;
 
 public interface Metadatum {
 
-    List<Item> getWert();
-
-    void setWert(String inWert);
-
     String getTyp();
 
     void setTyp(String inTyp);

--- a/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadatumImpl.java
+++ b/Kitodo/src/main/java/de/sub/goobi/metadaten/MetadatumImpl.java
@@ -57,22 +57,6 @@ public class MetadatumImpl implements Metadatum {
     }
 
     @Override
-    public List<Item> getWert() {
-        String value = this.md.getValue();
-        if (value != null) {
-            for (Item i : this.myValues.get(Modes.getBindState().getTitle()).getItemList()) {
-                i.setIsSelected(i.getValue().equals(value));
-            }
-        }
-        return this.myValues.get(Modes.getBindState().getTitle()).getItemList();
-    }
-
-    @Override
-    public void setWert(String inWert) {
-        this.md.setStringValue(inWert.trim());
-    }
-
-    @Override
     public String getTyp() {
         String label = this.md.getMetadataType().getLanguage(serviceManager.getUserService().getAuthenticatedUser().getMetadataLanguage());
         if (label == null) {
@@ -147,7 +131,7 @@ public class MetadatumImpl implements Metadatum {
                 }
             }
         }
-        setWert(val.toString());
+        setValue(val.toString());
     }
 
     @Override
@@ -175,7 +159,7 @@ public class MetadatumImpl implements Metadatum {
                 }
             }
             if (values != null) {
-                setWert(values);
+                setValue(values);
             }
         }
         return this.selectedItems;
@@ -201,7 +185,7 @@ public class MetadatumImpl implements Metadatum {
             }
         }
 
-        setWert(val.toString());
+        setValue(val.toString());
     }
 
     @Override
@@ -216,8 +200,7 @@ public class MetadatumImpl implements Metadatum {
         } else {
             for (Item i : this.myValues.get(Modes.getBindState().getTitle()).getItemList()) {
                 if (i.getIsSelected()) {
-                    value = i.getValue();
-                    setWert(value);
+                    setValue(i.getValue());
                     return i.getLabel();
                 }
             }
@@ -229,14 +212,14 @@ public class MetadatumImpl implements Metadatum {
     public void setSelectedItem(String selectedItem) {
         for (Item i : this.myValues.get(Modes.getBindState().getTitle()).getItemList()) {
             if (i.getLabel().equals(selectedItem)) {
-                setWert(i.getValue());
+                setValue(i.getValue());
             }
         }
     }
 
     @Override
     public void setValue(String value) {
-        setWert(value);
+        this.md.setStringValue(value.trim());
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/metadata/pagination/Paginator.java
+++ b/Kitodo/src/main/java/org/kitodo/metadata/pagination/Paginator.java
@@ -233,7 +233,7 @@ public class Paginator {
             if (!seqit.hasNext()) {
                 seqit = sequence.iterator();
             }
-            pagesToPaginate[pageNum].setWert(String.valueOf(seqit.next()));
+            pagesToPaginate[pageNum].setValue(String.valueOf(seqit.next()));
         }
     }
 
@@ -243,7 +243,7 @@ public class Paginator {
             if (!seqit.hasNext()) {
                 seqit = sequence.iterator();
             }
-            pagesToPaginate[num].setWert(String.valueOf(seqit.next()));
+            pagesToPaginate[num].setValue(String.valueOf(seqit.next()));
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/metadata/pagination/Paginator.java
+++ b/Kitodo/src/main/java/org/kitodo/metadata/pagination/Paginator.java
@@ -11,7 +11,7 @@
 
 package org.kitodo.metadata.pagination;
 
-import de.sub.goobi.metadaten.Metadatum;
+import de.sub.goobi.metadaten.Metadata;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -33,7 +33,7 @@ public class Paginator {
 
     private int[] selectedPages;
 
-    private Metadatum[] pagesToPaginate;
+    private Metadata[] pagesToPaginate;
 
     private Mode paginationMode = Mode.PAGES;
 
@@ -268,7 +268,7 @@ public class Paginator {
      *
      * @return Array of <code>Metadatum</code> instances.
      */
-    public Metadatum[] getPagesToPaginate() {
+    public Metadata[] getPagesToPaginate() {
         return pagesToPaginate;
     }
 
@@ -289,7 +289,7 @@ public class Paginator {
      * @param newPaginated
      *            Array of page objects.
      */
-    public void setPagesToPaginate(Metadatum[] newPaginated) {
+    public void setPagesToPaginate(Metadata[] newPaginated) {
         this.pagesToPaginate = newPaginated;
     }
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/metadata.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/metadata.xhtml
@@ -97,7 +97,7 @@
                                      tabindex="-1"
                                      title="#{msgs.metadataCopy}"
                                      action="#{Metadaten.copy}">
-                        <f:setPropertyActionListener value="#{item}" target="#{Metadaten.curMetadatum}"/>
+                        <f:setPropertyActionListener value="#{item}" target="#{Metadaten.currentMetadata}"/>
                     </p:commandButton>
 
                     <p:commandButton update="metadata:metadataTable"
@@ -106,7 +106,7 @@
                                      tabindex="-1"
                                      title="#{msgs.metadataDelete}"
                                      action="#{Metadaten.delete}">
-                        <f:setPropertyActionListener value="#{item}" target="#{Metadaten.curMetadatum}"/>
+                        <f:setPropertyActionListener value="#{item}" target="#{Metadaten.currentMetadata}"/>
                     </p:commandButton>
                 </p:column>
             </p:dataTable>
@@ -122,7 +122,7 @@
                     </p:selectOneMenu>
                 </p:row>
                 <p:row>
-                    <p:inputTextarea value="#{Metadaten.metadatum.value}" rows="2" style="width:83%;"/>
+                    <p:inputTextarea value="#{Metadaten.metadata.value}" rows="2" style="width:83%;"/>
                     <p:commandButton update="metadata:metadataTable" icon="fa fa-plus"
                                      style="vertical-align: top; margin-left: 10px"
                                      title="#{msgs.neueMetadatenHinzufuegen}" action="#{Metadaten.save}">

--- a/Kitodo/src/test/java/org/kitodo/metadata/pagination/MockMetadatum.java
+++ b/Kitodo/src/test/java/org/kitodo/metadata/pagination/MockMetadatum.java
@@ -11,7 +11,7 @@
 
 package org.kitodo.metadata.pagination;
 
-import de.sub.goobi.metadaten.Metadatum;
+import de.sub.goobi.metadaten.Metadata;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ import javax.faces.model.SelectItem;
 
 import org.kitodo.api.ugh.MetadataInterface;
 
-class MockMetadata implements Metadatum {
+class MockMetadata implements Metadata {
 
     private String value;
 

--- a/Kitodo/src/test/java/org/kitodo/metadata/pagination/MockMetadatum.java
+++ b/Kitodo/src/test/java/org/kitodo/metadata/pagination/MockMetadatum.java
@@ -13,12 +13,10 @@ package org.kitodo.metadata.pagination;
 
 import de.sub.goobi.metadaten.Metadatum;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.faces.model.SelectItem;
 
-import org.goobi.api.display.Item;
 import org.kitodo.api.ugh.MetadataInterface;
 
 class MockMetadata implements Metadatum {
@@ -64,10 +62,6 @@ class MockMetadata implements Metadatum {
         return value;
     }
 
-    public ArrayList<Item> getWert() {
-        return null;
-    }
-
     public void setIdentifier(int identifier) {
     }
 
@@ -87,10 +81,6 @@ class MockMetadata implements Metadatum {
     }
 
     public void setValue(String value) {
+        this.value = value;
     }
-
-    public void setWert(String inWert) {
-        value = inWert;
-    }
-
 }

--- a/Kitodo/src/test/java/org/kitodo/metadata/pagination/MockMetadatum.java
+++ b/Kitodo/src/test/java/org/kitodo/metadata/pagination/MockMetadatum.java
@@ -42,10 +42,6 @@ class MockMetadata implements Metadata {
         return null;
     }
 
-    public String getOutputType() {
-        return null;
-    }
-
     public String getSelectedItem() {
         return null;
     }

--- a/Kitodo/src/test/java/org/kitodo/metadata/pagination/PaginatorTest.java
+++ b/Kitodo/src/test/java/org/kitodo/metadata/pagination/PaginatorTest.java
@@ -11,7 +11,7 @@
 
 package org.kitodo.metadata.pagination;
 
-import de.sub.goobi.metadaten.Metadatum;
+import de.sub.goobi.metadaten.Metadata;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -45,7 +45,7 @@ public class PaginatorTest {
         paginator.setPageSelection(new int[] {0, 1, 2 });
         paginator.setPaginationType(Type.UNCOUNTED);
         paginator.setPaginationScope(Scope.SELECTED);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertAllPagenumbersSetToValue(paginator, "uncounted");
     }
@@ -57,7 +57,7 @@ public class PaginatorTest {
         paginator.setPaginationType(Type.UNCOUNTED);
         paginator.setPaginationScope(Scope.SELECTED);
         paginator.setPaginationStartValue("Foo");
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertAllPagenumbersSetToValue(paginator, "uncounted");
     }
@@ -68,7 +68,7 @@ public class PaginatorTest {
         paginator.setPageSelection(new int[] {0 });
         paginator.setPaginationType(Type.UNCOUNTED);
         paginator.setPaginationScope(Scope.FROMFIRST);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertAllPagenumbersSetToValue(paginator, "uncounted");
     }
@@ -81,7 +81,7 @@ public class PaginatorTest {
         paginator.setPaginationStartValue("50");
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.PAGES);
-        paginator .setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator .setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"50", "51", "52" });
     }
@@ -94,7 +94,7 @@ public class PaginatorTest {
         paginator.setPaginationStartValue("II");
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.PAGES);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"II", "III", "IV" });
     }
@@ -107,7 +107,7 @@ public class PaginatorTest {
         paginator.setPaginationStartValue("1");
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.COLUMNS);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"1", "3", "5" });
     }
@@ -120,7 +120,7 @@ public class PaginatorTest {
         paginator.setPaginationStartValue("1");
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.FOLIATION);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(),
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(),
                         new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"1", "1", "2", "2" });
@@ -134,7 +134,7 @@ public class PaginatorTest {
         paginator.setPaginationStartValue("1");
         paginator.setPaginationScope(Scope.SELECTED);
         paginator.setPaginationMode(Mode.RECTOVERSO);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata(),
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata(),
                         new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"1r", "1v", "2r", "2v" });
@@ -148,7 +148,7 @@ public class PaginatorTest {
         paginator.setPaginationStartValue("1");
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.RECTOVERSO_FOLIATION);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata() });
         paginator.setPaginationSeparator(" ");
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"1v 2r" });
@@ -161,7 +161,7 @@ public class PaginatorTest {
         paginator.setPaginationType(Type.UNCOUNTED);
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.RECTOVERSO);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(),
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(),
                         new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertAllPagenumbersSetToValue(paginator, "uncounted");
@@ -175,7 +175,7 @@ public class PaginatorTest {
         paginator.setPaginationScope(Scope.SELECTED);
         paginator.setPaginationMode(Mode.RECTOVERSO);
         paginator.setPaginationStartValue("1");
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata("uncounted"), new MockMetadata(),
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata("uncounted"), new MockMetadata(),
                 new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"uncounted", "1r", "1v", "2r" });
@@ -190,7 +190,7 @@ public class PaginatorTest {
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.PAGES);
         paginator.setFictitious(true);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"[50]", "[51]", "[52]" });
     }
@@ -204,7 +204,7 @@ public class PaginatorTest {
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.RECTOVERSO);
         paginator.setFictitious(true);
-        paginator.setPagesToPaginate(new Metadatum[] {
+        paginator.setPagesToPaginate(new Metadata[] {
                         new MockMetadata(), new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"[4711]r", "[4711]v", "[4712]r", "[4712]v" });
@@ -219,7 +219,7 @@ public class PaginatorTest {
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.PAGES);
         paginator.setFictitious(true);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"[III]", "[IV]", "[V]" });
     }
@@ -233,7 +233,7 @@ public class PaginatorTest {
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.FOLIATION);
         paginator.setFictitious(true);
-        paginator.setPagesToPaginate(new Metadatum[] {
+        paginator.setPagesToPaginate(new Metadata[] {
                         new MockMetadata(), new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"[1]", "[1]", "[2]", "[2]" });
@@ -247,7 +247,7 @@ public class PaginatorTest {
         paginator.setPaginationStartValue("1");
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.RECTOVERSO_FOLIATION);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.setPaginationSeparator(" ");
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"1v 2r", "2v 3r", "3v 4r" });
@@ -262,7 +262,7 @@ public class PaginatorTest {
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.RECTOVERSO_FOLIATION);
         paginator.setFictitious(true);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.setPaginationSeparator(" ");
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"[1]v [2]r", "[2]v [3]r", "[3]v [4]r" });
@@ -277,7 +277,7 @@ public class PaginatorTest {
         paginator.setPaginationScope(Scope.FROMFIRST);
         paginator.setPaginationMode(Mode.RECTOVERSO_FOLIATION);
         paginator.setFictitious(true);
-        paginator.setPagesToPaginate(new Metadatum[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
+        paginator.setPagesToPaginate(new Metadata[] {new MockMetadata(), new MockMetadata(), new MockMetadata() });
         paginator.setPaginationSeparator(" ");
         paginator.run();
         assertPagenumberSequence(paginator, new String[] {"[XX]v [XXI]r", "[XXI]v [XXII]r", "[XXII]v [XXIII]r" });
@@ -285,7 +285,7 @@ public class PaginatorTest {
 
     private void assertPagenumberSequence(Paginator paginator, String[] sequence) {
 
-        Metadatum[] newPaginated = paginator.getPagesToPaginate();
+        Metadata[] newPaginated = paginator.getPagesToPaginate();
 
         assertNotNull("Expected paginator result set.", newPaginated);
 
@@ -300,11 +300,11 @@ public class PaginatorTest {
     private void assertAllPagenumbersSetToValue(Paginator paginator, String expectedValue)
             throws ArrayComparisonFailure {
 
-        Metadatum[] newPaginated = paginator.getPagesToPaginate();
+        Metadata[] newPaginated = paginator.getPagesToPaginate();
 
         assertNotNull("Expected paginator result set.", newPaginated);
 
-        for (Metadatum m : newPaginated) {
+        for (Metadata m : newPaginated) {
             assertEquals("Actual paginator value did not match expected.", expectedValue, m.getValue());
         }
 


### PR DESCRIPTION
- remove not used methods: getWert and getObjectType
- remove duplicated method setWert (setValue calls this method and does nothing more)
- rename classes Metadatum to Metadata
- rename some of the metadata variables
- add JavaDocs to Metadata interface