### PR TITLE
Remove call to retrieve object after save to database - part 1

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/AuthorityDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/AuthorityDAO.java
@@ -48,7 +48,7 @@ public class AuthorityDAO extends BaseDAO<Authority> {
     @Override
     public Authority save(Authority authority) throws DAOException {
         storeObject(authority);
-        return retrieveObject(Authority.class, authority.getId());
+        return authority;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ClientDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ClientDAO.java
@@ -47,7 +47,7 @@ public class ClientDAO extends BaseDAO<Client> {
     @Override
     public Client save(Client client) throws DAOException {
         storeObject(client);
-        return retrieveObject(Client.class, client.getId());
+        return client;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FolderDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FolderDAO.java
@@ -46,7 +46,7 @@ public class FolderDAO extends BaseDAO<Folder> {
     @Override
     public Folder save(Folder folder) throws DAOException {
         storeObject(folder);
-        return retrieveObject(Folder.class, folder.getId());
+        return folder;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapGroupDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapGroupDAO.java
@@ -21,7 +21,7 @@ public class LdapGroupDAO extends BaseDAO<LdapGroup> {
     @Override
     public LdapGroup save(LdapGroup ldapGroup) throws DAOException {
         storeObject(ldapGroup);
-        return retrieveObject(LdapGroup.class, ldapGroup.getId());
+        return ldapGroup;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapServerDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapServerDAO.java
@@ -20,7 +20,7 @@ public class LdapServerDAO extends BaseDAO<LdapServer> {
     @Override
     public LdapServer save(LdapServer ldapGroup) throws DAOException {
         storeObject(ldapGroup);
-        return retrieveObject(LdapServer.class, ldapGroup.getId());
+        return ldapGroup;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RoleDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RoleDAO.java
@@ -51,7 +51,7 @@ public class RoleDAO extends BaseDAO<Role> {
     @Override
     public Role save(Role role) throws DAOException {
         storeObject(role);
-        return retrieveObject(Role.class, role.getId());
+        return role;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserDAO.java
@@ -49,7 +49,7 @@ public class UserDAO extends BaseDAO<User> {
     @Override
     public User save(User user) throws DAOException {
         storeObject(user);
-        return retrieveObject(User.class, user.getId());
+        return user;
     }
 
     @Override


### PR DESCRIPTION
The goal is to remove querying of newly inserted object as it is already in the session. There are problems for indexed beans which call save method 2 times in short time period, so first remove call only for not indexed bean.