### PR TITLE
Hierarchical METS export (1)

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/IncludedStructuralElement.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/IncludedStructuralElement.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.kitodo.api.Metadata;
+import org.kitodo.api.dataformat.mets.LinkedMetsResource;
 
 /**
  * The tree-like outline included structural element for digital representation.
@@ -31,6 +32,11 @@ public class IncludedStructuralElement {
      * this level.
      */
     private String label;
+
+    /**
+     * Specifies the link if there is one.
+     */
+    private LinkedMetsResource link;
 
     /**
      * The meta-data for this included structural element. This included
@@ -124,6 +130,25 @@ public class IncludedStructuralElement {
      */
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    /**
+     * Returns the link of this included structural element.
+     *
+     * @return the link
+     */
+    public LinkedMetsResource getLink() {
+        return link;
+    }
+
+    /**
+     * Sets the link of this included structural element.
+     *
+     * @param link
+     *            link to set
+     */
+    public void setLink(LinkedMetsResource link) {
+        this.link = link;
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/LinkedMetsResource.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/LinkedMetsResource.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataformat.mets;
+
+import java.math.BigInteger;
+import java.net.URI;
+
+/**
+ * Data about a linked METS resource.
+ */
+public class LinkedMetsResource {
+    /**
+     * The loctype of the linked METS resource.
+     */
+    private String loctype;
+
+    /**
+     * The order of the linked METS resource.
+     */
+    private BigInteger order;
+
+    /**
+     * The URI of the linked METS resource.
+     */
+    private URI uri;
+
+    /**
+     * Returns the loctype of the linked METS resource.
+     *
+     * @return the loctype
+     */
+    public String getLoctype() {
+        return loctype;
+    }
+
+    /**
+     * Sets the loctype of the linked METS resource.
+     *
+     * @param loctype
+     *            loctype to set
+     */
+    public void setLoctype(String loctype) {
+        this.loctype = loctype;
+    }
+
+    /**
+     * Returns the order of the linked METS resource.
+     *
+     * @return the order
+     */
+    public BigInteger getOrder() {
+        return order;
+    }
+
+    /**
+     * Sets the order of the linked METS resource.
+     *
+     * @param order
+     *            order to set
+     */
+    public void setOrder(BigInteger order) {
+        this.order = order;
+    }
+
+    /**
+     * Sets the URI of the linked METS resource.
+     *
+     * @return the URI
+     */
+    public URI getUri() {
+        return uri;
+    }
+
+    /**
+     * Returns the URI of the linked METS resource.
+     *
+     * @param uri
+     *            URI to set
+     */
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+}


### PR DESCRIPTION
**Extend the API for writing links in the METS export**
The core provides the data format module with the linked METS resources. For this, a bean with the necessary fields has been added. The children are a map, where the string determines the insertion position for the link.