### PR TITLE
delete modules folder on maven clean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,23 @@
         <module>Kitodo</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <inherited>false</inherited>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>modules</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
     <profiles>
         <profile>
             <id>all-tests</id>


### PR DESCRIPTION
use maven clean plugin to delete modules folder.
We have a problem with the service loader, if we have several versions of the same jar in the modules folder.