### PR TITLE
Cache and reuse the METS-internal IDs

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MediaFile.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MediaFile.java
@@ -25,6 +25,14 @@ import org.kitodo.dataformat.metskitodo.FileType.FLocat;
  */
 public class MediaFile implements FLocatXmlElementAccessInterface {
     /**
+     * Some magic numbers that are used in the METS XML file representation of
+     * this structure to describe relations between XML elements. They need to
+     * be stored because some scatty third-party scripts rely on them not being
+     * changed anymore once assigned.
+     */
+    private final String metsReferrerId;
+
+    /**
      * References computer file.
      */
     private URI uri;
@@ -35,17 +43,19 @@ public class MediaFile implements FLocatXmlElementAccessInterface {
      * of media file.
      */
     public MediaFile() {
+        metsReferrerId = UUID.randomUUID().toString();
     }
 
     /**
      * Constructor for creating a new media file reference from METS F locat.
      * 
-     * @param fLocat
-     *            F locat to create a new media file reference from
+     * @param file
+     *            File to create a new media file reference from
      */
-    MediaFile(FLocat fLocat) {
+    MediaFile(FileType file) {
+        metsReferrerId = file.getID();
         try {
-            uri = new URI(fLocat.getHref());
+            uri = new URI(file.getFLocat().get(0).getHref());
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
@@ -83,7 +93,7 @@ public class MediaFile implements FLocatXmlElementAccessInterface {
      */
     FileType toFile(String mimeType) {
         FileType file = new FileType();
-        file.setID(UUID.randomUUID().toString());
+        file.setID(metsReferrerId);
         file.setMIMETYPE(mimeType);
         FLocat fLocat = new FLocat();
         fLocat.setLOCTYPE("URL");

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MediaUnit.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MediaUnit.java
@@ -35,6 +35,14 @@ public class MediaUnit implements FileXmlElementAccessInterface {
     private Map<MediaVariant, MediaFile> mediaFiles = new HashMap<>();
 
     /**
+     * Some magic numbers that are used in the METS XML file representation of
+     * this structure to describe relations between XML elements. They need to
+     * be stored because some scatty third-party scripts rely on them not being
+     * changed anymore once assigned.
+     */
+    private final String metsReferrerId;
+
+    /**
      * Sequence number of the media unit. The playback order of the media units
      * when referenced from a structure is determined by this attribute (not by
      * the order of the references).
@@ -54,6 +62,7 @@ public class MediaUnit implements FileXmlElementAccessInterface {
      * with the service loader to get a new instance of media unit.
      */
     public MediaUnit() {
+        metsReferrerId = UUID.randomUUID().toString();
     }
 
     /**
@@ -77,7 +86,8 @@ public class MediaUnit implements FileXmlElementAccessInterface {
                             .orElseThrow(() -> new IllegalArgumentException(
                                     "Corrupt file: <mets:fptr> not referenced in <mets:fileGrp>"))
                             .getUSE()),
-                    file -> new MediaFile(file.getFLocat().get(0))));
+                    file -> new MediaFile(file)));
+        metsReferrerId = div.getID();
         order = div.getORDER().intValue();
         orderlabel = div.getORDERLABEL();
     }
@@ -190,9 +200,8 @@ public class MediaUnit implements FileXmlElementAccessInterface {
             Map<MediaUnit, String> mediaUnitIDs) {
 
         DivType div = new DivType();
-        String divId = UUID.randomUUID().toString();
-        div.setID(divId);
-        mediaUnitIDs.put(this, divId);
+        div.setID(metsReferrerId);
+        mediaUnitIDs.put(this, metsReferrerId);
         div.setORDER(BigInteger.valueOf(order));
         div.setORDERLABEL(orderlabel);
         for (Entry<MediaVariant, MediaFile> use : mediaFiles.entrySet()) {


### PR DESCRIPTION
The IDs used in METS to represent cross-relationships are cached and reused when writing the modified METS file so that third-party scripts can use them for recognition. For structures, media units, and media files for which Java objects are available, the assigned IDs are stored and reused. The meta-data sections have been switched to name-based UUIDs, with the name formed from the structure's stored UUID and a suffix for the affected meta-data section, so that the UUIDs for the meta-data sections are reproducibly formed.