### PR TITLE
Fix metadata editor errors

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -389,7 +389,7 @@ public class AddDocStrucTypeDialog {
                     newParent, dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
                 if (newParentDivisionView.getAllowedSubstructuralElements().containsKey(
                     dataEditor.getSelectedStructure().orElseThrow(IllegalStateException::new).getType())) {
-                    docStructAddTypeSelectionItemsForChildren.add(new SelectItem(newParent, entry.getValue()));
+                    docStructAddTypeSelectionItemsForParent.add(new SelectItem(newParent, entry.getValue()));
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -216,8 +216,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         galleryPanel.show();
         paginationPanel.show();
 
-        addDocStrucTypeDialog.prepare();
-        addMediaUnitDialog.prepare();
         editPagesDialog.prepare();
 
         if (logger.isTraceEnabled()) {
@@ -443,7 +441,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     void switchStructure(Object treeNodeData) throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         metadataPanel.preserveLogical();
         metadataPanel.showLogical(structurePanel.getSelectedStructure());
-        addDocStrucTypeDialog.prepare();
         if (Objects.nonNull(treeNodeData) && treeNodeData instanceof  StructureTreeNode) {
             StructureTreeNode structureTreeNode = (StructureTreeNode) treeNodeData;
             if (Objects.nonNull(structureTreeNode.getDataObject())) {
@@ -471,7 +468,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     void switchMediaUnit() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         metadataPanel.preservePhysical();
         metadataPanel.showPhysical(structurePanel.getSelectedMediaUnit());
-        addMediaUnitDialog.prepare();
         if (structurePanel.getSelectedMediaUnit().isPresent()) {
             // update gallery
             galleryPanel.updateSelection(structurePanel.getSelectedMediaUnit().get());

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -38,8 +38,8 @@
             <p:ajax event="dragdrop"
                     listener="#{DataEditorForm.structurePanel.onDragDrop}"
                     update="structureTreeForm:structureWrapperPanel,paginationForm:paginationWrapperPanel,metadataAccordion:logicalMetadataWrapperPanel,commentWrapperPanel,galleryWrapperPanel,dialogEditPages,addMetadataForm"/>
-            <p:treeNode expandedIcon="ui-icon-document"
-                        collapsedIcon="ui-icon-document">
+            <p:treeNode expandedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-open'}"
+                        collapsedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-collapsed'}">
                 <!--@elvariable id="logicalElementType" type="java.lang.String"-->
                 <ui:param name="logicalElementType" value="#{logicalNode.label}"/>
                 <h:outputText value="#{logicalElementType}" style="#{logicalNode.undefined ? 'background-color: gold' : ''}"/>
@@ -89,8 +89,8 @@
                 <p:ajax event="dragdrop"
                         listener="#{DataEditorForm.structurePanel.onDragDrop}"
                         update="structureTreeForm:structureWrapperPanel,paginationForm:paginationWrapperPanel,metadataAccordion:physicalMetadataWrapperPanel,commentWrapperPanel,galleryWrapperPanel,dialogEditPages,addMetadataForm"/>
-                <p:treeNode expandedIcon="ui-icon-document"
-                            collapsedIcon="ui-icon-document">
+                <p:treeNode expandedIcon="#{physicalNode.dataObject.type eq 'page' ? 'ui-icon-document' : 'ui-icon-folder-open'}"
+                            collapsedIcon="#{physicalNode.dataObject.type eq 'page' ? 'ui-icon-document' : 'ui-icon-folder-collapsed'}">
                     <!--@elvariable id="physicalElementType" type="java.lang.String"-->
                     <ui:param name="physicalElementType" value="#{physicalNode.label}"/>
                     <h:outputText value="#{physicalElementType}" style="#{physicalNode.undefined ? 'background-color: gold' : ''}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/deleteChildrenDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/deleteChildrenDialog.xhtml
@@ -30,28 +30,30 @@
         </h:outputFormat></p>
         <p:panelGrid>
             <p:row>
-                <p:commandButton id="deleteChildrenButton"
-                                 action="#{ProcessForm.deleteWithChildren}"
-                                 onstart="PF('deleteChildrenDialog').hide();"
-                                 update="@all"
-                                 styleClass="primary right"
-                                 value="#{msgs.yes}"
-                                 icon="fa fa-check"
-                                 iconPos="right"/>
-                <p:commandButton id="preserveChildrenButton"
-                                 action="#{ProcessForm.deleteWithoutChildren}"
-                                 onstart="PF('deleteChildrenDialog').hide();"
-                                 update="@all"
-                                 styleClass="secondary right"
-                                 value="#{msgs.no}"
-                                 icon="fa fa-close"
-                                 iconPos="right"/>
-                <p:commandButton value="#{msgs.cancel}"
-                                 immediate="true"
-                                 icon="fa fa-times fa-lg"
-                                 iconPos="right"
-                                 styleClass="secondary right"
-                                 onclick="PF('deleteChildrenDialog').hide();"/>
+                <h:form id="deleteChildrenForm">
+                    <p:commandButton id="deleteChildrenButton"
+                                     action="#{ProcessForm.deleteWithChildren}"
+                                     onstart="PF('deleteChildrenDialog').hide();"
+                                     update="@all"
+                                     styleClass="primary right"
+                                     value="#{msgs.yes}"
+                                     icon="fa fa-check"
+                                     iconPos="right"/>
+                    <p:commandButton id="preserveChildrenButton"
+                                     action="#{ProcessForm.deleteWithoutChildren}"
+                                     onstart="PF('deleteChildrenDialog').hide();"
+                                     update="@all"
+                                     styleClass="secondary right"
+                                     value="#{msgs.no}"
+                                     icon="fa fa-close"
+                                     iconPos="right"/>
+                    <p:commandButton value="#{msgs.cancel}"
+                                     immediate="true"
+                                     icon="fa fa-times fa-lg"
+                                     iconPos="right"
+                                     styleClass="secondary right"
+                                     onclick="PF('deleteChildrenDialog').hide();"/>
+                </h:form>
             </p:row>
         </p:panelGrid>
     </p:dialog>

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -91,7 +91,8 @@
                         </div>
                         <p:panel id="secondColumnPanel">
                             <div id="metadataPanel" data-min-height="100" class="#{viewMetadata ? '' : 'collapsed'}">
-                                <p:accordionPanel id="metadataAccordion">
+                                <p:accordionPanel id="metadataAccordion"
+                                                  multiple="true">
                                     <p:tab title="#{DataEditorForm.structurePanel.separateMedia ? msgs.logical : ''} #{msgs.metadata}">
                                         <ui:include src="/WEB-INF/templates/includes/metadataEditor/logicalMetadata.xhtml" />
                                     </p:tab>


### PR DESCRIPTION
Fixes an error that could occur when the user selected a logical structure element in the combined (`separateMedia = false`) structure tree after selecting a page in the same tree.