### PR TITLE
Resolves Hibernate classpath dependencies

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -127,14 +127,27 @@
             <version>${hibernate.version}</version>
         </dependency>
         <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-ehcache</artifactId>
+         <version>${hibernate.version}</version>
+            <exclusions>
+                <!-- exclude embedded ehcache 2.4.3 in order to use latest version -->
+                <exclusion>
+                    <groupId>net.sf.ehcache</groupId>
+                    <artifactId>ehcache</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- instead, include latest version of ehcache manually -->
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>2.10.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jcache</artifactId>
             <version>${hibernate.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ehcache</groupId>
-            <artifactId>ehcache</artifactId>
-            <version>3.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/Kitodo-DataManagement/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo-DataManagement/src/test/resources/hibernate.cfg.xml
@@ -41,7 +41,7 @@
         <!-- hibernate caching -->
         <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.use_query_cache">true</property>
-        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
+        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
 
         <!-- Enable Hibernate's automatic session context management -->

--- a/Kitodo/src/main/resources/ehcache.xml
+++ b/Kitodo/src/main/resources/ehcache.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
  *
  * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
@@ -11,65 +10,54 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
+<ehcache>
 
-<config
-        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-        xmlns='http://www.ehcache.org/v3'
-        xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
-        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.5.xsd
-        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.5.xsd">
+    <!-- Sets the path to the directory where cache .data files are created.
 
-    <service>
-        <jsr107:defaults enable-management="true" enable-statistics="true" default-template="defaultCacheTemplate"/>
-    </service>
+         If the path is a Java System Property it is replaced by
+         its value in the running VM.
 
-    <cache-template name="defaultCacheTemplate">
-        <expiry>
-            <tti unit="seconds">1800</tti>
-        </expiry>
-        <resources>
-            <heap unit="entries">100000</heap>
-        </resources>
-    </cache-template>
+         The following properties are translated:
+         user.home - User's home directory
+         user.dir - User's current working directory
+         java.io.tmpdir - Default temp file path -->
+    <diskStore path="java.io.tmpdir"/>
 
-    <cache-template name="shortLivedDefaultCacheTemplate">
-        <expiry>
-            <tti unit="seconds">60</tti>
-        </expiry>
-        <resources>
-            <heap unit="entries">1000000</heap>
-        </resources>
-    </cache-template>
+    <!--Default Cache configuration. These will applied to caches programmatically created through
+        the CacheManager.
 
-    <cache alias="org.hibernate.cache.spi.QueryResultsRegion">
-        <expiry>
-            <tti unit="seconds">1200</tti>
-        </expiry>
-        <heap>1024</heap>
-    </cache>
+        The following attributes are required:
 
-    <cache alias="org.hibernate.cache.spi.TimestampsRegion">
-        <expiry>
-            <none />
-        </expiry>
-        <heap>4096</heap>
-    </cache>
+        maxElementsInMemory            - Sets the maximum number of objects that will be created in memory
+        eternal                        - Sets whether elements are eternal. If eternal,  timeouts are ignored and the
+                                         element is never expired.
+        overflowToDisk                 - Sets whether elements can overflow to disk when the in-memory cache
+                                         has reached the maxInMemory limit.
 
-    <cache alias="org.hibernate.cache.spi.UpdateTimestampsCache">
-        <expiry>
-            <none />
-        </expiry>
-        <heap>4096</heap>
-    </cache>
+        The following attributes are optional:
+        timeToIdleSeconds              - Sets the time to idle for an element before it expires.
+                                         i.e. The maximum amount of time between accesses before an element expires
+                                         Is only used if the element is not eternal.
+                                         Optional attribute. A value of 0 means that an Element can idle for infinity.
+                                         The default value is 0.
+        timeToLiveSeconds              - Sets the time to live for an element before it expires.
+                                         i.e. The maximum time between creation time and when an element expires.
+                                         Is only used if the element is not eternal.
+                                         Optional attribute. A value of 0 means that and Element can live for infinity.
+                                         The default value is 0.
+        diskPersistent                 - Whether the disk store persists between restarts of the Virtual Machine.
+                                         The default value is false.
+        diskExpiryThreadIntervalSeconds- The number of seconds between runs of the disk expiry thread. The default value
+                                         is 120 seconds.
+        -->
 
-    <cache alias="org.hibernate.cache.internal.StandardQueryCache" uses-template="defaultCacheTemplate"/>
-    <cache alias="checkRulesCompliance" uses-template="defaultCacheTemplate"/>
-    <cache alias="TranslationsToEnglish" uses-template="defaultCacheTemplate"/>
-    <cache alias="TranslationsFromSwedish" uses-template="defaultCacheTemplate"/>
-    <cache alias="Translations" uses-template="defaultCacheTemplate"/>
-    <cache alias="SimplePageCachingFilter" uses-template="defaultCacheTemplate"/>
-    <cache alias="SimpleCachingHeadersPageCachingFilter" uses-template="defaultCacheTemplate"/>
-    <cache alias="AggregatedCountryData" uses-template="defaultCacheTemplate"/>
-    <cache alias="AggregatedBugData" uses-template="defaultCacheTemplate"/>
-
-</config>
+    <defaultCache
+        maxElementsInMemory="10000"
+        eternal="false"
+        overflowToDisk="true"
+        timeToIdleSeconds="120"
+        timeToLiveSeconds="120"
+        diskPersistent="false"
+        diskExpiryThreadIntervalSeconds="120"
+        />
+</ehcache>

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -49,7 +49,7 @@
         <!-- hibernate caching -->
         <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.use_query_cache">true</property>
-        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
+        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
 
         <!-- Enable Hibernate's automatic session context management -->

--- a/Kitodo/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/hibernate.cfg.xml
@@ -41,7 +41,7 @@
         <!-- hibernate caching -->
         <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.use_query_cache">true</property>
-        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
+        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
 
         <!-- Enable Hibernate's automatic session context management -->

--- a/Kitodo/src/test/resources/selenium/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/selenium/resources/hibernate.cfg.xml
@@ -40,7 +40,7 @@
         <!-- hibernate caching -->
         <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.use_query_cache">true</property>
-        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
+        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
 
         <!-- Enable Hibernate's automatic session context management -->


### PR DESCRIPTION
Newer Hibernate version requires explicit import of the "hibernate-ehcache" dependency. This is based on major version 2 of ehcache, therefore downgrading the ehcache version. Ehcache version 2 requires old format configuration file, uses ehcache.xml from Kitodo 2.x Branch.

Advantage: When upgrading from 2.x existing ehcache configuration can continue to be used.