### PR TITLE
Assign media to logical root element

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -55,8 +55,8 @@ public class GalleryPanel {
     private static final Pattern DROP_STRIPE = Pattern
             .compile("imagePreviewForm:structuredPages:(\\d+):structureElementDataList");
 
-    private static final Pattern UNASSIGNED_IMAGE = Pattern
-            .compile("imagePreviewForm:unassignedPagesList:(\\d+):unassignedPagePanel");
+    private static final Pattern UNSTRUCTURED_MEDIA = Pattern
+            .compile("imagePreviewForm:unstructuredMediaList:(\\d+):unstructuredMediaPanel");
 
     private final DataEditorForm dataEditor;
     private GalleryViewMode galleryViewMode = GalleryViewMode.LIST;
@@ -164,17 +164,28 @@ public class GalleryPanel {
      */
     public void onPageDrop(DragDropEvent event) {
         Matcher dragStripeImageMatcher = DRAG_STRIPE_IMAGE.matcher(event.getDragId());
-        Matcher dragUnassignedPageMatcher = UNASSIGNED_IMAGE.matcher(event.getDragId());
+        Matcher dragUnstructuredMediaMatcher = UNSTRUCTURED_MEDIA.matcher(event.getDragId());
         Matcher dropStripeMatcher = DROP_STRIPE.matcher(event.getDropId());
-        if (dragStripeImageMatcher.matches() && dropStripeMatcher.matches()) {
-            int fromStripeIndex = Integer.parseInt(dragStripeImageMatcher.group(1));
-            int fromStripeMediaIndex = Integer.parseInt(dragStripeImageMatcher.group(2));
+        if ((dragUnstructuredMediaMatcher.matches() || dragStripeImageMatcher.matches()) && dropStripeMatcher.matches()) {
+            int fromStripeIndex;
+            int fromStripeMediaIndex;
+            GalleryStripe fromStripe;
             int toStripeIndex = Integer.parseInt(dropStripeMatcher.group(1));
-            if (fromStripeIndex == toStripeIndex) {
+            if (dragStripeImageMatcher.matches()) {
+                fromStripeIndex = Integer.parseInt(dragStripeImageMatcher.group(1));
+                if (fromStripeIndex == toStripeIndex) {
+                    return;
+                }
+                fromStripeMediaIndex = Integer.parseInt(dragStripeImageMatcher.group(2));
+                fromStripe = stripes.get(fromStripeIndex);
+            } else if (dragUnstructuredMediaMatcher.matches()) {
+                // First (0) stripe represents logical root element (unstructured media)
+                fromStripe = stripes.get(0);
+                fromStripeMediaIndex = Integer.parseInt(dragUnstructuredMediaMatcher.group(1));
+            } else {
                 return;
             }
 
-            GalleryStripe fromStripe = stripes.get(fromStripeIndex);
             GalleryMediaContent mediaContent = fromStripe.getMedias().get(fromStripeMediaIndex);
             GalleryStripe toStripe = stripes.get(toStripeIndex);
 
@@ -188,20 +199,6 @@ public class GalleryPanel {
             for (View fromStripeView : fromStripe.getStructure().getViews()) {
                 fromStripe.getMedias().add(createGalleryMediaContent(fromStripeView));
             }
-            toStripe.getMedias().clear();
-            for (View toStripeView : toStripe.getStructure().getViews()) {
-                toStripe.getMedias().add(createGalleryMediaContent(toStripeView));
-            }
-            dataEditor.getStructurePanel().show();
-            return;
-        } else if (dropStripeMatcher.matches() && dragUnassignedPageMatcher.matches()) {
-            int toStripeIndex = Integer.parseInt(dropStripeMatcher.group(1));
-            int fromMediaIndex = Integer.parseInt(dragUnassignedPageMatcher.group(1));
-            GalleryMediaContent mediaContent = getUnassignedMedias().get(fromMediaIndex);
-            GalleryStripe toStripe = stripes.get(toStripeIndex);
-            toStripe.getStructure().getViews().add(mediaContent.getView());
-
-            // update stripe
             toStripe.getMedias().clear();
             for (View toStripeView : toStripe.getStructure().getViews()) {
                 toStripe.getMedias().add(createGalleryMediaContent(toStripeView));
@@ -380,17 +377,6 @@ public class GalleryPanel {
             }
         }
         return null;
-    }
-
-    /**
-     * Return list of all medias that are not assigned to a logical structure element.
-     *
-     * @return list of medias not assigned to a logical structure element
-     */
-    public List<GalleryMediaContent> getUnassignedMedias() {
-        return medias.stream()
-                .filter(c -> Objects.isNull(getLogicalStructureOfMedia(c)))
-                .collect(Collectors.toList());
     }
 
     GalleryMediaContent getGalleryMediaContent(View view) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.Logger;
 import org.kitodo.api.command.CommandResult;
 import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.MediaVariant;
+import org.kitodo.api.dataformat.View;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.filemanagement.FileManagementInterface;
 import org.kitodo.api.filemanagement.ProcessSubType;
@@ -987,7 +988,11 @@ public class FileService {
                     break;
                 }
             }
-            workpiece.getMediaUnits().add(insertionPoint, createMediaUnit(entry.getValue()));
+            MediaUnit mediaUnit = createMediaUnit(entry.getValue());
+            workpiece.getMediaUnit().getChildren().add(insertionPoint, mediaUnit);
+            View view = new View();
+            view.setMediaUnit(mediaUnit);
+            workpiece.getRootElement().getViews().add(view);
             canonicals.add(insertionPoint, entry.getKey());
         }
     }

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -233,6 +233,7 @@ dataEditor.mediaTree=Medien
 dataEditor.undefinedStructure=Die Einteilung ist im Regelsatz nicht bekannt
 dataEditor.undefinedKey=Der Schl\u00FCssel ist im Regelsatz nicht bekannt
 dataEditor.unlinkedMediaTree=Unverkn\u00FCpfte Medien
+dataEditor.unstructuredMedia=Unstrukturierte Medien
 dashboard=Dashboard
 dataPrivacy=Datenschutz
 # used in "LegalTexts.java"

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -233,6 +233,7 @@ dataEditor.mediaTree=Media
 dataEditor.undefinedStructure=The division isn't defined in the ruleset
 dataEditor.undefinedKey=The key isn't defined in the ruleset
 dataEditor.unlinkedMediaTree=Unlinked media
+dataEditor.unstructuredMedia=Unstructured media
 dashboard=Dashboard
 dataPrivacy=Data privacy
 # used in "LegalTexts.java"

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1699,7 +1699,7 @@ Column content
     color: var(--pure-white);
 }
 
-#imagePreviewForm\:unassignedPagesList .ui-datalist-item {
+#imagePreviewForm\:unstructuredMedia .ui-datalist-item {
     display: inline;
 }
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -71,9 +71,13 @@
                                 value="#{DataEditorForm.galleryPanel.stripes}"
                                 type="definition"
                                 binding="#{currentElement}">
-                        <h:outputText value="#{stripe.label}" style="font-weight: bold;"/>
+                        <!-- Index 0 of stripes is used to identify the logical root element. -->
+                        <h:outputText value="#{stripe.label}"
+                                      style="font-weight: bold;"
+                                      rendered="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe) ne 0}"/>
                         <!--@elvariable id="structuredThumbnail" type="org.kitodo.production.forms.dataeditor.GalleryMediaContent"-->
                         <p:dataList styleClass="structureElementDataList"
+                                    rendered="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe) ne 0}"
                                     id="structureElementDataList"
                                     var="media"
                                     value="#{stripe.medias}"
@@ -109,22 +113,23 @@
                         </p:droppable>
                     </p:dataList>
 
-                    <!-- Unassigned pages -->
-                    <h:outputText value="Unassigned pages"
+                    <!-- Unstructured media-->
+                    <h:outputText value="#{msgs['dataEditor.unstructuredMedia']}"
                                   styleClass="gallery-stripe-header"
                                   style="font-weight: bold;"/>
-                    <h:panelGroup id="unassignedPages"
+                    <h:panelGroup id="unstructuredMedia"
                                   layout="block">
+                        <!-- Index 0 of stripes is used to retrieve the logical root element. -->
                         <!--@elvariable id="currentMedia" type="org.kitodo.production.forms.dataeditor.GalleryMediaContent"-->
-                        <p:dataList id ="unassignedPagesList"
+                        <p:dataList id="unstructuredMediaList"
                                     styleClass="structureElementDataList"
-                                    value="#{DataEditorForm.galleryPanel.unassignedMedias}"
+                                    value="#{DataEditorForm.galleryPanel.stripes.get(0).medias}"
                                     binding="#{currentMedia}"
                                     var="media">
-                            <h:panelGroup id="unassignedPagePanel">
-                                <p:commandLink id="updateSelectedUnassignedPageLink"
+                            <h:panelGroup id="unstructuredMediaPanel">
+                                <p:commandLink id="updateSelectedUnstructuredMediaLink"
                                                action="#{DataEditorForm.galleryPanel.updateStructure(media)}"
-                                               update="structureTreeForm:physicalTree @this @(.active.thumbnail) imagePreviewForm:olWrapper">
+                                               update="structureTreeForm:physicalTree structureTreeForm:logicalTree @this @(.active.thumbnail) imagePreviewForm:olWrapper">
                                     <h:panelGroup layout="block"
                                                   styleClass="thumbnail-container">
                                         <p:outputPanel deferred="true"
@@ -141,8 +146,8 @@
                                     <f:setPropertyActionListener value="#{media}" target="#{DataEditorForm.galleryPanel.selectedMedia}"/>
                                 </p:commandLink>
                             </h:panelGroup>
-                            <p:draggable id="unassignedPagesDraggable"
-                                         for="imagePreviewForm:unassignedPagesList:#{currentMedia.rowIndex}:unassignedPagePanel"
+                            <p:draggable id="unstructuredMediaDraggable"
+                                         for="imagePreviewForm:unstructuredMediaList:#{currentMedia.rowIndex}:unstructuredMediaPanel"
                                          revert="true"
                                          scope="assignedPagesDroppable"
                                          stack=".ui-panel"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -141,6 +141,9 @@
                                                 <f:param name="id"
                                                          value="#{media.id}"/>
                                             </p:graphicImage>
+                                            <h:panelGroup class="thumbnail-overlay">
+                                                #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
+                                            </h:panelGroup>
                                         </p:outputPanel>
                                     </h:panelGroup>
                                     <f:setPropertyActionListener value="#{media}" target="#{DataEditorForm.galleryPanel.selectedMedia}"/>


### PR DESCRIPTION
- images are initially assigned to the logical root element
- 'unassigned pages' is renamed to 'unstructured media' and displays all media assigned to the logical root element
- the logical root element is excluded from the structured view in the gallery column (now displayed under 'unstructured media')