### PR TITLE
Count database objects implicitly

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
@@ -151,7 +151,7 @@ public class IndexingForm {
 
     /**
      * Get time when indexing has started.
-     * 
+     *
      * @return time when indexing has started as LocalDateTime
      */
     public LocalDateTime getIndexingStartedTime() {
@@ -459,7 +459,7 @@ public class IndexingForm {
 
     /**
      * Check if current mapping is empty.
-     * 
+     *
      * @return true if mapping is empty, otherwise false
      */
     public boolean isMappingEmpty() {
@@ -644,6 +644,7 @@ public class IndexingForm {
         for (ObjectType objectType : objectTypes) {
             updateCount(objectType);
         }
+        countDatabaseObjects();
         Ajax.update("@all");
     }
 

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -200,7 +200,6 @@ correctionSolutionFor=Korrekturl\u00F6sung f\u00FCr Schritt
 correctionSolveProblem=Korrekturl\u00F6sung konnte nicht an folgende Aufgabe gemeldet werden!
 couldNotCreateImageFolder=Das Verzeichnis f\u00FCr die Images konnte nicht angelegt werden
 count=Anzahl
-countDatabaseObjects=Datenbankobjekte z\u00E4hlen
 counting=Z\u00E4hlung
 createExcel=Exceldatei erzeugen
 createMapping=ElasticSearch Mapping erzeugen

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -200,7 +200,6 @@ correctionSolutionFor=Correction done for step
 correctionSolveProblem=Solution of correction could not be reported!
 couldNotCreateImageFolder=Image folder could not be created
 count=Count
-countDatabaseObjects=Count database objects
 counting=Counting
 createExcel=generate excel
 createMapping=Create ElasticSearch mapping

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/indexing.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/indexing.xhtml
@@ -70,19 +70,6 @@
                                 <p:graphicImage id="delete-index-success" alt="success" value="/pages/images/success.svg" style="max-height: 20px;" rendered="#{!indexingForm.indexingInProgress() and indexingForm.indexState == 'DELETE_SUCCESS'}"/>
                             </td>
                         </tr>
-                        <tr>
-                            <td colspan="2">
-                                <p:commandButton widgetVar="countDatabaseObjects"
-                                                 id="countDatabaseObjects"
-                                                 rendered="#{SecurityAccessController.hasAuthorityToEditIndex()}"
-                                                 value="#{msgs.countDatabaseObjects}"
-                                                 style="width: 100%;"
-                                                 action="#{indexingForm.countDatabaseObjects()}"
-                                                 disabled="#{!indexingForm.indexExists() or indexingForm.indexingInProgress()}"
-                                                 update="indexingTable"/>
-                            </td>
-                            <td/>
-                        </tr>
                         </tbody>
                     </table>
                     <table id="indexingTable">


### PR DESCRIPTION
Replace button to manually and explicitly count database objects on system page (introducing another potential cause for errors when managing the index) count database objects implicitly when page is loaded.