### PR TITLE
Point searchResult.xhtml to use new meta-data editor

### DIFF
--- a/Kitodo/src/main/webapp/pages/searchResult.xhtml
+++ b/Kitodo/src/main/webapp/pages/searchResult.xhtml
@@ -62,15 +62,9 @@
                     <f:param name="id" value="#{process.id}"/>
                 </h:link>
 
-                <h:commandLink id="readXML" action="#{MetadataProcessor.readXml}" title="#{msgs.metadataEdit}"
+                <h:commandLink id="readXML" action="#{DataEditorForm.open(process.id, 'processList')}" title="#{msgs.metadataEdit}"
                                rendered="#{SecurityAccessController.hasAuthorityToOpenMetadataEditor()}">
                     <h:outputText><i class="fa fa-file-o"/></h:outputText>
-                    <f:param name="ProzesseID" value="#{process.id}"/>
-                    <f:param name="BenutzerID" value="#{LoginForm.loggedUser.id}"/>
-                    <f:param name="stayOnCurrentPage" value="processList"/>
-                    <f:setPropertyActionListener value="processes" target="#{MetadataProcessor.referringView}"/>
-                    <f:actionListener binding="#{MetadataProcessor.setCorrectionComment(false)}"/>
-                    <f:actionListener binding="#{MetadataProcessor.setShowNewComment(false)}"/>
                 </h:commandLink>
 
                 <p:commandLink id="download" action="#{ProcessForm.downloadToHome}" title="#{msgs.linkHomeDirectory}"


### PR DESCRIPTION
searchResult.xhtml still references no longer existing `MetadataProcessor`. Changed to use new `DataEditorForm`.