### PR TITLE
Fix ehcache.xml usage

### DIFF
--- a/Kitodo-DataManagement/src/test/resources/ehcache.xml
+++ b/Kitodo-DataManagement/src/test/resources/ehcache.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<config
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='http://www.ehcache.org/v3'
+        xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.5.xsd
+        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.5.xsd">
+
+    <service>
+        <jsr107:defaults enable-management="true" enable-statistics="true" default-template="defaultCacheTemplate"/>
+    </service>
+
+    <cache-template name="defaultCacheTemplate">
+        <expiry>
+            <tti unit="seconds">1800</tti>
+        </expiry>
+        <resources>
+            <heap unit="entries">100000</heap>
+        </resources>
+    </cache-template>
+
+    <cache-template name="shortLivedDefaultCacheTemplate">
+        <expiry>
+            <tti unit="seconds">60</tti>
+        </expiry>
+        <resources>
+            <heap unit="entries">1000000</heap>
+        </resources>
+    </cache-template>
+
+    <cache alias="default-query-results-region">
+        <expiry>
+            <tti unit="seconds">1200</tti>
+        </expiry>
+        <heap>1024</heap>
+    </cache>
+
+    <cache alias="default-update-timestamps-region">
+        <expiry>
+            <none />
+        </expiry>
+        <heap>4096</heap>
+    </cache>
+
+    <cache alias="org.hibernate.cache.internal.StandardQueryCache" uses-template="defaultCacheTemplate"/>
+
+</config>

--- a/Kitodo-DataManagement/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo-DataManagement/src/test/resources/hibernate.cfg.xml
@@ -43,6 +43,8 @@
         <property name="hibernate.cache.use_query_cache">true</property>
         <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
+        <property name="hibernate.javax.cache.missing_cache_strategy">create</property>
+        <property name="hibernate.javax.cache.uri">ehcache.xml</property>
 
         <!-- Enable Hibernate's automatic session context management -->
         <property name="current_session_context_class">thread</property>

--- a/Kitodo/src/main/resources/ehcache.xml
+++ b/Kitodo/src/main/resources/ehcache.xml
@@ -41,21 +41,14 @@
         </resources>
     </cache-template>
 
-    <cache alias="org.hibernate.cache.spi.QueryResultsRegion">
+    <cache alias="default-query-results-region">
         <expiry>
             <tti unit="seconds">1200</tti>
         </expiry>
         <heap>1024</heap>
     </cache>
 
-    <cache alias="org.hibernate.cache.spi.TimestampsRegion">
-        <expiry>
-            <none />
-        </expiry>
-        <heap>4096</heap>
-    </cache>
-
-    <cache alias="org.hibernate.cache.spi.UpdateTimestampsCache">
+    <cache alias="default-update-timestamps-region">
         <expiry>
             <none />
         </expiry>

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -52,6 +52,7 @@
         <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
         <property name="hibernate.javax.cache.missing_cache_strategy">create</property>
+        <property name="hibernate.javax.cache.uri">ehcache.xml</property>
 
         <!-- Enable Hibernate's automatic session context management -->
         <property name="current_session_context_class">thread</property>

--- a/Kitodo/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/hibernate.cfg.xml
@@ -44,6 +44,7 @@
         <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
         <property name="hibernate.javax.cache.missing_cache_strategy">create</property>
+        <property name="hibernate.javax.cache.uri">ehcache.xml</property>
 
         <!-- Enable Hibernate's automatic session context management -->
         <property name="current_session_context_class">thread</property>

--- a/Kitodo/src/test/resources/selenium/resources/ehcache.xml
+++ b/Kitodo/src/test/resources/selenium/resources/ehcache.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<config
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='http://www.ehcache.org/v3'
+        xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.5.xsd
+        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.5.xsd">
+
+    <service>
+        <jsr107:defaults enable-management="true" enable-statistics="true" default-template="defaultCacheTemplate"/>
+    </service>
+
+    <cache-template name="defaultCacheTemplate">
+        <expiry>
+            <tti unit="seconds">1800</tti>
+        </expiry>
+        <resources>
+            <heap unit="entries">100000</heap>
+        </resources>
+    </cache-template>
+
+    <cache-template name="shortLivedDefaultCacheTemplate">
+        <expiry>
+            <tti unit="seconds">60</tti>
+        </expiry>
+        <resources>
+            <heap unit="entries">1000000</heap>
+        </resources>
+    </cache-template>
+
+    <cache alias="default-query-results-region">
+        <expiry>
+            <tti unit="seconds">1200</tti>
+        </expiry>
+        <heap>1024</heap>
+    </cache>
+
+    <cache alias="default-update-timestamps-region">
+        <expiry>
+            <none />
+        </expiry>
+        <heap>4096</heap>
+    </cache>
+
+    <cache alias="org.hibernate.cache.internal.StandardQueryCache" uses-template="defaultCacheTemplate"/>
+
+</config>

--- a/Kitodo/src/test/resources/selenium/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/selenium/resources/hibernate.cfg.xml
@@ -43,6 +43,7 @@
         <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
         <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
         <property name="hibernate.javax.cache.missing_cache_strategy">create</property>
+        <property name="hibernate.javax.cache.uri">ehcache.xml</property>
 
         <!-- Enable Hibernate's automatic session context management -->
         <property name="current_session_context_class">thread</property>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <commons-lang3.version>3.7</commons-lang3.version>
         <org.apache.xmlgraphics.version>2.0</org.apache.xmlgraphics.version>
         <hamcrest.version>2.1-rc3</hamcrest.version>
-        <hibernate.version>5.3.7.Final</hibernate.version>
+        <hibernate.version>5.4.3.Final</hibernate.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.1.6</jaxen.version>
         <jersey.version>1.19.3</jersey.version>


### PR DESCRIPTION
Currently the shipped ehcache.xml file is not used as no path to this file is provided. Using this file through the classpath is only possible since Hibernate 5.4.1 as before there was [no classpath support](https://hibernate.atlassian.net/browse/HHH-12979). After reading [Hibernate Caching](https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#caching) there must be some more time spend into it as

- default caching (like in our provided ehcache.xml file) is not adapted to our application and requirements
- it should be decided which entities and entity-relations should be cached (seperate branch but failing on selenium tests)
- it should be decieded if database queries and there results should be cached or not (can be defined on each single database query)

A possible alternative is to remove the support for the second level cache of hibernate and only use the hibernate built-in first level caching.

If this pull request is merged then local `hibernate.cfg.xml` should be adjusted. Maybe developers may should disable caching on their local hibernate configuration.
