### PR TITLE
Load the correct rule set

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -166,7 +166,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             this.process = ServiceManager.getProcessService().getById(id);
             this.user = ServiceManager.getUserService().getCurrentUser();
 
-            ruleset = openRulesetFile(process.getTemplate().getRuleset().getFile());
+            ruleset = openRulesetFile(process.getRuleset().getFile());
             if (!openMetsFile()) {
                 return referringView;
             }


### PR DESCRIPTION
If you specified a rule set other than the production template when you created the process, the rule set of the production template was still loaded. Now the rule set belonging to the process is loaded.