### PR TITLE
save processBaseURI only to database

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1072,8 +1072,8 @@ public class ProcessService extends ClientSearchService<Process, ProcessDTO, Pro
         if (Objects.isNull(process.getProcessBaseUri())) {
             process.setProcessBaseUri(fileService.getProcessBaseUriForExistingProcess(process));
             try {
-                save(process);
-            } catch (DataException e) {
+                saveToDatabase(process);
+            } catch (DAOException e) {
                 logger.error(e.getMessage(), e);
                 return URI.create("");
             }


### PR DESCRIPTION
The creation and saving of this field happens only for "old" kitodo 2.x processes.
Because we are indexing the metadata this is happening for all of them on the first index-all step.
Saving them to the database is sufficient then, because the indexing is happening twice otherwise.

Furthermore the previous used "save" method is also managing dependencies which leads to an indexing chain which tremendously slows down the index-all step.