### PR TITLE
Fix update custom columns in database

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/CustomListColumnInitializer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/CustomListColumnInitializer.java
@@ -11,6 +11,7 @@
 
 package org.kitodo.production.helper;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -49,9 +50,11 @@ public class CustomListColumnInitializer {
         try {
             processProperties = loadCustomColumnsFromConfigurationFile(ParameterCore.PROCESS_PROPERTIES, PROCESS_PREFIX);
             taskProcessProperties = loadCustomColumnsFromConfigurationFile(ParameterCore.TASK_CUSTOM_COLUMNS, TASK_PREFIX);
+            List<String> customColumns = new ArrayList<>();
+            customColumns.addAll(Arrays.asList(processProperties));
+            customColumns.addAll(Arrays.asList(taskProcessProperties));
 
-            updateCustomColumnsInDatabase(Arrays.asList(processProperties));
-            updateCustomColumnsInDatabase(Arrays.asList(taskProcessProperties));
+            updateCustomColumnsInDatabase(customColumns);
 
         } catch (DAOException e) {
             logger.error("Unable to update custom list columns in database!");


### PR DESCRIPTION
Calling the method `updateCustomColumnsInDatabase` twice only kept the second List of custom columns in database. The contents of the first list would be deleted by the latter.