### PR TITLE
Add missing else keyword

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/GoobiScript.java
+++ b/Goobi/src/de/sub/goobi/helper/GoobiScript.java
@@ -167,7 +167,7 @@ public class GoobiScript {
                 contentOnly = false;
             }
             deleteProcess(inProzesse, contentOnly);
-        } if (this.myParameters.get("action").equals("rewriteProcessMetadata")) {
+        } else if (this.myParameters.get("action").equals("rewriteProcessMetadata")) {
             rewriteProcessMetadata(inProzesse);
         } else {
             Helper.setFehlerMeldung(


### PR DESCRIPTION
Fix annoying error message while executing successful KitodoScript actions:

 
![Screenshot_2019-06-04_16-18-38](https://user-images.githubusercontent.com/2129672/58886626-8693a800-86e4-11e9-903f-90c83d45c767.png)
