### PR TITLE
Add data format API classes

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MediaUnit {
+    /**
+     * Each media unit can be available in different variants, for each of which
+     * a media file is available. This is in this map.
+     */
+    private Map<MediaVariant, URI> mediaFiles = new HashMap<>();
+
+    /**
+     * Sequence number of the media unit. The playback order of the media units
+     * when referenced from a structure is determined by this attribute (not by
+     * the order of the references).
+     */
+    private int order;
+
+    /**
+     * A human readable label for the order of this media unit. This need not be
+     * directly related to the order number. Examples of order labels could be
+     * “I, II, III, IV, V,  - , 1, 2, 3”, meanwhile the order would be “1, 2, 3,
+     * 4, 5, 6, 7, 8, 9”.
+     */
+    private String orderlabel;
+
+    /**
+     * Returns the map of available media variants with the corresponding media
+     * file URIs.
+     * 
+     * @return available media variants with corresponding media file URIs
+     */
+    public Map<MediaVariant, URI> getMediaFiles() {
+        return mediaFiles;
+    }
+
+    /**
+     * Returns the order number for this media unit.
+     * 
+     * @return the order number
+     */
+    public int getOrder() {
+        return order;
+    }
+
+    /**
+     * Returns the order label for this media unit.
+     * 
+     * @return the order label
+     */
+    public String getOrderlabel() {
+        return orderlabel;
+    }
+
+    /**
+     * Sets the order number for this media unit.
+     * 
+     * @param order
+     *            order number to set
+     */
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    /**
+     * Sets the order label for this media unit.
+     * 
+     * @param orderlabel
+     *            order label to set
+     */
+    public void setOrderlabel(String orderlabel) {
+        this.orderlabel = orderlabel;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
@@ -57,13 +57,13 @@ public class MediaUnit {
     }
 
     /**
-     * Sets the order label for this media unit.
+     * Sets the order number for this media unit.
      * 
-     * @param orderlabel
-     *            order label to set
+     * @param order
+     *            order number to set
      */
-    public void setOrderlabel(String orderlabel) {
-        this.orderlabel = orderlabel;
+    public void setOrder(int order) {
+        this.order = order;
     }
 
     /**
@@ -76,12 +76,12 @@ public class MediaUnit {
     }
 
     /**
-     * Sets the order number for this media unit.
+     * Sets the order label for this media unit.
      * 
-     * @param order
-     *            order number to set
+     * @param orderlabel
+     *            order label to set
      */
-    public void setOrder(int order) {
-        this.order = order;
+    public void setOrderlabel(String orderlabel) {
+        this.orderlabel = orderlabel;
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
@@ -57,6 +57,16 @@ public class MediaUnit {
     }
 
     /**
+     * Sets the order label for this media unit.
+     * 
+     * @param orderlabel
+     *            order label to set
+     */
+    public void setOrderlabel(String orderlabel) {
+        this.orderlabel = orderlabel;
+    }
+
+    /**
      * Returns the order label for this media unit.
      * 
      * @return the order label
@@ -73,15 +83,5 @@ public class MediaUnit {
      */
     public void setOrder(int order) {
         this.order = order;
-    }
-
-    /**
-     * Sets the order label for this media unit.
-     * 
-     * @param orderlabel
-     *            order label to set
-     */
-    public void setOrderlabel(String orderlabel) {
-        this.orderlabel = orderlabel;
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaVariant.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaVariant.java
@@ -1,0 +1,105 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+/**
+ * A variant of the {@code MediaUnit}s for a particular use. By use is meant a
+ * technical form of use. Therefore, the variant has as technical property the
+ * Internet MIME type. Examples of variants include thumbnails, full resolution
+ * images, file ready to print, OCR results, etc. For Production, a variant is
+ * always linked to a MIME type, it is not possible to have mixed MIME types in
+ * the same usage variant.
+ */
+public class MediaVariant {
+
+    /**
+     * Specifying the Internet MIME type for this type of use.
+     */
+    private String mimeType;
+
+    /**
+     * Identifier of use. In terms of METS, this is a string, but if the
+     * generated METS file is to be used with the DFG Viewer this string must be
+     * a prescribed value, depending on its intended use.
+     * 
+     * @see "https://www.zvdd.de/fileadmin/AGSDD-Redaktion/METS_Anwendungsprofil_2.0.pdf#page=12"
+     */
+    private String use;
+
+    /**
+     * Returns the MIME type of the media variant.
+     * 
+     * @return the MIME type
+     */
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    /**
+     * Returns the use of the media variant.
+     * 
+     * @return the use
+     */
+    public String getUse() {
+        return use;
+    }
+
+    /**
+     * Sets the MIME type of the media variant.
+     * 
+     * @param mimeType
+     *            MIME type to set
+     */
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    /**
+     * Sets the use of the media variant.
+     * 
+     * @param use
+     *            use type to set
+     */
+    public void setUse(String use) {
+        this.use = use;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((use == null) ? 0 : use.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        MediaVariant other = (MediaVariant) obj;
+        if (use == null) {
+            if (other.use != null) {
+                return false;
+            }
+        } else if (!use.equals(other.use)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaVariant.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaVariant.java
@@ -45,15 +45,6 @@ public class MediaVariant {
     }
 
     /**
-     * Returns the use of the media variant.
-     * 
-     * @return the use
-     */
-    public String getUse() {
-        return use;
-    }
-
-    /**
      * Sets the MIME type of the media variant.
      * 
      * @param mimeType
@@ -61,6 +52,15 @@ public class MediaVariant {
      */
     public void setMimeType(String mimeType) {
         this.mimeType = mimeType;
+    }
+
+    /**
+     * Returns the use of the media variant.
+     * 
+     * @return the use
+     */
+    public String getUse() {
+        return use;
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ProcessingNote.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ProcessingNote.java
@@ -1,0 +1,196 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+/**
+ * A processing note is a comment by an editor to communicate the status of
+ * editing to other editors of the file.
+ */
+public class ProcessingNote {
+    /**
+     * The name of the entity causing the entry.
+     */
+    private String name;
+
+    /**
+     * The text of the processing note.
+     */
+    private String note;
+
+    /**
+     * The role of the entity causing the entry.
+     */
+    private String role;
+
+    /**
+     * The type of the entity causing the entry.
+     */
+    private String type;
+
+    /**
+     * Returns the name of the entity causing the entry.
+     * 
+     * @return the name of the entity causing the entry
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the text of the entry.
+     * 
+     * @return the text of the entry
+     */
+    public String getNote() {
+        return note;
+    }
+
+    /**
+     * Returns the role of the entity causing the entry.
+     * 
+     * @return the role of the entity causing the entry
+     */
+    public String getRole() {
+        return role;
+    }
+
+    /**
+     * Returns the type of the entity causing the entry.
+     * 
+     * @return the type of the entity causing the entry
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the name of the entity causing the entry. This may be the name of a
+     * person, an institution, the software, or similar.
+     * 
+     * @param name
+     *            the name of the entity causing the entry
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Sets the text of the processing note.
+     * 
+     * @param note
+     *            the text of the processing note
+     */
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    /**
+     * Sets the role of the entity causing the edit comment. If possible, it
+     * should be one of the following strings that have semantics in METS: (It
+     * can also be other text.)
+     * <ul>
+     * <li>{@code CREATOR} − a person or institution responsible for the METS
+     * document
+     * <li>{@code EDITOR} − a person or institution that prepares the meta-data
+     * for encoding
+     * <li>{@code ARCHIVIST} − a person institution responsible for the
+     * document/collection
+     * <li>{@code PRESERVATION} − a person or institution responsible for
+     * preservation functions
+     * <li>{@code DISSEMINATOR} − a person or institution responsible for
+     * dissemination functions
+     * <li>{@code CUSTODIAN} − a person or institution charged with the
+     * oversight of a document/collection
+     * <li>{@code IPOWNER} − <i>Intellectual Property Owner</i>: a person or
+     * institution holding copyright, trade or service marks or other
+     * intellectual property rights for the object
+     * </ul>
+     * 
+     * @param role
+     *            role to set
+     */
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    /**
+     * Sets the type of the entity causing the edit comment. If possible, it
+     * should be one of the following strings that have semantics in METS: (It
+     * can also be other text.)
+     * <ul>
+     * <li>{@code INDIVIDUAL} − if an individual has served as the agent
+     * <li>{@code ORGANIZATION} − if an institution, corporate body,
+     * association, non-profit enterprise, government, religious body, etc. has
+     * served as the agent
+     * </ul>
+     * 
+     * @param type
+     *            type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((note == null) ? 0 : note.hashCode());
+        result = prime * result + ((role == null) ? 0 : role.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ProcessingNote other = (ProcessingNote) obj;
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        if (note == null) {
+            if (other.note != null) {
+                return false;
+            }
+        } else if (!note.equals(other.note)) {
+            return false;
+        }
+        if (role == null) {
+            if (other.role != null) {
+                return false;
+            }
+        } else if (!role.equals(other.role)) {
+            return false;
+        }
+        if (type == null) {
+            if (other.type != null) {
+                return false;
+            }
+        } else if (!type.equals(other.type)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ProcessingNote.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ProcessingNote.java
@@ -46,33 +46,6 @@ public class ProcessingNote {
     }
 
     /**
-     * Returns the text of the entry.
-     * 
-     * @return the text of the entry
-     */
-    public String getNote() {
-        return note;
-    }
-
-    /**
-     * Returns the role of the entity causing the entry.
-     * 
-     * @return the role of the entity causing the entry
-     */
-    public String getRole() {
-        return role;
-    }
-
-    /**
-     * Returns the type of the entity causing the entry.
-     * 
-     * @return the type of the entity causing the entry
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
      * Sets the name of the entity causing the entry. This may be the name of a
      * person, an institution, the software, or similar.
      * 
@@ -84,6 +57,15 @@ public class ProcessingNote {
     }
 
     /**
+     * Returns the text of the entry.
+     * 
+     * @return the text of the entry
+     */
+    public String getNote() {
+        return note;
+    }
+
+    /**
      * Sets the text of the processing note.
      * 
      * @param note
@@ -91,6 +73,15 @@ public class ProcessingNote {
      */
     public void setNote(String note) {
         this.note = note;
+    }
+
+    /**
+     * Returns the role of the entity causing the entry.
+     * 
+     * @return the role of the entity causing the entry
+     */
+    public String getRole() {
+        return role;
     }
 
     /**
@@ -120,6 +111,15 @@ public class ProcessingNote {
      */
     public void setRole(String role) {
         this.role = role;
+    }
+
+    /**
+     * Returns the type of the entity causing the entry.
+     * 
+     * @return the type of the entity causing the entry
+     */
+    public String getType() {
+        return type;
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/SortedList.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/SortedList.java
@@ -12,7 +12,6 @@
 package org.kitodo.api.dataformat;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -20,8 +19,7 @@ import java.util.ListIterator;
 import java.util.function.Function;
 
 /**
- * A list that is aware of and enforces the order of its members prescribed by
- * the ordinal number of the media units.
+ * A list that is enforces the order of its members.
  */
 class SortedList<T> extends ArrayList<T> {
     private static final long serialVersionUID = 1L;
@@ -32,109 +30,75 @@ class SortedList<T> extends ArrayList<T> {
     private Function<T, Integer> orderGetter;
 
     /**
-     * Constructor for an order-aware list.
+     * Constructor for a sorted list.
      * 
      * @param orderGetter
-     *            possibility to get an order number for T
+     *            possibility to get the order number for an element
      */
     public SortedList(Function<T, Integer> orderGetter) {
         this.orderGetter = orderGetter;
     }
 
-    /**
-     * Sorts the list by the media unit’s order value and can handle duplicate
-     * occurrences of the same number (unlike a TreeMap). The order of list
-     * items is changed only when necessary. The order of list members with the
-     * same ordinal number is not affected.
-     */
-    private void ensureOrder() {
-        Collections.sort(this, (one, another) -> orderGetter.apply(one).compareTo(orderGetter.apply(another)));
-    }
-
-    @Override
-    public Iterator<T> iterator() {
-        ensureOrder();
-        return super.iterator();
-    }
-
-    @Override
-    public Object[] toArray() {
-        ensureOrder();
-        return super.toArray();
-    }
-
-    @Override
-    public <T> T[] toArray(T[] a) {
-        ensureOrder();
-        return super.toArray(a);
-    }
-
-    @Override
-    public boolean add(T e) {
-        boolean result = super.add(e);
-        ensureOrder();
-        return result;
-    }
-
-    @Override
-    public void add(int index, T element) {
-        super.add(element);
-        ensureOrder();
-    }
-
-    public boolean addAll(Collection<? extends T> c) {
-        boolean result = super.addAll(c);
-        ensureOrder();
-        return result;
-    }
-
-    @Override
-    public boolean addAll(int index, Collection<? extends T> c) {
-        boolean result = super.addAll(c);
-        ensureOrder();
-        return result;
-    }
-
     @Override
     public T get(int index) {
-        ensureOrder();
+        sort();
         return super.get(index);
     }
 
     @Override
-    public T set(int index, T element) {
-        T result = super.set(index, element);
-        ensureOrder();
-        return result;
-    }
-
-    @Override
-    public int indexOf(Object o) {
-        ensureOrder();
-        return super.indexOf(o);
-    }
-
-    @Override
-    public int lastIndexOf(Object o) {
-        ensureOrder();
-        return super.lastIndexOf(o);
+    public int lastIndexOf(Object object) {
+        sort();
+        return super.lastIndexOf(object);
     }
 
     @Override
     public ListIterator<T> listIterator() {
-        ensureOrder();
+        sort();
         return super.listIterator();
     }
 
     @Override
     public ListIterator<T> listIterator(int index) {
-        ensureOrder();
+        sort();
         return super.listIterator(index);
     }
 
     @Override
+    public int indexOf(Object object) {
+        sort();
+        return super.indexOf(object);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        sort();
+        return super.iterator();
+    }
+
+    /**
+     * Sorts the list by the order value. The order of list items is changed
+     * only when necessary. The order of list members with the same ordinal
+     * number is not affected.
+     */
+    private void sort() {
+        Collections.sort(this, (one, another) -> orderGetter.apply(one).compareTo(orderGetter.apply(another)));
+    }
+
+    @Override
     public List<T> subList(int fromIndex, int toIndex) {
-        ensureOrder();
+        sort();
         return super.subList(fromIndex, toIndex);
+    }
+
+    @Override
+    public Object[] toArray() {
+        sort();
+        return super.toArray();
+    }
+
+    @Override
+    public <U> U[] toArray(U[] array) {
+        sort();
+        return super.toArray(array);
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/SortedList.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/SortedList.java
@@ -1,0 +1,140 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.function.Function;
+
+/**
+ * A list that is aware of and enforces the order of its members prescribed by
+ * the ordinal number of the media units.
+ */
+class SortedList<T> extends ArrayList<T> {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Possibility to get an order number for T.
+     */
+    private Function<T, Integer> orderGetter;
+
+    /**
+     * Constructor for an order-aware list.
+     * 
+     * @param orderGetter
+     *            possibility to get an order number for T
+     */
+    public SortedList(Function<T, Integer> orderGetter) {
+        this.orderGetter = orderGetter;
+    }
+
+    /**
+     * Sorts the list by the media unit’s order value and can handle duplicate
+     * occurrences of the same number (unlike a TreeMap). The order of list
+     * items is changed only when necessary. The order of list members with the
+     * same ordinal number is not affected.
+     */
+    private void ensureOrder() {
+        Collections.sort(this, (one, another) -> orderGetter.apply(one).compareTo(orderGetter.apply(another)));
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        ensureOrder();
+        return super.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        ensureOrder();
+        return super.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        ensureOrder();
+        return super.toArray(a);
+    }
+
+    @Override
+    public boolean add(T e) {
+        boolean result = super.add(e);
+        ensureOrder();
+        return result;
+    }
+
+    @Override
+    public void add(int index, T element) {
+        super.add(element);
+        ensureOrder();
+    }
+
+    public boolean addAll(Collection<? extends T> c) {
+        boolean result = super.addAll(c);
+        ensureOrder();
+        return result;
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends T> c) {
+        boolean result = super.addAll(c);
+        ensureOrder();
+        return result;
+    }
+
+    @Override
+    public T get(int index) {
+        ensureOrder();
+        return super.get(index);
+    }
+
+    @Override
+    public T set(int index, T element) {
+        T result = super.set(index, element);
+        ensureOrder();
+        return result;
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        ensureOrder();
+        return super.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        ensureOrder();
+        return super.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<T> listIterator() {
+        ensureOrder();
+        return super.listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(int index) {
+        ensureOrder();
+        return super.listIterator(index);
+    }
+
+    @Override
+    public List<T> subList(int fromIndex, int toIndex) {
+        ensureOrder();
+        return super.subList(fromIndex, toIndex);
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
@@ -100,6 +100,16 @@ public class Structure {
     }
 
     /**
+     * Sets the label of this structure.
+     * 
+     * @param label
+     *            label to set
+     */
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    /**
      * Returns the meta-data on this structure.
      * 
      * @return the meta-data
@@ -118,34 +128,6 @@ public class Structure {
     }
 
     /**
-     * Returns the type of this structure.
-     * 
-     * @return the type
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Returns the views associated with this structure.
-     * 
-     * @return the views
-     */
-    public List<View> getViews() {
-        return views;
-    }
-
-    /**
-     * Sets the label of this structure.
-     * 
-     * @param label
-     *            label to set
-     */
-    public void setLabel(String label) {
-        this.label = label;
-    }
-
-    /**
      * Sets the order label of this structure.
      * 
      * @param orderlabel
@@ -156,6 +138,15 @@ public class Structure {
     }
 
     /**
+     * Returns the type of this structure.
+     * 
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
      * Sets the type of this structure.
      * 
      * @param type
@@ -163,5 +154,14 @@ public class Structure {
      */
     public void setType(String type) {
         this.type = type;
+    }
+
+    /**
+     * Returns the views associated with this structure.
+     * 
+     * @return the views
+     */
+    public List<View> getViews() {
+        return views;
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
@@ -1,0 +1,167 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.kitodo.api.Metadata;
+
+/**
+ * The tree-like outline structure for digital representation. This structuring
+ * structure can be subdivided into arbitrary finely granular
+ * {@link #substructures}. It can be described by {@link #metadata}.
+ */
+public class Structure {
+    /**
+     * The label for this structure. The label is displayed in the graphical
+     * representation of the structure tree for this level.
+     */
+    private String label;
+
+    /**
+     * The meta-data for this structure. This structure level can be described
+     * with any meta-data.
+     */
+    private Collection<Metadata> metadata = new HashSet<>();
+
+    /**
+     * The order label of this structure. This is needed very rarely. It is not
+     * displayed, and unlike the name suggests, it does not specify the order of
+     * this substructure along with other substructures within its parent
+     * structure, but the order is determined by the order of references from
+     * the parent tree to each substructure. The order label may be used to
+     * store the machine-readable value if the label contains a human-readable
+     * value that can be mapped to a machine-readable value. An example of this
+     * are calendar dates. For example, a label of “the fifteenth year of the
+     * reign of Tiberius Caesar” could be stored as “{@code -0006}”.
+     */
+    private String orderlabel;
+
+    /**
+     * The substructures of this structure, which form the structure tree. The
+     * order of the substructures described by the order of the {@code <div>}
+     * elements in the {@code <structMap TYPE="LOGICAL">} in the METS file.
+     */
+    private List<Structure> substructures = new LinkedList<>();
+
+    /**
+     * The type of structure, for example, book, chapter, page. Although the
+     * data type of this variable is a string, it is recommended to use a
+     * controlled vocabulary. If the generated METS files are to be used with
+     * the DFG Viewer, the list of possible structure types is defined.
+     * 
+     * @see "https://dfg-viewer.de/en/structural-data-set/"
+     */
+    private String type;
+
+    /**
+     * The views on media units that this structure level comprises. Currently,
+     * only {@link AreaXmlElementAccess}s on media units as a whole are possible
+     * with Production, but here it has already been built for the future, that
+     * also {@code View}s on parts of {@link FileXmlElementAccess}s are to be
+     * made possible. The list of {@code View}s is aware of the order of the
+     * {@code MediaUnit}s encoded by the {@code MediaUnit}’s {@code order}
+     * property. Although this list implements the {@link List} interface, it
+     * always preserves the order as dictated by the {@code order} property of
+     * the {@code MediaUnit}s. Therefore, to reorder this list, you must change
+     * the {@code order} property of the {@code MediaUnit}s instead. It is not
+     * possible to code several sequences that are in conflict with each other.
+     */
+    private final List<View> views = new SortedList<View>(view -> view.getMediaUnit().getOrder());
+
+    /**
+     * Returns the substructures associated with this structure.
+     * 
+     * @return the substructures
+     */
+    public List<Structure> getChildren() {
+        return substructures;
+    }
+
+    /**
+     * Returns the label of this structure.
+     * 
+     * @return the label
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Returns the meta-data on this structure.
+     * 
+     * @return the meta-data
+     */
+    public Collection<Metadata> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Returns the order label of this structure.
+     * 
+     * @return the order label
+     */
+    public String getOrderlabel() {
+        return orderlabel;
+    }
+
+    /**
+     * Returns the type of this structure.
+     * 
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Returns the views associated with this structure.
+     * 
+     * @return the views
+     */
+    public List<View> getViews() {
+        return views;
+    }
+
+    /**
+     * Sets the label of this structure.
+     * 
+     * @param label
+     *            label to set
+     */
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    /**
+     * Sets the order label of this structure.
+     * 
+     * @param orderlabel
+     *            order label to set
+     */
+    public void setOrderlabel(String orderlabel) {
+        this.orderlabel = orderlabel;
+    }
+
+    /**
+     * Sets the type of this structure.
+     * 
+     * @param type
+     *            type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
@@ -37,15 +37,9 @@ public class Structure {
     private Collection<Metadata> metadata = new HashSet<>();
 
     /**
-     * The order label of this structure. This is needed very rarely. It is not
-     * displayed, and unlike the name suggests, it does not specify the order of
-     * this substructure along with other substructures within its parent
-     * structure, but the order is determined by the order of references from
-     * the parent tree to each substructure. The order label may be used to
-     * store the machine-readable value if the label contains a human-readable
-     * value that can be mapped to a machine-readable value. An example of this
-     * are calendar dates. For example, a label of “the fifteenth year of the
-     * reign of Tiberius Caesar” could be stored as “{@code -0006}”.
+     * The order label of this structure, used to store the machine-readable
+     * value if the label contains a human-readable value that can be mapped to
+     * a machine-readable value.
      */
     private String orderlabel;
 
@@ -67,19 +61,12 @@ public class Structure {
     private String type;
 
     /**
-     * The views on media units that this structure level comprises. Currently,
-     * only {@link AreaXmlElementAccess}s on media units as a whole are possible
-     * with Production, but here it has already been built for the future, that
-     * also {@code View}s on parts of {@link FileXmlElementAccess}s are to be
-     * made possible. The list of {@code View}s is aware of the order of the
-     * {@code MediaUnit}s encoded by the {@code MediaUnit}’s {@code order}
-     * property. Although this list implements the {@link List} interface, it
-     * always preserves the order as dictated by the {@code order} property of
-     * the {@code MediaUnit}s. Therefore, to reorder this list, you must change
-     * the {@code order} property of the {@code MediaUnit}s instead. It is not
-     * possible to code several sequences that are in conflict with each other.
+     * The views on {@link MediaUnit}s that this structure level comprises. The
+     * list ensures the enforcement of the order of the media units which is
+     * encoded by the media units’ {@code order} property. To reorder this list,
+     * you must change the order property of the media units.
      */
-    private final List<View> views = new SortedList<View>(view -> view.getMediaUnit().getOrder());
+    private final Collection<View> views = new SortedList<View>(view -> view.getMediaUnit().getOrder());
 
     /**
      * Returns the substructures associated with this structure.
@@ -161,7 +148,7 @@ public class Structure {
      * 
      * @return the views
      */
-    public List<View> getViews() {
+    public Collection<View> getViews() {
         return views;
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
@@ -14,9 +14,7 @@ package org.kitodo.api.dataformat;
 /**
  * A view on a media unit. The individual levels of the {@link Structure} refer
  * to {@code View}s on {@link MediaUnit}s. At the moment, each {@code View}
- * refers to exactly one {@code MediaUnit} as a whole. This concept level has
- * been added here in order to be able to expand it in the future in order to be
- * able to refer to individual parts of a {@code MediaUnit}.
+ * refers to exactly one {@code MediaUnit} as a whole.
  */
 public class View {
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+/**
+ * A view on a media unit. The individual levels of the {@link Structure} refer
+ * to {@code View}s on {@link MediaUnit}s. At the moment, each {@code View}
+ * refers to exactly one {@code MediaUnit} as a whole. This concept level has
+ * been added here in order to be able to expand it in the future in order to be
+ * able to refer to individual parts of a {@code MediaUnit}.
+ */
+public class View {
+    /**
+     * Media unit in view.
+     */
+    private MediaUnit mediaUnit;
+
+    /**
+     * Returns the media unit in the view.
+     * 
+     * @return the media unit
+     */
+    public MediaUnit getMediaUnit() {
+        return mediaUnit;
+    }
+
+    /**
+     * Inserts a media unit into the view.
+     * 
+     * @param mediaUnit
+     *            media unit to insert
+     */
+    public void setMediaUnit(MediaUnit mediaUnit) {
+        this.mediaUnit = mediaUnit;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -77,6 +77,16 @@ public class Workpiece {
     }
 
     /**
+     * Sets the creation date of the workpiece.
+     * 
+     * @param creationDate
+     *            creation date to set
+     */
+    public void setCreationDate(GregorianCalendar creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    /**
      * Returns the edit history.
      * 
      * @return the edit history
@@ -95,6 +105,16 @@ public class Workpiece {
     }
 
     /**
+     * Sets the ID of the workpiece.
+     * 
+     * @param id
+     *            ID to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
      * Returns the media units of this workpiece.
      * 
      * @return the media units
@@ -110,26 +130,6 @@ public class Workpiece {
      */
     public Structure getStructure() {
         return structure;
-    }
-
-    /**
-     * Sets the creation date of the workpiece.
-     * 
-     * @param creationDate
-     *            creation date to set
-     */
-    public void setCreationDate(GregorianCalendar creationDate) {
-        this.creationDate = creationDate;
-    }
-
-    /**
-     * Sets the ID of the workpiece.
-     * 
-     * @param id
-     *            ID to set
-     */
-    public void setId(String id) {
-        this.id = id;
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -1,0 +1,176 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.kitodo.api.Metadata;
+
+/**
+ * The administrative structure of the product of an element that passes through
+ * a Production workflow.
+ * 
+ * <p>
+ * A {@code Workpiece} has two essential characteristics: {@link MediaUnit}s and
+ * an outline {@link Structure}. {@code MediaUnit}s are the types of every
+ * single digital medium on a conceptual level, such as the individual pages of
+ * a book. Each {@code MediaUnit} can be in different {@link MediaVariant}s (for
+ * example, in different resolutions or file formats). Each {@code MediaVariant}
+ * of a {@code MediaUnit} resides in a place described by an URI.
+ * 
+ * <p>
+ * The {@code Structure} is a tree structure that can be finely subdivided, e.g.
+ * a book, in which the chapters, in it individual elements such as tables or
+ * figures. Each outline level points to the {@code MediaUnit}s that belong to
+ * it via {@link View}s. Currently, a {@code View} always contains exactly one
+ * {@code MediaUnit} unit, here a simple expandability is provided, so that in a
+ * future version excerpts from {@code MediaUnit}s can be described. Each
+ * outline level can be described with any {@link Metadata}.
+ */
+public class Workpiece {
+    /**
+     * The time this file was first created.
+     */
+    private GregorianCalendar creationDate = new GregorianCalendar();
+
+    /**
+     * The processing history.
+     */
+    private List<ProcessingNote> editHistory = new ArrayList<>();
+
+    /**
+     * The identifier of the workpiece.
+     */
+    private String id;
+
+    /**
+     * The media units that belong to this workpiece. The order of this
+     * collection is meaningful, but only describes the order in which the media
+     * units are displayed on the workstation of the compiler.
+     */
+    private List<MediaUnit> mediaUnits = new LinkedList<>();
+
+    /**
+     * The logical structure.
+     */
+    private Structure structure = new Structure();
+
+    /**
+     * Returns the creation date of the workpiece.
+     * 
+     * @return the creation date
+     */
+    public GregorianCalendar getCreationDate() {
+        return creationDate;
+    }
+
+    /**
+     * Returns the edit history. The head of each METS file has space for
+     * processing notes of the individual editors. In this way, the processing
+     * process of the digital representation can be understood.
+     * 
+     * @return the edit history
+     */
+    public List<ProcessingNote> getEditHistory() {
+        return editHistory;
+    }
+
+    /**
+     * Returns the ID of the workpiece.
+     * 
+     * @return the ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the media units of this workpiece.
+     * 
+     * @return the media units
+     */
+    public List<MediaUnit> getMediaUnits() {
+        return mediaUnits;
+    }
+
+    /**
+     * Returns the root element of the structure.
+     * 
+     * @return root element of the structure
+     */
+    public Structure getStructure() {
+        return structure;
+    }
+
+    /**
+     * Sets the creation date of the workpiece.
+     * 
+     * @param creationDate
+     *            creation date to set
+     */
+    public void setCreationDate(GregorianCalendar creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    /**
+     * Sets the ID of the workpiece.
+     * 
+     * @param id
+     *            ID to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Sets the structure of the workpiece.
+     * 
+     * @param structure
+     *            structure to set
+     */
+    public void setStructure(Structure structure) {
+        this.structure = structure;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Workpiece other = (Workpiece) obj;
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -16,28 +16,9 @@ import java.util.GregorianCalendar;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.kitodo.api.Metadata;
-
 /**
  * The administrative structure of the product of an element that passes through
  * a Production workflow.
- * 
- * <p>
- * A {@code Workpiece} has two essential characteristics: {@link MediaUnit}s and
- * an outline {@link Structure}. {@code MediaUnit}s are the types of every
- * single digital medium on a conceptual level, such as the individual pages of
- * a book. Each {@code MediaUnit} can be in different {@link MediaVariant}s (for
- * example, in different resolutions or file formats). Each {@code MediaVariant}
- * of a {@code MediaUnit} resides in a place described by an URI.
- * 
- * <p>
- * The {@code Structure} is a tree structure that can be finely subdivided, e.g.
- * a book, in which the chapters, in it individual elements such as tables or
- * figures. Each outline level points to the {@code MediaUnit}s that belong to
- * it via {@link View}s. Currently, a {@code View} always contains exactly one
- * {@code MediaUnit} unit, here a simple expandability is provided, so that in a
- * future version excerpts from {@code MediaUnit}s can be described. Each
- * outline level can be described with any {@link Metadata}.
  */
 public class Workpiece {
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -77,9 +77,7 @@ public class Workpiece {
     }
 
     /**
-     * Returns the edit history. The head of each METS file has space for
-     * processing notes of the individual editors. In this way, the processing
-     * process of the digital representation can be understood.
+     * Returns the edit history.
      * 
      * @return the edit history
      */


### PR DESCRIPTION
As part of the refactoring process to extract the incorrectly implemented service loaders for the METS module into data classes for the API, the data classes that will be created during the extraction are subsequently taken from the development and transferred to the API beforehand, so that these can be used as data classes for the data formats (METS, and possibly more in the future).