### PR TITLE
Add the domain to the meta-data class

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/MdSec.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/MdSec.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.api.dataformat.mets;
+package org.kitodo.api;
 
 /**
  * An enumeration of possible meta-data locations in a METS file. METS

--- a/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
@@ -11,8 +11,6 @@
 
 package org.kitodo.api;
 
-import org.kitodo.api.dataformat.mets.MdSec;
-
 public class Metadata {
     /**
      * In which conceptual area in the METS file this meta-data entry is stored.

--- a/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
@@ -21,9 +21,7 @@ public class Metadata {
     private String key;
 
     /**
-     * Specifies the location of the meta-data entry in the METS file. METS
-     * allows the storage of meta-data in five different areas with different
-     * semantics. See {@link MdSec} for details.
+     * Returns the domain of the meta-data.
      *
      * @return the location of the meta-data entry
      */
@@ -41,11 +39,7 @@ public class Metadata {
     }
 
     /**
-     * Specifies the location of the meta-data entry in the METS file. METS
-     * allows the storage of meta-data in five different areas with different
-     * semantics. See {@link MdSec} for details. Note that you cannot set the
-     * location for a meta-data entry that is a member of a meta-data group
-     * differently from the location of the meta-data group.
+     * Sets the domain of the meta-data.
      *
      * @param domain
      *            location to set for the meta-data entry

--- a/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
@@ -11,10 +11,27 @@
 
 package org.kitodo.api;
 
+import org.kitodo.api.dataformat.mets.MdSec;
+
 public class Metadata {
+    /**
+     * In which conceptual area in the METS file this meta-data entry is stored.
+     */
+    private MdSec domain;
 
     // The key of the metadata.
     private String key;
+
+    /**
+     * Specifies the location of the meta-data entry in the METS file. METS
+     * allows the storage of meta-data in five different areas with different
+     * semantics. See {@link MdSec} for details.
+     *
+     * @return the location of the meta-data entry
+     */
+    public MdSec getDomain() {
+        return domain;
+    }
 
     /**
      * Get the key o the metadata.
@@ -26,9 +43,24 @@ public class Metadata {
     }
 
     /**
-     *Set the key of the metadata.
+     * Specifies the location of the meta-data entry in the METS file. METS
+     * allows the storage of meta-data in five different areas with different
+     * semantics. See {@link MdSec} for details. Note that you cannot set the
+     * location for a meta-data entry that is a member of a meta-data group
+     * differently from the location of the meta-data group.
      *
-     * @param key The key value of the metadata.
+     * @param domain
+     *            location to set for the meta-data entry
+     */
+    public void setDomain(MdSec domain) {
+        this.domain = domain;
+    }
+
+    /**
+     * Set the key of the metadata.
+     *
+     * @param key
+     *            The key value of the metadata.
      */
     public void setKey(String key) {
         this.key = key;

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/MetadataAccessInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/MetadataAccessInterface.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.api.dataformat.mets;
 
+import org.kitodo.api.MdSec;
+
 /**
  * Abstract super-interface for the services that handle access to the
  * {@code <kitodo:metadata>} and {@code <kitodo:metadataGroup>} elements.

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/Metadata.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/Metadata.java
@@ -11,7 +11,7 @@
 
 package org.kitodo.dataformat.access;
 
-import org.kitodo.api.dataformat.mets.MdSec;
+import org.kitodo.api.MdSec;
 import org.kitodo.api.dataformat.mets.MetadataAccessInterface;
 
 /**

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetadataEntriesGroup.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetadataEntriesGroup.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.kitodo.api.dataformat.mets.MdSec;
+import org.kitodo.api.MdSec;
 import org.kitodo.api.dataformat.mets.MetadataAccessInterface;
 import org.kitodo.api.dataformat.mets.MetadataGroupXmlElementAccessInterface;
 import org.kitodo.dataformat.metskitodo.MetadataGroupType;

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetadataEntry.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetadataEntry.java
@@ -11,7 +11,7 @@
 
 package org.kitodo.dataformat.access;
 
-import org.kitodo.api.dataformat.mets.MdSec;
+import org.kitodo.api.MdSec;
 import org.kitodo.api.dataformat.mets.MetadataXmlElementAccessInterface;
 import org.kitodo.dataformat.metskitodo.MetadataType;
 

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/Structure.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/Structure.java
@@ -28,9 +28,9 @@ import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.kitodo.api.MdSec;
 import org.kitodo.api.dataformat.mets.AreaXmlElementAccessInterface;
 import org.kitodo.api.dataformat.mets.DivXmlElementAccessInterface;
-import org.kitodo.api.dataformat.mets.MdSec;
 import org.kitodo.api.dataformat.mets.MetadataAccessInterface;
 import org.kitodo.dataformat.metskitodo.AmdSecType;
 import org.kitodo.dataformat.metskitodo.DivType;

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/WorkpieceIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/WorkpieceIT.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
+import org.kitodo.api.MdSec;
 import org.kitodo.api.dataformat.mets.FileXmlElementAccessInterface;
-import org.kitodo.api.dataformat.mets.MdSec;
 
 public class WorkpieceIT {
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kitodo.api.MdSec;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewWithValuesInterface;
@@ -35,7 +36,6 @@ import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterfac
 import org.kitodo.api.dataformat.mets.AreaXmlElementAccessInterface;
 import org.kitodo.api.dataformat.mets.DivXmlElementAccessInterface;
 import org.kitodo.api.dataformat.mets.FileXmlElementAccessInterface;
-import org.kitodo.api.dataformat.mets.MdSec;
 import org.kitodo.api.dataformat.mets.MetadataAccessInterface;
 import org.kitodo.api.dataformat.mets.MetadataXmlElementAccessInterface;
 import org.kitodo.api.ugh.ContentFileInterface;

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 
+import org.kitodo.api.MdSec;
 import org.kitodo.api.dataformat.mets.FLocatXmlElementAccessInterface;
 import org.kitodo.api.dataformat.mets.FileXmlElementAccessInterface;
-import org.kitodo.api.dataformat.mets.MdSec;
 import org.kitodo.api.dataformat.mets.MetadataXmlElementAccessInterface;
 import org.kitodo.api.dataformat.mets.MetsXmlElementAccessInterface;
 import org.kitodo.api.dataformat.mets.UseXmlAttributeAccessInterface;


### PR DESCRIPTION
As part of the refactoring process to extract the incorrectly implemented service loaders for the METS module into data classes for the API, the domain is taken from the `org.kitodo.dataformat.access.Metadata` class to the `org.kitodo.api.Metadata` class to use this as a data class for meta-data.

In Production, meta-data can be stored in five different areas that describe different concept spaces. The different areas are represented in the METS file as different XML elements.