### PR TITLE
Speedup getInstance implementations

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/IndexRestClient.java
@@ -53,15 +53,18 @@ public class IndexRestClient extends KitodoRestClient {
      * @return unique instance of IndexRestClient
      */
     public static IndexRestClient getInstance() {
-        if (Objects.equals(instance, null)) {
+        IndexRestClient localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (IndexRestClient.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new IndexRestClient();
-                    instance.initiateClient();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new IndexRestClient();
+                    localReference.initiateClient();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -58,15 +58,18 @@ public class SearchRestClient extends KitodoRestClient {
      * @return unique instance of SearchRestClient
      */
     public static SearchRestClient getInstance() {
-        if (Objects.equals(instance, null)) {
+        SearchRestClient localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (SearchRestClient.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new SearchRestClient();
-                    instance.initiateClient();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new SearchRestClient();
+                    localReference.initiateClient();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/security/DynamicAuthenticationProvider.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/DynamicAuthenticationProvider.java
@@ -53,14 +53,17 @@ public class DynamicAuthenticationProvider implements AuthenticationProvider {
      * @return unique instance of DynamicAuthenticationProvider
      */
     public static DynamicAuthenticationProvider getInstance() {
-        if (Objects.equals(instance, null)) {
+        DynamicAuthenticationProvider localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (DynamicAuthenticationProvider.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new DynamicAuthenticationProvider();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new DynamicAuthenticationProvider();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
@@ -67,10 +67,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
      * singleton usage.
      */
     public SecurityConfig() {
-        if (Objects.equals(instance, null)) {
+        SecurityConfig localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (SecurityConfig.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = this;
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = this;
+                    instance = localReference;
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/AuthorityService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/AuthorityService.java
@@ -42,14 +42,17 @@ public class AuthorityService extends SearchDatabaseService<Authority, Authority
      * @return unique instance of AuthorityService
      */
     public static AuthorityService getInstance() {
-        if (Objects.equals(instance, null)) {
+        AuthorityService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (AuthorityService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new AuthorityService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new AuthorityService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
@@ -57,14 +57,17 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
      * @return unique instance of BatchService
      */
     public static BatchService getInstance() {
-        if (Objects.equals(instance, null)) {
+        BatchService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (BatchService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new BatchService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new BatchService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
@@ -33,14 +33,17 @@ public class ClientService extends SearchDatabaseService<Client, ClientDAO> {
      * @return unique instance of ClientService
      */
     public static ClientService getInstance() {
-        if (Objects.equals(instance, null)) {
+        ClientService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (ClientService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new ClientService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new ClientService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/CommentService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/CommentService.java
@@ -39,14 +39,17 @@ public class CommentService extends SearchDatabaseService<Comment, CommentDAO> {
      * @return unique instance of TaskService
      */
     public static CommentService getInstance() {
-        if (Objects.equals(instance, null)) {
+        CommentService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (CommentService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new CommentService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new CommentService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
@@ -51,14 +51,17 @@ public class DocketService extends ClientSearchService<Docket, DocketDTO, Docket
      * @return unique instance of DocketService
      */
     public static DocketService getInstance() {
-        if (Objects.equals(instance, null)) {
+        DocketService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (DocketService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new DocketService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new DocketService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -73,14 +73,17 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
      * @return unique instance of FilterService
      */
     public static FilterService getInstance() {
-        if (Objects.equals(instance, null)) {
+        FilterService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (FilterService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new FilterService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new FilterService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -64,14 +64,17 @@ public class ImportService {
      * @return unique instance of ImportService
      */
     public static ImportService getInstance() {
-        if (Objects.equals(instance, null)) {
+        ImportService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (ImportService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new ImportService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new ImportService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
@@ -81,14 +81,17 @@ public class LdapServerService extends SearchDatabaseService<LdapServer, LdapSer
      * @return unique instance of LdapServerService
      */
     public static LdapServerService getInstance() {
-        if (Objects.equals(instance, null)) {
+        LdapServerService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (LdapServerService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new LdapServerService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new LdapServerService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     private LdapServerService() {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ListColumnService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ListColumnService.java
@@ -48,14 +48,17 @@ public class ListColumnService extends SearchDatabaseService<ListColumn, ListCol
      * @return unique instance of ListColumnService
      */
     public static ListColumnService getInstance() {
-        if (Objects.isNull(instance)) {
+        ListColumnService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (ListColumnService.class) {
-                if (Objects.isNull(instance)) {
-                    instance = new ListColumnService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new ListColumnService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -168,14 +168,17 @@ public class ProcessService extends ClientSearchService<Process, ProcessDTO, Pro
      * @return unique instance of ProcessService
      */
     public static ProcessService getInstance() {
-        if (Objects.equals(instance, null)) {
+        ProcessService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (ProcessService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new ProcessService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new ProcessService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
@@ -63,14 +63,17 @@ public class ProjectService extends ClientSearchService<Project, ProjectDTO, Pro
      * @return unique instance of ProcessService
      */
     public static ProjectService getInstance() {
-        if (Objects.equals(instance, null)) {
+        ProjectService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (ProjectService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new ProjectService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new ProjectService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -53,14 +53,17 @@ public class PropertyService extends TitleSearchService<Property, PropertyDTO, P
      * @return unique instance of PropertyService
      */
     public static PropertyService getInstance() {
-        if (Objects.equals(instance, null)) {
+        PropertyService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (PropertyService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new PropertyService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new PropertyService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
@@ -45,14 +45,17 @@ public class RoleService extends SearchDatabaseService<Role, RoleDAO> {
      * @return unique instance of RoleService
      */
     public static RoleService getInstance() {
-        if (Objects.equals(instance, null)) {
+        RoleService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (RoleService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new RoleService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new RoleService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -59,14 +59,17 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, Rul
      * @return unique instance of RulesetService
      */
     public static RulesetService getInstance() {
-        if (Objects.equals(instance, null)) {
+        RulesetService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (RulesetService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new RulesetService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new RulesetService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -90,14 +90,17 @@ public class TaskService extends ClientSearchService<Task, TaskDTO, TaskDAO> {
      * @return unique instance of TaskService
      */
     public static TaskService getInstance() {
-        if (Objects.equals(instance, null)) {
+        TaskService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (TaskService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new TaskService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new TaskService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -70,14 +70,17 @@ public class TemplateService extends ClientSearchService<Template, TemplateDTO, 
      * @return unique instance of TemplateService
      */
     public static TemplateService getInstance() {
-        if (Objects.equals(instance, null)) {
+        TemplateService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (TemplateService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new TemplateService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new TemplateService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -76,14 +76,17 @@ public class UserService extends SearchDatabaseService<User, UserDAO> implements
      * @return unique instance of UserService
      */
     public static UserService getInstance() {
-        if (Objects.equals(instance, null)) {
+        UserService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (UserService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new UserService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new UserService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowConditionService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowConditionService.java
@@ -31,14 +31,17 @@ public class WorkflowConditionService extends SearchDatabaseService<WorkflowCond
      * @return unique instance of WorkflowConditionService
      */
     public static WorkflowConditionService getInstance() {
-        if (Objects.equals(instance, null)) {
+        WorkflowConditionService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (WorkflowConditionService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new WorkflowConditionService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new WorkflowConditionService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
@@ -51,14 +51,17 @@ public class WorkflowService extends ClientSearchService<Workflow, WorkflowDTO, 
      * @return unique instance of WorkflowService
      */
     public static WorkflowService getInstance() {
-        if (Objects.equals(instance, null)) {
+        WorkflowService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (WorkflowService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new WorkflowService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new WorkflowService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/RulesetManagementService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/RulesetManagementService.java
@@ -26,14 +26,17 @@ public class RulesetManagementService {
      * @return unique instance of MetsService
      */
     public static RulesetManagementService getInstance() {
-        if (Objects.equals(instance, null)) {
+        RulesetManagementService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (RulesetManagementService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new RulesetManagementService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new RulesetManagementService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
     
     private RulesetManagementService() {

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -36,14 +36,17 @@ public class MetsService {
      * @return unique instance of MetsService
      */
     public static MetsService getInstance() {
-        if (Objects.equals(instance, null)) {
+        MetsService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (MetsService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new MetsService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new MetsService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     private MetsService() {

--- a/Kitodo/src/main/java/org/kitodo/production/services/image/ImageService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/image/ImageService.java
@@ -109,13 +109,16 @@ public class ImageService {
      * @return unique instance of ImageService
      */
     public static ImageService getInstance() {
-        if (Objects.equals(instance, null)) {
+        ImageService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (ImageService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new ImageService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new ImageService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
@@ -28,14 +28,17 @@ public class SecurityAccessService extends SecurityAccess {
      * @return unique instance of SecurityAccessService
      */
     public static SecurityAccessService getInstance() {
-        if (Objects.equals(instance, null)) {
+        SecurityAccessService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (SecurityAccessService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new SecurityAccessService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new SecurityAccessService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/services/security/SessionService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/security/SessionService.java
@@ -85,13 +85,16 @@ public class SessionService {
      * @return unique instance of SessionService
      */
     public static SessionService getInstance() {
-        if (Objects.equals(instance, null)) {
+        SessionService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (SessionService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new SessionService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new SessionService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -84,14 +84,17 @@ public class WorkflowControllerService {
      * @return unique instance of WorkflowControllerService
      */
     public static WorkflowControllerService getInstance() {
-        if (Objects.equals(instance, null)) {
+        WorkflowControllerService localReference = instance;
+        if (Objects.isNull(localReference)) {
             synchronized (WorkflowControllerService.class) {
-                if (Objects.equals(instance, null)) {
-                    instance = new WorkflowControllerService();
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new WorkflowControllerService();
+                    instance = localReference;
                 }
             }
         }
-        return instance;
+        return localReference;
     }
 
     /**


### PR DESCRIPTION
According to different resources [1] and [2] there is a improvement up to 25% on usage of a local reference. As we did not allow inner assingments code must be adjusted a little bit.

This pull request depends on #2563.

[1] https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java
[2] https://www.oracle.com/technetwork/articles/javase/bloch-effective-08-qa-140880.html (Best Practices for Lazy Initialization)