### PR TITLE
Remove method getLocalizedTitle from Task bean - it doesn't translate

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
@@ -571,25 +571,6 @@ public class Task extends BaseIndexedBean {
         this.batchStep = batchStep;
     }
 
-    /**
-     * Get localized title.
-     *
-     * @return localized title as String
-     */
-    public String getLocalizedTitle() {
-        return this.localizedTitle;
-    }
-
-    /**
-     * Set localized titles as String.
-     *
-     * @param localizedTitle
-     *            as String
-     */
-    public void setLocalizedTitle(String localizedTitle) {
-        this.localizedTitle = localizedTitle;
-    }
-
     // Here will be methods which should be in TaskService but are used by jsp
     // files
     /**

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
@@ -17,7 +17,7 @@
         xmlns:p="http://primefaces.org/ui">
     <p:dataTable var="item" value="#{CurrentTaskForm.currentTask}">
         <p:column headerText="#{msgs.title}">
-            <h:outputText value="#{CurrentTaskForm.currentTask.localizedTitle}"/>
+            <h:outputText value="#{CurrentTaskForm.currentTask.title}"/>
         </p:column>
         <p:column headerText="#{msgs.processTitle}">
             <h:outputText value="#{item.process.title}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditDetails.xhtml
@@ -56,8 +56,7 @@
                                         <h:outputText value="#{msgs.title}:"/>
                                     </td>
                                     <td>
-                                        <h:outputText
-                                                value="#{CurrentTaskForm.batchHelper.currentStep.localizedTitle}"/>
+                                        <h:outputText value="#{CurrentTaskForm.batchHelper.currentStep.title}"/>
                                     </td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
Translation of title can be achieved by adding translation keys to messages files. Next call method getTranslated from HelperForm (change is made in PR https://github.com/kitodo/kitodo-production/pull/2296).