### PR TITLE
Loading screen update

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -907,12 +907,20 @@ Popup dialogs
     right: var(--default-double-size);
 }
 
-#loadingDialog {
-    padding: var(--default-half-size);
+#loadingScreen {
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(255,255,255,.5);
+    top: 0;
+    left: 0;
+    z-index: 3;
+    line-height: 100vh;
+    text-align: center;
 }
 
-#loadingDialog .ui-dialog-content {
-    padding: 0;
+#loadingScreen i.fa-spinner {
+    color: var(--blue);
 }
 
 .ui-accordion .ui-state-default,

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/defaultScript.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/defaultScript.js
@@ -1,0 +1,14 @@
+/**
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+$(document).ready(function() {
+    $('#loadingScreen').hide();
+});

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/resize.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/resize.js
@@ -44,6 +44,7 @@ $(document).ready(function() {
     $('#secondResizer').mousedown(function(e) {handleMouseDown(e)});
     $('#verticalResizer').mousedown(function(e) {handleMouseDown(e)});
     setSizes();
+    $("#loadingScreen").hide();
 });
 
 $(window).resize(setSizes);

--- a/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -35,7 +35,11 @@
             <h:panelGroup id="indexErrorPanel" layout="block" rendered="#{empty indexingForm.serverInformation}">
                <p:ajax event="click" onclick="PF('sticky-notifications').renderMessage({'summary':'The elastic search server is not running.','detail':'Elastic Search','severity':'info'});"/>
             </h:panelGroup>
-            <div class="flex-container">
+            <div id="loadingScreen">
+                <i class="fa fa-spinner fa-pulse fa-3x fa-fw"/>
+                <span class="sr-only">Loading...</span>
+            </div>
+            <div class="flex-container" style="z-index: 1; position: relative;">
                 <header class="flex-item" role="banner" id="portal-header">
                     <div class="wrapper">
                         <h:outputScript library="js" name="collapse.js" target="body"/>
@@ -65,15 +69,6 @@
                     </ui:insert>
                 </footer>
             </div>
-            <p:dialog widgetVar="loadingDialog"
-                      id="loadingDialog"
-                      modal="true"
-                      draggable="false"
-                      closable="false"
-                      resizable="false"
-                      showHeader="false">
-                <p:graphicImage id="loading" alt="loading" value="/pages/images/ajax-loader.gif"/>
-            </p:dialog>
             <p:confirmDialog global="true"
                              showEffect="fade"
                              hideEffect="fade"
@@ -96,6 +91,10 @@
             </p:confirmDialog>
             <ui:include src="/WEB-INF/templates/includes/legal.xhtml"/>
             <ui:insert name="dialog"/>
+            <ui:insert name="page-scripts">
+                <h:outputScript name="js/defaultScript.js"
+                                target="body" />
+            </ui:insert>
             <o:highlight styleClass="ui-state-error" />
         </h:body>
     </f:view>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/comments.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/comments.xhtml
@@ -53,7 +53,7 @@
                              update=":newCommentForm">
                 <p:resetInput target=":newCommentForm"/>
             </p:commandButton>
-            <p:ajaxStatus onstart="PF('loadingDialog').show()" oncomplete="PF('loadingDialog').hide()"/>
+            <p:ajaxStatus onstart="$('#loadingScreen').show()" oncomplete="$('#loadingScreen').hide()"/>
         </h:form>
     </p:panel>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/header/navigation.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/header/navigation.xhtml
@@ -163,8 +163,8 @@
                     <p:row>
                         <p:commandButton id="setSessionClientButton"
                                          action="#{SessionClientController.setSelectedClientAsSessionClient}"
-                                         onstart="PF('selectClientDialog').hide(); PF('loadingDialog').show();"
-                                         oncomplete="PF('loadingDialog').hide();"
+                                         onstart="PF('selectClientDialog').hide(); $('#loadingScreen').show();"
+                                         oncomplete="$('#loadingScreen').hide();"
                                          disabled="#{not SessionClientController.areClientsAvailableForUser()}"
                                          update="@all"
                                          styleClass="primary right"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalMetadata.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalMetadata.xhtml
@@ -62,8 +62,8 @@
                                      title="#{msgs.metadataDelete}"
                                      styleClass="secondary #{readOnly ? 'disabled' : ''}"
                                      disabled="#{readOnly}"
-                                     onclick="PF('loadingDialog').show();"
-                                     oncomplete="PF('loadingDialog').hide();"
+                                     onclick="$('#loadingScreen').show()"
+                                     oncomplete="$('#loadingScreen').hide()"
                                      action="#{item.deleteClick}">
                     </p:commandButton>
                     <p:commandButton update="metadataAccordion:metadata:metadataTable"
@@ -74,8 +74,8 @@
                                      title="#{msgs.metadataCopy}"
                                      styleClass="secondary #{readOnly ? 'disabled' : ''}"
                                      disabled="#{readOnly}"
-                                     onclick="PF('loadingDialog').show();"
-                                     oncomplete="PF('loadingDialog').hide();"
+                                     onclick="$('#loadingScreen').show()"
+                                     oncomplete="$('#loadingScreen').hide()"
                                      action="#{item.copyClick}">
                     </p:commandButton>
                 </p:column>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalMetadata.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalMetadata.xhtml
@@ -67,8 +67,8 @@
                                      title="#{msgs.metadataDelete}"
                                      styleClass="secondary #{readOnly ? 'disabled' : ''}"
                                      disabled="#{readOnly}"
-                                     onclick="PF('loadingDialog').show();"
-                                     oncomplete="PF('loadingDialog').hide();"
+                                     onclick="$('#loadingScreen').show()"
+                                     oncomplete="$('#loadingScreen').hide()"
                                      action="#{item.deleteClick}">
                     </p:commandButton>
                     <p:commandButton update="metadataAccordion:metadata:metadataTable"
@@ -79,8 +79,8 @@
                                      title="#{msgs.metadataCopy}"
                                      styleClass="secondary #{readOnly ? 'disabled' : ''}"
                                      disabled="#{readOnly}"
-                                     onclick="PF('loadingDialog').show();"
-                                     oncomplete="PF('loadingDialog').hide();"
+                                     onclick="$('#loadingScreen').show()"
+                                     oncomplete="$('#loadingScreen').hide()"
                                      action="#{item.copyClick}">
                     </p:commandButton>
                 </p:column>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -58,6 +58,8 @@
                         icon="fa fa-trash fa-sm"
                         styleClass="plain"
                         disabled="#{readOnly}"
+                        onclick="$('#loadingScreen').show()"
+                        oncomplete="$('#loadingScreen').hide()"
                         action="#{DataEditorForm.deleteButtonClick()}"
                         update="structureTreeForm,structureTreeForm:structureWrapperPanel,paginationForm:paginationWrapperPanel,metadataAccordion:logicalMetadataWrapperPanel,commentWrapperPanel,galleryWrapperPanel"/>
         </p:contextMenu>
@@ -102,6 +104,8 @@
                         styleClass="plain"
                         disabled="#{readOnly}"
                         action="#{DataEditorForm.deleteMediaUnit()}"
+                        onclick="$('#loadingScreen').show()"
+                        oncomplete="$('#loadingScreen').hide()"
                         update="structureTreeForm,paginationForm:paginationWrapperPanel,metadataAccordion:physicalMetadataWrapperPanel,galleryWrapperPanel"/>
         </p:contextMenu>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/processImport.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/processImport.xhtml
@@ -67,8 +67,8 @@
                              action="#{ImportForm.search}"
                              value="#{msgs.searchOPAC}"
                              title="#{msgs.searchOPAC}"
-                             onstart="PF('loadingDialog').show()"
-                             oncomplete="PF('loadingDialog').hide()"
+                             onstart="$('#loadingScreen').show()"
+                             oncomplete="$('#loadingScreen').hide()"
                              icon="fa fa-search" iconPos="right"
                              update="editForm hitlist"/>
         </h:panelGroup>

--- a/Kitodo/src/main/webapp/pages/desktop.xhtml
+++ b/Kitodo/src/main/webapp/pages/desktop.xhtml
@@ -98,7 +98,7 @@
                         <ui:include src="/WEB-INF/templates/includes/desktop/statisticWidget.xhtml"/>
                     </div>
                 </p:panel>
-                <p:ajaxStatus onstart="PF('loadingDialog').show()" oncomplete="PF('loadingDialog').hide()"/>
+                <p:ajaxStatus onstart="$('#loadingScreen').show()" oncomplete="$('#loadingScreen').hide()"/>
             </div>
         </ui:fragment>
     </ui:define>

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -28,10 +28,6 @@
 
         <p:panel id="metadataEditorContainer" style="margin: auto 16px; padding: 0;">
 
-            <!-- JavaScript -->
-            <h:outputScript name="js/resize.js" target="body"/>
-            <h:outputScript name="js/scroll.js" target="body"/>
-
             <p:panel id="metadataEditor">
                 <!-- Header -->
                 <p:panel id="metadataEditorHeader">
@@ -175,6 +171,11 @@
         <p:menuitem value="#{msgs.desktop}" url="desktop.jsf"/>
         <p:menuitem value="#{msgs.processes}" url="processes.jsf"/>
         <p:menuitem value="#{msgs.metadataEdit} (#{DataEditorForm.processTitle})"/>
+    </ui:define>
+
+    <ui:define name="page-scripts">
+        <h:outputScript name="js/resize.js" target="body"/>
+        <h:outputScript name="js/scroll.js" target="body"/>
     </ui:define>
 
 </ui:composition>

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -80,7 +80,7 @@
                 <ui:include src="/WEB-INF/templates/includes/processes/batchList.xhtml"/>
             </p:tab>
         </p:tabView>
-        <p:ajaxStatus onstart="PF('loadingDialog').show()" oncomplete="PF('loadingDialog').hide()"/>
+        <p:ajaxStatus onstart="$('#loadingScreen').show()" oncomplete="$('#loadingScreen').hide()"/>
     </ui:define>
 
     <ui:define name="breadcrumbs">

--- a/Kitodo/src/main/webapp/pages/projects.xhtml
+++ b/Kitodo/src/main/webapp/pages/projects.xhtml
@@ -83,7 +83,7 @@
                 <ui:include src="/WEB-INF/templates/includes/projects/rulesetList.xhtml"/>
             </p:tab>
         </p:tabView>
-        <p:ajaxStatus onstart="PF('loadingDialog').show()" oncomplete="PF('loadingDialog').hide()"/>
+        <p:ajaxStatus onstart="$('#loadingScreen').show()" oncomplete="$('#loadingScreen').hide()"/>
     </ui:define>
 
     <ui:define name="breadcrumbs">

--- a/Kitodo/src/main/webapp/pages/tasks.xhtml
+++ b/Kitodo/src/main/webapp/pages/tasks.xhtml
@@ -40,7 +40,7 @@
                 <ui:include src="/WEB-INF/templates/includes/tasks/taskList.xhtml"/>
             </p:tab>
         </p:tabView>
-        <p:ajaxStatus onstart="PF('loadingDialog').show()" oncomplete="PF('loadingDialog').hide()"/>
+        <p:ajaxStatus onstart="$('#loadingScreen').show()" oncomplete="$('#loadingScreen').hide()"/>
     </ui:define>
 
     <ui:define name="breadcrumbs">

--- a/Kitodo/src/main/webapp/pages/users.xhtml
+++ b/Kitodo/src/main/webapp/pages/users.xhtml
@@ -92,7 +92,7 @@
                 <ui:include src="/WEB-INF/templates/includes/users/ldapserverList.xhtml"/>
             </p:tab>
         </p:tabView>
-        <p:ajaxStatus onstart="PF('loadingDialog').show()" oncomplete="PF('loadingDialog').hide()"/>
+        <p:ajaxStatus onstart="$('#loadingScreen').show()" oncomplete="$('#loadingScreen').hide()"/>
     </ui:define>
 
     <ui:define name="breadcrumbs">


### PR DESCRIPTION
This pull request replaces the "loading dialog" that is displayed during Ajax requests with a new loading overlay that in addition is also displayed during initial page load, until the page is completely loaded and rendered. 

The aim of this change is to prevent users from interacting with the GUI before it has finished loading all resources required by JSF, which often results in strange behaviour caused by broken ViewStates (for example if the user clicks a command component - like the action buttons - in the ProcessList or in the MetadataEditor before the page loading is complete). 