### PR TITLE
Add missing method

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
@@ -60,6 +60,7 @@ import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.IncludedStructuralElement;
+import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.View;
 import org.kitodo.api.filemanagement.ProcessSubType;
 import org.kitodo.api.filemanagement.filters.IsDirectoryFilter;
@@ -2172,6 +2173,23 @@ public class MetadataProcessor {
     public String getLogicalPageNumber(LegacyDocStructHelperInterface docStruct) {
         for (String page : Arrays.stream(allPages).filter(Objects::nonNull).collect(Collectors.toList())) {
             int physicalPageNumber = getPhysicalPageNumber(docStruct);
+            if (page.startsWith(String.valueOf(physicalPageNumber))) {
+                return getLogicalPageNumberOfPaginatedImage(page);
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Gets the logical page number from a paginated docstruct.
+     *
+     * @param mediaUnit
+     *            the MediaUnit object
+     * @return The logical page number.
+     */
+    public String getLogicalPageNumber(MediaUnit mediaUnit) {
+        for (String page : Arrays.stream(allPages).filter(Objects::nonNull).collect(Collectors.toList())) {
+            int physicalPageNumber = mediaUnit.getOrder();
             if (page.startsWith(String.valueOf(physicalPageNumber))) {
                 return getLogicalPageNumberOfPaginatedImage(page);
             }


### PR DESCRIPTION
Meta-data editor does not work if there are pages in the process, because there is a method missing. The method is invoked only form JSF so the compiler does not notice. Adds the missing method.