### PR TITLE
Update checkstyle to version 8.18 to fix security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
                             <dependency>
                                 <groupId>com.puppycrawl.tools</groupId>
                                 <artifactId>checkstyle</artifactId>
-                                <version>8.12</version>
+                                <version>8.18</version>
                             </dependency>
                         </dependencies>
                         <executions>


### PR DESCRIPTION
Until [version 8.18](https://checkstyle.org/releasenotes.html#Release_8.18) checkstyle loads external DTD files without proper secure handling. 