### PR TITLE
Make the locking in the correct manner 

### DIFF
--- a/Kitodo/src/main/java/org/goobi/production/cli/helper/CopyProcess.java
+++ b/Kitodo/src/main/java/org/goobi/production/cli/helper/CopyProcess.java
@@ -267,7 +267,7 @@ public class CopyProcess extends ProzesskopieForm {
         }
 
         ServiceManager.getFileService().writeMetadataFile(this.myRdf, this.prozessKopie);
-        ServiceManager.getProcessService().readMetadataFile(this.prozessKopie);
+        ServiceManager.getProcessService().readMetadataFile(this.prozessKopie, false);
 
         /* damit die Sortierung stimmt nochmal einlesen */
         ServiceManager.getProcessService().refresh(this.prozessKopie);
@@ -448,7 +448,7 @@ public class CopyProcess extends ProzesskopieForm {
 
     /**
      * Evaluate the token as field name.
-     * 
+     *
      * @param token
      *            as String
      * @param stringBuilder

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -110,7 +110,7 @@ public class ExportDms extends ExportMets {
         this.exportDmsTask = exportDmsTask;
         try {
             return startExport(process, destination,
-                ServiceManager.getProcessService().readMetadataFile(process).getDigitalDocument());
+                ServiceManager.getProcessService().readMetadataFile(process, false).getDigitalDocument());
         } catch (IOException | RuntimeException e) {
             if (Objects.nonNull(exportDmsTask)) {
                 exportDmsTask.setException(e);

--- a/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
@@ -117,7 +117,7 @@ public class ExportMets {
          * to a content repository, therefore no use of file service.
          */
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            ServiceManager.getMetsService().print(workpiece, out);
+            ServiceManager.getMetsService().write(workpiece, out);
             try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(out.toByteArray())) {
                 StreamSource source = new StreamSource(byteArrayInputStream);
                 try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(new File(metaFile)))) {

--- a/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
@@ -66,7 +66,8 @@ public class ExportMets {
          */
         this.myPrefs = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
         String atsPpnBand = Helper.getNormalizedTitle(process.getTitle());
-        LegacyMetsModsDigitalDocumentHelper gdzfile = ServiceManager.getProcessService().readMetadataFile(process);
+        LegacyMetsModsDigitalDocumentHelper gdzfile = ServiceManager.getProcessService().readMetadataFile(process,
+            false);
 
         if (ServiceManager.getProcessService().handleExceptionsForConfiguration(gdzfile, process)) {
             return false;
@@ -116,7 +117,7 @@ public class ExportMets {
          * to a content repository, therefore no use of file service.
          */
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            ServiceManager.getMetsService().save(workpiece, out);
+            ServiceManager.getMetsService().print(workpiece, out);
             try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(out.toByteArray())) {
                 StreamSource source = new StreamSource(byteArrayInputStream);
                 try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(new File(metaFile)))) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
@@ -617,7 +617,7 @@ public class ProzesskopieForm implements Serializable {
                 insertImagePath();
             }
 
-            ServiceManager.getProcessService().readMetadataFile(this.prozessKopie);
+            ServiceManager.getProcessService().readMetadataFile(this.prozessKopie, false);
 
             startTaskScriptThreads();
         } catch (IOException e) {
@@ -938,7 +938,7 @@ public class ProzesskopieForm implements Serializable {
 
     /**
      * Adds a child node to a part of the logical structure tree.
-     * 
+     *
      * @param includedStructuralElement
      *            tree to add to
      * @param type

--- a/Kitodo/src/main/java/org/kitodo/production/helper/XmlArticleCounter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/XmlArticleCounter.java
@@ -45,7 +45,7 @@ public class XmlArticleCounter {
         // read document
         LegacyMetsModsDigitalDocumentHelper gdzfile;
         try {
-            gdzfile = ServiceManager.getProcessService().readMetadataFile(myProcess);
+            gdzfile = ServiceManager.getProcessService().readMetadataFile(myProcess, false);
         } catch (IOException | RuntimeException e) {
             Helper.setErrorMessage("xml error", logger, e);
             return -1;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -29,6 +29,7 @@ import org.kitodo.production.metadata.MetadataProcessor;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.dataeditor.RulesetManagementService;
 import org.kitodo.production.services.dataformat.MetsService;
+import org.kitodo.production.services.dataformat.OpenWorkpiece;
 import org.kitodo.production.services.file.FileService;
 
 /**
@@ -75,7 +76,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
     /**
      * The workpiece accessed via this soldering class.
      */
-    private Workpiece workpiece = new Workpiece();
+    private OpenWorkpiece openWorkpiece = new OpenWorkpiece();
 
     /**
      * The current ruleset.
@@ -93,7 +94,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
     @Deprecated
     public LegacyMetsModsDigitalDocumentHelper() {
         this.ruleset = rulesetManagementService.getRulesetManagement();
-        this.workpiece = new Workpiece();
+        this.openWorkpiece = new OpenWorkpiece();
 
         try {
             User user = new MetadataProcessor().getCurrentUser();
@@ -133,7 +134,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
     @Deprecated
     public LegacyMetsModsDigitalDocumentHelper(RulesetManagementInterface ruleset, Workpiece workpiece) {
         this(ruleset);
-        this.workpiece = workpiece;
+        this.openWorkpiece = new OpenWorkpiece();
     }
 
     /**
@@ -175,17 +176,18 @@ public class LegacyMetsModsDigitalDocumentHelper {
 
     @Deprecated
     public LegacyFileSetDocStructHelper getFileSet() {
-        return new LegacyFileSetDocStructHelper(workpiece.getMediaUnits());
+        return new LegacyFileSetDocStructHelper(openWorkpiece.getWorkpiece().getMediaUnits());
     }
 
     @Deprecated
     public LegacyDocStructHelperInterface getLogicalDocStruct() {
-        return new LegacyLogicalDocStructHelper(workpiece.getRootElement(), null, ruleset, priorityList);
+        return new LegacyLogicalDocStructHelper(openWorkpiece.getWorkpiece().getRootElement(), null, ruleset,
+                priorityList);
     }
 
     @Deprecated
     public LegacyDocStructHelperInterface getPhysicalDocStruct() {
-        return new LegacyFileSetDocStructHelper(workpiece.getMediaUnits());
+        return new LegacyFileSetDocStructHelper(openWorkpiece.getWorkpiece().getMediaUnits());
     }
 
     /**
@@ -194,7 +196,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
      * @return the workpiece
      */
     public Workpiece getWorkpiece() {
-        return workpiece;
+        return openWorkpiece.getWorkpiece();
     }
 
     @Deprecated
@@ -214,12 +216,16 @@ public class LegacyMetsModsDigitalDocumentHelper {
     @Deprecated
     public void read(String path) throws IOException {
         URI uri = new File(path).toURI();
-        workpiece = ServiceManager.getMetsService().loadWorkpiece(uri);
+        openWorkpiece = ServiceManager.getMetsService().open(uri);
+    }
+
+    public void releaseAllLocks() {
+        openWorkpiece.close();
     }
 
     @Deprecated
     public void setDigitalDocument(LegacyMetsModsDigitalDocumentHelper metsKitodoDocument) {
-        this.workpiece = metsKitodoDocument.workpiece;
+        this.openWorkpiece = metsKitodoDocument.openWorkpiece;
     }
 
     @Deprecated
@@ -246,7 +252,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
     @Deprecated
     public void write(String filename) throws IOException {
         URI uri = new File(filename).toURI();
-        ServiceManager.getMetsService().saveWorkpiece(workpiece, uri);
+        ServiceManager.getMetsService().saveAs(openWorkpiece, uri);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportSerialBatchTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportSerialBatchTask.java
@@ -180,7 +180,7 @@ public class ExportSerialBatchTask extends EmptyTask {
      */
     private static LegacyMetsModsDigitalDocumentHelper buildExportDocument(Process process, Iterable<String> allPointers)
             throws IOException {
-        LegacyMetsModsDigitalDocumentHelper result = ServiceManager.getProcessService().readMetadataFile(process)
+        LegacyMetsModsDigitalDocumentHelper result = ServiceManager.getProcessService().readMetadataFile(process, false)
                 .getDigitalDocument();
         LegacyDocStructHelperInterface root = result.getLogicalDocStruct();
         String type = "Volume";

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -154,13 +154,18 @@ public class KitodoScriptService {
 
     private void updateContentFiles(List<Process> processes) {
         for (Process process : processes) {
+            LegacyMetsModsDigitalDocumentHelper rdf = null;
             try {
-                LegacyMetsModsDigitalDocumentHelper rdf = ServiceManager.getProcessService().readMetadataFile(process);
+                rdf = ServiceManager.getProcessService().readMetadataFile(process, true);
                 rdf.getDigitalDocument().addAllContentFiles();
                 fileService.writeMetadataFile(rdf, process);
                 Helper.setMessage(KITODO_SCRIPT_FIELD, "ContentFiles updated: ", process.getTitle());
             } catch (IOException | RuntimeException e) {
                 Helper.setErrorMessage(KITODO_SCRIPT_FIELD, "Error while updating content files", logger, e);
+            } finally {
+                if (Objects.nonNull(rdf)) {
+                    rdf.releaseAllLocks();
+                }
             }
         }
         Helper.setMessage(KITODO_SCRIPT_FIELD, "", "updateContentFiles finished");

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1266,7 +1266,7 @@ public class ProcessService extends ClientSearchService<Process, ProcessDTO, Pro
      *
      * @param process
      *            object
-     * @param open
+     * @param keepOpen
      *            whether the locks on the read files shall be kept open. Use
      *            {@code false} in case of a read-only operation; use
      *            {@code true} in case the you want to save back to the same
@@ -1275,7 +1275,7 @@ public class ProcessService extends ClientSearchService<Process, ProcessDTO, Pro
      *            manually.
      * @return filer format
      */
-    public LegacyMetsModsDigitalDocumentHelper readMetadataFile(Process process, boolean open) throws IOException {
+    public LegacyMetsModsDigitalDocumentHelper readMetadataFile(Process process, boolean keepOpen) throws IOException {
         URI metadataFileUri = ServiceManager.getFileService().getMetadataFilePath(process);
 
         // check the format of the metadata - METS, XStream or RDF
@@ -1292,7 +1292,7 @@ public class ProcessService extends ClientSearchService<Process, ProcessDTO, Pro
                 throw e;
             }
         } finally {
-            if (!open) {
+            if (!keepOpen) {
                 ff.releaseAllLocks();
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -16,6 +16,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.logging.log4j.LogManager;
@@ -49,6 +51,9 @@ public class MetsService {
         return instance;
     }
 
+    /**
+     * Creates a new METS service.
+     */
     private MetsService() {
         metsXmlElementAccess = (MetsXmlElementAccessInterface) new KitodoServiceLoader<>(
                 MetsXmlElementAccessInterface.class).loadModule();
@@ -61,26 +66,50 @@ public class MetsService {
      *            address of the file to be loaded
      * @return loaded file
      * @throws IOException
-     *             if reading is not working (disk broken, ...)
+     *             if the lock can not be requested or if reading is not working
+     *             (disk broken, ...)
      */
-    public Workpiece loadWorkpiece(URI uri) throws IOException {
-        try (LockResult lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE)) {
-            if (lockResult.isSuccessful()) {
-                try (InputStream inputStream = ServiceManager.getFileService().read(uri, lockResult)) {
-                    logger.info("Reading {}", uri.toString());
-                    return metsXmlElementAccess.read(inputStream);
-                }
-            } else {
-                throw new IOException(createLockErrorMessage(uri, lockResult));
+    public OpenWorkpiece open(URI uri) throws IOException {
+        LockResult lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE);
+        if (lockResult.isSuccessful()) {
+            try (InputStream inputStream = ServiceManager.getFileService().read(uri, lockResult)) {
+                logger.info("Reading {}", uri.toString());
+                return new OpenWorkpiece(lockResult, uri, metsXmlElementAccess.read(inputStream));
             }
+        } else {
+            throw new IOException(createLockErrorMessage(uri, lockResult.getConflicts()));
+        }
+    }
+
+    public void print(Workpiece workpiece, OutputStream out) throws IOException {
+        metsXmlElementAccess.save(workpiece, out);
+    }
+
+    /**
+     * Function for writing METS file. It is assumed that an exclusive lock
+     * exists.
+     *
+     * @param openWorkpiece
+     *            data to be written
+     * @throws IOException
+     *             if writing does not work (partition full, or is generally not
+     *             supported, ...)
+     * @throws NullPointerException
+     *             if you try to save a new (empty) workpiece that does not have
+     *             an URI yet
+     */
+    public void save(OpenWorkpiece openWorkpiece) throws IOException {
+        URI uri = openWorkpiece.getUri();
+        try (OutputStream out = ServiceManager.getFileService().write(uri, openWorkpiece.getLockResult())) {
+            logger.info("Saving {}", uri.toString());
+            metsXmlElementAccess.save(openWorkpiece.getWorkpiece(), out);
         }
     }
 
     /**
-     * Function for writing METS files to URI. (URI target must allow writing
-     * operation.)
+     * The Save As method can save the workpiece under a different address.
      *
-     * @param workpiece
+     * @param openWorkpiece
      *            data to be written
      * @param uri
      *            address where should be written
@@ -88,21 +117,33 @@ public class MetsService {
      *             if writing does not work (partition full, or is generally not
      *             supported, ...)
      */
-    public void saveWorkpiece(Workpiece workpiece, URI uri) throws IOException {
-        try (LockResult lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE)) {
-            if (lockResult.isSuccessful()) {
-                try (OutputStream outputStream = ServiceManager.getFileService().write(uri, lockResult)) {
-                    logger.info("Saving {}", uri.toString());
-                    save(workpiece, outputStream);
+    public void saveAs(OpenWorkpiece openWorkpiece, URI uri) throws IOException {
+        if (uri.equals(openWorkpiece.getUri())) {
+            save(openWorkpiece);
+        } else {
+            LockResult lockResult = openWorkpiece.getLockResult();
+            if (Objects.isNull(lockResult)) {
+                lockResult = ServiceManager.getFileService().tryLock(uri, LockingMode.EXCLUSIVE);
+                if (!lockResult.isSuccessful()) {
+                    throw new IOException(createLockErrorMessage(uri, lockResult.getConflicts()));
                 }
+                openWorkpiece.setLockResult(lockResult);
             } else {
-                throw new IOException(createLockErrorMessage(uri, lockResult));
+                // TODO: after upgrading to Java 9, replace with Map.of()
+                Map<URI, LockingMode> requests = new HashMap<>(2);
+                requests.put(uri, LockingMode.EXCLUSIVE);
+                Map<URI, Collection<String>> conflicts = lockResult.tryLock(requests);
+                if (!conflicts.isEmpty()) {
+                    throw new IOException(createLockErrorMessage(uri, conflicts));
+                }
             }
+            try (OutputStream out = ServiceManager.getFileService().write(uri, lockResult)) {
+                logger.info("Saving {}", uri.toString());
+                metsXmlElementAccess.save(openWorkpiece.getWorkpiece(), out);
+            }
+            lockResult.close(openWorkpiece.getUri());
+            openWorkpiece.setUri(uri);
         }
-    }
-
-    public void save(Workpiece workpiece, OutputStream outputStream) throws IOException {
-        metsXmlElementAccess.save(workpiece, outputStream);
     }
 
     /**
@@ -111,12 +152,12 @@ public class MetsService {
      *
      * @param uri
      *            URI to be read/written
-     * @param lockResult
-     *            Lock result that did not work
+     * @param conflicts
+     *            reasons why that did not work
      * @return The error message for the exception.
      */
-    private String createLockErrorMessage(URI uri, LockResult lockResult) {
-        Collection<String> conflictingUsers = lockResult.getConflicts().get(uri);
+    private String createLockErrorMessage(URI uri, Map<URI, Collection<String>> conflicts) {
+        Collection<String> conflictingUsers = conflicts.get(uri);
         StringBuilder buffer = new StringBuilder();
         buffer.append("Cannot lock ");
         buffer.append(uri);

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -81,7 +81,7 @@ public class MetsService {
         }
     }
 
-    public void print(Workpiece workpiece, OutputStream out) throws IOException {
+    public void write(Workpiece workpiece, OutputStream out) throws IOException {
         metsXmlElementAccess.save(workpiece, out);
     }
 
@@ -102,7 +102,7 @@ public class MetsService {
         URI uri = openWorkpiece.getUri();
         try (OutputStream out = ServiceManager.getFileService().write(uri, openWorkpiece.getLockResult())) {
             logger.info("Saving {}", uri.toString());
-            metsXmlElementAccess.save(openWorkpiece.getWorkpiece(), out);
+            write(openWorkpiece.getWorkpiece(), out);
         }
     }
 
@@ -139,7 +139,7 @@ public class MetsService {
             }
             try (OutputStream out = ServiceManager.getFileService().write(uri, lockResult)) {
                 logger.info("Saving {}", uri.toString());
-                metsXmlElementAccess.save(openWorkpiece.getWorkpiece(), out);
+                write(openWorkpiece.getWorkpiece(), out);
             }
             lockResult.close(openWorkpiece.getUri());
             openWorkpiece.setUri(uri);

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/OpenWorkpiece.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/OpenWorkpiece.java
@@ -1,0 +1,125 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.dataformat;
+
+import java.net.URI;
+
+import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.api.filemanagement.LockResult;
+
+/**
+ * An open workpiece contains the data of a workpiece, and in addition open
+ * locks, which are needed for subsequent saving of the workpiece. Please note
+ * that an open workpiece must be {@code close()}d after finishing.
+ */
+public class OpenWorkpiece implements AutoCloseable {
+    /**
+     * The locks that the user holds.
+     */
+    private LockResult lockResult;
+
+    /**
+     * The data of the workpiece.
+     */
+    private final Workpiece workpiece;
+
+    /**
+     * The URI where the workpiece is saved as a file.
+     */
+    private URI uri;
+
+    /**
+     * Creates a new open work piece with an empty workpiece and without any
+     * locks.
+     */
+    public OpenWorkpiece() {
+        this.workpiece = new Workpiece();
+    }
+
+    /**
+     * Creates a new open workpiece with a workpiece, with its URI and open
+     * locks.
+     *
+     * @param lockResult
+     *            Result of the lock request
+     * @param uri
+     *            URI of the workpiece
+     * @param workpiece
+     *            data of the workpiece
+     */
+    OpenWorkpiece(LockResult lockResult, URI uri, Workpiece workpiece) {
+        this.lockResult = lockResult;
+        this.uri = uri;
+        this.workpiece = workpiece;
+    }
+
+    /**
+     * Releases all locks. The open workpiece implements the AutoCloseable
+     * interface. So it can be used in a try-with-resource expression. Closing
+     * causes the release of all locks and is therefore important.
+     */
+    @Override
+    public void close() {
+        lockResult.close();
+    }
+
+    /**
+     * Returns the lock results.
+     * 
+     * @return the lock results
+     */
+    LockResult getLockResult() {
+        return lockResult;
+    }
+
+    /**
+     * Sets a lock result. The method is used when an open workpiece with an
+     * empty workpiece and without locks is saved the first time.
+     *
+     * @param lockResult
+     *            lock result to set
+     */
+    void setLockResult(LockResult lockResult) {
+        this.lockResult = lockResult;
+    }
+
+    /**
+     * Returns the URI of the workpiece. This is the URI for which there is an
+     * exclusive open lock.
+     * 
+     * @return the URI of the workpiece
+     */
+    URI getUri() {
+        return uri;
+    }
+
+    /**
+     * Sets the URI of the workpiece. The method is used when a workpiece is
+     * saved to a different URI.
+     * 
+     * @param uri
+     *            URI of the workpiece to set.
+     */
+    void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * Returns the data of the workpiece.
+     * 
+     * @return the workpiece
+     */
+    public Workpiece getWorkpiece() {
+        return workpiece;
+    }
+
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
@@ -107,7 +107,7 @@ public class MetadataValidationService {
 
     /**
      * Loads the module for long-term archival validation.
-     * 
+     *
      * @return the loaded module
      */
     private MetadataValidationInterface getValidationModule() {
@@ -130,7 +130,7 @@ public class MetadataValidationService {
         LegacyPrefsHelper prefs = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
         LegacyMetsModsDigitalDocumentHelper gdzfile;
         try {
-            gdzfile = ServiceManager.getProcessService().readMetadataFile(process);
+            gdzfile = ServiceManager.getProcessService().readMetadataFile(process, false);
         } catch (IOException | RuntimeException e) {
             Helper.setErrorMessage("metadataReadError", new Object[] {process.getTitle() }, logger, e);
             return false;
@@ -167,7 +167,7 @@ public class MetadataValidationService {
 
     /**
      * Validates a workpiece based on a rule set.
-     * 
+     *
      * @param workpiece
      *            METS file
      * @param ruleset
@@ -188,7 +188,7 @@ public class MetadataValidationService {
 
     /**
      * Verifies that the rules for the identifier are met.
-     * 
+     *
      * @param workpiece
      *            METS file
      * @return the validation result
@@ -227,7 +227,7 @@ public class MetadataValidationService {
 
     /**
      * Returns the meta-data language for a user.
-     * 
+     *
      * @return the meta-data language
      */
     private List<LanguageRange> getMetadataLanguage() {
@@ -251,7 +251,7 @@ public class MetadataValidationService {
 
     /**
      * Merges several individual validation results into one validation result.
-     * 
+     *
      * @param results
      *            individual validation results
      * @return merged validation result

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -449,7 +449,7 @@ public class ProcessServiceIT {
         FileLoader.createMetadataFile();
 
         Process process = processService.getById(1);
-        LegacyMetsModsDigitalDocumentHelper digitalDocument = processService.readMetadataFile(process)
+        LegacyMetsModsDigitalDocumentHelper digitalDocument = processService.readMetadataFile(process, false)
                 .getDigitalDocument();
 
         String processTitle = process.getTitle();
@@ -479,7 +479,7 @@ public class ProcessServiceIT {
         Process process = processService.getById(1);
         LegacyPrefsHelper preferences = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
         fileService.writeMetadataAsTemplateFile(
-            new LegacyMetsModsDigitalDocumentHelper(((LegacyPrefsHelper) preferences).getRuleset()), process);
+            new LegacyMetsModsDigitalDocumentHelper(preferences.getRuleset()), process);
         boolean condition = fileService.fileExist(URI.create("1/template.xml"));
         assertTrue("It was not possible to write metadata as template file!", condition);
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.Workpiece;
-import org.kitodo.production.services.ServiceManager;
 
 public class MetsServiceIT {
 
@@ -30,8 +29,8 @@ public class MetsServiceIT {
      */
     @Test
     public void testReadXML() throws Exception {
-        Workpiece workpiece = ServiceManager.getMetsService()
-                .loadWorkpiece(new File("../Kitodo-DataFormat/src/test/resources/meta.xml").toURI());
+        URI uri = new File("../Kitodo-DataFormat/src/test/resources/meta.xml").toURI();
+        Workpiece workpiece = MetsService.getInstance().open(uri).getWorkpiece();
 
         // METS file has 183 associated images
         assertEquals(183, workpiece.getMediaUnits().size());


### PR DESCRIPTION
Previously, locking METS files was only sloppy while editing: Before reading or before writing, an exclusive lock was requested and then discarded. The fact that two users do not get each other in the way was ensured by the logic of the front-end. In the context of hierarchical processes, the locks are of crucial importance. Therefore, locking must now be done carefully. In particular, when opening a process all necessary locks must be obtained and kept until closing.

Follow-up to pull request #2426 