### PR TITLE
Show progress cursor during AJAX request

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -95,6 +95,9 @@ sup {
     100% {opacity: 1;}
     }
 
+html.progressCursor * {
+    cursor: progress;
+}
 
 /*----------------------------------------------------------------------
 Header

--- a/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -28,6 +28,8 @@
         <h:body styleClass="#{LoginForm.firstVisit ? 'first-visit' : ''}" lang="#{LanguageForm.locale}">
             <h:outputStylesheet name="css/kitodo.css"/>
             <h:outputStylesheet name="css/pattern-library.css"/>
+            <p:ajaxStatus onstart="$('html').addClass('progressCursor')"
+                          oncomplete="$('html').removeClass('progressCursor')" />
             <p:growl id="notifications" widgetVar="notifications" severity="info"/>
             <p:growl id="sticky-notifications" widgetVar="sticky-notifications" sticky="true" severity="info"/>
             <h:panelGroup id="indexErrorPanel" layout="block" rendered="#{empty indexingForm.serverInformation}">


### PR DESCRIPTION
This improves the responsiveness a bit: If you click on a button that requires an AJAX request, a small load wheel or a small hourglass appears on the mouse (or the correspondingly configured mouse pointer). Unfortunately, it does not (yet) work on buttons that trigger a link to a new page. So: you can see it with buttons where you stay on the same page.