### PR TITLE
Fix a bug that the meta-data is not saved

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/ugh/MetadataInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/ugh/MetadataInterface.java
@@ -11,6 +11,9 @@
 
 package org.kitodo.api.ugh;
 
+import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
+import org.kitodo.api.dataformat.mets.MetadataXmlElementAccessInterface;
+
 /**
  * A meta-data object represents a single meta-data entry. Each meta-data entry
  * has at least a value and a type. The type of the a meta-data element is
@@ -23,6 +26,13 @@ package org.kitodo.api.ugh;
  */
 public interface MetadataInterface {
     /**
+     * Returns the binding of the meta-data.
+     * 
+     * @return the binding
+     */
+    MetadataXmlElementAccessInterface getBinding();
+
+    /**
      * Returns the document structure instance, to which this meta-data object
      * belongs. This is extremely helpful, if only the meta-data instance is
      * stored in a list; the reference to the associated document structure
@@ -31,6 +41,13 @@ public interface MetadataInterface {
      * @return the document structure instance
      */
     DocStructInterface getDocStruct();
+
+    /**
+     * Returns the domain of the meta-data. There are six different ones.
+     * 
+     * @return the domain
+     */
+    Domain getDomain();
 
     /**
      * Returns the type of the meta-data instance. The MetadataType object which

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/BindingSaveInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/BindingSaveInterface.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.helper.metadata.legacytypeimplementations;
+
+/**
+ * The interface provides the method of storing the meta-data in the binding.
+ */
+public interface BindingSaveInterface {
+    /**
+     * Saves the meta-data in the binding.
+     * 
+     * @param legacyMetadataHelper
+     *            meta-data to save
+     */
+    void saveMetadata(LegacyMetadataHelper legacyMetadataHelper);
+}

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetadataHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetadataHelper.java
@@ -13,6 +13,8 @@ package org.kitodo.production.helper.metadata.legacytypeimplementations;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
+import org.kitodo.api.dataformat.mets.MetadataXmlElementAccessInterface;
 
 /**
  * Represents a legacy metadata. This is a soldering class to keep legacy code
@@ -36,6 +38,12 @@ public class LegacyMetadataHelper {
      */
     private LegacyInnerPhysicalDocStructHelper legacyInnerPhysicalDocStructHelper;
 
+    private BindingSaveInterface bindingSaveInterface;
+
+    private MetadataXmlElementAccessInterface binding;
+
+    private Domain domain;
+
     LegacyMetadataHelper(LegacyInnerPhysicalDocStructHelper legacyInnerPhysicalDocStructHelper,
             LegacyMetadataTypeHelper type, String value) {
         this.type = type;
@@ -48,8 +56,16 @@ public class LegacyMetadataHelper {
         this.value = "";
     }
 
+    public MetadataXmlElementAccessInterface getBinding() {
+        return binding;
+    }
+
     public LegacyInnerPhysicalDocStructHelper getDocStruct() {
         return legacyInnerPhysicalDocStructHelper;
+    }
+
+    public Domain getDomain() {
+        return domain;
     }
 
     public LegacyMetadataTypeHelper getMetadataType() {
@@ -58,6 +74,35 @@ public class LegacyMetadataHelper {
 
     public String getValue() {
         return value;
+    }
+
+    /**
+     * This allows the meta-data to be saved.
+     */
+    public void saveToBinding() {
+        bindingSaveInterface.saveMetadata(this);
+    }
+
+    /**
+     * Sets the binding to a meta-data XML access interface through a binding
+     * save interface. This is needed so that the meta-data in its container can
+     * automatically save itself if its value is subsequently changed. In fact,
+     * the value may be, aside from the value of a meta-data entry, the value of
+     * a field of the container, which makes the matter a bit unwieldy.
+     * 
+     * @param bsi
+     *            thee binding save interface via which the meta-data can
+     *            automatically save itself afterwards
+     * @param binding
+     *            the meta-data entry where the value should be stored, if
+     *            applicable
+     * @param domain
+     *            the domain where the meta-data entry is stored
+     */
+    public void setBinding(BindingSaveInterface bsi, MetadataXmlElementAccessInterface binding, Domain domain) {
+        this.bindingSaveInterface = bsi;
+        this.binding = binding;
+        this.domain = domain;
     }
 
     /**
@@ -79,6 +124,9 @@ public class LegacyMetadataHelper {
 
     public void setStringValue(String value) {
         this.value = value;
+        if (bindingSaveInterface != null) {
+            saveToBinding();
+        }
     }
 
     /**


### PR DESCRIPTION
The use of meta-data in legacy code is upside down: First, an empty meta-data is created and stored, and then the value is set, and the value is then supposed to propagate itself to the right place where it is stored. This had worked in the past by simply adding a mutable meta-data to a list. Now the matter is more complicated, because the meta-data value can also be in a field of the container and not in an own object at all. Basically, the implementation is an observer pattern or something that’s pretty much the same.