### PR TITLE
Remove null checks which always evaluate to the same value

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/GranularityForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/GranularityForm.java
@@ -287,7 +287,7 @@ public class GranularityForm {
      * @return the number of processes that will be created
      */
     public int getNumberOfProcesses() {
-        if (Objects.isNull(course.getNumberOfProcesses()) && Objects.nonNull(granularity)) {
+        if (Objects.nonNull(granularity)) {
             course.splitInto(granularity);
         }
         return course.getNumberOfProcesses();

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataProcessor.java
@@ -854,9 +854,8 @@ public class MetadataProcessor {
         ArrayList<LegacyDocStructHelperInterface> createdElements = new ArrayList<>(quantity);
 
         for (int i = 0; i < quantity; i++) {
-
             LegacyDocStructHelperInterface createdElement = digitalDocument.createDocStruct(docStructType);
-            if (docStructType != null && value != null && metadataType != null) {
+            if (Objects.nonNull(value) && Objects.nonNull(metadataType)) {
                 throw new UnsupportedOperationException("Dead code pending removal");
             }
             createdElements.add(createdElement);


### PR DESCRIPTION
- course.getNumberOfProcesses() - calls processes.size() - processes is initialized ArrayList, size returns 0 or more, never null

- docStructType != null - always true, it is private method called only once here:
```        
    LegacyLogicalDocStructTypeHelper docStructType = this.myPrefs.getDocStrctTypeByName(this.tempTyp);
    addNode(this.docStruct, this.digitalDocument, docStructType, this.positionOfNewDocStrucElement,
            this.metadataElementsToAdd, this.addMetaDataType, this.addMetaDataValue);
```

getDocStrctTypeByName(this.tempTyp); - doesn't return null, always some value