### PR TITLE
Default Client ID

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -621,6 +621,11 @@ public enum ParameterCore implements ParameterInterface {
      */
     PROCESS_PROPERTIES(new Parameter<>("processPropertyColumns")),
 
+    /**
+     * Default client parameter to be returned if no session client could be determined by user service.
+     */
+    DEFAULT_CLIENT_ID(new Parameter<>("defaultClientId", 0)),
+
     /*
      * ActiveMQ web services
      */

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -61,6 +61,8 @@ public class UserService extends SearchDatabaseService<User, UserDAO> implements
     private static final String LOGIN_NOT_VALID = "loginNotValid";
     private static final String CLIENT_ID = "clientId";
     private SecurityPasswordEncoder passwordEncoder = new SecurityPasswordEncoder();
+    private static final int DEFAULT_CLIENT_ID =
+            ConfigCore.getIntParameterOrDefaultValue(ParameterCore.DEFAULT_CLIENT_ID);
 
     /**
      * Constructor.
@@ -205,7 +207,7 @@ public class UserService extends SearchDatabaseService<User, UserDAO> implements
 
     /**
      * Gets the session client of the current authenticated user.
-     * 
+     *
      * @return The client object or null if no session client is set or no user is
      *         authenticated.
      */
@@ -226,7 +228,7 @@ public class UserService extends SearchDatabaseService<User, UserDAO> implements
         if (Objects.nonNull(getSessionClientOfAuthenticatedUser())) {
             return getSessionClientOfAuthenticatedUser().getId();
         }
-        return 0;
+        return DEFAULT_CLIENT_ID;
     }
 
     /**
@@ -254,7 +256,7 @@ public class UserService extends SearchDatabaseService<User, UserDAO> implements
 
     /**
      * Check validity of given login.
-     * 
+     *
      * @param login
      *            to validation
      * @return true or false
@@ -470,7 +472,7 @@ public class UserService extends SearchDatabaseService<User, UserDAO> implements
 
     /**
      * Changes the password for given User object.
-     * 
+     *
      * @param user
      *            The User object.
      * @param newPassword

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -654,3 +654,5 @@ file.maxWaitMilliseconds=150000
 
 metadata.search.fields=TitleDocMain&TSL_ATS
 
+# Default client parameter to be returned if no session client could be determined by user service.
+defaultClientId=0


### PR DESCRIPTION
Adds a key to `kitodo_config.properties` to define a default client ID that will be returned from `UserService.getSessionClientId()` if no session is available. Defaults to 0.