### PR TITLE
Replace priority with correction for task bean

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
@@ -42,9 +42,6 @@ public class Task extends BaseIndexedBean {
     @Column(name = "title")
     private String title;
 
-    @Column(name = "priority")
-    private Integer priority;
-
     @Column(name = "ordering")
     private Integer ordering;
 
@@ -73,6 +70,9 @@ public class Task extends BaseIndexedBean {
 
     @Column(name = "last")
     private boolean last = false;
+
+    @Column(name = "correction")
+    private boolean correction = false;
 
     @Column(name = "typeMetadata")
     private boolean typeMetadata = false;
@@ -170,7 +170,6 @@ public class Task extends BaseIndexedBean {
     public Task() {
         this.title = "";
         this.roles = new ArrayList<>();
-        this.priority = 0;
         this.ordering = 0;
     }
 
@@ -183,7 +182,6 @@ public class Task extends BaseIndexedBean {
     public Task(Task templateTask) {
         this.title = templateTask.getTitle();
         this.ordering = templateTask.getOrdering();
-        this.priority = templateTask.getPriority();
         this.typeAutomatic = templateTask.isTypeAutomatic();
         this.scriptName = templateTask.getScriptName();
         this.scriptPath = templateTask.getScriptPath();
@@ -215,14 +213,6 @@ public class Task extends BaseIndexedBean {
 
     public void setTitle(String title) {
         this.title = title;
-    }
-
-    public Integer getPriority() {
-        return this.priority;
-    }
-
-    public void setPriority(Integer priority) {
-        this.priority = priority;
     }
 
     public Integer getOrdering() {
@@ -339,6 +329,24 @@ public class Task extends BaseIndexedBean {
      */
     public void setLast(boolean last) {
         this.last = last;
+    }
+
+    /**
+     * Get correction.
+     *
+     * @return value of correction
+     */
+    public boolean isCorrection() {
+        return correction;
+    }
+
+    /**
+     * Set correction.
+     *
+     * @param correction as boolean
+     */
+    public void setCorrection(boolean correction) {
+        this.correction = correction;
     }
 
     public User getProcessingUser() {

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TaskDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TaskDAO.java
@@ -113,7 +113,7 @@ public class TaskDAO extends BaseDAO<Task> {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("ordering", ordering);
         parameters.put(KEY_PROCESS_ID, processId);
-        return getByQuery("FROM Task WHERE process_id = :processId AND ordering > :ordering AND priority = 10",
+        return getByQuery("FROM Task WHERE process_id = :processId AND ordering > :ordering AND correction = 1",
             parameters);
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/TaskType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/TaskType.java
@@ -32,7 +32,6 @@ public class TaskType extends BaseType<Task> {
 
         Map<String, Object> jsonObject = new HashMap<>();
         jsonObject.put(TaskTypeField.TITLE.getKey(), preventNull(task.getTitle()));
-        jsonObject.put(TaskTypeField.PRIORITY.getKey(), task.getPriority());
         jsonObject.put(TaskTypeField.ORDERING.getKey(), task.getOrdering());
         jsonObject.put(TaskTypeField.PROCESSING_STATUS.getKey(), processingStatus);
         jsonObject.put(TaskTypeField.EDIT_TYPE.getKey(), editType);
@@ -40,6 +39,7 @@ public class TaskType extends BaseType<Task> {
         jsonObject.put(TaskTypeField.PROCESSING_BEGIN.getKey(), getFormattedDate(task.getProcessingBegin()));
         jsonObject.put(TaskTypeField.PROCESSING_END.getKey(), getFormattedDate(task.getProcessingEnd()));
         jsonObject.put(TaskTypeField.HOME_DIRECTORY.getKey(), preventNull(String.valueOf(task.getHomeDirectory())));
+        jsonObject.put(TaskTypeField.CORRECTION.getKey(), task.isCorrection());
         jsonObject.put(TaskTypeField.TYPE_METADATA.getKey(), task.isTypeMetadata());
         jsonObject.put(TaskTypeField.TYPE_AUTOMATIC.getKey(), task.isTypeAutomatic());
         jsonObject.put(TaskTypeField.TYPE_IMAGES_READ.getKey(), task.isTypeImagesRead());

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/TaskTypeField.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/TaskTypeField.java
@@ -15,7 +15,6 @@ public enum TaskTypeField implements TypeInterface {
 
     ID("id"),
     TITLE("title"),
-    PRIORITY("priority"),
     ORDERING("ordering"),
     EDIT_TYPE("editType"),
     PROCESSING_STATUS("processingStatus"),
@@ -27,6 +26,7 @@ public enum TaskTypeField implements TypeInterface {
     PROCESSING_USER_NAME("processingUser.name"),
     PROCESSING_USER_SURNAME("processingUser.surname"),
     HOME_DIRECTORY("homeDirectory"),
+    CORRECTION("correction"),
     TYPE_METADATA("typeMetadata"),
     TYPE_AUTOMATIC("typeAutomatic"),
     TYPE_IMAGES_READ("typeImagesRead"),

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_80__Replace_priority_with_correction.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_80__Replace_priority_with_correction.sql
@@ -1,0 +1,30 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+-- 1. Add column for correction to task table
+--
+ALTER TABLE task ADD correction TINYINT(1);
+
+-- 2. Switch off safe updates
+--
+SET SQL_SAFE_UPDATES = 0;
+
+-- 3. Update correction column with data from priority column
+--
+UPDATE task SET correction = 1 WHERE priority = 10;
+
+-- 4. Switch on safe updates
+--
+SET SQL_SAFE_UPDATES = 1;
+
+-- 5. Drop priority column from task table
+--
+ALTER TABLE task DROP priority;

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/TaskTypeTest.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/TaskTypeTest.java
@@ -70,7 +70,6 @@ public class TaskTypeTest {
         Task firstTask = new Task();
         firstTask.setId(1);
         firstTask.setTitle("Testing");
-        firstTask.setPriority(1);
         firstTask.setOrdering(1);
         firstTask.setProcessingStatus(TaskStatus.DONE);
         firstTask.setEditType(TaskEditType.MANUAL_SINGLE);
@@ -92,7 +91,6 @@ public class TaskTypeTest {
         Task secondTask = new Task();
         secondTask.setId(2);
         secondTask.setTitle("Rendering");
-        secondTask.setPriority(2);
         secondTask.setOrdering(2);
         secondTask.setProcessingStatus(TaskStatus.INWORK);
         localDate = new LocalDate(2017, 2, 17);
@@ -121,7 +119,6 @@ public class TaskTypeTest {
 
         assertEquals("Key title doesn't match to given value!", "Testing", TaskTypeField.TITLE.getStringValue(actual));
         assertEquals("Key ordering doesn't match to given value!", 1, TaskTypeField.ORDERING.getIntValue(actual));
-        assertEquals("Key priority doesn't match to given value!", 1, TaskTypeField.PRIORITY.getIntValue(actual));
         assertEquals("Key editType doesn't match to given value!", 1, TaskTypeField.EDIT_TYPE.getIntValue(actual));
         assertEquals("Key processingStatus doesn't match to given value!", 3,
             TaskTypeField.PROCESSING_STATUS.getIntValue(actual));
@@ -142,6 +139,8 @@ public class TaskTypeTest {
         assertEquals("Key homeDirectory doesn't match to given value!", "1",
             TaskTypeField.HOME_DIRECTORY.getStringValue(actual));
         assertTrue("Key batchStep doesn't match to given value!", TaskTypeField.BATCH_STEP.getBooleanValue(actual));
+        assertFalse("Key correction doesn't match to given value!",
+                TaskTypeField.CORRECTION.getBooleanValue(actual));
         assertFalse("Key typeAutomatic doesn't match to given value!",
             TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(actual));
         assertTrue("Key typeMetadata doesn't match to given value!",
@@ -175,7 +174,6 @@ public class TaskTypeTest {
         assertEquals("Key title doesn't match to given value!", "Rendering",
             TaskTypeField.TITLE.getStringValue(actual));
         assertEquals("Key ordering doesn't match to given value!", 2, TaskTypeField.ORDERING.getIntValue(actual));
-        assertEquals("Key priority doesn't match to given value!", 2, TaskTypeField.PRIORITY.getIntValue(actual));
         assertEquals("Key editType doesn't match to given value!", 0, TaskTypeField.EDIT_TYPE.getIntValue(actual));
         assertEquals("Key processingStatus doesn't match to given value!", 2,
             TaskTypeField.PROCESSING_STATUS.getIntValue(actual));
@@ -196,6 +194,8 @@ public class TaskTypeTest {
         assertEquals("Key homeDirectory doesn't match to given value!", "0",
             TaskTypeField.HOME_DIRECTORY.getStringValue(actual));
         assertFalse("Key batchStep doesn't match to given value!", TaskTypeField.BATCH_STEP.getBooleanValue(actual));
+        assertFalse("Key correction doesn't match to given value!",
+                TaskTypeField.CORRECTION.getBooleanValue(actual));
         assertFalse("Key typeAutomatic doesn't match to given value!",
             TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(actual));
         assertFalse("Key typeMetadata doesn't match to given value!",
@@ -229,7 +229,6 @@ public class TaskTypeTest {
         assertEquals("Key title doesn't match to given value!", "Incomplete",
             TaskTypeField.TITLE.getStringValue(actual));
         assertEquals("Key ordering doesn't match to given value!", 0, TaskTypeField.ORDERING.getIntValue(actual));
-        assertEquals("Key priority doesn't match to given value!", 0, TaskTypeField.PRIORITY.getIntValue(actual));
         assertEquals("Key editType doesn't match to given value!", 0, TaskTypeField.EDIT_TYPE.getIntValue(actual));
         assertEquals("Key processingStatus doesn't match to given value!", 1,
             TaskTypeField.PROCESSING_STATUS.getIntValue(actual));
@@ -244,6 +243,8 @@ public class TaskTypeTest {
         assertEquals("Key homeDirectory doesn't match to given value!", "0",
             TaskTypeField.HOME_DIRECTORY.getStringValue(actual));
         assertFalse("Key batchStep doesn't match to given value!", TaskTypeField.BATCH_STEP.getBooleanValue(actual));
+        assertFalse("Key correction doesn't match to given value!",
+                TaskTypeField.CORRECTION.getBooleanValue(actual));
         assertFalse("Key typeAutomatic doesn't match to given value!",
             TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(actual));
         assertFalse("Key typeMetadata doesn't match to given value!",

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
@@ -26,7 +26,6 @@ public class TaskDTO extends BaseDTO {
 
     private String title;
     private String localizedTitle;
-    private Integer priority;
     private Integer ordering;
     private TaskStatus processingStatus;
     private String processingStatusTitle;
@@ -40,6 +39,7 @@ public class TaskDTO extends BaseDTO {
     private TemplateDTO template;
     private List<RoleDTO> roles = new ArrayList<>();
     private int rolesSize;
+    private boolean correction;
     private boolean typeAutomatic;
     private boolean typeMetadata;
     private boolean typeImagesRead;
@@ -84,25 +84,6 @@ public class TaskDTO extends BaseDTO {
      */
     public void setLocalizedTitle(String localizedTitle) {
         this.localizedTitle = localizedTitle;
-    }
-
-    /**
-     * Get priority as Integer.
-     * 
-     * @return priority as Integer
-     */
-    public Integer getPriority() {
-        return this.priority;
-    }
-
-    /**
-     * Set priority as Integer.
-     * 
-     * @param priority
-     *            as Integer
-     */
-    public void setPriority(Integer priority) {
-        this.priority = priority;
     }
 
     /**
@@ -350,6 +331,24 @@ public class TaskDTO extends BaseDTO {
      */
     public void setRolesSize(int rolesSize) {
         this.rolesSize = rolesSize;
+    }
+
+    /**
+     * Get correction.
+     *
+     * @return value of correction
+     */
+    public boolean isCorrection() {
+        return correction;
+    }
+
+    /**
+     * Set correction.
+     *
+     * @param correction as boolean
+     */
+    public void setCorrection(boolean correction) {
+        this.correction = correction;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/batch/BatchTaskHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/batch/BatchTaskHelper.java
@@ -368,7 +368,7 @@ public class BatchTaskHelper extends BatchHelper {
         for (Task task : this.steps) {
             this.myDav.uploadFromHome(task.getProcess());
             task.setProcessingStatus(TaskStatus.OPEN);
-            if (ServiceManager.getWorkflowControllerService().isCorrectionTask(task)) {
+            if (task.isCorrection()) {
                 task.setProcessingBegin(null);
             }
             task.setEditType(TaskEditType.MANUAL_MULTI);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -133,7 +133,7 @@ public class TaskService extends ClientSearchService<Task, TaskDTO, TaskDAO> {
         }
 
         if (hideCorrectionTasks) {
-            query.must(getQueryForPriority(10));
+            query.must(createSimpleQuery(TaskTypeField.CORRECTION.getKey(), false, true));
         }
 
         if (!showAutomaticTasks) {
@@ -259,7 +259,6 @@ public class TaskService extends ClientSearchService<Task, TaskDTO, TaskDAO> {
         taskDTO.setId(getIdFromJSONObject(jsonObject));
         taskDTO.setTitle(TaskTypeField.TITLE.getStringValue(jsonObject));
         taskDTO.setLocalizedTitle(getLocalizedTitle(taskDTO.getTitle()));
-        taskDTO.setPriority(TaskTypeField.PRIORITY.getIntValue(jsonObject));
         taskDTO.setOrdering(TaskTypeField.ORDERING.getIntValue(jsonObject));
         int taskStatus = TaskTypeField.PROCESSING_STATUS.getIntValue(jsonObject);
         taskDTO.setProcessingStatus(TaskStatus.getStatusFromValue(taskStatus));
@@ -270,6 +269,7 @@ public class TaskService extends ClientSearchService<Task, TaskDTO, TaskDAO> {
         taskDTO.setProcessingTime(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
         taskDTO.setProcessingBegin(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
         taskDTO.setProcessingEnd(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
+        taskDTO.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
         taskDTO.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
         taskDTO.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));
         taskDTO.setTypeImagesWrite(TaskTypeField.TYPE_IMAGES_WRITE.getBooleanValue(jsonObject));
@@ -681,17 +681,6 @@ public class TaskService extends ClientSearchService<Task, TaskDTO, TaskDAO> {
      */
     private QueryBuilder getQueryForTypeAutomatic(boolean typeAutomatic) {
         return createSimpleQuery(TaskTypeField.TYPE_AUTOMATIC.getKey(), typeAutomatic, true);
-    }
-
-    /**
-     * Get query for priority.
-     *
-     * @param priority
-     *            priority as int
-     * @return query as QueryBuilder
-     */
-    private QueryBuilder getQueryForPriority(int priority) {
-        return createSimpleQuery(TaskTypeField.PRIORITY.getKey(), priority, true);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -322,7 +322,7 @@ public class WorkflowControllerService {
         task.setProcessingStatus(TaskStatus.OPEN);
         taskService.replaceProcessingUser(task, null);
         // if we have a correction task here then never remove startdate
-        if (isCorrectionTask(task)) {
+        if (task.isCorrection()) {
             task.setProcessingBegin(null);
         }
         task.setEditType(TaskEditType.MANUAL_SINGLE);
@@ -334,27 +334,6 @@ public class WorkflowControllerService {
         metadataLock.setFree(task.getProcess().getId());
 
         updateProcessSortHelperStatus(task.getProcess());
-    }
-
-    /**
-     * Priority equal 10 means correction task.
-     *
-     * @param task
-     *            Task object
-     * @return true or false
-     */
-    public boolean isCorrectionTask(Task task) {
-        return task.getPriority() == 10;
-    }
-
-    /**
-     * Set Priority equal 10 means correction task.
-     *
-     * @param task
-     *            Task object
-     */
-    public void setCorrectionTask(Task task) {
-        task.setPriority(10);
     }
 
     /**
@@ -375,7 +354,7 @@ public class WorkflowControllerService {
 
         Task correctionTask = taskService.getById(getProblem().getId());
         correctionTask.setProcessingStatus(TaskStatus.OPEN);
-        setCorrectionTask(correctionTask);
+        correctionTask.setCorrection(true);
         correctionTask.setProcessingEnd(null);
 
         Property processProperty = prepareProblemMessageProperty(date, currentTask, correctionTask);
@@ -493,7 +472,7 @@ public class WorkflowControllerService {
             currentTask.getOrdering(), currentTask.getProcess().getId());
         for (Task taskInBetween : allTasksInBetween) {
             taskInBetween.setProcessingStatus(TaskStatus.LOCKED);
-            setCorrectionTask(taskInBetween);
+            taskInBetween.setCorrection(true);
             taskInBetween.setProcessingEnd(null);
             taskService.save(taskInBetween);
         }
@@ -506,14 +485,14 @@ public class WorkflowControllerService {
         for (Task taskInBetween : allTasksInBetween) {
             taskInBetween.setProcessingStatus(TaskStatus.DONE);
             taskInBetween.setProcessingEnd(date);
-            taskInBetween.setPriority(0);
+            taskInBetween.setCorrection(false);
             taskService.save(taskInBetween);
         }
     }
 
     private void openTaskForProcessing(Task correctionTask) throws DataException {
         correctionTask.setProcessingStatus(TaskStatus.OPEN);
-        setCorrectionTask(correctionTask);
+        correctionTask.setCorrection(true);
         correctionTask.setProcessingEnd(null);
         correctionTask.setProcessingTime(new Date());
         taskService.save(correctionTask);

--- a/Kitodo/src/main/java/org/kitodo/production/workflow/model/Converter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/workflow/model/Converter.java
@@ -107,7 +107,6 @@ public class Converter {
         task.setWorkflowId(kitodoTask.getWorkflowId());
         task.setTitle(kitodoTask.getTitle());
         task.setOrdering(taskInfo.getOrdering());
-        task.setPriority(kitodoTask.getPriority());
         task.setEditType(TaskEditType.getTypeFromValue(kitodoTask.getEditType()));
         task.setProcessingStatus(TaskStatus.getStatusFromValue(kitodoTask.getProcessingStatus()));
         task.setConcurrent(kitodoTask.isConcurrent());

--- a/Kitodo/src/main/java/org/kitodo/production/workflow/model/beans/KitodoTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/workflow/model/beans/KitodoTask.java
@@ -19,7 +19,6 @@ public class KitodoTask {
 
     private String workflowId;
     private String title;
-    private Integer priority;
     private Integer editType;
     private Integer processingStatus;
     private boolean concurrent;
@@ -47,7 +46,6 @@ public class KitodoTask {
     public KitodoTask(Task task) {
         this.workflowId = task.getId();
         this.title = task.getName();
-        this.priority = getIntegerValue(task.getAttributeValueNs(NAMESPACE, "priority"));
         this.editType = getIntegerValue(task.getAttributeValueNs(NAMESPACE, "editType"));
         this.processingStatus = getIntegerValue(task.getAttributeValueNs(NAMESPACE, "processingStatus"));
         this.concurrent = getBooleanValue(task.getAttributeValueNs(NAMESPACE, "concurrent"));
@@ -95,25 +93,6 @@ public class KitodoTask {
      */
     public String getTitle() {
         return title;
-    }
-
-    /**
-     * Get priority.
-     *
-     * @return value of priority
-     */
-    public Integer getPriority() {
-        return priority;
-    }
-
-    /**
-     * Set priority.
-     *
-     * @param priority
-     *            as Integer
-     */
-    public void setPriority(Integer priority) {
-        this.priority = priority;
     }
 
     /**

--- a/Kitodo/src/main/resources/mapping.json
+++ b/Kitodo/src/main/resources/mapping.json
@@ -709,9 +709,6 @@
                 "ordering": {
                     "type": "long"
                 },
-                "priority": {
-                    "type": "long"
-                },
                 "processForTask": {
                     "properties": {
                         "id": {
@@ -820,6 +817,9 @@
                         }
                     },
                     "fielddata": true
+                },
+                "correction": {
+                    "type": "boolean"
                 },
                 "typeAutomatic": {
                     "type": "boolean"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -156,7 +156,7 @@
 
                     <!-- Pass to next station for corrective purpose-->
                     <h:panelGroup
-                            rendered="#{task.priority>9 and CurrentTaskForm.sizeOfNextStepsForProblemSolution > 0}">
+                            rendered="#{task.correction and CurrentTaskForm.sizeOfNextStepsForProblemSolution > 0}">
                         <span class="toggle" data-for="toggle-2">
                             <h:outputText>
                                 <i class="fa fa-arrow-left"/> #{msgs.sendSolutionMessageNextTask}

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
@@ -25,9 +25,8 @@
         <p:column headerText="#{msgs.order}">
             <h:outputText value="#{item.ordering}"/>
         </p:column>
-        <p:column headerText="#{msgs.priority}">
-            <h:outputText value="#{item.priority}" rendered="#{item.priority!=10}"/>
-            <h:outputText value="#{msgs.correction}" rendered="#{item.priority==10}"/>
+        <p:column headerText="#{msgs.correction}">
+            <h:outputText value="#{msgs.correction}" rendered="#{item.correction}"/>
         </p:column>
         <p:column headerText="#{msgs.status}">
             <h:outputText value="#{item.processingStatus.title}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
@@ -98,8 +98,8 @@
                     <h:outputText value="#{msgs.processTitle}: "/>
                     <h:outputText value="#{item.process.title}"/>
 
-                    <h:outputText value="#{msgs.priority}: "/>
-                    <h:outputText value="#{item.priority}"/>
+                    <h:outputText value="#{msgs.correction}: "/>
+                    <h:outputText value="#{item.correction}"/>
 
                     <h:outputText value="#{msgs.processingBegin}: " rendered="#{item.processingBegin ne null and !HelperForm.anonymized}"/>
                     <h:outputText value="#{ProcessForm.getFormattedDate(item.processingBegin)}" rendered="#{item.processingBegin ne null and !HelperForm.anonymized}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditActions.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditActions.xhtml
@@ -98,7 +98,7 @@
                             </h:panelGroup>
 
                             <!-- Schritt weitergeben an nachfolgende Station für KorrekturBehobenZwecke -->
-                            <h:panelGroup rendered="#{CurrentTaskForm.batchHelper.currentStep.priority>9}">
+                            <h:panelGroup rendered="#{CurrentTaskForm.batchHelper.currentStep.correction}">
 
                                 <span class="toggle" data-for="toggle-2">
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditDetails.xhtml
@@ -78,13 +78,11 @@
                                 </tr>
                                 <tr>
                                     <td width="150">
-                                        <h:outputText value="#{msgs.priority}:"/>
+                                        <h:outputText value="#{msgs.correction}:"/>
                                     </td>
                                     <td>
-                                        <h:outputText value="#{CurrentTaskForm.batchHelper.currentStep.priority}"
-                                                      rendered="#{CurrentTaskForm.batchHelper.currentStep.priority!=10}"/>
                                         <h:outputText value="#{msgs.correction}"
-                                                      rendered="#{CurrentTaskForm.batchHelper.currentStep.priority==10}"/>
+                                                      rendered="#{CurrentTaskForm.batchHelper.currentStep.correction}"/>
                                     </td>
                                 </tr>
                                 <tr>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskEdit/taskEditDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskEdit/taskEditDetails.xhtml
@@ -18,14 +18,6 @@
     <p:panelGrid columns="2" layout="grid">
         <p:row>
             <div>
-                <p:outputLabel for="priority" value="#{msgs.priority}"/>
-                <p:inputText id="priority" value="#{ProcessForm.task.priority}" required="#{empty param['editForm:saveButtonToggler']}" class="input">
-                    <p:ajax event="blur"/>
-                </p:inputText>
-            </div>
-        </p:row>
-        <p:row>
-            <div>
                 <p:outputLabel for="status" value="#{msgs.status}"/>
                 <p:selectOneMenu id="status" value="#{ProcessForm.task.processingStatus}" required="#{empty param['editForm:saveButtonToggler']}" class="input">
                     <f:selectItem itemValue="" itemLabel="#{msgs.selectPlease}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -70,14 +70,11 @@
                             #{item.processingStatus.title == 'statusOpen' ? 'var(--light-orange)' : ''}
                             #{item.processingStatus.title == 'statusLocked' ? 'var(--orange)' : ''};"
             />
-            <h:outputText value="!" rendered="#{item.priority == 1}"/>
-            <h:outputText value="!!" rendered="#{item.priority == 2}"/>
-            <h:outputText value="!!!" rendered="#{item.priority == 3}"/>
         </p:column>
 
-        <p:column headerText="#{msgs.priority}"
-                  rendered="#{CurrentTaskForm.showColumn('task.priority')}">
-            <h:outputText value="#{item.priority}"/>
+        <p:column headerText="#{msgs.correction}"
+                  rendered="#{CurrentTaskForm.showColumn('task.correction')}">
+            <h:outputText value="#{item.correction}"/>
         </p:column>
 
         <p:column headerText="#{msgs.duration} (#{msgs.process})"
@@ -138,8 +135,8 @@
         <p:rowExpansion styleClass="expansion-class">
             <div class="row-expansion-wrapper">
                 <p:panelGrid columns="2" columnClasses="label, value" id="currentTaskDetailTable">
-                    <h:outputText value="#{msgs.priority}:"/>
-                    <h:outputText value="#{item.priority}"/>
+                    <h:outputText value="#{msgs.correction}:"/>
+                    <h:outputText value="#{item.correction}"/>
 
                     <h:outputText value="#{msgs.processingBegin}:"/>
                     <h:outputText value="#{item.processingBegin}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/taskList.xhtml
@@ -49,8 +49,8 @@
                     <h:outputText value="#{msgs.title}: "/>
                     <h:outputText value="#{item.template.title}"/>
 
-                    <h:outputText value="#{msgs.priority}: "/>
-                    <h:outputText value="#{item.priority}"/>
+                    <h:outputText value="#{msgs.correction}: "/>
+                    <h:outputText value="#{item.correction}"/>
 
                     <h:outputText value="#{msgs.processingBegin}: " rendered="#{item.processingBegin ne null and !HelperForm.anonymized}"/>
                     <h:outputText value="#{TemplateForm.getFormattedDate(item.processingBegin)}" rendered="#{item.processingBegin ne null and !HelperForm.anonymized}"/>

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -215,10 +217,14 @@ public class MockDatabase {
         ClassLoader classloader = Thread.currentThread().getContextClassLoader();
 
         try (InputStream inputStream = classloader.getResourceAsStream("mapping.json")) {
-            String mapping = IOUtils.toString(inputStream, "UTF-8");
-            try (JsonReader jsonReader = Json.createReader(new StringReader(mapping))) {
-                JsonObject jsonObject = jsonReader.readObject();
-                return jsonObject.toString();
+            if (Objects.nonNull(inputStream)) {
+                String mapping = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+                try (JsonReader jsonReader = Json.createReader(new StringReader(mapping))) {
+                    JsonObject jsonObject = jsonReader.readObject();
+                    return jsonObject.toString();
+                }
+            } else {
+                return "";
             }
         } catch (IOException e) {
             logger.error(e.getMessage(), e);
@@ -951,7 +957,7 @@ public class MockDatabase {
     private static List<Task> getTasks() {
         Task firstTask = new Task();
         firstTask.setTitle("Finished");
-        firstTask.setPriority(1);
+        firstTask.setCorrection(false);
         firstTask.setOrdering(1);
         firstTask.setEditType(TaskEditType.ADMIN);
         LocalDate localDate = new LocalDate(2016, 8, 20);
@@ -977,7 +983,7 @@ public class MockDatabase {
         Task thirdTask = new Task();
         thirdTask.setTitle("Progress");
         thirdTask.setOrdering(3);
-        thirdTask.setPriority(10);
+        thirdTask.setCorrection(true);
         thirdTask.setEditType(TaskEditType.MANUAL_SINGLE);
         thirdTask.setTypeImagesWrite(true);
         localDate = new LocalDate(2017, 1, 25);
@@ -987,14 +993,14 @@ public class MockDatabase {
         Task fourthTask = new Task();
         fourthTask.setTitle("Open");
         fourthTask.setOrdering(4);
-        fourthTask.setPriority(10);
+        fourthTask.setCorrection(true);
         fourthTask.setEditType(TaskEditType.MANUAL_SINGLE);
         fourthTask.setProcessingStatus(TaskStatus.OPEN);
 
         Task fifthTask = new Task();
         fifthTask.setTitle("Locked");
         fifthTask.setOrdering(5);
-        fifthTask.setPriority(10);
+        fifthTask.setCorrection(true);
         fifthTask.setEditType(TaskEditType.MANUAL_SINGLE);
         fifthTask.setTypeImagesWrite(true);
         fifthTask.setProcessingStatus(TaskStatus.LOCKED);

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/TaskServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/TaskServiceIT.java
@@ -70,8 +70,8 @@ public class TaskServiceIT {
 
     @Test
     public void shouldFindTask() {
-        await().untilAsserted(() -> assertTrue("Task was not found in index!",
-            taskService.findById(1).getTitle().equals("Finished") && taskService.findById(1).getPriority().equals(1)));
+        await().untilAsserted(() -> assertEquals("Task was not found in index!", "Finished",
+            taskService.findById(1).getTitle()));
     }
 
     @Test
@@ -83,8 +83,7 @@ public class TaskServiceIT {
     @Test
     public void shouldGetTask() throws Exception {
         Task task = taskService.getById(1);
-        boolean condition = task.getTitle().equals("Finished") && task.getPriority().equals(1);
-        assertTrue("Task was not found in database!", condition);
+        assertEquals("Task was not found in database!", "Finished", task.getTitle());
     }
 
     @Test
@@ -193,7 +192,7 @@ public class TaskServiceIT {
     @Test
     public void shouldGetCorrectionStep() throws Exception {
         Task task = taskService.getById(8);
-        boolean result = ServiceManager.getWorkflowControllerService().isCorrectionTask(task);
+        boolean result = task.isCorrection();
         assertTrue("Task is not correction task!", result);
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
@@ -368,7 +368,7 @@ public class WorkflowControllerServiceIT {
 
         assertTrue(
             "Report of problem was incorrect - task '" + correctionTask.getTitle() + "' is not a correction task!",
-            workflowService.isCorrectionTask(correctionTask));
+            correctionTask.isCorrection());
 
         Process process = currentTask.getProcess();
         for (Task task : process.getTasks()) {

--- a/Kitodo/src/test/java/org/kitodo/selenium/ListingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ListingST.java
@@ -145,7 +145,7 @@ public class ListingST extends BaseTestSelenium {
 
         List<String> detailsTask = tasksPage.getTaskDetails();
         assertEquals("Displayed wrong number of task's details", 5, detailsTask.size());
-        assertEquals("Displayed wrong task's priority", "10", detailsTask.get(0));
+        assertEquals("Displayed wrong task's priority", "true", detailsTask.get(0));
         assertEquals("Displayed wrong task's processing begin", "2017-01-25 00:00:00", detailsTask.get(1));
         assertEquals("Displayed wrong task's processing update", "", detailsTask.get(2));
         assertEquals("Displayed wrong task's processing user", "Nowak, Adam", detailsTask.get(3));

--- a/Kitodo/src/test/resources/mapping.json
+++ b/Kitodo/src/test/resources/mapping.json
@@ -709,9 +709,6 @@
                 "ordering": {
                     "type": "long"
                 },
-                "priority": {
-                    "type": "long"
-                },
                 "processForTask": {
                     "properties": {
                         "id": {
@@ -820,6 +817,9 @@
                         }
                     },
                     "fielddata": true
+                },
+                "correction": {
+                    "type": "boolean"
                 },
                 "typeAutomatic": {
                     "type": "boolean"


### PR DESCRIPTION
PO decided that priority is useless and should be removed. 

But priority had one function - marking correction tasks. So here priority is removed with persisting correction functionality.