### PR TITLE
Prevent double save of folders added to project

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
@@ -234,6 +234,7 @@ public class ProjectForm extends BaseForm {
                 }
                 this.deletedTemples = new ArrayList<>();
 
+                this.project = ServiceManager.getProjectService().getById(this.project.getId());
                 ServiceManager.getProjectService().save(this.project);
 
                 return projectListPath;


### PR DESCRIPTION
Getting object before final save to index and database prevents that newly inserted folders are saved double.