### PR TITLE
Remove duplicate / unused methods in TaskService for finding objects

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/production/services/data/TaskServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/TaskServiceIT.java
@@ -100,24 +100,6 @@ public class TaskServiceIT {
     }
 
     @Test
-    public void shouldFindManyByProcessingStatusAndUser() {
-        await().untilAsserted(() -> assertEquals("Not all tasks were found in database!", 2,
-            taskService.findByProcessingStatusAndUser(TaskStatus.DONE, 1, null).size()));
-    }
-
-    @Test
-    public void shouldFindOneByProcessingStatusAndUser() {
-        await().untilAsserted(() -> assertEquals("Not all tasks were found in database!", 1,
-            taskService.findByProcessingStatusAndUser(TaskStatus.INWORK, 2, null).size()));
-    }
-
-    @Test
-    public void shouldNotFindByProcessingStatusAndUser() {
-        await().untilAsserted(() -> assertEquals("Some tasks were found in database!", 0,
-            taskService.findByProcessingStatusAndUser(TaskStatus.INWORK, 3, null).size()));
-    }
-
-    @Test
     public void shouldReplaceProcessingUser() throws Exception {
         UserService userService = ServiceManager.getUserService();
 


### PR DESCRIPTION
- remove unused find methods, the whole find process happens now in loadData method
- remove duplicated code
- use single methods for creating specific queries