### PR TITLE
Prevent long headings from forcing buttons into next line

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1053,6 +1053,14 @@ main i.fa {
     margin-left: var(--default-double-size);
 }
 
+h3#headerText {
+    display: inline-block;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    width: calc(100% - 300px);
+    white-space: nowrap;
+}
+
 /*----------------------------------------------------------------------
 Metadata Editor
 ----------------------------------------------------------------------*/
@@ -1068,23 +1076,11 @@ Metadata Editor
 
 #metadataEditorHeader h3 {
     width: calc(100% - 450px);
-    display: inline-block;
-    white-space: nowrap;
-    overflow-x: hidden;
-    text-overflow: ellipsis;
 }
 
 #metadataEditorHeader .ui-panel,
 #metadataEditorHeader .ui-panel-content {
     padding: 0;
-}
-
-#metadataEditorHeader .button-wrapper {
-    position: absolute;
-    right: 0;
-    vertical-align: top;
-    white-space: nowrap;
-    float: right;
 }
 
 #metadataEditorWrapper {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
@@ -22,11 +22,10 @@
                                     SecurityAccessController.hasAuthorityToEditProcessImages() or
                                     SecurityAccessController.hasAuthorityToEditProcessStructureData()}"/>
     <p:panel styleClass="content-header">
-        <h3>
+        <h3 id="headerText">
             <h:outputText value="#{MetadataProcessor.process.title} - #{msgs.metadataEdit}"
                           title="#{MetadataProcessor.process.title} - #{msgs.metadataEdit}"/>
         </h3>
-        <span class="button-wrapper">
             <p:button value="#{msgs.exit}"
                       outcome="#{MetadataProcessor.referringView}"
                       icon="fa fa-times fa-lg"
@@ -51,6 +50,5 @@
                              style="margin-left: 16px;"
                              onclick="PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','detail':'#{msgs.youWillBeRedirected}','severity':'info'});"
                              update="notifications"/>
-        </span>
     </p:panel>
 </ui:composition>


### PR DESCRIPTION
When the heading was very long it could force buttons into the next line behind the content.
The displayed length of the heading is now limited to keep the buttons in the correct place.