### PR TITLE
Add a missing semicolon in an SQL script

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_13__Set_css_values_of_users_to_null.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_13__Set_css_values_of_users_to_null.sql
@@ -11,4 +11,4 @@
 
 -- Sets the used CSS-file for every user to null.
 
-UPDATE user SET css = NULL
+UPDATE user SET css = NULL;


### PR DESCRIPTION
There was a semicolon missing in one SQL script. Adds the missing semicolon.