### PR TITLE
Add test for converters and unify converters

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/converter/AuthorityConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/AuthorityConverter.java
@@ -16,29 +16,18 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Authority;
-import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class AuthorityConverter implements Converter {
-
-    private static final Logger logger = LogManager.getLogger(AuthorityConverter.class);
+public class AuthorityConverter extends BeanConverter implements Converter {
 
     @Override
-    public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String s) {
-        try {
-            return ServiceManager.getAuthorityService().getById(Integer.parseInt(s));
-        } catch (DAOException e) {
-            logger.error(e.getMessage());
-            return null;
-        }
+    public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
+        return getAsObject(ServiceManager.getAuthorityService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object o) {
-        return ((Authority) o).getId().toString();
+    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
+        return getAsString(value, "authority");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/BatchConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/BatchConverter.java
@@ -11,52 +11,24 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Batch;
-import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.data.database.persistence.BatchDAO;
-import org.kitodo.production.helper.Helper;
+import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class BatchConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(BatchConverter.class);
+public class BatchConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return new BatchDAO().getById(Integer.valueOf(value));
-            } catch (DAOException | NumberFormatException e) {
-                logger.error(e.getMessage(), e);
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getBatchService(), value);
     }
 
     @Override
     public String getAsString(FacesContext context, UIComponent component, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof Batch) {
-            return String.valueOf(((Batch) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException(Helper.getTranslation("errorConvert",
-                    Arrays.asList(value.getClass().getCanonicalName(), "Batch")));
-        }
+        return getAsString(value, "batch");
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/BeanConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/BeanConverter.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.converter;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import javax.faces.convert.ConverterException;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kitodo.data.database.beans.BaseBean;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.helper.Helper;
+import org.kitodo.production.services.data.base.SearchDatabaseService;
+
+public abstract class BeanConverter {
+
+    private static final Logger logger = LogManager.getLogger(BeanConverter.class);
+
+    /**
+     * Get as object for bean convert.
+     * 
+     * @param searchDatabaseService
+     *            service used for query the object
+     * @param value
+     *            id of object as String
+     * @return null if value is null, bean object if id is correct and exists in
+     *         database, "0" when id is incorrect or object with this id doesn't
+     *         exist in database
+     */
+    protected Object getAsObject(SearchDatabaseService searchDatabaseService, String value) {
+        if (StringUtils.isEmpty(value)) {
+            return null;
+        } else {
+            try {
+                return searchDatabaseService.getById(Integer.parseInt(value));
+            } catch (DAOException | NumberFormatException e) {
+                logger.error(e.getMessage(), e);
+                return "0";
+            }
+        }
+    }
+
+    /**
+     * Get as string for bean convert.
+     * 
+     * @param value
+     *            bean to be converted
+     * @param translationKey
+     *            for possible error message
+     * @return null when bean is null, otherwise string id or string representation
+     *         of value
+     */
+    protected String getAsString(Object value, String translationKey) {
+        if (Objects.isNull(value)) {
+            return null;
+        } else if (value instanceof BaseBean) {
+            Integer beanId = ((BaseBean) value).getId();
+            if (Objects.nonNull(beanId)) {
+                return String.valueOf(beanId);
+            }
+            return "0";
+        } else if (value instanceof String) {
+            return (String) value;
+        } else {
+            throw new ConverterException(Helper.getTranslation("errorConvert",
+                Arrays.asList(value.getClass().getCanonicalName(), translationKey)));
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ClientConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ClientConverter.java
@@ -11,53 +11,23 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Client;
-import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ClientConverter implements Converter {
-
-    private static final Logger logger = LogManager.getLogger(ClientConverter.class);
+public class ClientConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getClientService().getById(Integer.parseInt(value));
-            } catch (DAOException e) {
-                logger.error(e.getMessage());
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getClientService(), value);
     }
 
     @Override
     public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof Client) {
-            return String.valueOf(((Client) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException(Helper.getTranslation("errorConvert",
-                    Arrays.asList(value.getClass().getCanonicalName(), "Client")));
-        }
+        return getAsString(value, "client");
     }
-
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/DocketConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/DocketConverter.java
@@ -11,52 +11,24 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Docket;
-import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.data.database.persistence.DocketDAO;
-import org.kitodo.production.helper.Helper;
+import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class DocketConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(DocketConverter.class);
+public class DocketConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return new DocketDAO().getById(Integer.valueOf(value));
-            } catch (DAOException | NumberFormatException e) {
-                logger.error(e.getMessage(), e);
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getDocketService(), value);
     }
 
     @Override
     public String getAsString(FacesContext context, UIComponent component, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof Docket) {
-            return String.valueOf(((Docket) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException(Helper.getTranslation("errorConvert",
-                    Arrays.asList(value.getClass().getCanonicalName(), "Docket")));
-        }
+        return getAsString(value, "docket");
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/LdapGroupConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/LdapGroupConverter.java
@@ -11,48 +11,23 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.LdapGroup;
-import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class LdapGroupConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(LdapGroupConverter.class);
+public class LdapGroupConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getLdapGroupService().getById(Integer.parseInt(value));
-            } catch (DAOException e) {
-                logger.error(e.getMessage());
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getLdapGroupService(), value);
     }
 
     @Override
     public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof LdapGroup) {
-            return String.valueOf(((LdapGroup) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException("Incorrect type: " + value.getClass() + " must be 'LdapGroup'!");
-        }
+        return getAsString(value, "ldapGroup");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/LdapServerConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/LdapServerConverter.java
@@ -11,48 +11,23 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.LdapServer;
-import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class LdapServerConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(LdapServerConverter.class);
+public class LdapServerConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getLdapServerService().getById(Integer.parseInt(value));
-            } catch (DAOException e) {
-                logger.error(e.getMessage());
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getLdapServerService(), value);
     }
 
     @Override
     public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof LdapServer) {
-            return String.valueOf(((LdapServer) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException("Incorrect type: " + value.getClass() + " must be 'LdapServer'!");
-        }
+        return getAsString(value, "ldapServer");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ListColumnConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ListColumnConverter.java
@@ -11,51 +11,23 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.kitodo.data.database.beans.ListColumn;
-import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ListColumnConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(ListColumnConverter.class);
+public class ListColumnConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getListColumnService().getById(Integer.valueOf(value));
-            } catch (DAOException e) {
-                logger.error(e.getLocalizedMessage(), e);
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getListColumnService(), value);
     }
 
     @Override
     public String getAsString(FacesContext context, UIComponent component, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof ListColumn) {
-            return String.valueOf(((ListColumn) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException(Helper.getTranslation("errorConvert",
-                Arrays.asList(value.getClass().getCanonicalName(), "ListColumn")));
-        }
+        return getAsString(value, "listColumn");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ProcessConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ProcessConverter.java
@@ -11,53 +11,24 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Process;
-import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ProcessConverter implements Converter {
-
-    private static final Logger logger = LogManager.getLogger(ProcessConverter.class);
+public class ProcessConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getProcessService().getById(Integer.valueOf(value));
-            } catch (NumberFormatException | DAOException e) {
-                logger.error(e.getMessage(), e);
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getProcessService(), value);
     }
 
     @Override
     public String getAsString(FacesContext context, UIComponent component, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof Process) {
-            return String.valueOf(((Process) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException(Helper.getTranslation("errorConvert",
-                    Arrays.asList(value.getClass().getCanonicalName(), "Process")));
-        }
+        return getAsString(value, "process");
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ProjectConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ProjectConverter.java
@@ -11,52 +11,23 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Project;
-import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ProjectConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(ProjectConverter.class);
+public class ProjectConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getProjectService().getById(Integer.valueOf(value));
-            } catch (DAOException | NumberFormatException e) {
-                logger.error(e.getMessage(), e);
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getProjectService(), value);
     }
 
     @Override
     public String getAsString(FacesContext context, UIComponent component, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof Project) {
-            return String.valueOf(((Project) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException(Helper.getTranslation("errorConvert",
-                Arrays.asList(value.getClass().getCanonicalName(), "Project")));
-        }
+        return getAsString(value, "project");
     }
-
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/RulesetConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/RulesetConverter.java
@@ -11,52 +11,23 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Ruleset;
-import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class RulesetConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(RulesetConverter.class);
+public class RulesetConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getRulesetService().getById(Integer.valueOf(value));
-            } catch (DAOException | NumberFormatException e) {
-                logger.error(e.getMessage(), e);
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getRulesetService(), value);
     }
 
     @Override
     public String getAsString(FacesContext context, UIComponent component, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof Ruleset) {
-            return String.valueOf(((Ruleset) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException(Helper.getTranslation("errorConvert",
-                    Arrays.asList(value.getClass().getCanonicalName(), "Ruleset")));
-        }
+        return getAsString(value, "ruleset");
     }
-
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/WorkflowConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/WorkflowConverter.java
@@ -11,49 +11,24 @@
 
 package org.kitodo.production.converter;
 
-import java.util.Objects;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.convert.ConverterException;
 import javax.inject.Named;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kitodo.data.database.beans.Workflow;
-import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class WorkflowConverter implements Converter {
-    private static final Logger logger = LogManager.getLogger(WorkflowConverter.class);
+public class WorkflowConverter extends BeanConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
-            return null;
-        } else {
-            try {
-                return ServiceManager.getWorkflowService().getById(Integer.valueOf(value));
-            } catch (DAOException | NumberFormatException e) {
-                logger.error(e.getMessage(), e);
-                return "0";
-            }
-        }
+        return getAsObject(ServiceManager.getWorkflowService(), value);
     }
 
     @Override
     public String getAsString(FacesContext context, UIComponent component, Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        } else if (value instanceof Workflow) {
-            return String.valueOf(((Workflow) value).getId().intValue());
-        } else if (value instanceof String) {
-            return (String) value;
-        } else {
-            throw new ConverterException("Incorrect type: " + value.getClass() + " must be 'Workflow'!");
-        }
+        return getAsString(value, "workflow");
     }
 
 }

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -252,7 +252,7 @@ public class MockDatabase {
         return settingsMap;
     }
 
-    private static void insertAuthorities() throws DAOException {
+    public static void insertAuthorities() throws DAOException {
         List<Authority> authorities = new ArrayList<>();
 
         // Client

--- a/Kitodo/src/test/java/org/kitodo/production/converter/AuthorityConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/AuthorityConverterIT.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Authority;
+
+public class AuthorityConverterIT {
+
+    private static final String MESSAGE = "Authority was not converted correctly!";
+
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertAuthorities();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldGetAsObject() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        Authority authority = (Authority) authorityConverter.getAsObject(null, null, "20");
+        assertEquals(MESSAGE, 20, authority.getId().intValue());
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectString() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        String authority = (String) authorityConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", authority);
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectId() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        String authority = (String) authorityConverter.getAsObject(null, null, "1000");
+        assertEquals(MESSAGE, "0", authority);
+    }
+
+    @Test
+    public void shouldGetAsObjectNullObject() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        Object authority = authorityConverter.getAsObject(null, null, null);
+        assertNull(MESSAGE, authority);
+    }
+
+    @Test
+    public void shouldGetAsString() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        Authority newAuthority = new Authority();
+        newAuthority.setId(20);
+        String authority = authorityConverter.getAsString(null, null, newAuthority);
+        assertEquals(MESSAGE, "20", authority);
+    }
+
+    @Test
+    public void shouldGetAsStringWithoutId() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        Authority newAuthority = new Authority();
+        String authority = authorityConverter.getAsString(null, null, newAuthority);
+        assertEquals(MESSAGE, "0", authority);
+    }
+
+    @Test
+    public void shouldGetAsStringWithString() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        String authority = authorityConverter.getAsString(null, null, "20");
+        assertEquals(MESSAGE, "20", authority);
+    }
+
+    @Test
+    public void shouldNotGetAsStringNullObject() {
+        AuthorityConverter authorityConverter = new AuthorityConverter();
+        String authority = authorityConverter.getAsString(null, null, null);
+        assertNull(MESSAGE, authority);
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/converter/ClientConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/ClientConverterIT.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Client;
+
+public class ClientConverterIT {
+
+    private static final String MESSAGE = "Client was not converted correctly!";
+
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertClients();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldGetAsObject() {
+        ClientConverter clientConverter = new ClientConverter();
+        Client client = (Client) clientConverter.getAsObject(null, null, "2");
+        assertEquals(MESSAGE, 2, client.getId().intValue());
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectString() {
+        ClientConverter clientConverter = new ClientConverter();
+        String client = (String) clientConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", client);
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectId() {
+        ClientConverter clientConverter = new ClientConverter();
+        String client = (String) clientConverter.getAsObject(null, null, "10");
+        assertEquals(MESSAGE, "0", client);
+    }
+
+    @Test
+    public void shouldGetAsObjectNullObject() {
+        ClientConverter clientConverter = new ClientConverter();
+        Object client = clientConverter.getAsObject(null, null, null);
+        assertNull(MESSAGE, client);
+    }
+
+    @Test
+    public void shouldGetAsString() {
+        ClientConverter clientConverter = new ClientConverter();
+        Client newClient = new Client();
+        newClient.setId(20);
+        String client = clientConverter.getAsString(null, null, newClient);
+        assertEquals(MESSAGE, "20", client);
+    }
+
+    @Test
+    public void shouldGetAsStringWithoutId() {
+        ClientConverter clientConverter = new ClientConverter();
+        Client newClient = new Client();
+        String client = clientConverter.getAsString(null, null, newClient);
+        assertEquals(MESSAGE, "0", client);
+    }
+
+    @Test
+    public void shouldGetAsStringWithString() {
+        ClientConverter clientConverter = new ClientConverter();
+        String client = clientConverter.getAsString(null, null, "20");
+        assertEquals(MESSAGE, "20", client);
+    }
+
+    @Test
+    public void shouldNotGetAsStringNullObject() {
+        ClientConverter clientConverter = new ClientConverter();
+        String client = clientConverter.getAsString(null, null, null);
+        assertNull(MESSAGE, client);
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/converter/DocketConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/DocketConverterIT.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Docket;
+
+public class DocketConverterIT {
+
+    private static final String MESSAGE = "Docket was not converted correctly!";
+
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertClients();
+        MockDatabase.insertDockets();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldGetAsObject() {
+        DocketConverter docketConverter = new DocketConverter();
+        Docket docket = (Docket) docketConverter.getAsObject(null, null, "2");
+        assertEquals(MESSAGE, 2, docket.getId().intValue());
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectString() {
+        DocketConverter docketConverter = new DocketConverter();
+        String docket = (String) docketConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", docket);
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectId() {
+        DocketConverter docketConverter = new DocketConverter();
+        String docket = (String) docketConverter.getAsObject(null, null, "10");
+        assertEquals(MESSAGE, "0", docket);
+    }
+
+    @Test
+    public void shouldGetAsObjectNullObject() {
+        DocketConverter docketConverter = new DocketConverter();
+        Object docket = docketConverter.getAsObject(null, null, null);
+        assertNull(MESSAGE, docket);
+    }
+
+    @Test
+    public void shouldGetAsString() {
+        DocketConverter docketConverter = new DocketConverter();
+        Docket newDocket = new Docket();
+        newDocket.setId(20);
+        String docket = docketConverter.getAsString(null, null, newDocket);
+        assertEquals(MESSAGE, "20", docket);
+    }
+
+    @Test
+    public void shouldGetAsStringWithoutId() {
+        DocketConverter docketConverter = new DocketConverter();
+        Docket newDocket = new Docket();
+        String docket = docketConverter.getAsString(null, null, newDocket);
+        assertEquals(MESSAGE, "0", docket);
+    }
+
+    @Test
+    public void shouldGetAsStringWithString() {
+        DocketConverter docketConverter = new DocketConverter();
+        String docket = docketConverter.getAsString(null, null, "20");
+        assertEquals(MESSAGE, "20", docket);
+    }
+
+    @Test
+    public void shouldNotGetAsStringNullObject() {
+        DocketConverter docketConverter = new DocketConverter();
+        String docket = docketConverter.getAsString(null, null, null);
+        assertNull(MESSAGE, docket);
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/converter/RulesetConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/RulesetConverterIT.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Ruleset;
+
+public class RulesetConverterIT {
+
+    private static final String MESSAGE = "Ruleset was not converted correctly!";
+
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertClients();
+        MockDatabase.insertRulesets();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldGetAsObject() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        Ruleset ruleset = (Ruleset) rulesetConverter.getAsObject(null, null, "2");
+        assertEquals(MESSAGE, 2, ruleset.getId().intValue());
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectString() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        String ruleset = (String) rulesetConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", ruleset);
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectId() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        String ruleset = (String) rulesetConverter.getAsObject(null, null, "10");
+        assertEquals(MESSAGE, "0", ruleset);
+    }
+
+    @Test
+    public void shouldGetAsObjectNullObject() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        Object ruleset = rulesetConverter.getAsObject(null, null, null);
+        assertNull(MESSAGE, ruleset);
+    }
+
+    @Test
+    public void shouldGetAsString() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        Ruleset newRuleset = new Ruleset();
+        newRuleset.setId(20);
+        String ruleset = rulesetConverter.getAsString(null, null, newRuleset);
+        assertEquals(MESSAGE, "20", ruleset);
+    }
+
+    @Test
+    public void shouldGetAsStringWithoutId() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        Ruleset newRuleset = new Ruleset();
+        String ruleset = rulesetConverter.getAsString(null, null, newRuleset);
+        assertEquals(MESSAGE, "0", ruleset);
+    }
+
+    @Test
+    public void shouldGetAsStringWithString() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        String ruleset = rulesetConverter.getAsString(null, null, "20");
+        assertEquals(MESSAGE, "20", ruleset);
+    }
+
+    @Test
+    public void shouldNotGetAsStringNullObject() {
+        RulesetConverter rulesetConverter = new RulesetConverter();
+        String ruleset = rulesetConverter.getAsString(null, null, null);
+        assertNull(MESSAGE, ruleset);
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/converter/WorkflowConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/WorkflowConverterIT.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Workflow;
+
+public class WorkflowConverterIT {
+
+    private static final String MESSAGE = "Workflow was not converted correctly!";
+
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertRolesFull();
+        MockDatabase.insertWorkflows();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldGetAsObject() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        Workflow workflow = (Workflow) workflowConverter.getAsObject(null, null, "2");
+        assertEquals(MESSAGE, 2, workflow.getId().intValue());
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectString() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        String workflow = (String) workflowConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", workflow);
+    }
+
+    @Test
+    public void shouldGetAsObjectIncorrectId() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        String workflow = (String) workflowConverter.getAsObject(null, null, "10");
+        assertEquals(MESSAGE, "0", workflow);
+    }
+
+    @Test
+    public void shouldGetAsObjectNullObject() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        Object workflow = workflowConverter.getAsObject(null, null, null);
+        assertNull(MESSAGE, workflow);
+    }
+
+    @Test
+    public void shouldGetAsString() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        Workflow newWorkflow = new Workflow();
+        newWorkflow.setId(20);
+        String workflow = workflowConverter.getAsString(null, null, newWorkflow);
+        assertEquals(MESSAGE, "20", workflow);
+    }
+
+    @Test
+    public void shouldGetAsStringWithoutId() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        Workflow newWorkflow = new Workflow();
+        String workflow = workflowConverter.getAsString(null, null, newWorkflow);
+        assertEquals(MESSAGE, "0", workflow);
+    }
+
+    @Test
+    public void shouldGetAsStringWithString() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        String workflow = workflowConverter.getAsString(null, null, "20");
+        assertEquals(MESSAGE, "20", workflow);
+    }
+
+    @Test
+    public void shouldNotGetAsStringNullObject() {
+        WorkflowConverter workflowConverter = new WorkflowConverter();
+        String workflow = workflowConverter.getAsString(null, null, null);
+        assertNull(MESSAGE, workflow);
+    }
+}


### PR DESCRIPTION
- use abstract class for maintaining exactly the same getAsObject and getAsString for all bean converters

@solth @oliver-stoehr @IkramMaalej @Kathrin-Huber if you find that those methods should look differently, e.g. not return null, please write here your propositions ;)