### PR TITLE
Use enum for HTTP methods

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
@@ -14,6 +14,8 @@ package org.kitodo.data.elasticsearch;
 import java.io.IOException;
 import java.util.Collections;
 
+import javax.ws.rs.HttpMethod;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.StatusLine;
@@ -95,7 +97,7 @@ public abstract class KitodoRestClient implements RestClientInterface {
      * @return information about the server
      */
     public String getServerInformation() throws IOException {
-        Response response = restClient.performRequest("GET", "/", Collections.singletonMap("pretty", "true"));
+        Response response = restClient.performRequest(HttpMethod.GET, "/", Collections.singletonMap("pretty", "true"));
         return EntityUtils.toString(response.getEntity());
     }
 
@@ -105,7 +107,7 @@ public abstract class KitodoRestClient implements RestClientInterface {
      * @return mapping
      */
     public String getMapping() throws IOException {
-        Response response = restClient.performRequest("GET", "/" + index + "/_mapping",
+        Response response = restClient.performRequest(HttpMethod.GET, "/" + index + "/_mapping",
             Collections.singletonMap("pretty", "true"));
         return EntityUtils.toString(response.getEntity());
     }
@@ -130,7 +132,7 @@ public abstract class KitodoRestClient implements RestClientInterface {
             query = "{\"settings\" : {\"index\" : {\"number_of_shards\" : 1,\"number_of_replicas\" : 0}}}";
         }
         HttpEntity entity = new NStringEntity(query, ContentType.APPLICATION_JSON);
-        Response indexResponse = restClient.performRequest("PUT", "/" + index, Collections.emptyMap(), entity);
+        Response indexResponse = restClient.performRequest(HttpMethod.PUT, "/" + index, Collections.emptyMap(), entity);
         int statusCode = processStatusCode(indexResponse.getStatusLine());
         return statusCode == 200 || statusCode == 201;
     }
@@ -141,7 +143,7 @@ public abstract class KitodoRestClient implements RestClientInterface {
      * @return false if doesn't exists, true if exists
      */
     public boolean indexExists() throws IOException, CustomResponseException {
-        Response indexResponse = restClient.performRequest("GET", "/" + index, Collections.emptyMap());
+        Response indexResponse = restClient.performRequest(HttpMethod.GET, "/" + index, Collections.emptyMap());
         int statusCode = processStatusCode(indexResponse.getStatusLine());
         return statusCode == 200 || statusCode == 201;
     }
@@ -150,7 +152,7 @@ public abstract class KitodoRestClient implements RestClientInterface {
      * Delete the whole index. Used for cleaning after tests!
      */
     public void deleteIndex() throws IOException {
-        restClient.performRequest("DELETE", "/" + index);
+        restClient.performRequest(HttpMethod.DELETE, "/" + index);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
+import javax.ws.rs.HttpMethod;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
@@ -75,7 +77,7 @@ public class IndexRestClient extends KitodoRestClient {
      */
     public void addDocument(HttpEntity entity, Integer id, boolean forceRefresh)
             throws IOException, CustomResponseException {
-        Response indexResponse = restClient.performRequest("PUT",
+        Response indexResponse = restClient.performRequest(HttpMethod.PUT,
             "/" + this.getIndex() + "/" + this.getType() + "/" + id, getParameters(forceRefresh), entity);
         processStatusCode(indexResponse.getStatusLine());
     }
@@ -92,7 +94,7 @@ public class IndexRestClient extends KitodoRestClient {
         final ArrayList<String> output = new ArrayList<>();
 
         for (Map.Entry<Integer, HttpEntity> entry : documentsToIndex.entrySet()) {
-            restClient.performRequestAsync("PUT", "/" + this.getIndex() + "/" + this.getType() + "/" + entry.getKey(),
+            restClient.performRequestAsync(HttpMethod.PUT, "/" + this.getIndex() + "/" + this.getType() + "/" + entry.getKey(),
                 Collections.emptyMap(), entry.getValue(), new ResponseListener() {
                     @Override
                     public void onSuccess(Response response) {
@@ -122,7 +124,7 @@ public class IndexRestClient extends KitodoRestClient {
      */
     void deleteDocument(Integer id, boolean forceRefresh) throws IOException, CustomResponseException {
         try {
-            restClient.performRequest("DELETE", "/" + this.getIndex() + "/" + this.getType() + "/" + id,
+            restClient.performRequest(HttpMethod.DELETE, "/" + this.getIndex() + "/" + this.getType() + "/" + id,
                 getParameters(forceRefresh));
         } catch (ResponseException e) {
             if (e.getResponse().getStatusLine().getStatusCode() == 404) {
@@ -146,7 +148,7 @@ public class IndexRestClient extends KitodoRestClient {
                 + "      \"fielddata\": true,\n" + "      \"fields\": {\n" + "        \"raw\": {\n"
                 + "          \"type\":  \"text\",\n" + "          \"index\": false}\n" + "    }\n" + "  }}}";
         HttpEntity entity = new NStringEntity(query, ContentType.APPLICATION_JSON);
-        Response indexResponse = restClient.performRequest("PUT",
+        Response indexResponse = restClient.performRequest(HttpMethod.PUT,
             "/" + this.getIndex() + "/_mapping/" + type + "?update_all_types", Collections.emptyMap(), entity);
         processStatusCode(indexResponse.getStatusLine());
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/Indexer.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/Indexer.java
@@ -11,11 +11,11 @@
 
 package org.kitodo.data.elasticsearch.index;
 
-import com.sun.research.ws.wadl.HTTPMethods;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
 
 import org.apache.http.HttpEntity;
 import org.kitodo.data.database.beans.BaseIndexedBean;
@@ -28,7 +28,7 @@ import org.kitodo.data.elasticsearch.index.type.BaseType;
  */
 public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Index {
 
-    private HTTPMethods method;
+    private String method;
     private static final String INCORRECT_HTTP = "Incorrect HTTP method!";
 
     /**
@@ -52,7 +52,7 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
     }
 
     /**
-     * Perform request depending on given parameters of HTTPMethods.
+     * Perform request depending on given parameters of HTTP Method.
      *
      * @param baseIndexedBean
      *            bean object which will be added or deleted from index
@@ -67,10 +67,10 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
             throws IOException, CustomResponseException {
         IndexRestClient restClient = initiateRestClient();
 
-        if (method == HTTPMethods.PUT) {
+        if (method.equals(HttpMethod.PUT)) {
             HttpEntity document = baseType.createDocument(baseIndexedBean);
             restClient.addDocument(document, baseIndexedBean.getId(), forceRefresh);
-        } else if (method == HTTPMethods.DELETE) {
+        } else if (method.equals(HttpMethod.DELETE)) {
             restClient.deleteDocument(baseIndexedBean.getId(), forceRefresh);
         } else {
             throw new CustomResponseException(INCORRECT_HTTP);
@@ -91,7 +91,7 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
             throws IOException, CustomResponseException {
         IndexRestClient restClient = initiateRestClient();
 
-        if (method == HTTPMethods.DELETE) {
+        if (method.equals(HttpMethod.DELETE)) {
             restClient.deleteDocument(beanId, forceRefresh);
         } else {
             throw new CustomResponseException(INCORRECT_HTTP);
@@ -111,7 +111,7 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
             throws InterruptedException, CustomResponseException {
         IndexRestClient restClient = initiateRestClient();
 
-        if (method == HTTPMethods.PUT) {
+        if (method.equals(HttpMethod.PUT)) {
             Map<Integer, HttpEntity> documents = baseType.createDocuments(baseIndexedBeans);
             restClient.addType(documents);
         } else {
@@ -131,7 +131,7 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
      *
      * @return method for request
      */
-    public HTTPMethods getMethod() {
+    public String getMethod() {
         return method;
     }
 
@@ -142,7 +142,7 @@ public class Indexer<T extends BaseIndexedBean, S extends BaseType> extends Inde
      *            Determines if we want to add (update) or delete document - true
      *            add, false delete
      */
-    public void setMethod(HTTPMethods method) {
+    public void setMethod(String method) {
         this.method = method;
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.ws.rs.HttpMethod;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
@@ -68,7 +70,7 @@ public class SearchRestClient extends KitodoRestClient {
     String countDocuments(String query) throws DataException {
         String wrappedQuery = "{\n \"query\": " + query + "\n}";
         HttpEntity entity = new NStringEntity(wrappedQuery, ContentType.APPLICATION_JSON);
-        return performRequest(entity, "GET", "_count");
+        return performRequest(entity, HttpMethod.GET, "_count");
     }
 
     /**
@@ -84,7 +86,7 @@ public class SearchRestClient extends KitodoRestClient {
     String aggregateDocuments(String query, String aggregation) throws DataException {
         String wrappedQuery = "{\n \"query\": " + query + "\n,\n \"aggs\": " + aggregation + "\n}";
         HttpEntity entity = new NStringEntity(wrappedQuery, ContentType.APPLICATION_JSON);
-        return performRequest(entity, "POST", "_search?size=0");
+        return performRequest(entity, HttpMethod.POST, "_search?size=0");
     }
 
     /**
@@ -97,7 +99,7 @@ public class SearchRestClient extends KitodoRestClient {
     String getDocument(Integer id) throws DataException {
         String output = "";
         try {
-            Response response = restClient.performRequest("GET", "/" + index + "/" + type + "/" + id.toString(),
+            Response response = restClient.performRequest(HttpMethod.GET, "/" + index + "/" + type + "/" + id.toString(),
                     getParameter());
             output = EntityUtils.toString(response.getEntity());
         } catch (ResponseException e) {
@@ -144,7 +146,7 @@ public class SearchRestClient extends KitodoRestClient {
 
         HttpEntity entity = new NStringEntity(wrappedQuery, ContentType.APPLICATION_JSON);
         try {
-            Response response = restClient.performRequest("GET", "/" + index + "/" + type + "/_search?",
+            Response response = restClient.performRequest(HttpMethod.GET, "/" + index + "/" + type + "/_search?",
                     parameters, entity);
             output = EntityUtils.toString(response.getEntity());
         } catch (ResponseException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -17,8 +17,6 @@ import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
-import com.sun.research.ws.wadl.HTTPMethods;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -31,6 +29,7 @@ import java.util.Set;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
+import javax.ws.rs.HttpMethod;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -246,7 +245,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      */
     @SuppressWarnings("unchecked")
     public void saveToIndex(T baseIndexedBean, boolean forceRefresh) throws CustomResponseException, IOException {
-        indexer.setMethod(HTTPMethods.PUT);
+        indexer.setMethod(HttpMethod.PUT);
         if (Objects.nonNull(baseIndexedBean)) {
             indexer.performSingleRequest(baseIndexedBean, type, forceRefresh);
         }
@@ -261,7 +260,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     @SuppressWarnings("unchecked")
     public void addAllObjectsToIndex(List<T> baseIndexedBeans)
             throws CustomResponseException, DAOException, InterruptedException {
-        indexer.setMethod(HTTPMethods.PUT);
+        indexer.setMethod(HttpMethod.PUT);
         indexer.performMultipleRequests(baseIndexedBeans, type);
         for (T baseIndexedBean : baseIndexedBeans) {
             updateIndexFlag(baseIndexedBean);
@@ -279,7 +278,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      */
     @SuppressWarnings("unchecked")
     public void removeFromIndex(T baseIndexedBean, boolean forceRefresh) throws CustomResponseException, IOException {
-        indexer.setMethod(HTTPMethods.DELETE);
+        indexer.setMethod(HttpMethod.DELETE);
         if (baseIndexedBean != null) {
             indexer.performSingleRequest(baseIndexedBean, type, forceRefresh);
         }
@@ -295,7 +294,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      *            object is right after that available for display
      */
     public void removeFromIndex(Integer id, boolean forceRefresh) throws CustomResponseException, IOException {
-        indexer.setMethod(HTTPMethods.DELETE);
+        indexer.setMethod(HttpMethod.DELETE);
         indexer.performSingleRequest(id, forceRefresh);
     }
 


### PR DESCRIPTION
- remove usage of plain Strings
- remove usage of temporal class - com.sun.research.ws.wadl.HTTPMethods