### PR TITLE
Remove redundant method convertDtoToBean

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/ProcessForm.java
@@ -621,16 +621,16 @@ public class ProcessForm extends TemplateBaseForm {
 
     private void download(WebDav webDav, ProcessDTO processDTO) {
         try {
-            Process process = ServiceManager.getProcessService().convertDtoToBean(processDTO);
+            Process processForDownload = ServiceManager.getProcessService().getById(processDTO.getId());
             if (!ServiceManager.getProcessService().isImageFolderInUse(processDTO)) {
-                webDav.downloadToHome(process, false);
+                webDav.downloadToHome(processForDownload, false);
             } else {
                 Helper.setMessage(
                     Helper.getTranslation("directory ") + " " + processDTO.getTitle() + " "
                             + Helper.getTranslation("isInUse"),
                     ServiceManager.getUserService()
-                            .getFullName(ServiceManager.getProcessService().getImageFolderInUseUser(process)));
-                webDav.downloadToHome(process, true);
+                            .getFullName(ServiceManager.getProcessService().getImageFolderInUseUser(processForDownload)));
+                webDav.downloadToHome(processForDownload, true);
             }
         } catch (DAOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);

--- a/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/services/data/ProcessService.java
@@ -648,17 +648,6 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
     }
 
     /**
-     * Convert DTO to bean object.
-     *
-     * @param processDTO
-     *            DTO object
-     * @return bean object
-     */
-    public Process convertDtoToBean(ProcessDTO processDTO) throws DAOException {
-        return ServiceManager.getProcessService().getById(processDTO.getId());
-    }
-
-    /**
      * Convert list of DTOs to list of beans.
      *
      * @param dtos
@@ -668,7 +657,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
     public List<Process> convertDtosToBeans(List<ProcessDTO> dtos) throws DAOException {
         List<Process> processes = new ArrayList<>();
         for (ProcessDTO processDTO : dtos) {
-            processes.add(convertDtoToBean(processDTO));
+            processes.add(getById(processDTO.getId()));
         }
         return processes;
     }


### PR DESCRIPTION
It basically calls getById, no need for it.