### PR TITLE
Move load() and save() functions to MetsService

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -214,7 +214,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
     @Deprecated
     public void read(String path) throws IOException {
         URI uri = new File(path).toURI();
-        workpiece = ServiceManager.getMetsService().load(uri);
+        workpiece = ServiceManager.getMetsService().loadWorkpiece(uri);
     }
 
     @Deprecated
@@ -246,7 +246,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
     @Deprecated
     public void write(String filename) throws IOException {
         URI uri = new File(filename).toURI();
-        ServiceManager.getMetsService().save(workpiece, uri);
+        ServiceManager.getMetsService().saveWorkpiece(workpiece, uri);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -63,7 +63,7 @@ public class MetsService {
      * @throws IOException
      *             if reading is not working (disk broken, ...)
      */
-    public Workpiece load(URI uri) throws IOException {
+    public Workpiece loadWorkpiece(URI uri) throws IOException {
         try (LockResult lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE)) {
             if (lockResult.isSuccessful()) {
                 try (InputStream inputStream = ServiceManager.getFileService().read(uri, lockResult)) {
@@ -88,12 +88,12 @@ public class MetsService {
      *             if writing does not work (partition full, or is generally not
      *             supported, ...)
      */
-    public void save(Workpiece workpiece, URI uri) throws IOException {
+    public void saveWorkpiece(Workpiece workpiece, URI uri) throws IOException {
         try (LockResult lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE)) {
             if (lockResult.isSuccessful()) {
                 try (OutputStream outputStream = ServiceManager.getFileService().write(uri, lockResult)) {
                     logger.info("Saving {}", uri.toString());
-                    metsXmlElementAccess.save(workpiece, outputStream);
+                    save(workpiece, outputStream);
                 }
             } else {
                 throw new IOException(createLockErrorMessage(uri, lockResult));

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -14,13 +14,21 @@ package org.kitodo.production.services.dataformat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.util.Collection;
 import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.dataformat.mets.MetsXmlElementAccessInterface;
+import org.kitodo.api.filemanagement.LockResult;
+import org.kitodo.api.filemanagement.LockingMode;
+import org.kitodo.production.services.ServiceManager;
 import org.kitodo.serviceloader.KitodoServiceLoader;
 
 public class MetsService {
+    private static final Logger logger = LogManager.getLogger(MetsService.class);
 
     private static volatile MetsService instance = null;
     private MetsXmlElementAccessInterface metsXmlElementAccess;
@@ -46,11 +54,76 @@ public class MetsService {
                 MetsXmlElementAccessInterface.class).loadModule();
     }
 
-    public Workpiece load(InputStream in) throws IOException {
-        return metsXmlElementAccess.read(in);
+    /**
+     * Function for loading METS files from URI.
+     *
+     * @param uri
+     *            address of the file to be loaded
+     * @return loaded file
+     * @throws IOException
+     *             if reading is not working (disk broken, ...)
+     */
+    public Workpiece load(URI uri) throws IOException {
+        try (LockResult lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE)) {
+            if (lockResult.isSuccessful()) {
+                try (InputStream inputStream = ServiceManager.getFileService().read(uri, lockResult)) {
+                    logger.info("Reading {}", uri.toString());
+                    return metsXmlElementAccess.read(inputStream);
+                }
+            } else {
+                throw new IOException(createLockErrorMessage(uri, lockResult));
+            }
+        }
     }
 
-    public void save(Workpiece workpiece, OutputStream out) throws IOException {
-        metsXmlElementAccess.save(workpiece, out);
+    /**
+     * Function for writing METS files to URI. (URI target must allow writing
+     * operation.)
+     *
+     * @param workpiece
+     *            data to be written
+     * @param uri
+     *            address where should be written
+     * @throws IOException
+     *             if writing does not work (partition full, or is generally not
+     *             supported, ...)
+     */
+    public void save(Workpiece workpiece, URI uri) throws IOException {
+        try (LockResult lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE)) {
+            if (lockResult.isSuccessful()) {
+                try (OutputStream outputStream = ServiceManager.getFileService().write(uri, lockResult)) {
+                    logger.info("Saving {}", uri.toString());
+                    metsXmlElementAccess.save(workpiece, outputStream);
+                }
+            } else {
+                throw new IOException(createLockErrorMessage(uri, lockResult));
+            }
+        }
+    }
+
+    public void save(Workpiece workpiece, OutputStream outputStream) throws IOException {
+        metsXmlElementAccess.save(workpiece, outputStream);
+    }
+
+    /**
+     * Extracts the formation of the error message as it occurs during both
+     * reading and writing. In addition, the error is logged.
+     *
+     * @param uri
+     *            URI to be read/written
+     * @param lockResult
+     *            Lock result that did not work
+     * @return The error message for the exception.
+     */
+    private String createLockErrorMessage(URI uri, LockResult lockResult) {
+        Collection<String> conflictingUsers = lockResult.getConflicts().get(uri);
+        StringBuilder buffer = new StringBuilder();
+        buffer.append("Cannot lock ");
+        buffer.append(uri);
+        buffer.append(" because it is already locked by ");
+        buffer.append(String.join(" & ", conflictingUsers));
+        String message = buffer.toString();
+        logger.info(message);
+        return message;
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.production.services.ServiceManager;
 
 public class MetsServiceIT {
 
@@ -29,8 +30,8 @@ public class MetsServiceIT {
      */
     @Test
     public void testReadXML() throws Exception {
-        Workpiece workpiece = MetsService.getInstance()
-                .load(new File("../Kitodo-DataFormat/src/test/resources/meta.xml").toURI());
+        Workpiece workpiece = ServiceManager.getMetsService()
+                .loadWorkpiece(new File("../Kitodo-DataFormat/src/test/resources/meta.xml").toURI());
 
         // METS file has 183 associated images
         assertEquals(183, workpiece.getMediaUnits().size());

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -14,8 +14,6 @@ package org.kitodo.production.services.dataformat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -31,10 +29,8 @@ public class MetsServiceIT {
      */
     @Test
     public void testReadXML() throws Exception {
-        Workpiece workpiece;
-        try (InputStream in = new FileInputStream(new File("../Kitodo-DataFormat/src/test/resources/meta.xml"))) {
-            workpiece = MetsService.getInstance().load(in);
-        }
+        Workpiece workpiece = MetsService.getInstance()
+                .load(new File("../Kitodo-DataFormat/src/test/resources/meta.xml").toURI());
 
         // METS file has 183 associated images
         assertEquals(183, workpiece.getMediaUnits().size());


### PR DESCRIPTION
Moves the functionality to load and save METS files to where they should be, namely in the `MetsService`.