### PR TITLE
Increase hibernate and selenium version

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.1.Final</version>
+            <version>5.4.2.Final</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml</groupId>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -32,7 +32,7 @@
         <parent.basedir>${basedir}/../</parent.basedir>
         <maxAllowedViolations>88</maxAllowedViolations>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
-        <selenium.version>3.9.1</selenium.version>
+        <selenium.version>3.12.0</selenium.version>
         <cargo.plugin.version>1.6.8</cargo.plugin.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <commons-io.version>2.6</commons-io.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <hamcrest.version>2.1-rc3</hamcrest.version>
-        <hibernate.version>5.2.17.Final</hibernate.version>
+        <hibernate.version>5.3.7.Final</hibernate.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.1.6</jaxen.version>
         <jersey.version>1.19.3</jersey.version>


### PR DESCRIPTION
Increase of the hibernate demanded also increase of selenium version ,as they both use net.bytebuddy:byte-buddy. Hibernate needs at least 1.8.x, but previous selenium version was bringing in 1.7.x