### PR TITLE
Fix deletion of processes with comments

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -91,7 +91,7 @@ public class Process extends BaseTemplateBean {
     @OneToMany(mappedBy = "process", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Task> tasks;
 
-    @OneToMany(mappedBy = "process", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "process", cascade = CascadeType.ALL)
     private List<Comment> comments;
 
     @ManyToMany(cascade = CascadeType.ALL)


### PR DESCRIPTION
Processes with comments could not be deleted, because they would be referenced by their comments.