### PR TITLE
Remove UGH (2)

### DIFF
--- a/Kitodo/src/main/java/org/goobi/production/cli/helper/CopyProcess.java
+++ b/Kitodo/src/main/java/org/goobi/production/cli/helper/CopyProcess.java
@@ -45,7 +45,8 @@ import org.kitodo.production.helper.AdditionalField;
 import org.kitodo.production.helper.BeanHelper;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.UghHelper;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.services.ServiceManager;
 
 public class CopyProcess extends ProzesskopieForm {
@@ -77,9 +78,9 @@ public class CopyProcess extends ProzesskopieForm {
         clearValues();
         PrefsInterface myPrefs = ServiceManager.getRulesetService().getPreferences(this.template.getRuleset());
         try {
-            this.myRdf = UghImplementation.INSTANCE.createMetsMods(myPrefs);
+            this.myRdf = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) myPrefs).getRuleset());
             this.myRdf.read(this.metadataFile.getPath());
-        } catch (PreferencesException | ReadException e) {
+        } catch (ReadException e) {
             logger.error(e.getMessage(), e);
         }
         this.prozessKopie = new Process();
@@ -115,9 +116,9 @@ public class CopyProcess extends ProzesskopieForm {
         clearValues();
         PrefsInterface myPrefs = ServiceManager.getRulesetService().getPreferences(this.template.getRuleset());
         try {
-            this.myRdf = UghImplementation.INSTANCE.createMetsMods(myPrefs);
+            this.myRdf = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) myPrefs).getRuleset());
             this.myRdf.read(this.metadataFile.getPath());
-        } catch (PreferencesException | ReadException e) {
+        } catch (ReadException e) {
             logger.error(e.getMessage(), e);
         }
         this.prozessKopie = new Process();
@@ -143,7 +144,7 @@ public class CopyProcess extends ProzesskopieForm {
         try {
             PrefsInterface myPrefs = ServiceManager.getRulesetService().getPreferences(this.template.getRuleset());
             /* den Opac abfragen und ein RDF draus bauen lassen */
-            this.myRdf = UghImplementation.INSTANCE.createMetsMods(myPrefs);
+            this.myRdf = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) myPrefs).getRuleset());
             this.myRdf.read(this.metadataFile.getPath());
             this.docType = this.myRdf.getDigitalDocument().getLogicalDocStruct().getDocStructType().getName();
 
@@ -319,9 +320,9 @@ public class CopyProcess extends ProzesskopieForm {
 
         FileformatInterface ff;
         try {
-            ff = UghImplementation.INSTANCE.createMetsMods(myPrefs);
+            ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) myPrefs).getRuleset());
             ff.read(this.metadataFile.getPath());
-        } catch (PreferencesException | ReadException e) {
+        } catch (ReadException e) {
             logger.error(e.getMessage(), e);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -40,6 +40,8 @@ import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.helper.enums.MetadataFormat;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.ImageHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.helper.tasks.EmptyTask;
 import org.kitodo.production.helper.tasks.ExportDmsTask;
 import org.kitodo.production.helper.tasks.TaskManager;
@@ -278,7 +280,7 @@ public class ExportDms extends ExportMets {
         try {
             switch (MetadataFormat.findFileFormatsHelperByName(process.getProject().getFileFormatDmsExport())) {
                 case METS:
-                    gdzfile = UghImplementation.INSTANCE.createMetsModsImportExport(this.myPrefs);
+                    gdzfile = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) this.myPrefs).getRuleset());
                     break;
                 case METS_AND_RDF:
                 default:

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -46,7 +46,6 @@ import org.kitodo.production.helper.tasks.EmptyTask;
 import org.kitodo.production.helper.tasks.ExportDmsTask;
 import org.kitodo.production.helper.tasks.TaskManager;
 import org.kitodo.production.helper.tasks.TaskSitter;
-import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.copier.CopierData;
 import org.kitodo.production.metadata.copier.DataCopier;
 import org.kitodo.production.services.ServiceManager;
@@ -284,13 +283,12 @@ public class ExportDms extends ExportMets {
                     break;
                 case METS_AND_RDF:
                 default:
-                    gdzfile = UghImplementation.INSTANCE.createRDFFile(this.myPrefs);
-                    break;
+                    throw new UnsupportedOperationException("Dead code pending removal");
             }
 
             gdzfile.setDigitalDocument(newFile);
             return gdzfile;
-        } catch (PreferencesException | RuntimeException e) {
+        } catch (RuntimeException e) {
             if (exportDmsTask != null) {
                 exportDmsTask.setException(e);
                 logger.error(Helper.getTranslation(ERROR_EXPORT, Collections.singletonList(process.getTitle())), e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
@@ -83,9 +83,9 @@ import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.SelectItemList;
 import org.kitodo.production.helper.UghHelper;
 import org.kitodo.production.helper.WikiFieldHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
-import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.copier.CopierData;
 import org.kitodo.production.metadata.copier.DataCopier;
 import org.kitodo.production.services.ServiceManager;
@@ -874,7 +874,7 @@ public class ProzesskopieForm implements Serializable {
                     digitalDocument.getPhysicalDocStruct().getAllMetadata().remove(metadata);
                 }
             }
-            MetadataInterface newMetadata = UghImplementation.INSTANCE.createMetadata(mdt);
+            MetadataInterface newMetadata = new LegacyMetadataHelper(mdt);
             String path = ServiceManager.getFileService().getImagesDirectory(this.prozessKopie)
                     + this.prozessKopie.getTitle().trim() + "_" + DIRECTORY_SUFFIX;
             if (SystemUtils.IS_OS_WINDOWS) {
@@ -1007,7 +1007,7 @@ public class ProzesskopieForm implements Serializable {
     private void addCollections(DocStructInterface colStruct) {
         for (String s : this.digitalCollections) {
             try {
-                MetadataInterface md = UghImplementation.INSTANCE.createMetadata(UghHelper.getMetadataType(
+                MetadataInterface md = new LegacyMetadataHelper(UghHelper.getMetadataType(
                     ServiceManager.getRulesetService().getPreferences(this.prozessKopie.getRuleset()),
                     "singleDigCollection"));
                 md.setStringValue(s);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/UghHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/UghHelper.java
@@ -22,7 +22,7 @@ import org.kitodo.api.ugh.PrefsInterface;
 import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.exceptions.UghHelperException;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.services.ServiceManager;
 
 public class UghHelper {
@@ -80,7 +80,7 @@ public class UghHelper {
             List<? extends MetadataInterface> all = inStruct.getAllMetadataByType(inMetadataType);
             if (all.isEmpty()) {
                 try {
-                    MetadataInterface md = UghImplementation.INSTANCE.createMetadata(inMetadataType);
+                    MetadataInterface md = new LegacyMetadataHelper(inMetadataType);
                     md.setDocStruct(inStruct);
                     inStruct.addMetadata(md);
                     return md;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
@@ -558,7 +558,7 @@ public class ImageHelper {
      * @return ContentFile object
      */
     private ContentFileInterface createContentFile(URI image) {
-        ContentFileInterface contentFile = UghImplementation.INSTANCE.createContentFile();
+        ContentFileInterface contentFile = new LegacyContentFileHelper();
         contentFile.setLocation(image.getPath());
         return contentFile;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
@@ -61,7 +61,7 @@ import org.kitodo.exceptions.InvalidImagesException;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyContentFileHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyRomanNumeralHelper;
 import org.kitodo.production.metadata.MetadataProcessor;
 import org.kitodo.production.metadata.comparator.MetadataImageComparator;
 import org.kitodo.production.services.ServiceManager;
@@ -580,7 +580,7 @@ public class ImageHelper {
             return String.valueOf(currentPhysicalOrder);
         } else if (defaultPagination.equalsIgnoreCase(
             (String) ParameterCore.METS_EDITOR_DEFAULT_PAGINATION.getParameter().getPossibleValues().get(1))) {
-            RomanNumeralInterface roman = UghImplementation.INSTANCE.createRomanNumeral();
+            RomanNumeralInterface roman = new LegacyRomanNumeralHelper();
             roman.setValue(currentPhysicalOrder);
             return roman.getNumber();
         } else {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
@@ -59,6 +59,8 @@ import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.exceptions.InvalidImagesException;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyContentFileHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.MetadataProcessor;
 import org.kitodo.production.metadata.comparator.MetadataImageComparator;
@@ -490,7 +492,7 @@ public class ImageHelper {
         // problems with FilePath
         MetadataTypeInterface metadataTypeForPath = this.myPrefs.getMetadataTypeByName("pathimagefiles");
         try {
-            MetadataInterface mdForPath = UghImplementation.INSTANCE.createMetadata(metadataTypeForPath);
+            MetadataInterface mdForPath = new LegacyMetadataHelper(metadataTypeForPath);
             URI pathURI = ServiceManager.getProcessService().getImagesTifDirectory(false, process.getId(),
                 process.getTitle(), process.getProcessBaseUri());
             String pathString = new File(pathURI).getPath();
@@ -530,7 +532,7 @@ public class ImageHelper {
     private MetadataInterface createMetadataForLogicalPageNumber(int currentPhysicalOrder, String defaultPagination)
             throws MetadataTypeNotAllowedException {
         MetadataTypeInterface metadataType = this.myPrefs.getMetadataTypeByName("logicalPageNumber");
-        MetadataInterface metadata = UghImplementation.INSTANCE.createMetadata(metadataType);
+        MetadataInterface metadata = new LegacyMetadataHelper(metadataType);
         metadata.setStringValue(determinePagination(currentPhysicalOrder, defaultPagination));
         return metadata;
     }
@@ -545,7 +547,7 @@ public class ImageHelper {
     private MetadataInterface createMetadataForPhysicalPageNumber(int currentPhysicalOrder)
             throws MetadataTypeNotAllowedException {
         MetadataTypeInterface metadataType = this.myPrefs.getMetadataTypeByName("physPageNumber");
-        MetadataInterface metadata = UghImplementation.INSTANCE.createMetadata(metadataType);
+        MetadataInterface metadata = new LegacyMetadataHelper(metadataType);
         metadata.setStringValue(String.valueOf(currentPhysicalOrder));
         return metadata;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/MetadataHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/MetadataHelper.java
@@ -41,6 +41,7 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.production.enums.SortType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.HelperComparator;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.comparator.MetadataComparator;
 import org.kitodo.production.services.ServiceManager;
@@ -220,7 +221,7 @@ public class MetadataHelper {
                             p.setRole(mdt.getName());
                             inStruct.addPerson(p);
                         } else {
-                            MetadataInterface md = UghImplementation.INSTANCE.createMetadata(mdt);
+                            MetadataInterface md = new LegacyMetadataHelper(mdt);
                             inStruct.addMetadata(md); // add this new metadata
                             // element
                         }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/MetadataHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/MetadataHelper.java
@@ -42,7 +42,6 @@ import org.kitodo.production.enums.SortType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.HelperComparator;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
-import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.comparator.MetadataComparator;
 import org.kitodo.production.services.ServiceManager;
 
@@ -217,9 +216,7 @@ public class MetadataHelper {
                 if (!(inStruct.getAllMetadataByType(mdt) != null && !inStruct.getAllMetadataByType(mdt).isEmpty())) {
                     try {
                         if (mdt.isPerson()) {
-                            PersonInterface p = UghImplementation.INSTANCE.createPerson(mdt);
-                            p.setRole(mdt.getName());
-                            inStruct.addPerson(p);
+                            throw new UnsupportedOperationException("Dead code pending removal");
                         } else {
                             MetadataInterface md = new LegacyMetadataHelper(mdt);
                             inStruct.addMetadata(md); // add this new metadata

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportNewspaperBatchTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportNewspaperBatchTask.java
@@ -51,7 +51,8 @@ import org.kitodo.export.ExportDms;
 import org.kitodo.production.helper.ArrayListMap;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.VariableReplacer;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.services.ServiceManager;
 
 public class ExportNewspaperBatchTask extends EmptyTask {
@@ -474,7 +475,7 @@ public class ExportNewspaperBatchTask extends EmptyTask {
             TypeNotAllowedForParentException, MetadataTypeNotAllowedException, TypeNotAllowedAsChildException {
 
         PrefsInterface ruleSet = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
-        MetsModsInterface result = UghImplementation.INSTANCE.createMetsMods(ruleSet);
+        MetsModsInterface result = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) ruleSet).getRuleset());
         URI metadataFilePath = ServiceManager.getFileService().getMetadataFilePath(process);
         result.read(ServiceManager.getFileService().getFile(metadataFilePath).toString());
 

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
@@ -87,6 +87,7 @@ import org.kitodo.production.helper.XmlArticleCounter.CountType;
 import org.kitodo.production.helper.batch.BatchTaskHelper;
 import org.kitodo.production.helper.metadata.ImageHelper;
 import org.kitodo.production.helper.metadata.MetadataHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.display.Modes;
 import org.kitodo.production.metadata.display.enums.BindState;
@@ -262,7 +263,7 @@ public class MetadataProcessor {
     public void copy() {
         MetadataInterface md;
         try {
-            md = UghImplementation.INSTANCE.createMetadata(this.currentMetadata.getMd().getMetadataType());
+            md = new LegacyMetadataHelper(this.currentMetadata.getMd().getMetadataType());
 
             md.setStringValue(this.currentMetadata.getMd().getValue());
             this.docStruct.addMetadata(md);
@@ -300,8 +301,7 @@ public class MetadataProcessor {
      */
     public void save() {
         try {
-            MetadataInterface md = UghImplementation.INSTANCE
-                    .createMetadata(this.myPrefs.getMetadataTypeByName(this.tempTyp));
+            MetadataInterface md = new LegacyMetadataHelper(this.myPrefs.getMetadataTypeByName(this.tempTyp));
             md.setStringValue(this.selectedMetadata.getValue());
 
             this.docStruct.addMetadata(md);
@@ -312,8 +312,8 @@ public class MetadataProcessor {
         // if TitleDocMain, then create equal sort titles with the same content
         if (this.tempTyp.equals("TitleDocMain") && this.myPrefs.getMetadataTypeByName("TitleDocMainShort") != null) {
             try {
-                MetadataInterface secondMetadata = UghImplementation.INSTANCE
-                        .createMetadata(this.myPrefs.getMetadataTypeByName("TitleDocMainShort"));
+                MetadataInterface secondMetadata = new LegacyMetadataHelper(
+                        this.myPrefs.getMetadataTypeByName("TitleDocMainShort"));
                 secondMetadata.setStringValue(this.selectedMetadata.getValue());
                 this.docStruct.addMetadata(secondMetadata);
             } catch (MetadataTypeNotAllowedException e) {
@@ -446,16 +446,11 @@ public class MetadataProcessor {
 
         for (MetadataTypeInterface mdt : types) {
             selectItems.add(new SelectItem(mdt.getName(), this.metaHelper.getMetadatatypeLanguage(mdt)));
-            try {
-                MetadataInterface md = UghImplementation.INSTANCE.createMetadata(mdt);
-                MetadataImpl mdum = new MetadataImpl(md, counter, this.myPrefs, this.process);
-                counter++;
-                if (tempMetadataList != null) {
-                    tempMetadataList.add(mdum);
-                }
-
-            } catch (MetadataTypeNotAllowedException e) {
-                logger.error("Fehler beim sortieren der Metadaten: " + e.getMessage());
+            MetadataInterface md = new LegacyMetadataHelper(mdt);
+            MetadataImpl mdum = new MetadataImpl(md, counter, this.myPrefs, this.process);
+            counter++;
+            if (tempMetadataList != null) {
+                tempMetadataList.add(mdum);
             }
         }
         return selectItems;
@@ -640,7 +635,7 @@ public class MetadataProcessor {
 
     private void addMetadataToPhysicalDocStruct(MetadataTypeInterface mdt) {
         try {
-            MetadataInterface md = UghImplementation.INSTANCE.createMetadata(mdt);
+            MetadataInterface md = new LegacyMetadataHelper(mdt);
             Integer value = Integer.valueOf(currentRepresentativePage);
             md.setStringValue(String.valueOf(value + 1));
             this.digitalDocument.getPhysicalDocStruct().addMetadata(md);

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
@@ -88,7 +88,6 @@ import org.kitodo.production.helper.batch.BatchTaskHelper;
 import org.kitodo.production.helper.metadata.ImageHelper;
 import org.kitodo.production.helper.metadata.MetadataHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
-import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.display.Modes;
 import org.kitodo.production.metadata.display.enums.BindState;
 import org.kitodo.production.metadata.display.helper.ConfigDisplayRules;
@@ -280,20 +279,7 @@ public class MetadataProcessor {
      */
     public void copyPerson() {
         PersonInterface per;
-        try {
-            per = UghImplementation.INSTANCE
-                    .createPerson(this.myPrefs.getMetadataTypeByName(this.curPerson.getP().getRole()));
-            per.setFirstName(this.curPerson.getP().getFirstName());
-            per.setLastName(this.curPerson.getP().getLastName());
-            per.setRole(this.curPerson.getP().getRole());
-
-            this.docStruct.addPerson(per);
-        } catch (IncompletePersonObjectException e) {
-            logger.error("Fehler beim copy von Personen (IncompletePersonObjectException): " + e.getMessage());
-        } catch (MetadataTypeNotAllowedException e) {
-            logger.error("Fehler beim copy von Personen (MetadataTypeNotAllowedException): " + e.getMessage());
-        }
-        saveMetadataAsBean(this.docStruct);
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
     /**
@@ -330,21 +316,7 @@ public class MetadataProcessor {
      * Save person.
      */
     public void savePerson() {
-        try {
-            PersonInterface per = UghImplementation.INSTANCE
-                    .createPerson(this.myPrefs.getMetadataTypeByName(this.tempPersonRolle));
-            per.setFirstName(this.tempPersonVorname);
-            per.setLastName(this.tempPersonNachname);
-            per.setRole(this.tempPersonRolle);
-            String[] authorityFile = parseAuthorityFileArgs(tempPersonRecord);
-            per.setAutorityFile(authorityFile[0], authorityFile[1], authorityFile[2]);
-            this.docStruct.addPerson(per);
-            saveMetadataAsBean(this.docStruct);
-        } catch (IncompletePersonObjectException e) {
-            Helper.setErrorMessage("Incomplete data for person", logger, e);
-        } catch (MetadataTypeNotAllowedException e) {
-            Helper.setErrorMessage("Person is for this structure not allowed", logger, e);
-        }
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/copier/LocalMetadataSelector.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/copier/LocalMetadataSelector.java
@@ -11,199 +11,32 @@
 
 package org.kitodo.production.metadata.copier;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.kitodo.api.ugh.DocStructInterface;
-import org.kitodo.api.ugh.MetadataInterface;
-import org.kitodo.api.ugh.MetadataTypeInterface;
-import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
-import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
-import org.kitodo.production.legacy.UghImplementation;
 
-/**
- * A LocalMetadataSelector provides methods to retrieve or modify metadata on a
- * document structure node.
- *
- * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
- */
 public class LocalMetadataSelector extends MetadataSelector {
-    private static final Logger logger = LogManager.getLogger(LocalMetadataSelector.class);
 
-    /**
-     * Metadata type to return.
-     */
-    private final MetadataTypeInterface selector = UghImplementation.INSTANCE.createMetadataType();
-
-    /**
-     * Creates a new LocalMetadataSelector.
-     *
-     * @param path
-     *            Path to metadatum, must consist of an “@” character followed
-     *            by a metadata element name, i.e. “@TitleDocMain”
-     * @throws ConfigurationException
-     *             if the metadata path doesn’t start with an “@” character
-     */
     public LocalMetadataSelector(String path) throws ConfigurationException {
-        if (!path.startsWith(METADATA_SEPARATOR)) {
-            throw new ConfigurationException(
-                    "Cannot create local metadata selector: Path must start with \"@\", but is: " + path);
-        }
-        selector.setName(path.substring(1));
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
-    /**
-     * Checks if no metadata as named by the path is available at that document
-     * structure node, and only in this case adds a metadata as named by the
-     * path with the value passed to the function.
-     *
-     * @param data
-     *            document to work on, required to access the rule set
-     * @param logicalNode
-     *            document structure node to check and enrich
-     * @param value
-     *            value to write if no metadatum of this type is available
-     * @see org.kitodo.production.metadata.copier.MetadataSelector#createIfPathExistsOnly(
-     *      org.kitodo.production.metadata.copier.CopierData, org.kitodo.api.ugh.DocStructInterface,
-     *      java.lang.String)
-     */
     @Override
     protected void createIfPathExistsOnly(CopierData data, DocStructInterface logicalNode, String value) {
-        if (findMetadatumIn(logicalNode) != null) {
-            return;
-        }
-        tryToCreateANewMetadatum(data, logicalNode, value);
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
-
-    /**
-     * Sets the value of the metadata described by the path to the value passed
-     * to the function or creates a metadata as described by the path,
-     * respectively.
-     *
-     * @param data
-     *            document to work on, required to access the rule set
-     * @param logicalNode
-     *            document structure node to check and enrich
-     * @param value
-     *            value to write if no metadatum of this type is available
-     * @see org.kitodo.production.metadata.copier.MetadataSelector#createIfPathExistsOnly(
-     *      org.kitodo.production.metadata.copier.CopierData, org.kitodo.api.ugh.DocStructInterface,
-     *      java.lang.String)
-     */
 
     @Override
     protected void createOrOverwrite(CopierData data, DocStructInterface logicalNode, String value) {
-        MetadataInterface existingMetadatum = findMetadatumIn(logicalNode);
-        if (existingMetadatum != null) {
-            existingMetadatum.setStringValue(value);
-        } else {
-            tryToCreateANewMetadatum(data, logicalNode, value);
-        }
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
-    /**
-     * Returns all concrete metadata selectors the potentially generic metadata
-     * selector expression resolves to.
-     *
-     * @param node
-     *            Node of the logical document structure to work on
-     * @return all metadata selectors the expression resolves to
-     * @see org.kitodo.production.metadata.copier.MetadataSelector#findAll(org.kitodo.api.ugh.DocStructInterface)
-     */
     @Override
     protected Iterable<MetadataSelector> findAll(DocStructInterface node) {
-        ArrayList<MetadataSelector> result = new ArrayList<>(1);
-        List<MetadataTypeInterface> addableTypes = node.getAddableMetadataTypes();
-        if (addableTypes != null) {
-            for (MetadataTypeInterface addable : addableTypes) {
-                if (selector.getName().equals(addable.getName())) {
-                    result.add(this);
-                    break;
-                }
-            }
-        }
-        return result;
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
-    /**
-     * Return the value of the metadata named by the path used to construct the
-     * metadata selector, or null if no such metadata is available here.
-     *
-     * @param node
-     *            document structure node to examine
-     * @return the value of the metadata, or null if absent
-     * @see org.kitodo.production.metadata.copier.MetadataSelector#findIn(org.kitodo.api.ugh.DocStructInterface)
-     */
     @Override
     protected String findIn(DocStructInterface node) {
-        MetadataInterface found = findMetadatumIn(node);
-        return found != null ? found.getValue() : null;
-    }
-
-    /**
-     * Returns the metadata named by the path used to construct the metadata
-     * selector, or null if no such metadata is available here.
-     *
-     * @param node
-     *            document structure node to examine
-     * @return the metadata, or null if absent
-     * @see org.kitodo.production.metadata.copier.MetadataSelector#findIn(org.kitodo.api.ugh.DocStructInterface)
-     */
-    private MetadataInterface findMetadatumIn(DocStructInterface node) {
-        List<? extends MetadataInterface> metadata = node.getAllMetadataByType(selector);
-        for (MetadataInterface metadatum : metadata) {
-            if (selector.getName().equals(metadatum.getMetadataType().getName())) {
-                return metadatum;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns a string that textually represents this LocalMetadataSelector.
-     *
-     * @return a string representation of this LocalMetadataSelector
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return METADATA_SEPARATOR + selector.getName();
-    }
-
-    /**
-     * Adds a metadata as named by the path with the value passed to the
-     * function. Doesn’t do anything if that isn’t possible.
-     *
-     * @param data
-     *            document to work on, required to access the rule set
-     * @param logicalNode
-     *            document structure node to check and enrich
-     * @param value
-     *            value to write if no metadataof this type is available
-     */
-    private void tryToCreateANewMetadatum(CopierData data, DocStructInterface logicalNode, String value) {
-        MetadataInterface copy;
-        try {
-            copy = new LegacyMetadataHelper(data.getPreferences().getMetadataTypeByName(selector.getName()));
-        } catch (RuntimeException e) {
-            // copy rule failed, skip it
-            logger.debug("Cannot create metadata element {}: Accessing the rule set failed with exception: {}",
-                selector.getName(), e.getMessage());
-            return;
-        }
-        try {
-            copy.setStringValue(value);
-            logicalNode.addMetadata(copy);
-        } catch (MetadataTypeNotAllowedException e) {
-            // copy rules aren’t related to the rule set but depend on it, so
-            // copy rules that don’t work with the current rule set are ignored
-            String nodeName = logicalNode.getDocStructType() != null ? logicalNode.getDocStructType().getName()
-                    : "without type";
-            logger.debug("Cannot assign metadata element {} (\"{}\") to structural element {}: {}",
-                    selector.getName(), value, nodeName, e.getMessage());
-        }
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/copier/LocalMetadataSelector.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/copier/LocalMetadataSelector.java
@@ -21,6 +21,7 @@ import org.kitodo.api.ugh.DocStructInterface;
 import org.kitodo.api.ugh.MetadataInterface;
 import org.kitodo.api.ugh.MetadataTypeInterface;
 import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.legacy.UghImplementation;
 
 /**
@@ -186,14 +187,7 @@ public class LocalMetadataSelector extends MetadataSelector {
     private void tryToCreateANewMetadatum(CopierData data, DocStructInterface logicalNode, String value) {
         MetadataInterface copy;
         try {
-            copy = UghImplementation.INSTANCE
-                    .createMetadata(data.getPreferences().getMetadataTypeByName(selector.getName()));
-        } catch (MetadataTypeNotAllowedException e) {
-            // copy rules aren’t related to the rule set but depend on it, so
-            // copy rules that don’t work with the current rule set are ignored
-            logger.debug("Cannot create metadata element {}: The type isn’t defined by the rule set used.",
-                selector.getName());
-            return;
+            copy = new LegacyMetadataHelper(data.getPreferences().getMetadataTypeByName(selector.getName()));
         } catch (RuntimeException e) {
             // copy rule failed, skip it
             logger.debug("Cannot create metadata element {}: Accessing the rule set failed with exception: {}",

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/PersonMetadataGroup.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/PersonMetadataGroup.java
@@ -11,7 +11,6 @@
 
 package org.kitodo.production.metadata.elements.renderable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
@@ -23,11 +22,8 @@ import org.kitodo.api.ugh.MetadataGroupTypeInterface;
 import org.kitodo.api.ugh.MetadataInterface;
 import org.kitodo.api.ugh.MetadataTypeInterface;
 import org.kitodo.api.ugh.PersonInterface;
-import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
-import org.kitodo.production.legacy.UghImplementation;
-import org.kitodo.production.metadata.MetadataProcessor;
 
 /**
  * Specialised RenderableMetadataGroup with fixed fields to edit the internal
@@ -208,21 +204,6 @@ public class PersonMetadataGroup extends RenderableMetadataGroup implements Rend
     @Override
     public List<PersonInterface> toMetadata() {
         PersonInterface person;
-        try {
-            person = UghImplementation.INSTANCE.createPerson(metadataType);
-        } catch (MetadataTypeNotAllowedException e) {
-            throw new NullPointerException(e.getMessage());
-        }
-        String normdataRecord = getField(Field.NORMDATA_RECORD).getValue();
-        if (normdataRecord != null && normdataRecord.length() > 0
-                && !normdataRecord.equals(ConfigCore.getParameter(ParameterCore.AUTHORITY_DEFAULT, ""))) {
-            String[] authorityFile = MetadataProcessor.parseAuthorityFileArgs(normdataRecord);
-            person.setAutorityFile(authorityFile[0], authorityFile[1], authorityFile[2]);
-        }
-        person.setFirstName(getField(Field.FIRSTNAME).getValue());
-        person.setLastName(getField(Field.LASTNAME).getValue());
-        List<PersonInterface> result = new ArrayList<>(1);
-        result.add(person);
-        return result;
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/PersonMetadataGroup.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/PersonMetadataGroup.java
@@ -26,7 +26,6 @@ import org.kitodo.api.ugh.PersonInterface;
 import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.MetadataProcessor;
 
@@ -49,9 +48,6 @@ public class PersonMetadataGroup extends RenderableMetadataGroup implements Rend
         FIRSTNAME("vorname", false),
         LASTNAME("nachname", false);
 
-        private boolean isIdentifier;
-        private String resourceKey;
-
         /**
          * Field constructor. Creates a Field enum constant.
          *
@@ -63,27 +59,6 @@ public class PersonMetadataGroup extends RenderableMetadataGroup implements Rend
          *            an identifier
          */
         Field(String resourceKey, boolean isIdentifier) {
-            this.isIdentifier = isIdentifier;
-            this.resourceKey = resourceKey;
-        }
-
-        /**
-         * Returns a key string to look up the translated labels for the field
-         * in the messages file.
-         *
-         * @return key string to look up the labels for the field
-         */
-        private String getResourceKey() {
-            return resourceKey;
-        }
-
-        /**
-         * Returns whether or not the given field is an identifier.
-         *
-         * @return whether the given field is an identifier
-         */
-        private boolean isIdentifier() {
-            return isIdentifier;
         }
     }
 
@@ -131,39 +106,7 @@ public class PersonMetadataGroup extends RenderableMetadataGroup implements Rend
      * @return a fictitious MetadataGroupType with the person’s subfields
      */
     private static MetadataGroupTypeInterface getGroupTypeFor(MetadataTypeInterface type) {
-        MetadataGroupTypeInterface result = UghImplementation.INSTANCE.createMetadataGroupType();
-        result.setName(type.getName());
-        result.setAllLanguages(type.getAllLanguages());
-        if (type.getNum() != null) {
-            result.setNum(type.getNum());
-        }
-        for (Field field : Field.values()) {
-            result.addMetadataType(getMetadataTypeFor(type, field));
-        }
-        return result;
-    }
-
-    /**
-     * Creates a fictitious MetadataType for the given field of the given
-     * metadata type, assuming that the latter is a person. The method is called
-     * from the constructor and thus should not be overloaded.
-     *
-     * @param type
-     *            a metadata type which represents a person
-     * @param field
-     *            a field of the person record
-     * @return a fictitious MetadataGroupType with the person’s subfields
-     */
-    private static MetadataTypeInterface getMetadataTypeFor(MetadataTypeInterface type, Field field) {
-        MetadataTypeInterface result = UghImplementation.INSTANCE.createMetadataType();
-        result.setName(type.getName() + '.' + field.toString());
-        if (type.getNum() != null) {
-            result.setNum(type.getNum());
-        }
-        result.setAllLanguages(Helper.getAllStrings(field.getResourceKey()));
-        result.setPerson(false);
-        result.setIdentifier(field.isIdentifier());
-        return result;
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/RenderableMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/RenderableMetadata.java
@@ -20,9 +20,8 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.kitodo.api.ugh.MetadataGroupInterface;
 import org.kitodo.api.ugh.MetadataInterface;
 import org.kitodo.api.ugh.MetadataTypeInterface;
-import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
 import org.kitodo.exceptions.UnreachableCodeException;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.metadata.display.Item;
 import org.kitodo.production.metadata.display.enums.BindState;
 import org.kitodo.production.metadata.display.enums.DisplayType;
@@ -206,11 +205,7 @@ public abstract class RenderableMetadata {
      */
     protected MetadataInterface getMetadata(String value) {
         MetadataInterface result;
-        try {
-            result = UghImplementation.INSTANCE.createMetadata(metadataType);
-        } catch (MetadataTypeNotAllowedException e) {
-            throw new NullPointerException(e.getMessage());
-        }
+        result = new LegacyMetadataHelper(metadataType);
         result.setStringValue(value);
         return result;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/RenderableMetadataGroup.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/elements/renderable/RenderableMetadataGroup.java
@@ -27,9 +27,7 @@ import org.kitodo.api.ugh.MetadataGroupTypeInterface;
 import org.kitodo.api.ugh.MetadataInterface;
 import org.kitodo.api.ugh.MetadataTypeInterface;
 import org.kitodo.api.ugh.PersonInterface;
-import org.kitodo.api.ugh.exceptions.MetadataTypeNotAllowedException;
 import org.kitodo.exceptions.MetadataException;
-import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.MetadataProcessor;
 
 /**
@@ -418,25 +416,7 @@ public class RenderableMetadataGroup extends RenderableMetadata {
      */
     public MetadataGroupInterface toMetadataGroup() {
         MetadataGroupInterface result;
-        try {
-            result = UghImplementation.INSTANCE.createMetadataGroup(type);
-        } catch (MetadataTypeNotAllowedException e) {
-            throw new NullPointerException("MetadataGroupType must not be null at MetadataGroup creation.");
-        }
-        result.getMetadataList().clear();
-        result.getPersonList().clear();
-
-        for (RenderableGroupableMetadata member : members.values()) {
-            for (MetadataInterface element : member.toMetadata()) {
-                if (member instanceof PersonMetadataGroup) {
-                    result.addPerson(((PersonInterface) element));
-                } else {
-                    result.addMetadata(element);
-                }
-            }
-
-        }
-        return result;
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/pagination/Paginator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/pagination/Paginator.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.kitodo.api.ugh.RomanNumeralInterface;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyRomanNumeralHelper;
 import org.kitodo.production.metadata.Metadata;
 import org.kitodo.production.metadata.pagination.enums.Mode;
 import org.kitodo.production.metadata.pagination.enums.Scope;
@@ -96,7 +96,7 @@ public class Paginator {
         }
         // roman numbers
         if (paginationType == Type.ROMAN) {
-            RomanNumeralInterface roman = UghImplementation.INSTANCE.createRomanNumeral();
+            RomanNumeralInterface roman = new LegacyRomanNumeralHelper();
             roman.setValue(paginationStartValue);
         }
     }
@@ -253,7 +253,7 @@ public class Paginator {
         if (paginationType == Type.ARABIC) {
             paginationBaseValue = Integer.parseInt(paginationStartValue);
         } else if (paginationType == Type.ROMAN) {
-            RomanNumeralInterface r = UghImplementation.INSTANCE.createRomanNumeral();
+            RomanNumeralInterface r = new LegacyRomanNumeralHelper();
             r.setValue(paginationStartValue);
             paginationBaseValue = r.intValue();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/pagination/sequence/RomanNumberSequence.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/pagination/sequence/RomanNumberSequence.java
@@ -14,7 +14,7 @@ package org.kitodo.production.metadata.pagination.sequence;
 import java.util.ArrayList;
 
 import org.kitodo.api.ugh.RomanNumeralInterface;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyRomanNumeralHelper;
 
 public class RomanNumberSequence extends ArrayList<String> {
 
@@ -33,7 +33,7 @@ public class RomanNumberSequence extends ArrayList<String> {
     }
 
     private void generateElements(int start, int end, int increment) {
-        RomanNumeralInterface r = UghImplementation.INSTANCE.createRomanNumeral();
+        RomanNumeralInterface r = new LegacyRomanNumeralHelper();
         for (int i = start; i <= end; i = (i + increment)) {
             r.setValue(i);
             this.add(r.toString());

--- a/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/PicaMassImport.java
+++ b/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/PicaMassImport.java
@@ -79,7 +79,8 @@ import org.kitodo.config.enums.KitodoConfigFile;
 import org.kitodo.data.database.beans.Property;
 import org.kitodo.exceptions.ImportPluginException;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.plugin.importer.massimport.sru.SRUHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -437,7 +438,7 @@ public class PicaMassImport implements IImportPlugin, IPlugin {
             if (ff != null) {
                 r.setId(this.currentIdentifier);
                 try {
-                    MetsModsInterface mm = UghImplementation.INSTANCE.createMetsMods(this.prefs);
+                    MetsModsInterface mm = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) this.prefs).getRuleset());
                     mm.setDigitalDocument(ff.getDigitalDocument());
                     String fileName = getImportFolder() + getProcessTitle() + ".xml";
                     logger.debug("Writing '{}' into given folder...", fileName);

--- a/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/PicaMassImport.java
+++ b/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/PicaMassImport.java
@@ -78,6 +78,7 @@ import org.kitodo.api.ugh.exceptions.WriteException;
 import org.kitodo.config.enums.KitodoConfigFile;
 import org.kitodo.data.database.beans.Property;
 import org.kitodo.exceptions.ImportPluginException;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.plugin.importer.massimport.sru.SRUHelper;
 import org.w3c.dom.Document;
@@ -178,7 +179,7 @@ public class PicaMassImport implements IImportPlugin, IPlugin {
             } else {
                 // generating ats
                 ats = createAtstsl(currentTitle, author);
-                MetadataInterface atstsl = UghImplementation.INSTANCE.createMetadata(atsType);
+                MetadataInterface atstsl = new LegacyMetadataHelper(atsType);
                 atstsl.setStringValue(ats);
                 logicalDS.addMetadata(atstsl);
             }
@@ -212,7 +213,7 @@ public class PicaMassImport implements IImportPlugin, IPlugin {
             try {
                 // pathimagefiles
                 MetadataTypeInterface mdt = prefs.getMetadataTypeByName("pathimagefiles");
-                MetadataInterface newmd = UghImplementation.INSTANCE.createMetadata(mdt);
+                MetadataInterface newmd = new LegacyMetadataHelper(mdt);
                 newmd.setStringValue("/images/");
                 digitalDocument.getPhysicalDocStruct().addMetadata(newmd);
 
@@ -225,13 +226,12 @@ public class PicaMassImport implements IImportPlugin, IPlugin {
                         volumes = Collections.emptyList();
                     }
                     for (String collection : this.currentCollectionList) {
-                        MetadataInterface mdCollection = UghImplementation.INSTANCE.createMetadata(mdTypeCollection);
+                        MetadataInterface mdCollection = new LegacyMetadataHelper(mdTypeCollection);
                         mdCollection.setStringValue(collection);
                         topLogicalStruct.addMetadata(mdCollection);
                         for (DocStructInterface volume : volumes) {
                             try {
-                                MetadataInterface mdCollectionForVolume = UghImplementation.INSTANCE
-                                        .createMetadata(mdTypeCollection);
+                                MetadataInterface mdCollectionForVolume = new LegacyMetadataHelper(mdTypeCollection);
                                 mdCollectionForVolume.setStringValue(collection);
                                 volume.addMetadata(mdCollectionForVolume);
                             } catch (MetadataTypeNotAllowedException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/sru/SRUHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/plugin/importer/massimport/sru/SRUHelper.java
@@ -33,15 +33,10 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
-import org.kitodo.api.ugh.DigitalDocumentInterface;
-import org.kitodo.api.ugh.DocStructInterface;
-import org.kitodo.api.ugh.DocStructTypeInterface;
 import org.kitodo.api.ugh.FileformatInterface;
-import org.kitodo.api.ugh.PicaPlusInterface;
 import org.kitodo.api.ugh.PrefsInterface;
 import org.kitodo.api.ugh.exceptions.PreferencesException;
 import org.kitodo.api.ugh.exceptions.ReadException;
-import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.plugin.importer.massimport.googlecode.fascinator.redbox.sru.SRUClient;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;
@@ -167,15 +162,6 @@ public class SRUHelper {
     public static FileformatInterface parsePicaFormat(Node pica, PrefsInterface prefs)
             throws ReadException, PreferencesException {
 
-        PicaPlusInterface pp = UghImplementation.INSTANCE.createPicaPlus(prefs);
-        pp.read(pica);
-        DigitalDocumentInterface dd = pp.getDigitalDocument();
-        FileformatInterface ff = UghImplementation.INSTANCE.createXStream(prefs);
-        ff.setDigitalDocument(dd);
-        /* BoundBook hinzufügen */
-        DocStructTypeInterface dst = prefs.getDocStrctTypeByName("BoundBook");
-        DocStructInterface dsBoundBook = dd.createDocStruct(dst);
-        dd.setPhysicalDocStruct(dsBoundBook);
-        return ff;
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -44,7 +44,7 @@ import org.kitodo.exceptions.UghHelperException;
 import org.kitodo.export.ExportDms;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.UghHelper;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.file.FileService;
 
@@ -519,7 +519,7 @@ public class KitodoScriptService {
                 for (MetadataInterface md : allImagePaths) {
                     rdf.getDigitalDocument().getPhysicalDocStruct().getAllMetadata().remove(md);
                 }
-                MetadataInterface newMetadata = UghImplementation.INSTANCE.createMetadata(mdt);
+                MetadataInterface newMetadata = new LegacyMetadataHelper(mdt);
                 if (SystemUtils.IS_OS_WINDOWS) {
                     newMetadata.setStringValue("file:/" + fileService.getImagesDirectory(process)
                             + process.getTitle() + DIRECTORY_SUFFIX);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1238,7 +1238,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
         FileformatInterface ff;
         switch (type) {
             case "metsmods":
-                ff = UghImplementation.INSTANCE.createMetsModsImportExport(prefs);
+                ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) prefs).getRuleset());
                 break;
             case "mets":
                 ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) prefs).getRuleset());
@@ -1826,7 +1826,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
             gdzFile = readMetadataFile(metadataPath, preferences);
             switch (MetadataFormat.findFileFormatsHelperByName(process.getProject().getFileFormatDmsExport())) {
                 case METS:
-                    newFile = UghImplementation.INSTANCE.createMetsModsImportExport(preferences);
+                    newFile = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) preferences).getRuleset());
                     break;
                 case METS_AND_RDF:
                 default:
@@ -2033,7 +2033,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
     protected boolean writeMetsFile(Process process, String targetFileName, FileformatInterface gdzfile,
             boolean writeLocalFilegroup) throws PreferencesException, IOException, WriteException, JAXBException {
         PrefsInterface preferences = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
-        MetsModsImportExportInterface mm = UghImplementation.INSTANCE.createMetsModsImportExport(preferences);
+        MetsModsImportExportInterface mm = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) preferences).getRuleset());
         mm.setWriteLocal(writeLocalFilegroup);
         URI imageFolderPath = fileService.getImagesDirectory(process);
         File imageFolder = new File(imageFolderPath);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1242,9 +1242,6 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
             case "mets":
                 ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) prefs).getRuleset());
                 break;
-            case "xstream":
-                ff = UghImplementation.INSTANCE.createXStream(prefs);
-                break;
             default:
                 throw new UnsupportedOperationException("Dead code pending removal");
         }
@@ -1265,10 +1262,6 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
             case "mets":
                 fileFormat = new LegacyMetsModsDigitalDocumentHelper(
                         ((LegacyPrefsHelper) rulesetService.getPreferences(process.getRuleset())).getRuleset());
-                break;
-            case "xstream":
-                fileFormat = UghImplementation.INSTANCE
-                        .createXStream(rulesetService.getPreferences(process.getRuleset()));
                 break;
             default:
                 throw new UnsupportedOperationException("Dead code pending removal");

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1247,8 +1247,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
                 ff = UghImplementation.INSTANCE.createXStream(prefs);
                 break;
             default:
-                ff = UghImplementation.INSTANCE.createRDFFile(prefs);
-                break;
+                throw new UnsupportedOperationException("Dead code pending removal");
         }
         ff.read(ConfigCore.getKitodoDataDirectory() + metadataFile.getPath());
 
@@ -1273,9 +1272,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
                         .createXStream(rulesetService.getPreferences(process.getRuleset()));
                 break;
             default:
-                fileFormat = UghImplementation.INSTANCE
-                        .createRDFFile(rulesetService.getPreferences(process.getRuleset()));
-                break;
+                throw new UnsupportedOperationException("Dead code pending removal");
         }
         return fileFormat;
     }
@@ -1830,8 +1827,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
                     break;
                 case METS_AND_RDF:
                 default:
-                    newFile = UghImplementation.INSTANCE.createRDFFile(preferences);
-                    break;
+                    throw new UnsupportedOperationException("Dead code pending removal");
             }
             newFile.setDigitalDocument(gdzFile.getDigitalDocument());
             gdzFile = newFile;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -119,6 +119,8 @@ import org.kitodo.production.helper.VariableReplacer;
 import org.kitodo.production.helper.WikiFieldHelper;
 import org.kitodo.production.helper.metadata.ImageHelper;
 import org.kitodo.production.helper.metadata.MetadataHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.metadata.MetadataLock;
 import org.kitodo.production.metadata.copier.CopierData;
@@ -1239,7 +1241,7 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
                 ff = UghImplementation.INSTANCE.createMetsModsImportExport(prefs);
                 break;
             case "mets":
-                ff = UghImplementation.INSTANCE.createMetsMods(prefs);
+                ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) prefs).getRuleset());
                 break;
             case "xstream":
                 ff = UghImplementation.INSTANCE.createXStream(prefs);
@@ -1263,8 +1265,8 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
                         .createMetsModsImportExport(rulesetService.getPreferences(process.getRuleset()));
                 break;
             case "mets":
-                fileFormat = UghImplementation.INSTANCE
-                        .createMetsMods(rulesetService.getPreferences(process.getRuleset()));
+                fileFormat = new LegacyMetsModsDigitalDocumentHelper(
+                        ((LegacyPrefsHelper) rulesetService.getPreferences(process.getRuleset())).getRuleset());
                 break;
             case "xstream":
                 fileFormat = UghImplementation.INSTANCE

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -85,7 +85,6 @@ import org.kitodo.api.ugh.exceptions.ReadException;
 import org.kitodo.api.ugh.exceptions.WriteException;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
-import org.kitodo.config.xml.fileformats.FileFormatsConfig;
 import org.kitodo.data.database.beans.Batch;
 import org.kitodo.data.database.beans.Batch.Type;
 import org.kitodo.data.database.beans.Folder;
@@ -2170,15 +2169,8 @@ public class ProcessService extends TitleSearchService<Process, ProcessDTO, Proc
 
     private VirtualFileGroupInterface prepareVirtualFileGroup(Folder folder, VariableReplacer variableReplacer)
             throws JAXBException {
-        VirtualFileGroupInterface virtualFileGroup = UghImplementation.INSTANCE.createVirtualFileGroup();
-        virtualFileGroup.setName(folder.getFileGroup());
-        virtualFileGroup.setPathToFiles(variableReplacer.replace(folder.getUrlStructure()));
-        virtualFileGroup.setMimetype(folder.getMimeType());
-        if (FileFormatsConfig.getFileFormat(folder.getMimeType()).isPresent()) {
-            virtualFileGroup.setFileSuffix(
-                folder.getUGHTail(FileFormatsConfig.getFileFormat(folder.getMimeType()).get().getExtension(false)));
-        }
-        return virtualFileGroup;
+
+        throw new UnsupportedOperationException("Dead code pending removal");
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -38,7 +38,7 @@ import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.dto.ClientDTO;
 import org.kitodo.production.dto.RulesetDTO;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.TitleSearchService;
 import org.primefaces.model.SortOrder;
@@ -210,7 +210,7 @@ public class RulesetService extends TitleSearchService<Ruleset, RulesetDTO, Rule
      * @return preferences
      */
     public PrefsInterface getPreferences(Ruleset ruleset) {
-        PrefsInterface myPreferences = UghImplementation.INSTANCE.createPrefs();
+        PrefsInterface myPreferences = new LegacyPrefsHelper();
         try {
             myPreferences.loadPrefs(ConfigCore.getParameter(ParameterCore.DIR_RULESETS) + ruleset.getFile());
         } catch (PreferencesException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -51,6 +51,8 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.helper.enums.MetadataFormat;
 import org.kitodo.production.file.BackupFileRotation;
 import org.kitodo.production.helper.metadata.ImageHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.command.CommandService;
@@ -517,7 +519,7 @@ public class FileService {
         Ruleset ruleset = process.getRuleset();
         switch (MetadataFormat.findFileFormatsHelperByName(process.getProject().getFileFormatInternal())) {
             case METS:
-                ff = UghImplementation.INSTANCE.createMetsMods(rulesetService.getPreferences(ruleset));
+                ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) rulesetService.getPreferences(ruleset)).getRuleset());
                 break;
             case RDF:
                 ff = UghImplementation.INSTANCE.createRDFFile(rulesetService.getPreferences(ruleset));

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -53,7 +53,6 @@ import org.kitodo.production.file.BackupFileRotation;
 import org.kitodo.production.helper.metadata.ImageHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
-import org.kitodo.production.legacy.UghImplementation;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.command.CommandService;
 import org.kitodo.production.services.data.RulesetService;
@@ -521,11 +520,8 @@ public class FileService {
             case METS:
                 ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) rulesetService.getPreferences(ruleset)).getRuleset());
                 break;
-            case RDF:
-                throw new UnsupportedOperationException("Dead code pending removal");
             default:
-                ff = UghImplementation.INSTANCE.createXStream(rulesetService.getPreferences(ruleset));
-                break;
+                throw new UnsupportedOperationException("Dead code pending removal");
         }
         // createBackupFile();
         URI metadataFileUri = getMetadataFilePath(process);

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -522,8 +522,7 @@ public class FileService {
                 ff = new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) rulesetService.getPreferences(ruleset)).getRuleset());
                 break;
             case RDF:
-                ff = UghImplementation.INSTANCE.createRDFFile(rulesetService.getPreferences(ruleset));
-                break;
+                throw new UnsupportedOperationException("Dead code pending removal");
             default:
                 ff = UghImplementation.INSTANCE.createXStream(rulesetService.getPreferences(ruleset));
                 break;

--- a/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
@@ -44,7 +44,7 @@ import org.kitodo.exceptions.UghHelperException;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.UghHelper;
 import org.kitodo.production.helper.metadata.ImageHelper;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.serviceloader.KitodoServiceLoader;
 
@@ -451,7 +451,7 @@ public class MetadataValidationService {
         List<? extends MetadataInterface> createMetadata = docStruct.getAllMetadataByType(mdt);
         if (createMetadata == null || createMetadata.isEmpty()) {
             try {
-                MetadataInterface createdElement = UghImplementation.INSTANCE.createMetadata(mdt);
+                MetadataInterface createdElement = new LegacyMetadataHelper(mdt);
                 String value = "";
                 // go through all the metadata to append and append to the
                 // element

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -44,7 +44,8 @@ import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.dto.PropertyDTO;
-import org.kitodo.production.legacy.UghImplementation;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.file.FileService;
 
@@ -478,7 +479,8 @@ public class ProcessServiceIT {
     public void shouldWriteMetadataAsTemplateFile() throws Exception {
         Process process = processService.getById(1);
         PrefsInterface preferences = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
-        fileService.writeMetadataAsTemplateFile(UghImplementation.INSTANCE.createMetsMods(preferences), process);
+        fileService.writeMetadataAsTemplateFile(
+            new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) preferences).getRuleset()), process);
         boolean condition = fileService.fileExist(URI.create("1/template.xml"));
         assertTrue("It was not possible to write metadata as template file!", condition);
 


### PR DESCRIPTION
Removes calls to unimplemented UGH methods.

According to information, the UGH is only used in the meta-data editor. Therefore, the replacement implementation implemented only the methods used by the meta-data editor. Consequently, any code that uses methods that have not been implemented is already dead and can be removed.

[compare against part 1](https://github.com/matthias-ronge/kitodo-production/compare/KIT-1155.1...KIT-1155.2)