### PR TITLE
Hierarchical METS export (3)

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -85,6 +85,9 @@ public class Process extends BaseTemplateBean {
     @JoinColumn(name = "parent_id", foreignKey = @ForeignKey(name = "FK_process_parent_id"))
     private Process parent;
 
+    @Column(name = "position")
+    private String position;
+
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Process> children;
 
@@ -317,6 +320,25 @@ public class Process extends BaseTemplateBean {
      */
     public void setParent(Process parent) {
         this.parent = parent;
+    }
+
+    /**
+     * Get position.
+     *
+     * @return value of position
+     */
+    public String getPosition() {
+        return position;
+    }
+
+    /**
+     * Set position.
+     *
+     * @param position
+     *            as String
+     */
+    public void setPosition(String position) {
+        this.position = position;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_82__Add_another_hierarchy_column_to_process.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_82__Add_another_hierarchy_column_to_process.sql
@@ -1,0 +1,14 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+-- 1. Add column for position to process table
+--
+ALTER TABLE process ADD position VARCHAR(255);


### PR DESCRIPTION
**Add a field for the position to the process**
The position indicates at which position a child is linked within the logical structure of his parent. The syntax for this string is: `(\d+,)*\d+\.\d+`

Example (for a year of a newspaper): `2,15,0.5` = in the second month, in the 15th day, before the first non-linked child. (Child count is 1-based.)