### PR TITLE
Link folders to project in tests

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -63,11 +63,11 @@ import org.kitodo.data.database.beans.LinkingMode;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Property;
+import org.kitodo.data.database.beans.Role;
 import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.beans.User;
-import org.kitodo.data.database.beans.Role;
 import org.kitodo.data.database.beans.Workflow;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.helper.enums.PasswordEncryption;
@@ -77,8 +77,8 @@ import org.kitodo.data.database.helper.enums.TaskStatus;
 import org.kitodo.data.database.persistence.HibernateUtil;
 import org.kitodo.data.elasticsearch.index.IndexRestClient;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.enums.ObjectType;
 import org.kitodo.exceptions.WorkflowException;
+import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.BeanHelper;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.security.password.SecurityPasswordEncoder;
@@ -745,10 +745,19 @@ public class MockDatabase {
         fifthFolder.setCreateFolder(true);
         fifthFolder.setLinkingMode(LinkingMode.ALL);
 
+        firstFolder.setProject(project);
         project.getFolders().add(firstFolder);
+
+        secondFolder.setProject(project);
         project.getFolders().add(secondFolder);
+
+        thirdFolder.setProject(project);
         project.getFolders().add(thirdFolder);
+
+        fourthFolder.setProject(project);
         project.getFolders().add(fourthFolder);
+
+        fifthFolder.setProject(project);
         project.getFolders().add(fifthFolder);
 
         ServiceManager.getProjectService().save(project);

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/FolderServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/FolderServiceIT.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.services.data;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -21,6 +22,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.Folder;
+import org.kitodo.data.database.beans.Project;
+import org.kitodo.production.services.ServiceManager;
 
 /**
  * Tests for TaskService class.
@@ -54,5 +57,15 @@ public class FolderServiceIT {
 
         List<Folder> folders = folderService.getAll();
         assertEquals("Folder was not found in database!", 5, folders.size());
+        for (Folder folder : folders) {
+            assertNotEquals("No project assigned", null, folder.getProject());
+        }
+
+        Project project = ServiceManager.getProjectService().getById(1);
+        assertEquals("No project assigned", 5, project.getFolders().size());
+        for (Folder folder : project.getFolders()) {
+            assertNotEquals("No project assigned", null, folder.getProject());
+            assertEquals("No project assigned", project.getTitle(), folder.getProject().getTitle());
+        }
     }
 }


### PR DESCRIPTION
As @Beacze found in tests the folders were not linked with the project when being inserted into the database, and the test did not check for it either. This is added hereby.