### PR TITLE
Remove sudo line as not supported any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ addons:
       - ant-optional
       - tomcat7-common
 
-sudo: required
-
 cache:
 
 env:


### PR DESCRIPTION
According to this [blog entry](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) `sudo` lines are not supported any more on Travis CI runs.