### PR TITLE
Fix file uploads for mass import

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/baseEditView.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/baseEditView.xhtml
@@ -18,7 +18,7 @@
         xmlns:p="http://primefaces.org/ui" >
     <ui:define name="content">
         <p:panel id="listWrapper">
-            <h:form id="editForm">
+            <h:form id="editForm" enctype="multipart/form-data">
                 <p:panel styleClass="content-header">
                     <ui:insert name="contentHeader">
                         <h3>Kitodo.Production</h3>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/uploadImport.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/uploadImport.xhtml
@@ -58,7 +58,7 @@
                 <p:panel>
                     <p:fileUpload id="fileUpload3" value="#{MassImportForm.uploadedFile}"
                                   mode="simple" skinSimple="true" required="false"/>
-                    <p:commandButton value="#{msgs.uploadFile}" id="uploadButton" action="#{MassImportForm.uploadFile}"/>
+                    <p:commandButton value="#{msgs.uploadFile}" id="uploadButton" action="#{MassImportForm.uploadFile}" ajax="false"/>
                 </p:panel>
             </div>
         </p:row>


### PR DESCRIPTION
File upload needs two things:

- form type: multipart/form-data
- disabled ajax

Additional fix in this PR: Use FileUtils instead FileService (uploaded file is not metadata file).

@IkramMaalej, @solth , @oliver-stoehr : your opinion about this changes would be useful :)