### PR TITLE
Update myfaces to the newest version and remove comment about it being outdated

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/forms/LanguageForm.java
+++ b/Kitodo/src/main/java/org/kitodo/forms/LanguageForm.java
@@ -128,9 +128,6 @@ public class LanguageForm implements Serializable {
     public List<Map<String, Object>> getSupportedLocales() {
         List<Map<String, Object>> result = new ArrayList<>();
         Locale currentDisplayLanguage = FacesContext.getCurrentInstance().getViewRoot().getLocale();
-        // It seems we have an old Faces API, Faces 2.1’s getSupportedLocales()
-        // returns Iterator<Locale>
-        // TODO: Update JSF API
         Iterator<Locale> localesIterator = FacesContext.getCurrentInstance().getApplication().getSupportedLocales();
         while (localesIterator.hasNext()) {
             Locale supportedLocale = localesIterator.next();

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <jersey.version>1.19.3</jersey.version>
         <jhove.version>1.20.1</jhove.version>
         <joda-time.version>2.10</joda-time.version>
-        <myfaces.version>2.2.12</myfaces.version>
+        <myfaces.version>2.3.2</myfaces.version>
         <mysql.version>5.1.38</mysql.version>
         <poi.version>3.6</poi.version>
         <primefaces.version>6.2</primefaces.version>


### PR DESCRIPTION
Version 2.3.2 was released in Sep, 2018 - it is the last released version.