### PR TITLE
Fix up and use ruleset XSD file

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/AcquisitionStage.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/AcquisitionStage.java
@@ -30,7 +30,7 @@ public class AcquisitionStage {
     /**
      * The settings valid on this stage.
      */
-    @XmlElement(name = "setting", required = true)
+    @XmlElement(name = "setting", namespace = "http://names.kitodo.org/ruleset/v2", required = true)
     private List<Setting> settings = new LinkedList<>();
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/DeclarationElement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/DeclarationElement.java
@@ -24,13 +24,13 @@ class DeclarationElement {
     /**
      * The declared divisions.
      */
-    @XmlElement(name = "division", required = true)
+    @XmlElement(name = "division", namespace = "http://names.kitodo.org/ruleset/v2", required = true)
     private List<Division> divisions = new LinkedList<>();
 
     /**
      * The declared keys.
      */
-    @XmlElement(name = "key")
+    @XmlElement(name = "key", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Key> keys = new LinkedList<>();
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Division.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Division.java
@@ -52,14 +52,14 @@ public class Division {
      * Human-readable identifiers for the type. There can be several, depending
      * on the language.
      */
-    @XmlElement(name = "label", required = true)
+    @XmlElement(name = "label", namespace = "http://names.kitodo.org/ruleset/v2", required = true)
     private List<Label> labels = new LinkedList<>();
 
     /**
      * In this element, if there is, it is stored that the division of this
      * division is done by divisions, which map a calendar date.
      */
-    @XmlElement
+    @XmlElement(namespace = "http://names.kitodo.org/ruleset/v2")
     private SubdivisionByDateElement subdivisionByDate;
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/EditingElement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/EditingElement.java
@@ -25,13 +25,13 @@ class EditingElement {
     /**
      * The editor settings.
      */
-    @XmlElement(name = "setting")
+    @XmlElement(name = "setting", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Setting> settings = new LinkedList<>();
 
     /**
      * The acquisition stages.
      */
-    @XmlElement(name = "acquisitionStage")
+    @XmlElement(name = "acquisitionStage", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<AcquisitionStage> acquisitionStages = new LinkedList<>();
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Key.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Key.java
@@ -45,37 +45,37 @@ public class Key {
     /**
      * The labels of the key in different languages.
      */
-    @XmlElement(name = "label", required = true)
+    @XmlElement(name = "label", namespace = "http://names.kitodo.org/ruleset/v2", required = true)
     private List<Label> labels = new LinkedList<>();
 
     /**
      * The codomain of the key.
      */
-    @XmlElement
+    @XmlElement(namespace = "http://names.kitodo.org/ruleset/v2")
     private CodomainElement codomain;
 
     /**
      * The options of select lists.
      */
-    @XmlElement(name = "option")
+    @XmlElement(name = "option", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Option> options = new LinkedList<>();
 
     /**
      * A pattern.
      */
-    @XmlElement
+    @XmlElement(namespace = "http://names.kitodo.org/ruleset/v2")
     private String pattern;
 
     /**
      * Preset values.
      */
-    @XmlElement(name = "preset")
+    @XmlElement(name = "preset", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<String> presets = new LinkedList<>();
 
     /**
      * The keys in the key, for nesting keys.
      */
-    @XmlElement(name = "key")
+    @XmlElement(name = "key", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Key> keys = new LinkedList<>();
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Namespace.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Namespace.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * format was stalled when it was already three-quarters finished. There, this
  * would not have been necessary.
  */
-@XmlRootElement(name = "namespace")
+@XmlRootElement(name = "namespace", namespace = "http://names.kitodo.org/ruleset/v2")
 public class Namespace {
     /**
      * Identifier URI of the namespace.
@@ -43,13 +43,13 @@ public class Namespace {
      * The labels for the namespace. (The label is not currently in use, but
      * could be used to display the namespace in the ruleset editor.)
      */
-    @XmlElement(name = "label")
+    @XmlElement(name = "label", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Label> labels = new LinkedList<>();
 
     /**
      * The members of the namespace.
      */
-    @XmlElement(name = "option")
+    @XmlElement(name = "option", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Option> options = new LinkedList<>();
 
     public Collection<Option> getOptions() {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Option.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Option.java
@@ -30,7 +30,7 @@ public class Option {
     /**
      * Optional labels.
      */
-    @XmlElement(name = "label")
+    @XmlElement(name = "label", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Label> labels = new LinkedList<>();
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Rule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Rule.java
@@ -68,7 +68,7 @@ public class Rule {
     /**
      * List of permit rules. Recursion is possible.
      */
-    @XmlElement(name = "permit")
+    @XmlElement(name = "permit", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Rule> permits = new LinkedList<>();
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Ruleset.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Ruleset.java
@@ -34,7 +34,7 @@ import org.kitodo.dataeditor.ruleset.UniversalRule;
  * heart of Production. It consists of three sections: declaration, correlation
  * and editing.
  */
-@XmlRootElement(name = "ruleset")
+@XmlRootElement(name = "ruleset", namespace = "http://names.kitodo.org/ruleset/v2")
 public class Ruleset {
 
     /**
@@ -47,21 +47,21 @@ public class Ruleset {
     /**
      * The declaration section defines divisions and keys.
      */
-    @XmlElement(name = "declaration")
+    @XmlElement(name = "declaration", namespace = "http://names.kitodo.org/ruleset/v2")
     private DeclarationElement declaration = new DeclarationElement();
 
     /**
      * The correlation section defines relationships between divisions and keys.
      */
-    @XmlElementWrapper(name = "correlation")
-    @XmlElement(name = "restriction")
+    @XmlElementWrapper(name = "correlation", namespace = "http://names.kitodo.org/ruleset/v2")
+    @XmlElement(name = "restriction", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Rule> restrictions = new LinkedList<>();
 
     /**
      * In the editing section settings for the editor concerning keys are
      * defined.
      */
-    @XmlElement(name = "editing")
+    @XmlElement(name = "editing", namespace = "http://names.kitodo.org/ruleset/v2")
     private EditingElement editing;
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Setting.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Setting.java
@@ -76,7 +76,7 @@ public class Setting {
     /**
      * The settings for sub-keys.
      */
-    @XmlElement(name = "setting")
+    @XmlElement(name = "setting", namespace = "http://names.kitodo.org/ruleset/v2")
     private List<Setting> settings = new LinkedList<>();
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/SubdivisionByDateElement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/SubdivisionByDateElement.java
@@ -30,7 +30,7 @@ class SubdivisionByDateElement {
     /**
      * Divisions to structure the temporal course.
      */
-    @XmlElement(name = "division", required = true)
+    @XmlElement(name = "division", namespace = "http://names.kitodo.org/ruleset/v2", required = true)
     private List<Division> divisions;
 
     List<Division> getDivisions() {

--- a/Kitodo-DataEditor/src/main/resources/ruleset.xsd
+++ b/Kitodo-DataEditor/src/main/resources/ruleset.xsd
@@ -89,6 +89,15 @@
         </xs:simpleContent>
     </xs:complexType>
 
+    <xs:element name="namespace">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="option" minOccurs="0" maxOccurs="unbounded" type="ruleset:Option"/>
+            </xs:sequence>
+            <xs:attribute type="xs:anyURI" name="about"/>
+        </xs:complexType>
+    </xs:element>
+
     <xs:complexType name="Option">
         <xs:sequence>
             <xs:element name="label" minOccurs="0" maxOccurs="unbounded" type="ruleset:Label"/>

--- a/Kitodo-DataEditor/src/main/resources/ruleset.xsd
+++ b/Kitodo-DataEditor/src/main/resources/ruleset.xsd
@@ -14,35 +14,36 @@
 <!--
     This file provides an XML Schema for the ruleset. It was derived from the
     Java classes for parsing the ruleset. The structure and naming follow the
-    the Java classes. This file is not used by the source code. It exists at
-    the suggestion of Henning Gerhardt so that it can be used to validate a
-    ruleset file with an (external) XML validation service.
+    the Java classes.
 -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ruleset="http://names.kitodo.org/ruleset/v2"
+           elementFormDefault="qualified"
+           targetNamespace="http://names.kitodo.org/ruleset/v2">
 
     <xs:complexType name="AcquisitionStage">
         <xs:sequence>
-            <xs:element name="setting" minOccurs="1" maxOccurs="unbounded" type="Setting"/>
+            <xs:element name="setting" minOccurs="1" maxOccurs="unbounded" type="ruleset:Setting"/>
         </xs:sequence>
         <xs:attribute use="required" type="xs:string" name="name"/>
     </xs:complexType>
 
     <xs:complexType name="CodomainElement">
-        <xs:attribute type="Type" name="type"/>
+        <xs:attribute type="ruleset:Type" name="type"/>
         <xs:attribute type="xs:anyURI" name="namespace"/>
     </xs:complexType>
 
     <xs:complexType name="DeclarationElement">
         <xs:sequence>
-            <xs:element name="division" minOccurs="1" maxOccurs="unbounded" type="Division" />
-            <xs:element name="key" minOccurs="0" maxOccurs="unbounded" type="Key"/>
+            <xs:element name="division" minOccurs="1" maxOccurs="unbounded" type="ruleset:Division" />
+            <xs:element name="key" minOccurs="0" maxOccurs="unbounded" type="ruleset:Key"/>
         </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="Division">
         <xs:sequence>
-            <xs:element type="Label" minOccurs="1" maxOccurs="unbounded" name="label"/>
-            <xs:element type="SubdivisionByDateElement" minOccurs="0" maxOccurs="1" name="subdivisionByDate"/>
+            <xs:element type="ruleset:Label" minOccurs="1" maxOccurs="unbounded" name="label"/>
+            <xs:element type="ruleset:SubdivisionByDateElement" minOccurs="0" maxOccurs="1" name="subdivisionByDate"/>
         </xs:sequence>
         <xs:attribute use="required" type="xs:NMTOKEN" name="id"/>
         <xs:attribute type="xs:NMTOKEN" name="dates"/>
@@ -62,22 +63,22 @@
 
     <xs:complexType name="EditingElement">
         <xs:sequence>
-            <xs:element name="setting" minOccurs="0" maxOccurs="unbounded" type="Setting"/>
-            <xs:element name="acquisitionStage" minOccurs="0" maxOccurs="unbounded" type="AcquisitionStage"/>
+            <xs:element name="setting" minOccurs="0" maxOccurs="unbounded" type="ruleset:Setting"/>
+            <xs:element name="acquisitionStage" minOccurs="0" maxOccurs="unbounded" type="ruleset:AcquisitionStage"/>
         </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="Key">
         <xs:sequence>
-            <xs:element name="label" minOccurs="1" maxOccurs="unbounded" type="Label"/>
-            <xs:element name="codomain" minOccurs="0" maxOccurs="1" type="CodomainElement"/>
-            <xs:element name="option" minOccurs="0" maxOccurs="unbounded" type="Option"/>
+            <xs:element name="label" minOccurs="1" maxOccurs="unbounded" type="ruleset:Label"/>
+            <xs:element name="codomain" minOccurs="0" maxOccurs="1" type="ruleset:CodomainElement"/>
+            <xs:element name="option" minOccurs="0" maxOccurs="unbounded" type="ruleset:Option"/>
             <xs:element name="pattern" minOccurs="0" maxOccurs="1" type="xs:string"/>
             <xs:element name="preset" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
-            <xs:element name="key" minOccurs="0" maxOccurs="unbounded" type="Key"/>
+            <xs:element name="key" minOccurs="0" maxOccurs="unbounded" type="ruleset:Key"/>
         </xs:sequence>
         <xs:attribute use="required" type="xs:NMTOKEN" name="id"/>
-        <xs:attribute type="DomainAttribute" name="domain" default="description"/>
+        <xs:attribute type="ruleset:DomainAttribute" name="domain" default="description"/>
     </xs:complexType>
 
     <xs:complexType name="Label">
@@ -90,35 +91,35 @@
 
     <xs:complexType name="Option">
         <xs:sequence>
-            <xs:element name="label" minOccurs="0" maxOccurs="unbounded" type="Label"/>
+            <xs:element name="label" minOccurs="0" maxOccurs="unbounded" type="ruleset:Label"/>
         </xs:sequence>
         <xs:attribute use="required" type="xs:string" name="value"/>
     </xs:complexType>
 
     <xs:complexType name="Rule">
         <xs:sequence>
-            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="Rule"/>
+            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:Rule"/>
         </xs:sequence>
-        <xs:attribute type="xs:NMTOKEN" name="divioion"/>
+        <xs:attribute type="xs:NMTOKEN" name="division"/>
         <xs:attribute type="xs:NMTOKEN" name="key"/>
         <xs:attribute type="xs:string" name="value"/>
         <xs:attribute type="xs:nonNegativeInteger" name="minOccurs"/>
         <xs:attribute type="xs:nonNegativeInteger" name="maxOccurs"/>
-        <xs:attribute type="Unspecified" name="unspecified"/>
+        <xs:attribute type="ruleset:Unspecified" name="unspecified"/>
     </xs:complexType>
 
     <xs:element name="ruleset">
         <xs:complexType>
             <xs:sequence>
-            <xs:element name="declaration" minOccurs="1" maxOccurs="1" type="DeclarationElement"/>
-            <xs:element name="correlation" minOccurs="0" maxOccurs="1">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="restriction" minOccurs="1" maxOccurs="unbounded" type="Rule"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="editing" minOccurs="0" maxOccurs="1" type="EditingElement"/>
+                <xs:element name="declaration" minOccurs="1" maxOccurs="1" type="ruleset:DeclarationElement"/>
+                <xs:element name="correlation" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="restriction" minOccurs="1" maxOccurs="unbounded" type="ruleset:Rule"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="editing" minOccurs="0" maxOccurs="1" type="ruleset:EditingElement"/>
             </xs:sequence>
             <xs:attribute type="xs:string" name="lang"/>
         </xs:complexType>
@@ -126,7 +127,7 @@
 
     <xs:complexType name="Setting">
         <xs:sequence>
-            <xs:element name="declaration" minOccurs="0" maxOccurs="unbounded" type="Setting"/>
+            <xs:element name="setting" minOccurs="0" maxOccurs="unbounded" type="ruleset:Setting"/>
         </xs:sequence>
         <xs:attribute type="xs:NMTOKEN" name="key"/>
         <xs:attribute type="xs:boolean" name="alwaysShowing" default="false"/>
@@ -137,7 +138,7 @@
 
     <xs:complexType name="SubdivisionByDateElement">
         <xs:sequence>
-            <xs:element name="declaration" minOccurs="1" maxOccurs="unbounded" type="Division"/>
+            <xs:element name="division" minOccurs="1" maxOccurs="unbounded" type="ruleset:Division"/>
         </xs:sequence>
         <xs:attribute name="yearBegin">
             <xs:simpleType>

--- a/Kitodo-DataEditor/src/test/resources/testAnExtensiveRulesetCanBeLoaded.xml
+++ b/Kitodo-DataEditor/src/test/resources/testAnExtensiveRulesetCanBeLoaded.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <!--
         'declaration' tag:
             Declares the object classes of the divisions and keys.

--- a/Kitodo-DataEditor/src/test/resources/testAvailabilityOfPresets.xml
+++ b/Kitodo-DataEditor/src/test/resources/testAvailabilityOfPresets.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testAvailabilityOfSubkeyViews.xml
+++ b/Kitodo-DataEditor/src/test/resources/testAvailabilityOfSubkeyViews.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testCorrectReturnOfOptions.xml
+++ b/Kitodo-DataEditor/src/test/resources/testCorrectReturnOfOptions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testCorrectValidationOfOptions.xml
+++ b/Kitodo-DataEditor/src/test/resources/testCorrectValidationOfOptions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testCorrectValidationOfRegularExpressions.xml
+++ b/Kitodo-DataEditor/src/test/resources/testCorrectValidationOfRegularExpressions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testDisplaySettingsWithAcquisitionStage.xml
+++ b/Kitodo-DataEditor/src/test/resources/testDisplaySettingsWithAcquisitionStage.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testDisplaySettingsWithoutAcquisitionStage.xml
+++ b/Kitodo-DataEditor/src/test/resources/testDisplaySettingsWithoutAcquisitionStage.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testDivisionsAreCorrectlyTranslated.xml
+++ b/Kitodo-DataEditor/src/test/resources/testDivisionsAreCorrectlyTranslated.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -16,7 +16,9 @@
      can be cataloged. For each book author, year, title, publisher and place
      of publication can be recorded. Otherwise there are no further
      requirements. -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testDivisionsSubdividedByDateHaveOnlyTheCorrectChildren.xml
+++ b/Kitodo-DataEditor/src/test/resources/testDivisionsSubdividedByDateHaveOnlyTheCorrectChildren.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="newspaper">
             <label>Newspaper ‹complete edition›</label>

--- a/Kitodo-DataEditor/src/test/resources/testDivisionsSubdividedByDateReportDateSchemeAndField.xml
+++ b/Kitodo-DataEditor/src/test/resources/testDivisionsSubdividedByDateReportDateSchemeAndField.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="playtime">
             <label>Playtime ‹complete edition›</label>

--- a/Kitodo-DataEditor/src/test/resources/testFieldsWithMinOccursGreaterZeroAreAlwaysShown.xml
+++ b/Kitodo-DataEditor/src/test/resources/testFieldsWithMinOccursGreaterZeroAreAlwaysShown.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testKeysReturnTheSpecifiedDomain.xml
+++ b/Kitodo-DataEditor/src/test/resources/testKeysReturnTheSpecifiedDomain.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testRulesAreCorrectlyMerged.xml
+++ b/Kitodo-DataEditor/src/test/resources/testRulesAreCorrectlyMerged.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testRulesRemoveKeysWithZeroMaxOccurs.xml
+++ b/Kitodo-DataEditor/src/test/resources/testRulesRemoveKeysWithZeroMaxOccurs.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testTheDisplayModeIsSetUsingTheCodomain.xml
+++ b/Kitodo-DataEditor/src/test/resources/testTheDisplayModeIsSetUsingTheCodomain.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictDivisions.xml
+++ b/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictDivisions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictKeys.xml
+++ b/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictKeys.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictOptions.xml
+++ b/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictOptions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictOptionsAlsoInTheValidation.xml
+++ b/Kitodo-DataEditor/src/test/resources/testUnspecifiedForbiddenRulesRestrictOptionsAlsoInTheValidation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testUnspecifiedUnrestrictedRulesSortDivisionsWithoutRestrictingThem.xml
+++ b/Kitodo-DataEditor/src/test/resources/testUnspecifiedUnrestrictedRulesSortDivisionsWithoutRestrictingThem.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="phonographicRecord">
             <label>Record</label>

--- a/Kitodo-DataEditor/src/test/resources/testUnspecifiedUnrestrictedRulesSortKeysWithoutRestrictingThem.xml
+++ b/Kitodo-DataEditor/src/test/resources/testUnspecifiedUnrestrictedRulesSortKeysWithoutRestrictingThem.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="article">
             <label>Article</label>

--- a/Kitodo-DataEditor/src/test/resources/testUnspecifiedUnrestrictedRulesSortOptionsWithoutRestrictingThem.xml
+++ b/Kitodo-DataEditor/src/test/resources/testUnspecifiedUnrestrictedRulesSortOptionsWithoutRestrictingThem.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testValidationByCodomain.xml
+++ b/Kitodo-DataEditor/src/test/resources/testValidationByCodomain.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<ruleset>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd">
     <declaration>
         <division id="book">
             <label>Book</label>

--- a/Kitodo-DataEditor/src/test/resources/testValidationByCodomainNamespace.xml
+++ b/Kitodo-DataEditor/src/test/resources/testValidationByCodomainNamespace.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,7 +11,10 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<namespace about="http://test.example/testValidationByCodomainNamespace">
+<namespace xmlns="http://names.kitodo.org/ruleset/v2"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../main/resources/ruleset.xsd"
+           about="http://test.example/testValidationByCodomainNamespace">
     <option value="http://test.example/testValidationByCodomainNamespace#val1"/>
     <option value="http://test.example/testValidationByCodomainNamespace#val2"/>
     <option value="http://test.example/testValidationByCodomainNamespace#val3"/>

--- a/Kitodo/src/test/resources/rulesets/ruleset_test.xml
+++ b/Kitodo/src/test/resources/rulesets/ruleset_test.xml
@@ -1,17 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
-  *
-  * This file is part of the Kitodo project.
-  *
-  * It is licensed under GNU General Public License version 3 or later.
-  *
-  * For the full copyright and license information, please read the
-  * GPL3-License.txt file that was distributed with this source code.
-  -->
-
-<ruleset>
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ../../../../../Kitodo-DataEditor/src/main/resources/ruleset.xsd">
     <declaration>
         <division id="something">
             <label>Outline element</label>


### PR DESCRIPTION
An XSD file was written for the rule sets, but this has never been used and so it was not noticed that it is buggy and does not work. This pull request is to repair the XSD file and use it with the existing ruleset files. To enable validation, the ruleset needs to be declared into a namespace.