### PR TITLE
Add volatile keyword to instance variables

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
@@ -41,7 +41,7 @@ public class IndexRestClient extends KitodoRestClient {
     /**
      * IndexRestClient singleton.
      */
-    private static IndexRestClient instance = null;
+    private static volatile IndexRestClient instance = null;
     private final Object lock = new Object();
 
     private IndexRestClient() {

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -47,7 +47,7 @@ public class SearchRestClient extends KitodoRestClient {
     /**
      * SearchRestClient singleton.
      */
-    private static SearchRestClient instance = null;
+    private static volatile SearchRestClient instance = null;
 
     private SearchRestClient() {
     }

--- a/Kitodo/src/main/java/org/kitodo/production/security/DynamicAuthenticationProvider.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/DynamicAuthenticationProvider.java
@@ -32,7 +32,7 @@ import org.springframework.security.ldap.authentication.LdapAuthenticationProvid
  */
 public class DynamicAuthenticationProvider implements AuthenticationProvider {
 
-    private static DynamicAuthenticationProvider instance = null;
+    private static volatile DynamicAuthenticationProvider instance = null;
     private AuthenticationProvider authenticationProvider = null;
 
     private boolean ldapAuthentication;

--- a/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
@@ -31,7 +31,7 @@ import org.springframework.security.web.access.intercept.FilterSecurityIntercept
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-    private static SecurityConfig instance = null;
+    private static volatile SecurityConfig instance = null;
     private SessionRegistry sessionRegistry;
     private static final String CLIENT_ANY = "CLIENT_ANY";
     private static final String GLOBAL = "GLOBAL";

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/AuthorityService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/AuthorityService.java
@@ -24,7 +24,7 @@ import org.primefaces.model.SortOrder;
 
 public class AuthorityService extends SearchDatabaseService<Authority, AuthorityDAO> {
 
-    private static AuthorityService instance = null;
+    private static volatile AuthorityService instance = null;
 
     private static final String GLOBAL_AUTHORITY_SUFFIX = "_globalAssignable";
     private static final String CLIENT_AUTHORITY_SUFFIX = "_clientAssignable";

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
@@ -41,7 +41,7 @@ import org.primefaces.model.SortOrder;
 
 public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> {
 
-    private static BatchService instance = null;
+    private static volatile BatchService instance = null;
     private static final String BATCH = "batch";
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
@@ -25,7 +25,7 @@ import org.primefaces.model.SortOrder;
 
 public class ClientService extends SearchDatabaseService<Client, ClientDAO> {
 
-    private static ClientService instance = null;
+    private static volatile ClientService instance = null;
 
     /**
      * Return singleton variable of type ClientService.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/CommentService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/CommentService.java
@@ -24,7 +24,7 @@ import org.primefaces.model.SortOrder;
 
 public class CommentService extends SearchDatabaseService<Comment, CommentDAO> {
 
-    private static CommentService instance = null;
+    private static volatile CommentService instance = null;
 
     /**
      * Constructor.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
@@ -35,7 +35,7 @@ import org.primefaces.model.SortOrder;
 
 public class DocketService extends ClientSearchService<Docket, DocketDTO, DocketDAO> {
 
-    private static DocketService instance = null;
+    private static volatile DocketService instance = null;
 
     /**
      * Constructor with Searcher and Indexer assigning.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -58,7 +58,7 @@ import org.primefaces.model.SortOrder;
 public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
 
     private static final Logger logger = LogManager.getLogger(FilterService.class);
-    private static FilterService instance = null;
+    private static volatile FilterService instance = null;
 
     /**
      * Constructor with Searcher and Indexer assigning.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -55,7 +55,7 @@ public class ImportService {
 
     private static final Logger logger = LogManager.getLogger(ImportService.class);
 
-    private static ImportService instance = null;
+    private static volatile ImportService instance = null;
     private static ExternalDataImportInterface importModule;
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
@@ -72,7 +72,7 @@ import org.primefaces.model.SortOrder;
 public class LdapServerService extends SearchDatabaseService<LdapServer, LdapServerDAO> {
 
     private static final Logger logger = LogManager.getLogger(LdapServerService.class);
-    private static LdapServerService instance = null;
+    private static volatile LdapServerService instance = null;
     private SecurityPasswordEncoder passwordEncoder = new SecurityPasswordEncoder();
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ListColumnService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ListColumnService.java
@@ -33,7 +33,7 @@ import org.primefaces.model.SortOrder;
 
 public class ListColumnService extends SearchDatabaseService<ListColumn, ListColumnDAO> {
 
-    private static ListColumnService instance = null;
+    private static volatile ListColumnService instance = null;
 
     /**
      * Constructor necessary to use searcher in child classes.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -136,7 +136,7 @@ public class ProcessService extends ClientSearchService<Process, ProcessDTO, Pro
     private final MetadataLock msp = new MetadataLock();
     private final FileService fileService = ServiceManager.getFileService();
     private static final Logger logger = LogManager.getLogger(ProcessService.class);
-    private static ProcessService instance = null;
+    private static volatile ProcessService instance = null;
     private boolean showClosedProcesses = false;
     private boolean showInactiveProjects = false;
     private static final String DIRECTORY_PREFIX = ConfigCore.getParameter(ParameterCore.DIRECTORY_PREFIX, "orig");

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
@@ -47,7 +47,7 @@ import org.primefaces.model.SortOrder;
 
 public class ProjectService extends ClientSearchService<Project, ProjectDTO, ProjectDAO> {
 
-    private static ProjectService instance = null;
+    private static volatile ProjectService instance = null;
 
     /**
      * Constructor with Searcher and Indexer assigning.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -38,7 +38,7 @@ import org.primefaces.model.SortOrder;
 
 public class PropertyService extends TitleSearchService<Property, PropertyDTO, PropertyDAO> {
 
-    private static PropertyService instance = null;
+    private static volatile PropertyService instance = null;
 
     /**
      * Constructor with Searcher and Indexer assigning.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
@@ -28,7 +28,7 @@ import org.primefaces.model.SortOrder;
 
 public class RoleService extends SearchDatabaseService<Role, RoleDAO> {
 
-    private static RoleService instance = null;
+    private static volatile RoleService instance = null;
 
     private static final String CLIENT_ID = "clientId";
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -43,7 +43,7 @@ import org.primefaces.model.SortOrder;
 public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, RulesetDAO> {
 
     private static final Logger logger = LogManager.getLogger(RulesetService.class);
-    private static RulesetService instance = null;
+    private static volatile RulesetService instance = null;
 
     /**
      * Constructor with Searcher and Indexer assigning.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -71,7 +71,7 @@ import org.primefaces.model.SortOrder;
 public class TaskService extends ClientSearchService<Task, TaskDTO, TaskDAO> {
 
     private static final Logger logger = LogManager.getLogger(TaskService.class);
-    private static TaskService instance = null;
+    private static volatile TaskService instance = null;
     private boolean onlyOpenTasks = false;
     private boolean onlyOwnTasks = false;
     private boolean showAutomaticTasks = false;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -53,7 +53,7 @@ import org.primefaces.model.SortOrder;
 public class TemplateService extends ClientSearchService<Template, TemplateDTO, TemplateDAO> {
 
     private static final Logger logger = LogManager.getLogger(TemplateService.class);
-    private static TemplateService instance = null;
+    private static volatile TemplateService instance = null;
     private boolean showInactiveTemplates = false;
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -57,7 +57,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 public class UserService extends SearchDatabaseService<User, UserDAO> implements UserDetailsService {
 
     private static final Logger logger = LogManager.getLogger(UserService.class);
-    private static UserService instance = null;
+    private static volatile UserService instance = null;
     private static final String CLIENT_ID = "clientId";
     private SecurityPasswordEncoder passwordEncoder = new SecurityPasswordEncoder();
     private static final int DEFAULT_CLIENT_ID =

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowConditionService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowConditionService.java
@@ -23,7 +23,7 @@ import org.primefaces.model.SortOrder;
 
 public class WorkflowConditionService extends SearchDatabaseService<WorkflowCondition, WorkflowConditionDAO> {
 
-    private static WorkflowConditionService instance = null;
+    private static volatile WorkflowConditionService instance = null;
 
     /**
      * Return singleton variable of type WorkflowConditionService.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
@@ -35,7 +35,7 @@ import org.primefaces.model.SortOrder;
 
 public class WorkflowService extends ClientSearchService<Workflow, WorkflowDTO, WorkflowDAO> {
 
-    private static WorkflowService instance = null;
+    private static volatile WorkflowService instance = null;
 
     /**
      * Private constructor with Searcher and Indexer assigning.

--- a/Kitodo/src/main/java/org/kitodo/production/services/image/ImageService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/image/ImageService.java
@@ -27,7 +27,7 @@ import org.kitodo.serviceloader.KitodoServiceLoader;
 public class ImageService {
 
     private ImageManagementInterface imageManagement;
-    private static ImageService instance = null;
+    private static volatile ImageService instance = null;
 
     private ImageService() {
         imageManagement = new KitodoServiceLoader<ImageManagementInterface>(ImageManagementInterface.class)

--- a/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
@@ -20,7 +20,7 @@ import org.springframework.security.core.Authentication;
 
 public class SecurityAccessService extends SecurityAccess {
 
-    private static SecurityAccessService instance = null;
+    private static volatile SecurityAccessService instance = null;
 
     /**
      * Return singleton variable of type SecurityAccessService.

--- a/Kitodo/src/main/java/org/kitodo/production/services/security/SessionService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/security/SessionService.java
@@ -25,7 +25,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 public class SessionService {
 
-    private static SessionService instance = null;
+    private static volatile SessionService instance = null;
     private SessionRegistry sessionRegistry;
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -68,7 +68,7 @@ public class WorkflowControllerService {
     private final ReentrantLock flagWaitLock = new ReentrantLock();
     private final WebDav webDav = new WebDav();
     private static final Logger logger = LogManager.getLogger(WorkflowControllerService.class);
-    private static WorkflowControllerService instance = null;
+    private static volatile WorkflowControllerService instance = null;
     private TaskService taskService = ServiceManager.getTaskService();
 
     /**


### PR DESCRIPTION
Good practise on creating singletons is beside the already used double check the adding of `volatile` keyword to the instance holding class member variable.