### PR TITLE
Saving the linked units

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -67,6 +67,16 @@
             <version>${log4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.myfaces.core</groupId>
             <artifactId>myfaces-api</artifactId>
             <version>${myfaces.version}</version>

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.dataformat.access;
+package org.kitodo.api.dataformat;
 
 /**
  * A common interface for {@code Structure}s and {@code LinkedStructure}s.

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
@@ -11,20 +11,25 @@
 
 package org.kitodo.api.dataformat;
 
-import org.kitodo.api.dataformat.mets.DivXmlElementAccessInterface;
-
 /**
  * A common interface for {@code Structure}s and {@code LinkedStructure}s.
  * 
  * @see Structure
  */
-interface ExistingOrLinkedStructure extends DivXmlElementAccessInterface {
+interface ExistingOrLinkedStructure {
     /**
      * Returns the label of this structure.
      * 
      * @return the label
      */
     String getLabel();
+
+    /**
+     * Returns the type of this structure.
+     * 
+     * @return the type
+     */
+    String getType();
 
     /**
      * Returns whether this structure is a link to a structure in another
@@ -41,4 +46,12 @@ interface ExistingOrLinkedStructure extends DivXmlElementAccessInterface {
      *            label to set
      */
     void setLabel(String label);
+
+    /**
+     * Sets the type of this structure.
+     * 
+     * @param type
+     *            type to set
+     */
+    void setType(String type);
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
@@ -18,10 +18,25 @@ package org.kitodo.api.dataformat;
  */
 interface ExistingOrLinkedStructure {
     /**
+     * Returns the label of this structure.
+     * 
+     * @return the label
+     */
+    String getLabel();
+
+    /**
      * Returns whether this structure is a link to a structure in another
      * workpiece.
      * 
      * @return whether this structure is a link
      */
     boolean isLinked();
+
+    /**
+     * Sets the label of this structure.
+     * 
+     * @param label
+     *            label to set
+     */
+    void setLabel(String label);
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat;
+
+/**
+ * A common interface for {@code Structure}s and {@code LinkedStructure}s.
+ * 
+ * @see Structure
+ */
+interface ExistingOrLinkedStructure {
+    /**
+     * Returns whether this structure is a link to a structure in another
+     * workpiece.
+     * 
+     * @return whether this structure is a link
+     */
+    boolean isLinked();
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.api.dataformat;
+package org.kitodo.dataformat.access;
 
 /**
  * A common interface for {@code Structure}s and {@code LinkedStructure}s.

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
@@ -11,12 +11,14 @@
 
 package org.kitodo.api.dataformat;
 
+import org.kitodo.api.dataformat.mets.DivXmlElementAccessInterface;
+
 /**
  * A common interface for {@code Structure}s and {@code LinkedStructure}s.
  * 
  * @see Structure
  */
-interface ExistingOrLinkedStructure {
+interface ExistingOrLinkedStructure extends DivXmlElementAccessInterface {
     /**
      * Returns the label of this structure.
      * 

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/ExistingOrLinkedStructure.java
@@ -16,7 +16,7 @@ package org.kitodo.api.dataformat;
  * 
  * @see Structure
  */
-interface ExistingOrLinkedStructure {
+public interface ExistingOrLinkedStructure {
     /**
      * Returns the label of this structure.
      * 

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
@@ -17,7 +17,8 @@ import java.net.URI;
 /**
  * A link to a structure in a different {@code Workpiece}.
  */
-class LinkedStructure implements ExistingOrLinkedStructure {
+public class LinkedStructure implements ExistingOrLinkedStructure {
+
     /**
      * The label of the linked structure. The label is saved in the linked file.
      */

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
@@ -13,12 +13,6 @@ package org.kitodo.api.dataformat;
 
 import java.math.BigInteger;
 import java.net.URI;
-import java.util.Collection;
-import java.util.List;
-
-import org.kitodo.api.dataformat.mets.AreaXmlElementAccessInterface;
-import org.kitodo.api.dataformat.mets.DivXmlElementAccessInterface;
-import org.kitodo.api.dataformat.mets.MetadataAccessInterface;
 
 /**
  * A link to a structure in a different {@code Workpiece}.
@@ -110,33 +104,8 @@ class LinkedStructure implements ExistingOrLinkedStructure {
     }
 
     @Override
-    public List<AreaXmlElementAccessInterface> getAreas() {
-        throw new UnsupportedOperationException("areas is not supported by linked structure");
-    }
-
-    @Override
-    public List<DivXmlElementAccessInterface> getChildren() {
-        throw new UnsupportedOperationException("children is not supported by linked structure");
-    }
-
-    @Override
-    public Collection<MetadataAccessInterface> getMetadata() {
-        throw new UnsupportedOperationException("metadata is not supported by linked structure");
-    }
-
-    @Override
-    public String getOrderlabel() {
-        throw new UnsupportedOperationException("orderlabel is not supported by linked structure");
-    }
-
-    @Override
     public String getType() {
         return type;
-    }
-
-    @Override
-    public void setOrderlabel(String orderlabel) {
-        throw new UnsupportedOperationException("orderlabel is not supported by linked structure");
     }
 
     @Override

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.dataformat.access;
+package org.kitodo.api.dataformat;
 
 import java.math.BigInteger;
 import java.net.URI;

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/LinkedStructure.java
@@ -13,25 +13,44 @@ package org.kitodo.api.dataformat;
 
 import java.math.BigInteger;
 import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+
+import org.kitodo.api.dataformat.mets.AreaXmlElementAccessInterface;
+import org.kitodo.api.dataformat.mets.DivXmlElementAccessInterface;
+import org.kitodo.api.dataformat.mets.MetadataAccessInterface;
 
 /**
  * A link to a structure in a different {@code Workpiece}.
  */
 class LinkedStructure implements ExistingOrLinkedStructure {
     /**
-     * The label of the linked structure.
+     * The label of the linked structure. The label is saved in the linked file.
      */
     private String label;
 
     /**
      * The order is a number that serves to place other structures together with
      * them in the correct order in the same parental structure. After a link
-     * has been made, the order value no longer affects the order.
+     * has been made, the order value no longer affects the order. The order is
+     * saved in the file that contains the link.
      */
     private BigInteger order;
 
     /**
-     * The URI of the linked process.
+     * The type of structure, for example, book, chapter, page. Although the
+     * data type of this variable is a string, it is recommended to use a
+     * controlled vocabulary. If the generated METS files are to be used with
+     * the DFG Viewer, the list of possible structure types is defined. The type
+     * is saved in the linked file.
+     * 
+     * @see "https://dfg-viewer.de/en/structural-data-set/"
+     */
+    private String type;
+
+    /**
+     * The URI of the linked process. The URI is saved in the file that contains
+     * the link.
      */
     private URI uri;
 
@@ -88,5 +107,40 @@ class LinkedStructure implements ExistingOrLinkedStructure {
      */
     public void setUri(URI uri) {
         this.uri = uri;
+    }
+
+    @Override
+    public List<AreaXmlElementAccessInterface> getAreas() {
+        throw new UnsupportedOperationException("areas is not supported by linked structure");
+    }
+
+    @Override
+    public List<DivXmlElementAccessInterface> getChildren() {
+        throw new UnsupportedOperationException("children is not supported by linked structure");
+    }
+
+    @Override
+    public Collection<MetadataAccessInterface> getMetadata() {
+        throw new UnsupportedOperationException("metadata is not supported by linked structure");
+    }
+
+    @Override
+    public String getOrderlabel() {
+        throw new UnsupportedOperationException("orderlabel is not supported by linked structure");
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public void setOrderlabel(String orderlabel) {
+        throw new UnsupportedOperationException("orderlabel is not supported by linked structure");
+    }
+
+    @Override
+    public void setType(String type) {
+        this.type = type;
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
@@ -151,21 +151,12 @@ public class Structure implements ExistingOrLinkedStructure {
         this.orderlabel = orderlabel;
     }
 
-    /**
-     * Returns the type of this structure.
-     * 
-     * @return the type
-     */
+    @Override
     public String getType() {
         return type;
     }
 
-    /**
-     * Sets the type of this structure.
-     * 
-     * @param type
-     *            type to set
-     */
+    @Override
     public void setType(String type) {
         this.type = type;
     }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
@@ -23,7 +23,7 @@ import org.kitodo.api.Metadata;
  * structure can be subdivided into arbitrary finely granular
  * {@link #substructures}. It can be described by {@link #metadata}.
  */
-public class Structure {
+public class Structure implements ExistingOrLinkedStructure {
     /**
      * The label for this structure. The label is displayed in the graphical
      * representation of the structure tree for this level.
@@ -116,6 +116,11 @@ public class Structure {
      */
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    @Override
+    public boolean isLinked() {
+        return false;
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Structure.java
@@ -48,7 +48,7 @@ public class Structure implements ExistingOrLinkedStructure {
      * order of the substructures described by the order of the {@code <div>}
      * elements in the {@code <structMap TYPE="LOGICAL">} in the METS file.
      */
-    private List<Structure> substructures = new LinkedList<>();
+    private List<ExistingOrLinkedStructure> substructures = new LinkedList<>();
 
     /**
      * The type of structure, for example, book, chapter, page. Although the
@@ -95,7 +95,7 @@ public class Structure implements ExistingOrLinkedStructure {
      * 
      * @return the substructures
      */
-    public List<Structure> getChildren() {
+    public List<ExistingOrLinkedStructure> getChildren() {
         return substructures;
     }
 

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -47,6 +47,12 @@ public class Workpiece {
     private Structure structure = new Structure();
 
     /**
+     * The list of parent linked structures. The list is to be read from top to
+     * bottom, i.e. the element 0 of the list is the topmost structure.
+     */
+    private List<LinkedStructure> uplinks = new ArrayList<>();
+
+    /**
      * Returns the creation date of the workpiece.
      * 
      * @return the creation date
@@ -140,6 +146,15 @@ public class Workpiece {
      */
     public void setStructure(Structure structure) {
         this.structure = structure;
+    }
+
+    /**
+     * Returns the list of parent linked structures.
+     * 
+     * @return the list of parent linked structures
+     */
+    public List<LinkedStructure> getUplinks() {
+        return uplinks;
     }
 
     @Override

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -149,9 +149,9 @@ public class Workpiece {
     }
 
     /**
-     * Returns the list of parent linked structures.
+     * Returns the uplinks of this workpiece
      * 
-     * @return the list of parent linked structures
+     * @return the uplinks
      */
     public List<LinkedStructure> getUplinks() {
         return uplinks;

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -54,7 +54,7 @@ public class Workpiece {
 
     /**
      * Returns the creation date of the workpiece.
-     * 
+     *
      * @return the creation date
      */
     public GregorianCalendar getCreationDate() {
@@ -63,7 +63,7 @@ public class Workpiece {
 
     /**
      * Sets the creation date of the workpiece.
-     * 
+     *
      * @param creationDate
      *            creation date to set
      */
@@ -73,7 +73,7 @@ public class Workpiece {
 
     /**
      * Returns the edit history.
-     * 
+     *
      * @return the edit history
      */
     public List<ProcessingNote> getEditHistory() {
@@ -82,7 +82,7 @@ public class Workpiece {
 
     /**
      * Returns the ID of the workpiece.
-     * 
+     *
      * @return the ID
      */
     public String getId() {
@@ -91,7 +91,7 @@ public class Workpiece {
 
     /**
      * Sets the ID of the workpiece.
-     * 
+     *
      * @param id
      *            ID to set
      */
@@ -101,7 +101,7 @@ public class Workpiece {
 
     /**
      * Returns the media unit of this workpiece.
-     * 
+     *
      * @return the media units
      */
     public MediaUnit getMediaUnit() {
@@ -110,7 +110,7 @@ public class Workpiece {
 
     /**
      * Returns the media units of this workpiece.
-     * 
+     *
      * @return the media units
      * @deprecated Use {@code getMediaUnit().getChildren()}.
      */
@@ -121,7 +121,7 @@ public class Workpiece {
 
     /**
      * Returns the root element of the structure.
-     * 
+     *
      * @return root element of the structure
      */
     public Structure getStructure() {
@@ -130,7 +130,7 @@ public class Workpiece {
 
     /**
      * Sets the media unit of the workpiece.
-     * 
+     *
      * @param mediaUnit
      *            media unit to set
      */
@@ -140,7 +140,7 @@ public class Workpiece {
 
     /**
      * Sets the structure of the workpiece.
-     * 
+     *
      * @param structure
      *            structure to set
      */
@@ -149,8 +149,8 @@ public class Workpiece {
     }
 
     /**
-     * Returns the uplinks of this workpiece
-     * 
+     * Returns the uplinks of this workpiece.
+     *
      * @return the uplinks
      */
     public List<LinkedStructure> getUplinks() {

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/InputStreamProviderInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/InputStreamProviderInterface.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat.mets;
+
+import java.io.InputStream;
+import java.net.URI;
+
+/**
+ * A functional interface for a function
+ * {@code InputStream getInputStream(URI uri, boolean couldHaveToBeWrittenInTheFuture)}.
+ */
+public interface InputStreamProviderInterface {
+
+    /**
+     * A function that opens an input stream from a source identified by an URI.
+     * If used, the calling function is responsible of closing the stream.
+     *
+     * @param uri
+     *            the identifier for the file
+     * @param couldHaveToBeWrittenInTheFuture
+     *            whether the file could have to be written in the future
+     * @return an open input stream
+     */
+    InputStream getInputStream(URI uri, boolean couldHaveToBeWrittenInTheFuture);
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/MetsXmlElementAccessInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/MetsXmlElementAccessInterface.java
@@ -14,7 +14,10 @@ package org.kitodo.api.dataformat.mets;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.util.function.Function;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.dataformat.Workpiece;
 
 /**
@@ -46,11 +49,16 @@ public interface MetsXmlElementAccessInterface {
      *
      * @param in
      *            open input channel for reading the file
+     * @param getInputStreamFunction
+     *            A reference to a function
+     *            {@code InputStream getInputStream(URI uri, Boolean couldHaveToBeWrittenInTheFuture)}.
+     *            If invoked, the calling function is responsible of closing the
+     *            stream.
      * @return the read workpiece
      * @throws IOException
      *             if the reading fails
      */
-    Workpiece read(InputStream in) throws IOException;
+    Workpiece read(InputStream in, Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) throws IOException;
 
     /**
      * Writes the workpiece to a METS file.

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/MetsXmlElementAccessInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/MetsXmlElementAccessInterface.java
@@ -14,10 +14,7 @@ package org.kitodo.api.dataformat.mets;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.dataformat.Workpiece;
 
 /**
@@ -50,15 +47,12 @@ public interface MetsXmlElementAccessInterface {
      * @param in
      *            open input channel for reading the file
      * @param getInputStreamFunction
-     *            A reference to a function
-     *            {@code InputStream getInputStream(URI uri, Boolean couldHaveToBeWrittenInTheFuture)}.
-     *            If invoked, the calling function is responsible of closing the
-     *            stream.
+     *            reference to a function that opens an input stream
      * @return the read workpiece
      * @throws IOException
      *             if the reading fails
      */
-    Workpiece read(InputStream in, Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) throws IOException;
+    Workpiece read(InputStream in, InputStreamProviderInterface getInputStreamFunction) throws IOException;
 
     /**
      * Writes the workpiece to a METS file.

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -11,8 +11,6 @@
 
 package org.kitodo.dataformat.access;
 
-import java.io.InputStream;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
@@ -39,6 +37,7 @@ import org.kitodo.api.dataformat.ExistingOrLinkedStructure;
 import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.Structure;
 import org.kitodo.api.dataformat.View;
+import org.kitodo.api.dataformat.mets.InputStreamProviderInterface;
 import org.kitodo.dataformat.metskitodo.AmdSecType;
 import org.kitodo.dataformat.metskitodo.DivType;
 import org.kitodo.dataformat.metskitodo.KitodoType;
@@ -88,7 +87,7 @@ public class DivXmlElementAccess extends Structure {
 
     /**
      * Constructor to read a structure from METS.
-     * 
+     *
      * @param div
      *            METS {@code <div>} element from which the structure is to be
      *            built
@@ -98,14 +97,11 @@ public class DivXmlElementAccess extends Structure {
      * @param mediaUnitsMap
      *            From this map, the media units are read, which must be
      *            referenced here by their ID.
-     * @param getInputStreamFunction
-     *            A reference to a function
-     *            {@code InputStream getInputStream(URI uri, Boolean couldHaveToBeWrittenInTheFuture)}.
-     *            If invoked, the calling function is responsible of closing the
-     *            stream.
+     * @param inputStreamProvider
+     *            a function that opens an input stream
      */
     DivXmlElementAccess(DivType div, Mets mets, Map<String, Set<FileXmlElementAccess>> mediaUnitsMap,
-            Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) {
+            InputStreamProviderInterface inputStreamProvider) {
         super();
         super.setLabel(div.getLABEL());
         for (Object mdSecType : div.getDMDID()) {
@@ -118,9 +114,9 @@ public class DivXmlElementAccess extends Structure {
         super.setOrderlabel(div.getORDERLABEL());
         for (DivType child : div.getDiv()) {
             if (child.getMptr().isEmpty()) {
-                super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, getInputStreamFunction));
+                super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, inputStreamProvider));
             } else {
-                super.getChildren().add(new MptrXmlElementAccess(child, mets, getInputStreamFunction).linkedStructure);
+                super.getChildren().add(new MptrXmlElementAccess(child, mets, inputStreamProvider).linkedStructure);
             }
         }
         super.setType(div.getTYPE());
@@ -137,11 +133,11 @@ public class DivXmlElementAccess extends Structure {
     /**
      * Determines from a METS data structure of which type is a meta-data
      * section.
-     * 
+     *
      * <p>
      * Implementation note: This method would be a good candidate for
      * parallelization.
-     * 
+     *
      * @param mets
      *            METS data structure that determines what type of meta-data
      *            section is
@@ -197,7 +193,7 @@ public class DivXmlElementAccess extends Structure {
 
     /**
      * Creates a METS {@code <div>} element from this structure.
-     * 
+     *
      * @param mediaUnitIDs
      *            the assigned identifier for each media unit so that the link
      *            pairs of the struct link section can be formed later
@@ -240,7 +236,7 @@ public class DivXmlElementAccess extends Structure {
     /**
      * Creates a meta-data section of the specified domain of the Kitodo type
      * and returns it with its connection to the METS if there is data for it.
-     * 
+     *
      * @param domain
      *            Domain for which a metadata section is to be generated
      * @return a metadata section, if there is data for it
@@ -273,7 +269,7 @@ public class DivXmlElementAccess extends Structure {
     /**
      * Generates an {@code <amdSec>} if administrative meta-data exists on this
      * structure.
-     * 
+     *
      * @param div
      *            div where ADMID references must be added to the generated
      *            meta-data sections
@@ -296,7 +292,7 @@ public class DivXmlElementAccess extends Structure {
      * Adds a meta-data section to an administrative meta-data section, if there
      * is one. This function deduplicates fourfold existing function for four
      * different meta-data sections.
-     * 
+     *
      * @param optionalMdSec
      *            perhaps existing meta-data section to be added if it exists
      * @param mdSecType

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -116,7 +116,8 @@ public class DivXmlElementAccess extends Structure {
             if (child.getMptr().isEmpty()) {
                 super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, inputStreamProvider));
             } else {
-                super.getChildren().add(new MptrXmlElementAccess(child, mets, inputStreamProvider).linkedStructure);
+                super.getChildren()
+                        .add(new MptrXmlElementAccess(child, mets, inputStreamProvider).getLinkedStructure());
             }
         }
         super.setType(div.getTYPE());

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -34,6 +34,7 @@ import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.MetadataGroup;
 import org.kitodo.api.dataformat.ExistingOrLinkedStructure;
+import org.kitodo.api.dataformat.LinkedStructure;
 import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.Structure;
 import org.kitodo.api.dataformat.View;
@@ -205,7 +206,7 @@ public class DivXmlElementAccess extends Structure {
      *            the METS structure in which the meta-data is added
      * @return a METS {@code <div>} element
      */
-    DivType toDiv(Map<MediaUnit, String> mediaUnitIDs, LinkedList<Pair<String, String>> smLinkData, Mets mets) {
+    public DivType toDiv(Map<MediaUnit, String> mediaUnitIDs, LinkedList<Pair<String, String>> smLinkData, Mets mets) {
         DivType div = new DivType();
         div.setID(metsReferrerId);
         div.setLABEL(super.getLabel());
@@ -229,7 +230,12 @@ public class DivXmlElementAccess extends Structure {
         }
 
         for (ExistingOrLinkedStructure substructure : super.getChildren()) {
-            div.getDiv().add(new DivXmlElementAccess((Structure) substructure).toDiv(mediaUnitIDs, smLinkData, mets));
+            if (substructure instanceof Structure) {
+                div.getDiv()
+                        .add(new DivXmlElementAccess((Structure) substructure).toDiv(mediaUnitIDs, smLinkData, mets));
+            } else {
+                div.getDiv().add(new MptrXmlElementAccess((LinkedStructure) substructure).toDiv());
+            }
         }
         return div;
     }

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.dataformat.access;
 
+import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
@@ -95,8 +97,14 @@ public class DivXmlElementAccess extends Structure {
      * @param mediaUnitsMap
      *            From this map, the media units are read, which must be
      *            referenced here by their ID.
+     * @param getInputStreamFunction
+     *            A reference to a function
+     *            {@code InputStream getInputStream(URI uri, Boolean couldHaveToBeWrittenInTheFuture)}.
+     *            If invoked, the calling function is responsible of closing the
+     *            stream.
      */
-    DivXmlElementAccess(DivType div, Mets mets, Map<String, Set<FileXmlElementAccess>> mediaUnitsMap) {
+    DivXmlElementAccess(DivType div, Mets mets, Map<String, Set<FileXmlElementAccess>> mediaUnitsMap,
+            Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) {
         super();
         super.setLabel(div.getLABEL());
         for (Object mdSecType : div.getDMDID()) {
@@ -108,7 +116,7 @@ public class DivXmlElementAccess extends Structure {
         metsReferrerId = div.getID();
         super.setOrderlabel(div.getORDERLABEL());
         for (DivType child : div.getDiv()) {
-            super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap));
+            super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, getInputStreamFunction));
         }
         super.setType(div.getTYPE());
         Set<FileXmlElementAccess> fileXmlElementAccesses = mediaUnitsMap.get(div.getID());

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -35,6 +35,7 @@ import org.kitodo.api.MdSec;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.MetadataGroup;
+import org.kitodo.api.dataformat.ExistingOrLinkedStructure;
 import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.Structure;
 import org.kitodo.api.dataformat.View;
@@ -116,7 +117,11 @@ public class DivXmlElementAccess extends Structure {
         metsReferrerId = div.getID();
         super.setOrderlabel(div.getORDERLABEL());
         for (DivType child : div.getDiv()) {
-            super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, getInputStreamFunction));
+            if (child.getMptr().isEmpty()) {
+                super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, getInputStreamFunction));
+            } else {
+                super.getChildren().add(new MptrXmlElementAccess(child, mets, getInputStreamFunction).linkedStructure);
+            }
         }
         super.setType(div.getTYPE());
         Set<FileXmlElementAccess> fileXmlElementAccesses = mediaUnitsMap.get(div.getID());
@@ -226,8 +231,8 @@ public class DivXmlElementAccess extends Structure {
             mets.getAmdSec().add(admSec);
         }
 
-        for (Structure substructure : super.getChildren()) {
-            div.getDiv().add(new DivXmlElementAccess(substructure).toDiv(mediaUnitIDs, smLinkData, mets));
+        for (ExistingOrLinkedStructure substructure : super.getChildren()) {
+            div.getDiv().add(new DivXmlElementAccess((Structure) substructure).toDiv(mediaUnitIDs, smLinkData, mets));
         }
         return div;
     }

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/LinkedStructure.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/LinkedStructure.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.dataformat.access;
+
+import java.math.BigInteger;
+import java.net.URI;
+
+/**
+ * A link to a structure in a different {@code Workpiece}.
+ */
+class LinkedStructure implements ExistingOrLinkedStructure {
+    /**
+     * The label of the linked structure.
+     */
+    private String label;
+
+    /**
+     * The order is a number that serves to place other structures together with
+     * them in the correct order in the same parental structure. After a link
+     * has been made, the order value no longer affects the order.
+     */
+    private BigInteger order;
+
+    /**
+     * The URI of the linked process.
+     */
+    private URI uri;
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Returns the order value of the linked structure.
+     * 
+     * @return the order value
+     */
+    public BigInteger getOrder() {
+        return order;
+    }
+
+    /**
+     * Returns the URI of the linked {@code Workpiece}.
+     * 
+     * @return the URI of the linked {@code Workpiece}
+     * @see Workpiece
+     */
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public boolean isLinked() {
+        return true;
+    }
+
+    @Override
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    /**
+     * Sets the order value of the linked structure.
+     * 
+     * @param order
+     *            order value to set
+     */
+    public void setOrder(BigInteger order) {
+        this.order = order;
+    }
+
+    /**
+     * Sets the URI of the linked {@code Workpiece}.
+     * 
+     * @param uri
+     *            URI to set
+     * @see Workpiece
+     */
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+}

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -97,7 +97,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         this.workpiece = workpiece;
     }
 
-    private static final Workpiece toWorkpiece(Mets mets,
+    static final Workpiece toWorkpiece(Mets mets,
             Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) {
         Workpiece workpiece = new Workpiece();
         MetsHdr metsHdr = mets.getMetsHdr();
@@ -140,7 +140,9 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
             }
         }
         workpiece.setStructure(getStructMapsStreamByType(mets, "LOGICAL")
-                .map(structMap -> new DivXmlElementAccess(structMap.getDiv(), mets, mediaUnitsMap)).collect(Collectors.toList())
+                .map(structMap -> new DivXmlElementAccess(structMap.getDiv(), mets, mediaUnitsMap,
+                        getInputStreamFunction))
+                .collect(Collectors.toList())
                 .iterator().next());
         return workpiece;
     }
@@ -200,7 +202,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      *            If invoked, the calling function is responsible of closing the
      *            stream.
      */
-    private static Mets readMets(InputStream in) throws IOException {
+    static Mets readMets(InputStream in) throws IOException {
         try {
             JAXBContext jc = JAXBContext.newInstance(Mets.class);
             Unmarshaller unmarshaller = jc.createUnmarshaller();

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -14,7 +14,6 @@ package org.kitodo.dataformat.access;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -60,7 +59,7 @@ import org.kitodo.dataformat.metskitodo.StructMapType;
  * The administrative structure of the product of an element that passes through
  * a Production workflow. The file format for this management structure is METS
  * XML after the ZVDD DFG Viewer Application Profile.
- * 
+ *
  * <p>
  * A {@code Workpiece} has two essential characteristics: {@link FileXmlElementAccess}s and
  * an outline {@link DivXmlElementAccess}. {@code MediaUnit}s are the types of every
@@ -68,7 +67,7 @@ import org.kitodo.dataformat.metskitodo.StructMapType;
  * a book. Each {@code MediaUnit} can be in different {@link UseXmlAttributeAccess}s (for
  * example, in different resolutions or file formats). Each {@code MediaVariant}
  * of a {@code MediaUnit} resides in a {@link FLocatXmlElementAccess} in the data store.
- * 
+ *
  * <p>
  * The {@code Structure} is a tree structure that can be finely subdivided, e.g.
  * a book, in which the chapters, in it individual elements such as tables or
@@ -77,7 +76,7 @@ import org.kitodo.dataformat.metskitodo.StructMapType;
  * {@code MediaUnit} unit, here a simple expandability is provided, so that in a
  * future version excerpts from {@code MediaUnit}s can be described. Each
  * outline level can be described with any {@link MetadataXmlElementsAccess}.
- * 
+ *
  * @see "https://www.zvdd.de/fileadmin/AGSDD-Redaktion/METS_Anwendungsprofil_2.0.pdf"
  */
 public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
@@ -94,17 +93,13 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         workpiece = new Workpiece();
     }
 
-    /**
-     * Creates a workpiece from a METS XML structure. Due to limitations of the
-     * API, this can only be done by calling {@link #read(InputStream)} and then
-     * replacing the content of the current editor, but at least the
-     * implementation is clean.
-     * 
-     * @param mets
-     *            METS XML structure to read
-     */
-    private MetsXmlElementAccess(Mets mets) {
-        this();
+    private MetsXmlElementAccess(Workpiece workpiece) {
+        this.workpiece = workpiece;
+    }
+
+    private static final Workpiece toWorkpiece(Mets mets,
+            Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) {
+        Workpiece workpiece = new Workpiece();
         MetsHdr metsHdr = mets.getMetsHdr();
         if (Objects.nonNull(metsHdr)) {
             workpiece.setCreationDate(metsHdr.getCREATEDATE().toGregorianCalendar());
@@ -140,16 +135,18 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         for (Object smLinkOrSmLinkGrp : mets.getStructLink().getSmLinkOrSmLinkGrp()) {
             if (smLinkOrSmLinkGrp instanceof SmLink) {
                 SmLink smLink = (SmLink) smLinkOrSmLinkGrp;
-                mediaUnitsMap.computeIfAbsent(smLink.getFrom(), any -> new HashSet<FileXmlElementAccess>());
+                mediaUnitsMap.computeIfAbsent(smLink.getFrom(), any -> new HashSet<>());
                 mediaUnitsMap.get(smLink.getFrom()).add(divIDsToMediaUnits.get(smLink.getTo()));
             }
         }
         workpiece.setStructure(getStructMapsStreamByType(mets, "LOGICAL")
                 .map(structMap -> new DivXmlElementAccess(structMap.getDiv(), mets, mediaUnitsMap)).collect(Collectors.toList())
                 .iterator().next());
+        return workpiece;
     }
 
-    private void readMeadiaUnitsTreeRecursive(DivType div, Mets mets, Map<String, MediaVariant> useXmlAttributeAccess,
+    private static void readMeadiaUnitsTreeRecursive(DivType div, Mets mets,
+            Map<String, MediaVariant> useXmlAttributeAccess,
             MediaUnit mediaUnit, Map<String, FileXmlElementAccess> divIDsToMediaUnits) {
 
         for (DivType child : div.getDiv()) {
@@ -161,13 +158,9 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         }
     }
 
-    private MetsXmlElementAccess(Workpiece workpiece) {
-        this.workpiece = workpiece;
-    }
-
     /**
      * The method helps to read {@code <structMap>}s from METS.
-     * 
+     *
      * @param mets
      *            METS that can be read from
      * @param type
@@ -180,7 +173,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
 
     /**
      * Reads METS from an InputStream. JAXB is used to parse the XML.
-     * 
+     *
      * @param in
      *            InputStream to read from
      * @param getInputStreamFunction
@@ -192,26 +185,39 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
     @Override
     public Workpiece read(InputStream in, Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction)
             throws IOException {
+
+        return toWorkpiece(readMets(in), getInputStreamFunction);
+    }
+
+    /**
+     * Reads METS from an InputStream. JAXB is used to parse the XML.
+     *
+     * @param in
+     *            InputStream to read from
+     * @param getInputStreamFunction
+     *            A reference to a function
+     *            {@code InputStream getInputStream(URI uri, Boolean couldHaveToBeWrittenInTheFuture)}.
+     *            If invoked, the calling function is responsible of closing the
+     *            stream.
+     */
+    private static Mets readMets(InputStream in) throws IOException {
         try {
             JAXBContext jc = JAXBContext.newInstance(Mets.class);
             Unmarshaller unmarshaller = jc.createUnmarshaller();
-            Mets mets = (Mets) unmarshaller.unmarshal(in);
-            return new MetsXmlElementAccess(mets).workpiece;
+            return (Mets) unmarshaller.unmarshal(in);
         } catch (JAXBException e) {
             if (e.getCause() instanceof IOException) {
                 throw (IOException) e.getCause();
             } else {
                 throw new IOException(e.getMessage(), e);
             }
-        } catch (UncheckedIOException e) {
-            throw e.getCause();
         }
     }
 
     /**
      * Writes the contents of this workpiece as a METS file into an output
      * stream.
-     * 
+     *
      * @param out
      *            writable output stream
      * @throws IOException
@@ -236,7 +242,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
     /**
      * Generates a METS XML structure from this workpiece in the form of Java
      * objects in the main memory.
-     * 
+     *
      * @return a METS XML structure from this workpiece
      */
     private Mets toMets() {
@@ -262,7 +268,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
     /**
      * Creates the header of the METS file. The header area stores the time
      * stamp, the ID and the processing notes.
-     * 
+     *
      * @return the header of the METS file
      */
     private MetsHdr generateMetsHdr() {
@@ -284,7 +290,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      * Creates an object of class XMLGregorianCalendar. Creating this
      * JAXB-specific class is quite complicated and has therefore been
      * outsourced to a separate method.
-     * 
+     *
      * @param gregorianCalendar
      *            value of the calendar
      * @return an object of class XMLGregorianCalendar
@@ -308,7 +314,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      * file groups, each file group accommodating the files of a media variant.
      * Therefore, the media units are first resolved according to their media
      * variants, then the corresponding XML elements are generated.
-     * 
+     *
      * @param mediaFilesToIDFiles
      *            In this map, for each media unit, the corresponding XML file
      *            element is added, so that it can be used for linking later.
@@ -358,7 +364,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
     /**
      * Creates the physical struct map. In the physical struct map, the
      * individual files with their variants are enumerated and labeled.
-     * 
+     *
      * @param mediaFilesToIDFiles
      *            A map of the media files to the XML file elements used to
      *            declare them in the file section. To output a link to the ID,
@@ -393,7 +399,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      * Creates the struct link section. The struct link section stores which
      * files are attached to which nodes and leaves of the description
      * structure.
-     * 
+     *
      * @param smLinkData
      *            The list of related IDs
      * @return the struct link section

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -201,7 +201,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      *            a function that opens an input stream
      * @return a list of the parent structures of the document
      */
-    private static final LinkedList<LinkedStructure> findMyself(DivType div, Mets current, URI parentUri,
+    private static final LinkedList<LinkedStructure> findCurrentStructureInParent(DivType div, Mets current, URI parentUri,
             InputStreamProviderInterface inputStreamProvider) {
 
         if (!div.getMptr().isEmpty()) {
@@ -211,7 +211,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
             return found ? new LinkedList<>() : null;
         } else {
             Optional<Pair<DivType, LinkedList<LinkedStructure>>> optionalResult = div.getDiv().stream().map(child -> {
-                LinkedList<LinkedStructure> links = findMyself(child, current, parentUri, inputStreamProvider);
+                LinkedList<LinkedStructure> links = findCurrentStructureInParent(child, current, parentUri, inputStreamProvider);
                 return links != null ? Pair.of(child, links) : null;
             }).filter(Objects::nonNull).reduce((one, another) -> {
                 if (one.getRight().equals(another.getRight())) {
@@ -344,7 +344,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
                     LinkedList<LinkedStructure> found = getStructMapsStreamByType(parent, "LOGICAL")
                             .map(structMap -> structMap.getDiv())
                             .map(div -> div.getMptr().isEmpty() ? div : div.getDiv().get(0))
-                            .map(div -> findMyself(div, current, parentUri, inputStreamProvider))
+                            .map(div -> findCurrentStructureInParent(div, current, parentUri, inputStreamProvider))
                             .filter(Objects::nonNull).reduce((one, another) -> {
                                 if (one.equals(another)) {
                                     return one;

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -14,6 +14,7 @@ package org.kitodo.dataformat.access;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -181,9 +183,15 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      * 
      * @param in
      *            InputStream to read from
+     * @param getInputStreamFunction
+     *            A reference to a function
+     *            {@code InputStream getInputStream(URI uri, Boolean couldHaveToBeWrittenInTheFuture)}.
+     *            If invoked, the calling function is responsible of closing the
+     *            stream.
      */
     @Override
-    public Workpiece read(InputStream in) throws IOException {
+    public Workpiece read(InputStream in, Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction)
+            throws IOException {
         try {
             JAXBContext jc = JAXBContext.newInstance(Mets.class);
             Unmarshaller unmarshaller = jc.createUnmarshaller();
@@ -195,6 +203,8 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
             } else {
                 throw new IOException(e.getMessage(), e);
             }
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -439,7 +439,19 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         LinkedList<Pair<String, String>> smLinkData = new LinkedList<>();
         StructMapType logical = new StructMapType();
         logical.setTYPE("LOGICAL");
-        logical.setDiv(new DivXmlElementAccess(workpiece.getStructure()).toDiv(mediaUnitIDs, smLinkData, mets));
+        DivType structureRoot = new DivXmlElementAccess(workpiece.getStructure()).toDiv(mediaUnitIDs, smLinkData, mets);
+        List<LinkedStructure> uplinks = workpiece.getUplinks();
+        if (uplinks.isEmpty()) {
+            logical.setDiv(structureRoot);
+        } else {
+            DivType uplinkHolder = new DivType();
+            Mptr uplink = new Mptr();
+            uplink.setHref(uplinks.get(uplinks.size() - 1).getUri().getPath());
+            uplinkHolder.getMptr().add(uplink);
+            uplinkHolder.getDiv().add(structureRoot);
+            logical.setDiv(uplinkHolder);
+        }
+
         mets.getStructMap().add(logical);
 
         mets.setStructLink(createStructLink(smLinkData));

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -28,7 +28,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -87,17 +86,6 @@ import org.kitodo.dataformat.metskitodo.StructMapType;
  * @see "https://www.zvdd.de/fileadmin/AGSDD-Redaktion/METS_Anwendungsprofil_2.0.pdf"
  */
 public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
-    /**
-     * There must not be multiple references to the child, or they must be
-     * identical.
-     */
-    private static final BinaryOperator<LinkedList<LinkedStructure>> CHILD_REFERENCED_ONCE = (one, another) -> {
-        if (one.equals(another)) {
-            return one;
-        }
-        throw new IllegalStateException("Child is referenced from parent multiple times");
-    };
-
     /**
      * The data object of this mets XML element access.
      */

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -268,7 +268,14 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         return mets.getStructMap().parallelStream().filter(structMap -> structMap.getTYPE().equals(type));
     }
 
-    static final URI hrefToUri(String href) {
+    /**
+     * Converts a URI given as a string to a URI object.
+     *
+     * @param href
+     *            URI to be converted
+     * @return URI as {@code URI} object
+     */
+    public static final URI hrefToUri(String href) {
         try {
             return new URI(href);
         } catch (URISyntaxException e) {
@@ -333,7 +340,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      * @throws UncheckedIOException
      *             if the reading fails (to be used in lambda expressions)
      */
-    static final Mets readMets(InputStreamProviderInterface inputStreamProvider, URI uri,
+    public static final Mets readMets(InputStreamProviderInterface inputStreamProvider, URI uri,
             boolean couldHaveToBeWrittenInTheFuture) {
 
         try (InputStream in = inputStreamProvider.getInputStream(uri, couldHaveToBeWrittenInTheFuture)) {

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -103,7 +103,16 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         this.workpiece = workpiece;
     }
 
-    static final Workpiece toWorkpiece(Mets mets,
+    /**
+     * Converts a mets to a workpiece.
+     *
+     * @param mets
+     *            mets to convert
+     * @param inputStreamProvider
+     *            a functional interface that returns an input stream for an URI
+     * @return the workpiece
+     */
+    public static final Workpiece toWorkpiece(Mets mets,
             InputStreamProviderInterface inputStreamProvider) {
 
         Workpiece workpiece = new Workpiece();
@@ -295,7 +304,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
      * @throws IOException
      *             if the reading fails
      */
-    static Mets readMets(InputStream in) throws IOException {
+    public static Mets readMets(InputStream in) throws IOException {
         try {
             JAXBContext jc = JAXBContext.newInstance(Mets.class);
             Unmarshaller unmarshaller = jc.createUnmarshaller();

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -251,7 +251,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         try {
             return new URI(href);
         } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(e.getMessage(), e);
+            throw new IllegalArgumentException("Erroneous URI: \"" + href + "\" (" + e.getMessage() + ')', e);
         }
     }
 

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -151,7 +151,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
             structLink = new StructLink();
         }
         Map<String, Set<FileXmlElementAccess>> mediaUnitsMap = new HashMap<>();
-        for (Object smLinkOrSmLinkGrp : mets.getStructLink().getSmLinkOrSmLinkGrp()) {
+        for (Object smLinkOrSmLinkGrp : structLink.getSmLinkOrSmLinkGrp()) {
             if (smLinkOrSmLinkGrp instanceof SmLink) {
                 SmLink smLink = (SmLink) smLinkOrSmLinkGrp;
                 mediaUnitsMap.computeIfAbsent(smLink.getFrom(), any -> new HashSet<>());

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -144,6 +144,11 @@ public class MptrXmlElementAccess {
         return linkedStructure;
     }
 
+    /**
+     * Creates a METS {@code <div>} element from this linked structure.
+     *
+     * @return a METS {@code <div>} element
+     */
     public DivType toDiv() {
         DivType div = new DivType();
         div.setORDER(linkedStructure.getOrder());

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -30,7 +30,7 @@ import org.kitodo.dataformat.metskitodo.StructMapType;
 
 public class MptrXmlElementAccess {
 
-    LinkedStructure linkedStructure = new LinkedStructure();
+    private LinkedStructure linkedStructure = new LinkedStructure();
 
     /**
      * Constructor to read a linked structure from METS.
@@ -122,5 +122,14 @@ public class MptrXmlElementAccess {
         if (!Objects.deepEquals(linked, current)) {
             throw new IllegalStateException("METS file linked as child points to different parent METS");
         }
+    }
+
+    /**
+     * Returns the linked structure of this {@code <mptr>} XML element access.
+     * 
+     * @return the linked structure
+     */
+    public LinkedStructure getLinkedStructure() {
+        return linkedStructure;
     }
 }

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -114,7 +114,7 @@ public class MptrXmlElementAccess {
         try (InputStream in = getInputStreamFunction.apply(Pair.of(new URI(optionalParentLink.get()), false))) {
             linked = MetsXmlElementAccess.readMets(in);
         }
-        if (linked.equals(current)) {
+        if (!Objects.deepEquals(linked, current)) {
             throw new IllegalStateException("METS file linked as child points to different parent METS");
         }
     }

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -70,6 +70,17 @@ public class MptrXmlElementAccess {
     }
 
     /**
+     * Creates a new {@code <mets:mptr>} XML element accessor for a given linked
+     * structure.
+     *
+     * @param linkedStructure
+     *            data object to work on
+     */
+    MptrXmlElementAccess(LinkedStructure linkedStructure) {
+        this.linkedStructure = linkedStructure;
+    }
+
+    /**
      * Checks if the child METS file is a child of this METS file. If the child
      * being found for some reason is not actually the child of this process,
      * editing can corrupt the other process that was erroneously assumed as a
@@ -126,10 +137,19 @@ public class MptrXmlElementAccess {
 
     /**
      * Returns the linked structure of this {@code <mptr>} XML element access.
-     * 
+     *
      * @return the linked structure
      */
     public LinkedStructure getLinkedStructure() {
         return linkedStructure;
+    }
+
+    public DivType toDiv() {
+        DivType div = new DivType();
+        div.setORDER(linkedStructure.getOrder());
+        Mptr mptr = new Mptr();
+        mptr.setHref(linkedStructure.getUri().getPath());
+        div.getMptr().add(mptr);
+        return div;
     }
 }

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -47,9 +47,11 @@ public class MptrXmlElementAccess {
      *             parent’s METS
      */
     MptrXmlElementAccess(DivType div, Mets parent, InputStreamProviderInterface inputStreamProvider) {
+        String href = null;
         try {
             linkedStructure.setOrder(div.getORDER());
-            URI uri = new URI(div.getMptr().stream().findFirst().get().getHref());
+            href = div.getMptr().stream().findFirst().get().getHref();
+            URI uri = new URI(href);
             linkedStructure.setUri(uri);
             Mets child;
             try (InputStream in = inputStreamProvider.getInputStream(uri, true)) {
@@ -62,7 +64,7 @@ public class MptrXmlElementAccess {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (URISyntaxException e) {
-            throw new DataBindingException(e.getMessage(), e);
+            throw new DataBindingException("Erroneous URI: \"" + href + "\" (" + e.getMessage() + ')', e);
         }
     }
 

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -68,20 +68,6 @@ public class MptrXmlElementAccess {
         } catch (URISyntaxException e) {
             throw new DataBindingException(e.getMessage(), e);
         }
-        // =======
-        // LinkedStructure(DivType div, Mets parent, Function<Pair<URI,
-        // Boolean>, InputStream> getInputStreamFunction) {
-        // this.order = div.getORDER();
-        // this.uri =
-        // Workpiece.hrefToUri(div.getMptr().stream().findFirst().get().getHref());
-        // Mets child = Workpiece.readMets(getInputStreamFunction, uri, true);
-        // ensureParenthood(parent, child, getInputStreamFunction);
-        // Structure linked = new Workpiece(child,
-        // getInputStreamFunction).getStructMap();
-        // this.label = linked.getLabel();
-        // this.type = linked.getType();
-        // >>>>>>> Add reading of parent
-        // references:Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/LinkedStructure.java
     }
 
     /**

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -1,0 +1,122 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.dataformat.access;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.xml.bind.DataBindingException;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.kitodo.api.dataformat.LinkedStructure;
+import org.kitodo.api.dataformat.Structure;
+import org.kitodo.dataformat.metskitodo.DivType;
+import org.kitodo.dataformat.metskitodo.Mets;
+
+public class MptrXmlElementAccess {
+
+    LinkedStructure linkedStructure = new LinkedStructure();
+
+    /**
+     * Constructor to read a linked structure from METS.
+     * 
+     * @param div
+     *            METS {@code <div>} element from which the structure is to be
+     *            built
+     * @param mets
+     *            METS data structure of the current workpiece
+     * @param getInputStreamFunction
+     *            A reference to a function
+     *            {@code InputStream getInputStream(URI uri, Boolean couldHaveToBeWrittenInTheFuture)}.
+     *            If invoked, the calling function is responsible of closing the
+     *            stream.
+     * @throws IllegalStateException
+     *             if the child does not have a link to the parent, or the
+     *             parent link of the child returns METS data different from the
+     *             parent’s METS
+     */
+    MptrXmlElementAccess(DivType div, Mets parent, Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) {
+        try {
+            linkedStructure.setOrder(div.getORDER());
+            URI uri = new URI(div.getMptr().stream().findFirst().get().getHref());
+            linkedStructure.setUri(uri);
+            Mets child;
+            try (InputStream in = getInputStreamFunction.apply(Pair.of(uri, true))) {
+                child = MetsXmlElementAccess.readMets(in);
+            }
+            ensureParenthood(parent, child, getInputStreamFunction);
+            Structure linked = MetsXmlElementAccess.toWorkpiece(child, getInputStreamFunction).getStructure();
+            linkedStructure.setLabel(linked.getLabel());
+            linkedStructure.setType(linked.getType());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (URISyntaxException e) {
+            throw new DataBindingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Checks if the child METS file is a child of this METS file. If the child
+     * being found for some reason is not actually the child of this process,
+     * editing can corrupt the other process that was erroneously assumed as a
+     * child. Therefore, it is checked at this point whether the assumed child
+     * is actually a child. For this, the link is opened and the METS data
+     * compared. If the link is missing or the METS data is not equal, the child
+     * is a mistake, and an exception is throne.
+     * 
+     * @param current
+     *            METS data of the current process
+     * @param child
+     *            METS data of the process linked as child
+     * @throws IOException
+     *             if file system I/O fails
+     * @throws URISyntaxException
+     *             if an URI found in a METS file is syntactically wrong
+     * @throws IllegalStateException
+     *             if the child does not have a link to the parent, or the
+     *             parent link of the child returns METS data different from the
+     *             parent’s METS
+     */
+    private void ensureParenthood(Mets current, Mets child,
+            Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) throws IOException, URISyntaxException {
+
+        Optional<String> optionalParentLink = child.getStructMap().parallelStream()
+                .filter(structMap -> "LOGICAL".equals(structMap.getTYPE())).map(structMap -> structMap.getDiv())
+                .filter(Objects::nonNull).flatMap(div -> div.getMptr().parallelStream()).map(mptr -> mptr.getHref())
+                .reduce((one, another) -> {
+                    if (!one.equals(another)) {
+                        throw new IllegalStateException("Parent link is ambiguous");
+                    } else {
+                        return one;
+                    }
+                });
+
+        if (!optionalParentLink.isPresent()) {
+            throw new IllegalStateException("METS file linked as child misses parent link");
+        }
+
+        Mets linked;
+        try (InputStream in = getInputStreamFunction.apply(Pair.of(new URI(optionalParentLink.get()), false))) {
+            linked = MetsXmlElementAccess.readMets(in);
+        }
+        if (linked.equals(current)) {
+            throw new IllegalStateException("METS file linked as child points to different parent METS");
+        }
+    }
+
+}

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -68,6 +68,20 @@ public class MptrXmlElementAccess {
         } catch (URISyntaxException e) {
             throw new DataBindingException(e.getMessage(), e);
         }
+        // =======
+        // LinkedStructure(DivType div, Mets parent, Function<Pair<URI,
+        // Boolean>, InputStream> getInputStreamFunction) {
+        // this.order = div.getORDER();
+        // this.uri =
+        // Workpiece.hrefToUri(div.getMptr().stream().findFirst().get().getHref());
+        // Mets child = Workpiece.readMets(getInputStreamFunction, uri, true);
+        // ensureParenthood(parent, child, getInputStreamFunction);
+        // Structure linked = new Workpiece(child,
+        // getInputStreamFunction).getStructMap();
+        // this.label = linked.getLabel();
+        // this.type = linked.getType();
+        // >>>>>>> Add reading of parent
+        // references:Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/LinkedStructure.java
     }
 
     /**
@@ -85,15 +99,13 @@ public class MptrXmlElementAccess {
      *            METS data of the process linked as child
      * @throws IOException
      *             if file system I/O fails
-     * @throws URISyntaxException
-     *             if an URI found in a METS file is syntactically wrong
      * @throws IllegalStateException
      *             if the child does not have a link to the parent, or the
      *             parent link of the child returns METS data different from the
      *             parent’s METS
      */
     private void ensureParenthood(Mets current, Mets child,
-            Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) throws IOException, URISyntaxException {
+            Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction) throws IOException {
 
         Optional<String> optionalParentLink = child.getStructMap().parallelStream()
                 .filter(structMap -> "LOGICAL".equals(structMap.getTYPE())).map(structMap -> structMap.getDiv())
@@ -111,12 +123,12 @@ public class MptrXmlElementAccess {
         }
 
         Mets linked;
-        try (InputStream in = getInputStreamFunction.apply(Pair.of(new URI(optionalParentLink.get()), false))) {
+        try (InputStream in = getInputStreamFunction
+                .apply(Pair.of(MetsXmlElementAccess.hrefToUri(optionalParentLink.get()), false))) {
             linked = MetsXmlElementAccess.readMets(in);
         }
         if (!Objects.deepEquals(linked, current)) {
             throw new IllegalStateException("METS file linked as child points to different parent METS");
         }
     }
-
 }

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -28,10 +28,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.MetadataEntry;
@@ -44,16 +42,13 @@ import org.kitodo.api.dataformat.ProcessingNote;
 import org.kitodo.api.dataformat.Structure;
 import org.kitodo.api.dataformat.View;
 import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.api.dataformat.mets.InputStreamProviderInterface;
 
 public class MetsXmlElementAccessIT {
 
     private static final File OUT_FILE = new File("src/test/resources/out.xml");
 
-    public static final Function<Pair<URI, Boolean>, InputStream> GET_INPUT_STREAM_FUNCTION = args -> {
-        URI uri = args.getLeft();
-        @SuppressWarnings("unused")
-        boolean couldHaveToBeWrittenInTheFuture = args.getRight();
-
+    private static final InputStreamProviderInterface INPUT_STREAM_PROVIDER = (uri, unused) -> {
         try {
             return new FileInputStream(new File("src/test/resources/" + uri.getPath()));
         } catch (FileNotFoundException e) {
@@ -113,7 +108,7 @@ public class MetsXmlElementAccessIT {
     @Test
     public void testReadingHierarchyOfTop() throws Exception {
         Workpiece workpiece = new MetsXmlElementAccess()
-                .read(new FileInputStream(new File("src/test/resources/top.xml")), GET_INPUT_STREAM_FUNCTION);
+                .read(new FileInputStream(new File("src/test/resources/top.xml")), INPUT_STREAM_PROVIDER);
 
         List<ExistingOrLinkedStructure> topStructMapChildren = workpiece.getStructure().getChildren();
         ExistingOrLinkedStructure firstBranch = topStructMapChildren.get(0);
@@ -151,7 +146,7 @@ public class MetsXmlElementAccessIT {
     public void testReadingHierarchyOfBetween() throws Exception {
         Workpiece workpiece = new MetsXmlElementAccess().read(
             new FileInputStream(new File("src/test/resources/between.xml")),
-            GET_INPUT_STREAM_FUNCTION);
+            INPUT_STREAM_PROVIDER);
 
         ExistingOrLinkedStructure downlink = workpiece.getStructure().getChildren().get(0);
         assertEquals(LinkedStructure.class, downlink.getClass());
@@ -179,7 +174,7 @@ public class MetsXmlElementAccessIT {
     public void testReadingHierarchyOfLeaf() throws Exception {
         Workpiece workpiece = new MetsXmlElementAccess().read(
             new FileInputStream(new File("src/test/resources/leaf.xml")),
-            GET_INPUT_STREAM_FUNCTION);
+            INPUT_STREAM_PROVIDER);
 
         List<LinkedStructure> leafUplinks = workpiece.getUplinks();
         assertEquals(3, leafUplinks.size());
@@ -206,28 +201,28 @@ public class MetsXmlElementAccessIT {
     public void testReadingHierarchyFailsIfSubordinateFileHasNoBackreference() throws Exception {
         new MetsXmlElementAccess().read(
             new FileInputStream(new File("src/test/resources/subordinate-no-backreference_between.xml")),
-            GET_INPUT_STREAM_FUNCTION);
+            INPUT_STREAM_PROVIDER);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testReadingHierarchyFailsIfSubordinateFileHasWrongBackreference() throws Exception {
         new MetsXmlElementAccess().read(
             new FileInputStream(new File("src/test/resources/subordinate-wrong-backreference_between.xml")),
-            GET_INPUT_STREAM_FUNCTION);
+            INPUT_STREAM_PROVIDER);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testReadingHierarchyFailsIfSuperordinateFileHasNoBackreference() throws Exception {
         new MetsXmlElementAccess().read(
             new FileInputStream(new File("src/test/resources/superordinate-no-backreference_leaf.xml")),
-            GET_INPUT_STREAM_FUNCTION);
+            INPUT_STREAM_PROVIDER);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testReadingHierarchyFailsIfSuperordinateFileHasAmbiguousBackreference() throws Exception {
         new MetsXmlElementAccess().read(
             new FileInputStream(new File("src/test/resources/superordinate-ambiguous-backreference_leaf.xml")),
-            GET_INPUT_STREAM_FUNCTION);
+            INPUT_STREAM_PROVIDER);
     }
 
     @Test

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Files;
@@ -51,7 +52,7 @@ public class MetsXmlElementAccessIT {
     @Test
     public void testRead() throws Exception {
         Workpiece workpiece = new MetsXmlElementAccess()
-                .read(new FileInputStream(new File("src/test/resources/meta.xml")));
+                .read(new FileInputStream(new File("src/test/resources/meta.xml")), null);
 
         // METS file has 183 associated images
         assertEquals(183, workpiece.getMediaUnits().size());
@@ -218,7 +219,10 @@ public class MetsXmlElementAccessIT {
         }
 
         // read the file and see if everything is in it
-        Workpiece reread = new MetsXmlElementAccess().read(new FileInputStream(new File("src/test/resources/out.xml")));
+        Workpiece reread;
+        try (InputStream inputStream = new FileInputStream(OUT_FILE)) {
+            reread = new MetsXmlElementAccess().read(inputStream, null);
+        }
 
         assertEquals(1, reread.getEditHistory().size());
         List<MediaUnit> mediaUnits = reread.getMediaUnits();

--- a/Kitodo-DataFormat/src/test/resources/another.xml
+++ b/Kitodo-DataFormat/src/test/resources/another.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="top.xml"/>
+      <div LABEL="Anther METS file" TYPE="leaf"/>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/between.xml
+++ b/Kitodo-DataFormat/src/test/resources/between.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="top.xml"/>
+      <div LABEL="Between the METS files" TYPE="between">
+        <div ORDER="1">
+          <mptr xlink:href="leaf.xml"/>
+        </div>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/leaf.xml
+++ b/Kitodo-DataFormat/src/test/resources/leaf.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="between.xml"/>
+      <div LABEL="Leaf METS file" TYPE="leaf"/>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/other.xml
+++ b/Kitodo-DataFormat/src/test/resources/other.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="top.xml"/>
+      <div LABEL="Other METS file" TYPE="leaf"/>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/subordinate-no-backreference_between.xml
+++ b/Kitodo-DataFormat/src/test/resources/subordinate-no-backreference_between.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="subordinate-no-backreference_top.xml"/>
+      <div LABEL="Between the METS files" TYPE="between">
+        <div ORDER="1">
+          <mptr xlink:href="subordinate-no-backreference_leaf.xml"/>
+        </div>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/subordinate-no-backreference_leaf.xml
+++ b/Kitodo-DataFormat/src/test/resources/subordinate-no-backreference_leaf.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <!-- no wrapping <div> with <mptr href="between.xml"/> here -->
+    <div LABEL="Leaf METS file" TYPE="leaf"/>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/subordinate-no-backreference_top.xml
+++ b/Kitodo-DataFormat/src/test/resources/subordinate-no-backreference_top.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div LABEL="Top METS file" TYPE="top">
+      <div ORDER="1">
+        <mptr xlink:href="subordinate-no-backreference_between.xml"/>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/subordinate-wrong-backreference_between.xml
+++ b/Kitodo-DataFormat/src/test/resources/subordinate-wrong-backreference_between.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="subordinate-wrong-backreference_top.xml"/>
+      <div LABEL="Between the METS files" TYPE="between">
+        <div ORDER="1">
+          <mptr xlink:href="subordinate-wrong-backreference_leaf.xml"/>
+        </div>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/subordinate-wrong-backreference_leaf.xml
+++ b/Kitodo-DataFormat/src/test/resources/subordinate-wrong-backreference_leaf.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="between.xml"/><!-- Wrong link: would have to be subordinate-wrong-backreference_between.xml -->
+      <div LABEL="Leaf METS file" TYPE="leaf"/>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/subordinate-wrong-backreference_top.xml
+++ b/Kitodo-DataFormat/src/test/resources/subordinate-wrong-backreference_top.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div LABEL="Top METS file" TYPE="top">
+      <div ORDER="1">
+        <mptr xlink:href="subordinate-wrong-backreference_between.xml"/>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/superordinate-ambiguous-backreference_leaf.xml
+++ b/Kitodo-DataFormat/src/test/resources/superordinate-ambiguous-backreference_leaf.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="superordinate-ambiguous-backreference_top.xml"/>
+      <div LABEL="Leaf METS file" TYPE="leaf"/>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/superordinate-ambiguous-backreference_top.xml
+++ b/Kitodo-DataFormat/src/test/resources/superordinate-ambiguous-backreference_top.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div LABEL="Top METS file" TYPE="top">
+      <div LABEL="This branch?" TYPE="between">
+        <div ORDER="10">
+          <mptr xlink:href="superordinate-ambiguous-backreference_leaf.xml"/>
+        </div>
+      </div>
+      <div LABEL="Or this one?" TYPE="between">
+        <div ORDER="10">
+          <mptr xlink:href="superordinate-ambiguous-backreference_leaf.xml"/>
+        </div>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/superordinate-no-backreference_leaf.xml
+++ b/Kitodo-DataFormat/src/test/resources/superordinate-no-backreference_leaf.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div>
+      <mptr xlink:href="superordinate-no-backreference_top.xml"/>
+      <div LABEL="Leaf METS file" TYPE="leaf"/>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/superordinate-no-backreference_top.xml
+++ b/Kitodo-DataFormat/src/test/resources/superordinate-no-backreference_top.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div LABEL="Top METS file" TYPE="top">
+      <div LABEL="My branch" TYPE="between">
+        <div ORDER="10">
+          <mptr xlink:href="leaf.xml"/><!-- Wrong link: would have to be superordinate-no-backreference_leaf.xml -->
+        </div>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/top.xml
+++ b/Kitodo-DataFormat/src/test/resources/top.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <structMap TYPE="LOGICAL">
+    <div LABEL="Top METS file" TYPE="top">
+      <div ORDER="1">
+        <mptr xlink:href="between.xml"/>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/Kitodo-DataFormat/src/test/resources/top.xml
+++ b/Kitodo-DataFormat/src/test/resources/top.xml
@@ -2,8 +2,20 @@
 <mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
   <structMap TYPE="LOGICAL">
     <div LABEL="Top METS file" TYPE="top">
-      <div ORDER="1">
-        <mptr xlink:href="between.xml"/>
+      <div LABEL="Other branch" TYPE="one">
+        <div ORDER="1">
+          <mptr xlink:href="other.xml"/>
+        </div>
+      </div>
+      <div LABEL="My branch" TYPE="two">
+        <div ORDER="10">
+          <mptr xlink:href="between.xml"/>
+        </div>
+      </div>
+      <div LABEL="Another branch" TYPE="three">
+        <div ORDER="100">
+          <mptr xlink:href="another.xml"/>
+        </div>
       </div>
     </div>
   </structMap>

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
+import org.kitodo.api.dataformat.ExistingOrLinkedStructure;
 import org.kitodo.api.dataformat.Structure;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.filemanagement.LockResult;
@@ -170,10 +171,15 @@ public class LegacyMetsModsDigitalDocumentHelper {
     @Deprecated
     public LegacyDocStructHelperInterface createDocStruct(LegacyLogicalDocStructTypeHelper docStructType) {
         if (!docStructType.equals(LegacyInnerPhysicalDocStructTypePageHelper.INSTANCE)) {
-            return new LegacyLogicalDocStructHelper(new Structure(), null, ruleset, priorityList);
+            return createRootLegacyLogicalDocStructHelper(new Structure());
         } else {
             return new LegacyInnerPhysicalDocStructHelper();
         }
+    }
+
+    public LegacyLogicalDocStructHelper createRootLegacyLogicalDocStructHelper(
+            ExistingOrLinkedStructure existingOrLinkedStructure) {
+        return new LegacyLogicalDocStructHelper(existingOrLinkedStructure, null, ruleset, priorityList);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -30,6 +30,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataformat.ExistingOrLinkedStructure;
 import org.kitodo.api.dataformat.Structure;
 import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.api.dataformat.mets.InputStreamProviderInterface;
 import org.kitodo.api.filemanagement.LockResult;
 import org.kitodo.api.filemanagement.LockingMode;
 import org.kitodo.data.database.beans.User;
@@ -121,7 +122,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
 
     /**
      * Creates a new legacy METS MODS digital document helper with a ruleset.
-     * 
+     *
      * @param ruleset
      *            ruleset to set
      */
@@ -133,7 +134,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
 
     /**
      * Creates a new legacy METS MODS digital document helper with a workpiece.
-     * 
+     *
      * @param ruleset
      *            ruleset to set
      * @param workpiece
@@ -185,7 +186,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
     /**
      * Extracts the formation of the error message as it occurs during both
      * reading and writing. In addition, the error is logged.
-     * 
+     *
      * @param uri
      *            URI to be read/written
      * @param lockResult
@@ -226,7 +227,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
 
     /**
      * Returns the workpiece of the legacy METS/MODS digital document helper.
-     * 
+     *
      * @return the workpiece
      */
     public Workpiece getWorkpiece() {
@@ -256,7 +257,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
                 try (InputStream in = fileService.read(uri, lockResult)) {
                     logger.info("Reading {}", uri.toString());
                     workpiece = ServiceManager.getMetsService().load(in,
-                        args -> getInputStream(args.getLeft(), lockResult, args.getRight()));
+                        getInputStream(lockResult));
                 }
             } else {
                 throw new IOException(createLockErrorMessage(uri, lockResult.getConflicts()));
@@ -264,7 +265,8 @@ public class LegacyMetsModsDigitalDocumentHelper {
         }
     }
 
-    private InputStream getInputStream(URI uri, LockResult lockResult, boolean couldHaveToBeWrittenInTheFuture) {
+    private InputStreamProviderInterface getInputStream(LockResult lockResult) {
+        return (uri, couldHaveToBeWrittenInTheFuture) -> {
         try {
             Map<URI, LockingMode> requests = new HashMap<>(2);
             requests.put(uri,
@@ -278,6 +280,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        };
     }
 
     @Deprecated
@@ -328,7 +331,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
      * operation. The name was chosen deliberately short in order to keep the
      * calling code clear. This method must be implemented in every class
      * because it uses the logger tailored to the class.
-     * 
+     *
      * @param exception
      *            created {@code UnsupportedOperationException}
      * @return the exception

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
@@ -1676,11 +1676,10 @@ public class MetadataProcessor {
      */
     public Iterable<TreeNode> getTrees() {
         List<TreeNode> result = new ArrayList<>();
-        LegacyMetsModsDigitalDocumentHelper legacyMetsModsDigitalDocumentHelper = digitalDocument;
-        for (LinkedStructure linkedStructure : legacyMetsModsDigitalDocumentHelper.getWorkpiece().getUplinks()) {
+        for (LinkedStructure linkedStructure : digitalDocument.getWorkpiece().getUplinks()) {
             DefaultTreeNode elder = new DefaultTreeNode("Invisble container node", null);
-            TreeNode node = new DefaultTreeNode(
-                    legacyMetsModsDigitalDocumentHelper.createRootLegacyLogicalDocStructHelper(linkedStructure), elder);
+            TreeNode node = new DefaultTreeNode(digitalDocument.createRootLegacyLogicalDocStructHelper(linkedStructure),
+                    elder);
             node.setSelected(selectedTreeNode != null && selectedTreeNode.equals(node));
             result.add(setExpandingAll(elder, true));
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -14,8 +14,11 @@ package org.kitodo.production.services.dataformat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.Objects;
+import java.util.function.Function;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.dataformat.mets.MetsXmlElementAccessInterface;
 import org.kitodo.serviceloader.KitodoServiceLoader;
@@ -46,8 +49,9 @@ public class MetsService {
                 MetsXmlElementAccessInterface.class).loadModule();
     }
 
-    public Workpiece load(InputStream in) throws IOException {
-        return metsXmlElementAccess.read(in);
+    public Workpiece load(InputStream in, Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction)
+            throws IOException {
+        return metsXmlElementAccess.read(in, getInputStreamFunction);
     }
 
     public void save(Workpiece workpiece, OutputStream out) throws IOException {

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -14,12 +14,10 @@ package org.kitodo.production.services.dataformat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.util.Objects;
-import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.api.dataformat.mets.InputStreamProviderInterface;
 import org.kitodo.api.dataformat.mets.MetsXmlElementAccessInterface;
 import org.kitodo.serviceloader.KitodoServiceLoader;
 
@@ -49,9 +47,9 @@ public class MetsService {
                 MetsXmlElementAccessInterface.class).loadModule();
     }
 
-    public Workpiece load(InputStream in, Function<Pair<URI, Boolean>, InputStream> getInputStreamFunction)
+    public Workpiece load(InputStream in, InputStreamProviderInterface inputStreamProvider)
             throws IOException {
-        return metsXmlElementAccess.read(in, getInputStreamFunction);
+        return metsXmlElementAccess.read(in, inputStreamProvider);
     }
 
     public void save(Workpiece workpiece, OutputStream out) throws IOException {

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -33,7 +33,7 @@ public class MetsServiceIT {
     public void testReadXML() throws Exception {
         Workpiece workpiece;
         try (InputStream in = new FileInputStream(new File("../Kitodo-DataFormat/src/test/resources/meta.xml"))) {
-            workpiece = MetsService.getInstance().load(in);
+            workpiece = MetsService.getInstance().load(in, null);
         }
 
         // METS file has 183 associated images

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -16,11 +16,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -82,12 +84,12 @@ public class MetsServiceIT {
     @Test
     public void testReadingHierarchy() throws Exception {
         Workpiece workpiece = MetsService.getInstance()
-                .load(new FileInputStream(new File("../Kitodo-DataFormat/src/test/resources/between.xml")),
+                .load(Files.newInputStream(Paths.get("../Kitodo-DataFormat/src/test/resources/between.xml")),
                     (uri, couldHaveToBeWrittenInTheFuture) -> {
                         try {
-                            return new FileInputStream(
-                                    new File("../Kitodo-DataFormat/src/test/resources/" + uri.getPath()));
-                        } catch (FileNotFoundException e) {
+                            return Files.newInputStream(
+                                Paths.get("../Kitodo-DataFormat/src/test/resources/" + uri.getPath()));
+                        } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }
                     });

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -84,13 +84,13 @@ public class MetsServiceIT {
         Workpiece workpiece = MetsService.getInstance()
                 .load(new FileInputStream(new File("../Kitodo-DataFormat/src/test/resources/between.xml")),
                     (uri, couldHaveToBeWrittenInTheFuture) -> {
-            try {
-                return new FileInputStream(
+                        try {
+                            return new FileInputStream(
                                     new File("../Kitodo-DataFormat/src/test/resources/" + uri.getPath()));
-            } catch (FileNotFoundException e) {
-                throw new UncheckedIOException(e);
-            }
-        });
+                        } catch (FileNotFoundException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
 
         ExistingOrLinkedStructure downlink = workpiece.getStructure().getChildren().get(0);
         assertTrue(downlink.isLinked());

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -82,10 +82,11 @@ public class MetsServiceIT {
     @Test
     public void testReadingHierarchy() throws Exception {
         Workpiece workpiece = MetsService.getInstance()
-                .load(new FileInputStream(new File("../Kitodo-DataFormat/src/test/resources/between.xml")), args -> {
+                .load(new FileInputStream(new File("../Kitodo-DataFormat/src/test/resources/between.xml")),
+                    (uri, couldHaveToBeWrittenInTheFuture) -> {
             try {
                 return new FileInputStream(
-                        new File("../Kitodo-DataFormat/src/test/resources/" + args.getLeft().getPath()));
+                                    new File("../Kitodo-DataFormat/src/test/resources/" + uri.getPath()));
             } catch (FileNotFoundException e) {
                 throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
This saves the linked processes back to METS.
Please note the explanations in the individual commits. I have tried to better explain why I made the respective changes.

This pull request is based on #2146