### PR TITLE
Remove sudo line as not supported any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ jdk:
   - oraclejdk8
   - openjdk8
 
-sudo: required
-
 addons:
   chrome: stable
   apt:


### PR DESCRIPTION
According to this [blog entry](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) `sudo` lines are not supported any more on Travis CI runs.