### PR TITLE
Create folders according to the folder configuration

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -119,20 +119,6 @@ public enum ParameterCore implements ParameterInterface {
      */
 
     /**
-     * Boolean, defaults to {@code false}.
-     */
-    CREATE_ORIG_FOLDER_IF_NOT_EXISTS(new Parameter<>("createOrigFolderIfNotExists", false)),
-
-    /*
-     * Parameters.java has been sorted to corresponding to kitodo_config.properties,
-     * including the section headers as you see. However there is an entry
-     * createSourceFolder in kitodo_config.properties, but there is no constant for
-     * it here. This comment is to explain where the constant is if someone compares
-     * the two files in the future:
-     */
-    CREATE_SOURCE_FOLDER(new Parameter<UndefinedParameter>("createSourceFolder")),
-
-    /**
      * Prefix of image directory name created on process creation.
      */
     DIRECTORY_PREFIX(new Parameter<>("DIRECTORY_PREFIX", "orig")),

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
@@ -718,8 +718,6 @@ public class ProzesskopieForm implements Serializable {
                 insertImagePath();
             }
 
-            // Create configured directories
-            ServiceManager.getProcessService().createProcessDirs(this.prozessKopie);
             ServiceManager.getProcessService().readMetadataFile(this.prozessKopie);
 
             startTaskScriptThreads();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
@@ -660,7 +660,7 @@ public class ProzesskopieForm implements Serializable {
     }
 
     /**
-     * Anlegen des Prozesses und save der Metadaten.
+     * Create the process and save the meta-data.
      */
     public String createNewProcess() {
         if (!isContentValid(true)) {
@@ -678,19 +678,16 @@ public class ProzesskopieForm implements Serializable {
             return null;
         }
 
-        String baseProcessDirectory = ServiceManager.getProcessService().getProcessDataDirectory(this.prozessKopie)
-                .toString();
-        boolean successful = false;
         try {
-            successful = ServiceManager.getFileService().createMetaDirectory(URI.create(""), baseProcessDirectory);
-        } catch (IOException e) {
+            URI processBaseUri = ServiceManager.getFileService().createProcessLocation(prozessKopie);
+            prozessKopie.setProcessBaseUri(processBaseUri);
+        } catch (Exception e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
-        }
-        if (!successful) {
-            String message = "Metadata directory: " + baseProcessDirectory + " in path: "
-                    + ConfigCore.getKitodoDataDirectory() + " was not created!";
-            logger.error(message);
-            Helper.setErrorMessage(message);
+            try {
+                ServiceManager.getProcessService().remove(prozessKopie);
+            } catch (Exception ex) {
+                logger.catching(ex);
+            }
             return null;
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
@@ -217,6 +217,20 @@ public class Subfolder {
     }
 
     /**
+     * Returns the relative path to the directory storing the files.
+     * 
+     * @return relative path to the directory
+     */
+    public String getRelativeDirectoryPath() {
+        String pathWithVariables = folder.getPath();
+        int lastSeparator = pathWithVariables.lastIndexOf(File.separatorChar);
+        if (pathWithVariables.indexOf('*', lastSeparator) > -1) {
+            pathWithVariables = pathWithVariables.substring(0, lastSeparator);
+        }
+        return variableReplacer.replace(pathWithVariables);
+    }
+
+    /**
      * Returns the URI to a file in this folder.
      *
      * @param canonical

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -136,8 +136,6 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
     private static final String LOCKED = "locked";
     private static final String OPEN = "open";
     private static final String PROCESS_TITLE = "(processtitle)";
-    private static final boolean CREATE_ORIG_FOLDER_IF_NOT_EXISTS = ConfigCore
-            .getBooleanParameter(ParameterCore.CREATE_ORIG_FOLDER_IF_NOT_EXISTS);
     private static final boolean USE_ORIG_FOLDER = ConfigCore
             .getBooleanParameterOrDefaultValue(ParameterCore.USE_ORIG_FOLDER);
 
@@ -845,10 +843,6 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
             tifDirectory = URI.create(result.getRawPath() + getNormalizedTitle(processTitle) + "_" + DIRECTORY_SUFFIX);
         }
 
-        if (!USE_ORIG_FOLDER && CREATE_ORIG_FOLDER_IF_NOT_EXISTS) {
-            fileService.createDirectory(result, tifDirectory.getRawPath());
-        }
-
         return tifDirectory;
     }
 
@@ -913,10 +907,6 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
                         + getNormalizedTitle(process.getTitle()) + "_" + DIRECTORY_SUFFIX);
             }
 
-            if (CREATE_ORIG_FOLDER_IF_NOT_EXISTS && Objects.nonNull(process.getSortHelperStatus())
-                    && process.getSortHelperStatus().equals("100000000")) {
-                fileService.createDirectory(result, origDirectory.getRawPath());
-            }
             return origDirectory;
         } else {
             return getImagesTifDirectory(useFallBack, process.getId(), process.getTitle(), process.getProcessBaseUri());
@@ -1617,19 +1607,6 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
     public void addToWikiField(User user, String message, Process process) {
         String text = message + " (" + user.getSurname() + ")";
         addToWikiField("user", text, process);
-    }
-
-    /**
-     * The method createProcessDirs() starts creation of directories configured by
-     * parameter processDirs within kitodo_config.properties
-     */
-    public void createProcessDirs(Process process) throws IOException {
-        String[] processDirs = ConfigCore.getStringArrayParameter(ParameterCore.PROCESS_DIRS);
-
-        for (String processDir : processDirs) {
-            fileService.createDirectory(this.getProcessDataDirectory(process),
-                processDir.replace(PROCESS_TITLE, getNormalizedTitle(process.getTitle())));
-        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -61,6 +61,9 @@ public class FileService {
     private static final Logger logger = LogManager.getLogger(FileService.class);
     private static final String TEMPORARY_FILENAME_PREFIX = "temporary_";
 
+    private volatile FileManagementInterface fileManagementModule = new KitodoServiceLoader<FileManagementInterface>(
+            FileManagementInterface.class).loadModule();
+
     /**
      * Creates a MetaDirectory.
      *
@@ -99,7 +102,6 @@ public class FileService {
      *         directoryName is null or empty
      */
     public URI createDirectory(URI parentFolderUri, String directoryName) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         if (Objects.nonNull(directoryName)) {
             return fileManagementModule.create(parentFolderUri, directoryName, false);
         }
@@ -134,7 +136,6 @@ public class FileService {
      * @return the uri of the new file
      */
     public URI createResource(String fileName) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.create(null, fileName, true);
     }
 
@@ -148,7 +149,6 @@ public class FileService {
      * @return the URI of the created resource
      */
     public URI createResource(URI targetFolder, String name) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.create(targetFolder, name, true);
     }
 
@@ -164,7 +164,6 @@ public class FileService {
      * @deprecated Use {@link #writeAsCurrentUser(URI)} instead.
      */
     public OutputStream write(URI uri) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.write(uri);
     }
 
@@ -183,7 +182,6 @@ public class FileService {
      *             if write fails
      */
     public OutputStream write(URI uri, LockResult access) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.write(uri, access);
     }
 
@@ -213,7 +211,6 @@ public class FileService {
      * @deprecated Use {@link #readAsCurrentUser(URI)} instead.
      */
     public InputStream read(URI uri) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.read(uri);
     }
 
@@ -232,7 +229,6 @@ public class FileService {
      *             if read fails
      */
     public InputStream read(URI uri, LockResult access) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.read(uri, access);
     }
 
@@ -249,7 +245,6 @@ public class FileService {
      *             is thrown if the rename fails permanently
      */
     public URI renameFile(URI fileUri, String newFileName) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.rename(fileUri, newFileName);
     }
 
@@ -262,7 +257,6 @@ public class FileService {
      * @return number of files as Integer
      */
     public Integer getNumberOfFiles(URI directory) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getNumberOfFiles(null, directory);
     }
 
@@ -275,7 +269,6 @@ public class FileService {
      * @return number of files as Integer
      */
     public Integer getNumberOfImageFiles(URI directory) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getNumberOfFiles(ImageHelper.imageNameFilter, directory);
     }
 
@@ -287,7 +280,6 @@ public class FileService {
      * @return size of directory as Long
      */
     public Long getSizeOfDirectory(URI directory) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getSizeOfDirectory(directory);
     }
 
@@ -300,7 +292,6 @@ public class FileService {
      *            destination file as uri
      */
     public void copyDirectory(URI sourceDirectory, URI targetDirectory) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         fileManagementModule.copy(sourceDirectory, targetDirectory);
     }
 
@@ -315,7 +306,6 @@ public class FileService {
      *             if copying fails
      */
     public void copyFile(URI sourceUri, URI destinationUri) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         fileManagementModule.copy(sourceUri, destinationUri);
     }
 
@@ -330,7 +320,6 @@ public class FileService {
      *             if copying fails.
      */
     public void copyFileToDirectory(URI sourceDirectory, URI targetDirectory) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         fileManagementModule.copy(sourceDirectory, targetDirectory);
     }
 
@@ -344,7 +333,6 @@ public class FileService {
      *             if get of module fails
      */
     public boolean delete(URI uri) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.delete(uri);
     }
 
@@ -356,7 +344,6 @@ public class FileService {
      * @return true, if the file exists
      */
     public boolean fileExist(URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.fileExist(uri);
     }
 
@@ -368,7 +355,6 @@ public class FileService {
      * @return true, if it is a file, false otherwise
      */
     public boolean isFile(URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.isFile(uri);
     }
 
@@ -380,7 +366,6 @@ public class FileService {
      * @return true, if it is a directory.
      */
     public boolean isDirectory(URI dir) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.isDirectory(dir);
     }
 
@@ -392,7 +377,6 @@ public class FileService {
      * @return true, if it's readable, false otherwise.
      */
     public boolean canRead(URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.canRead(uri);
     }
 
@@ -404,7 +388,6 @@ public class FileService {
      * @return the name of the file
      */
     public String getFileName(URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         String fileNameWithExtension = fileManagementModule.getFileNameWithExtension(uri);
         if (fileNameWithExtension.contains(".")) {
             return fileNameWithExtension.substring(0, fileNameWithExtension.indexOf('.'));
@@ -420,7 +403,6 @@ public class FileService {
      * @return the name of the file
      */
     public String getFileNameWithExtension(URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getFileNameWithExtension(uri);
     }
 
@@ -435,7 +417,6 @@ public class FileService {
      *             if get of module fails
      */
     public void moveDirectory(URI sourceUri, URI targetUri) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         fileManagementModule.move(sourceUri, targetUri);
     }
 
@@ -450,7 +431,6 @@ public class FileService {
      *             if get of module fails
      */
     public void moveFile(URI sourceUri, URI targetUri) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         fileManagementModule.move(sourceUri, targetUri);
     }
 
@@ -462,7 +442,6 @@ public class FileService {
      * @return a List of sub URIs
      */
     public List<URI> getSubUris(URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getSubUris(null, uri);
     }
 
@@ -476,7 +455,6 @@ public class FileService {
      * @return a List of sub URIs
      */
     public List<URI> getSubUris(FilenameFilter filter, URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getSubUris(filter, uri);
     }
 
@@ -680,7 +658,6 @@ public class FileService {
      * @return the URI.
      */
     public URI getProcessBaseUriForExistingProcess(Process process) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         URI processBaseUri = process.getProcessBaseUri();
         if (Objects.isNull(processBaseUri) && Objects.nonNull(process.getId())) {
             process.setProcessBaseUri(fileManagementModule.createUriForExistingProcess(process.getId().toString()));
@@ -720,7 +697,6 @@ public class FileService {
         if (Objects.isNull(resourceName)) {
             resourceName = "";
         }
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getProcessSubTypeUri(processDataDirectory, processTitle, processSubType,
             resourceName);
     }
@@ -745,7 +721,6 @@ public class FileService {
         if (Objects.isNull(resourceName)) {
             resourceName = "";
         }
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getProcessSubTypeUri(processDataDirectory,
                 ServiceManager.getProcessService().getNormalizedTitle(process.getTitle()), processSubType, resourceName);
     }
@@ -803,7 +778,6 @@ public class FileService {
     public boolean deleteProcessContent(Process process) throws IOException {
         for (ProcessSubType processSubType : ProcessSubType.values()) {
             URI processSubTypeURI = getProcessSubTypeURI(process, processSubType, null);
-            FileManagementInterface fileManagementModule = getFileManagementModule();
             if (!fileManagementModule.delete(processSubTypeURI)) {
                 return false;
             }
@@ -855,7 +829,6 @@ public class FileService {
      * @return true, if link creation was successful
      */
     public boolean createSymLink(URI homeUri, URI targetUri, boolean onlyRead, User user) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.createSymLink(homeUri, targetUri, onlyRead, user.getLogin());
     }
 
@@ -867,18 +840,11 @@ public class FileService {
      * @return true, if deletion was successful
      */
     public boolean deleteSymLink(URI homeUri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.deleteSymLink(homeUri);
     }
 
     public File getFile(URI uri) {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.getFile(uri);
-    }
-
-    private FileManagementInterface getFileManagementModule() {
-        KitodoServiceLoader<FileManagementInterface> loader = new KitodoServiceLoader<>(FileManagementInterface.class);
-        return loader.loadModule();
     }
 
     /**
@@ -984,7 +950,6 @@ public class FileService {
      *             is missing
      */
     public LockResult tryLock(Map<URI, LockingMode> requests) throws IOException {
-        FileManagementInterface fileManagementModule = getFileManagementModule();
         return fileManagementModule.tryLock(getCurrentLockingUser(), requests);
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -118,7 +118,7 @@ public class FileService {
      *             If an I/O error occurs.
      */
     public void createDirectoryForUser(URI dirName, String userName) throws IOException {
-        if (!ServiceManager.getFileService().fileExist(dirName)) {
+        if (!fileExist(dirName)) {
             CommandService commandService = ServiceManager.getCommandService();
             List<String> commandParameter = Arrays.asList(userName, new File(dirName).getAbsolutePath());
             commandService.runCommand(new File(ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_DIR_USER_HOME)),
@@ -908,7 +908,7 @@ public class FileService {
     public void createDummyImagesForProcess(Process process, int numberOfNewImages)
             throws IOException, URISyntaxException {
         URI imagesDirectory = getSourceDirectory(process);
-        int startValue = ServiceManager.getFileService().getNumberOfFiles(imagesDirectory) + 1;
+        int startValue = getNumberOfFiles(imagesDirectory) + 1;
         URI dummyImage = getDummyImagePath();
 
         // Load number of digits to create valid filenames

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -74,12 +74,6 @@ directory.debug=/usr/local/kitodo/debug/
 # Directory management
 # -----------------------------------
 
-# OrigOrdner anlegen, wenn nicht vorhanden
-createOrigFolderIfNotExists=true
-
-# indicates whether the source folder should be created automatically or not, default is false
-createSourceFolder=false
-
 # following parameters DIRECTORY_PREFIX and DIRECTORY_SUFFIX are used on creating image directory
 # when a process is created.
 # Resulting image directory name is <DIRECTORY_PREFIX>_<ProcessTitle>_<DIRECTORY_SUFFIX>

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -513,14 +513,6 @@ public class ProcessServiceIT {
         assertEquals("Processes have different wikiField values!", process, actual);
     }
 
-    @Ignore("find out what exactly was created")
-    @Test
-    public void shouldCreateProcessDirs() throws Exception {
-        Process process = processService.getById(2);
-        processService.createProcessDirs(process);
-        // assertEquals("Process directories are not created!", expected, actual);
-    }
-
     @Test
     public void shouldGetDigitalDocument() throws Exception {
         FileLoader.createMetadataFile();

--- a/Kitodo/src/test/java/org/kitodo/production/services/file/FileServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/file/FileServiceTest.java
@@ -59,11 +59,13 @@ public class FileServiceTest {
         File script = new File(ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_DIR_META));
         ExecutionPermission.setExecutePermission(script);
 
-        boolean result = fileService.createMetaDirectory(URI.create("fileServiceTest"), "testMetaScript");
+        URI parentFolderUri = URI.create("fileServiceTest");
+        URI result = fileService.createMetaDirectory(parentFolderUri, "testMetaScript");
         File file = fileService.getFile((URI.create("fileServiceTest/testMetaScript")));
         ExecutionPermission.setNoExecutePermission(script);
 
-        assertTrue("Result of execution was incorrect!", result);
+        assertTrue("Result of execution was incorrect!",
+            URI.create((parentFolderUri.getPath() + '/' + "testMetaScript")).equals(result));
         assertTrue("Created resource is not directory!", file.isDirectory());
         assertFalse("Created resource is file!", file.isFile());
         assertTrue("Directory was not created!", file.exists());


### PR DESCRIPTION
When you create processes, subfolders are created in the task directory. Which, depended on the confused settings in the `kitodo_config.properties`. Creating the directory was done by a shell script, although that was not necessary. The configured `Folder`s and the existing switch _Create folder during the creation of a process_ did not have any effect.

Empty folders are now created during the process creation according to the `Folder` settings of the respective project. The folders are created without script, using the File Management.