### PR TITLE
Follow the renaming requirements of Hamcrest

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -182,8 +182,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest-library.version}</version>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Kitodo-ImageManagement/pom.xml
+++ b/Kitodo-ImageManagement/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest-library.version}</version>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Kitodo-LongTermPreservationValidation/pom.xml
+++ b/Kitodo-LongTermPreservationValidation/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest-library.version}</version>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -270,8 +270,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest-library.version}</version>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-lang3.version>3.7</commons-lang3.version>
-        <hamcrest-library.version>2.1-rc3</hamcrest-library.version>
+        <hamcrest.version>2.1-rc3</hamcrest.version>
         <hibernate.version>5.2.17.Final</hibernate.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.1.6</jaxen.version>


### PR DESCRIPTION
They have simply uploaded a new JAR file over the existing version number, which apparently does not contain the classes anymore.