### PR TITLE
Add XSLT for export internal format to DFG Viewer

### DIFF
--- a/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
+++ b/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
@@ -45,11 +45,13 @@
 
         <xsl:variable name="recordIdentifier" select="kitodo:metadata[@name='CatalogIDDigital']"/>
 
-        <mods:titleInfo>
-            <mods:title>
-                <xsl:value-of select="$title"/>
-            </mods:title>
-        </mods:titleInfo>
+        <xsl:if test="$title">
+            <mods:titleInfo>
+                <mods:title>
+                    <xsl:value-of select="$title"/>
+                </mods:title>
+            </mods:titleInfo>
+        </xsl:if>
 
         <xsl:choose>
             <xsl:when test="$role='author'">
@@ -76,40 +78,58 @@
             </xsl:when>
         </xsl:choose>
 
-        <mods:originInfo eventType="publication">
-            <mods:place>
-                <mods:placeTerm type="text">
-                    <xsl:value-of select="$place"/>
-                </mods:placeTerm>
-                <mods:publisher>
-                    <xsl:value-of select="$publisher"/>
-                </mods:publisher>
-                <mods:dateIssued keyDate="yes" encoding="iso8601">
-                    <xsl:value-of select="$dateIssued"/>
-                </mods:dateIssued>
-            </mods:place>
-        </mods:originInfo>
+        <xsl:if test="$place or $publisher or $dateIssued">
+            <mods:originInfo eventType="publication">
+                <mods:place>
+                    <xsl:if test="$place">
+                        <mods:placeTerm type="text">
+                            <xsl:value-of select="$place"/>
+                        </mods:placeTerm>
+                    </xsl:if>
+                    <xsl:if test="$publisher">
+                        <mods:publisher>
+                            <xsl:value-of select="$publisher"/>
+                        </mods:publisher>
+                    </xsl:if>
+                    <xsl:if test="$dateIssued">
+                        <mods:dateIssued keyDate="yes" encoding="iso8601">
+                            <xsl:value-of select="$dateIssued"/>
+                        </mods:dateIssued>
+                    </xsl:if>
+                </mods:place>
+            </mods:originInfo>
+        </xsl:if>
 
-        <mods:physicalDescription>
-            <mods:extent>
-                <xsl:value-of select="$physicalDescription"/>
-            </mods:extent>
-        </mods:physicalDescription>
+        <xsl:if test="$physicalDescription">
+            <mods:physicalDescription>
+                <mods:extent>
+                    <xsl:value-of select="$physicalDescription"/>
+                </mods:extent>
+            </mods:physicalDescription>
+        </xsl:if>
 
-        <mods:location>
-            <mods:shelfLocator>
-                <xsl:value-of select="$shelfLocator"/>
-            </mods:shelfLocator>
-            <mods:url>
-                <xsl:value-of select="$url"/>
-            </mods:url>
-        </mods:location>
+        <xsl:if test="$shelfLocator or $url">
+            <mods:location>
+                <xsl:if test="$shelfLocator">
+                    <mods:shelfLocator>
+                        <xsl:value-of select="$shelfLocator"/>
+                    </mods:shelfLocator>
+                </xsl:if>
+                <xsl:if test="$url">
+                    <mods:url>
+                        <xsl:value-of select="$url"/>
+                    </mods:url>
+                </xsl:if>
+            </mods:location>
+        </xsl:if>
 
-        <mods:recordInfo>
-            <mods:recordIdentifier>
-                <xsl:value-of select="$recordIdentifier"/>
-            </mods:recordIdentifier>
-        </mods:recordInfo>
+        <xsl:if test="$recordIdentifier">
+            <mods:recordInfo>
+                <mods:recordIdentifier>
+                    <xsl:value-of select="$recordIdentifier"/>
+                </mods:recordIdentifier>
+            </mods:recordInfo>
+        </xsl:if>
     </xsl:template>
 
     <!-- pass-through rule -->

--- a/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
+++ b/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
@@ -27,20 +27,30 @@
         </mods:mods>
     </xsl:template>
 
-    <!-- ### TitleDocMain ### -->
-    <xsl:template match="kitodo:metadata[@name='TitleDocMain']">
+    <xsl:template match="kitodo:kitodo">
+        <xsl:variable name="title" select="kitodo:metadata[@name='TitleDocMain']"/>
+
+        <xsl:variable name="role" select="kitodo:metadataGroup[@name='Person']/kitodo:metadata[@name='Role']"/>
+        <xsl:variable name="last_name" select="kitodo:metadataGroup[@name='Person']/kitodo:metadata[@name='lastName']"/>
+        <xsl:variable name="first_name" select="kitodo:metadataGroup[@name='Person']/kitodo:metadata[@name='firstName']"/>
+
+        <xsl:variable name="place" select="kitodo:metadata[@name='PlaceOfPublication']"/>
+        <xsl:variable name="publisher" select="kitodo:metadata[@name='PublisherName']"/>
+        <xsl:variable name="dateIssued" select="kitodo:metadata[@name='PublicationYear']"/>
+
+        <xsl:variable name="physicalDescription" select="kitodo:metadata[@name='FormatSourcePrint']"/>
+
+        <xsl:variable name="shelfLocator" select="kitodo:metadata[@name='shelfmarksource']"/>
+        <xsl:variable name="url" select="kitodo:metadata[@name='slub_link']"/>
+
+        <xsl:variable name="recordIdentifier" select="kitodo:metadata[@name='CatalogIDDigital']"/>
+
         <mods:titleInfo>
             <mods:title>
-                <xsl:value-of select="normalize-space()"/>
+                <xsl:value-of select="$title"/>
             </mods:title>
         </mods:titleInfo>
-    </xsl:template>
 
-    <!-- ### Author, slub_Recipient ### -->
-    <xsl:template match="kitodo:metadataGroup[@name='Person']">
-        <xsl:variable name="role" select="../kitodo:metadata[@name='Role']"/>
-        <xsl:variable name="last_name" select="../kitodo:metadata[@name='lastName']"/>
-        <xsl:variable name="first_name" select="../kitodo:metadata[@name='firstName']"/>
         <xsl:choose>
             <xsl:when test="$role='author'">
                 <mods:name>
@@ -65,71 +75,41 @@
                 </mods:name>
             </xsl:when>
         </xsl:choose>
-    </xsl:template>
 
-    <!-- ### PlaceOfPublication ### -->
-    <xsl:template match="kitodo:metadata[@name='PlaceOfPublication']">
         <mods:originInfo eventType="publication">
             <mods:place>
                 <mods:placeTerm type="text">
-                    <xsl:value-of select="normalize-space()"/>
+                    <xsl:value-of select="$place"/>
                 </mods:placeTerm>
+                <mods:publisher>
+                    <xsl:value-of select="$publisher"/>
+                </mods:publisher>
+                <mods:dateIssued keyDate="yes" encoding="iso8601">
+                    <xsl:value-of select="$dateIssued"/>
+                </mods:dateIssued>
             </mods:place>
         </mods:originInfo>
-    </xsl:template>
 
-    <!-- ### PublisherName ### -->
-    <xsl:template match="kitodo:metadata[@name='PublisherName']">
-        <mods:originInfo eventType="publication">
-            <mods:publisher>
-                <xsl:value-of select="normalize-space()"/>
-            </mods:publisher>
-        </mods:originInfo>
-    </xsl:template>
-
-    <!-- ### PublicationYear ### -->
-    <xsl:template match="kitodo:metadata[@name='PublicationYear']">
-        <mods:originInfo eventType="publication">
-            <mods:dateIssued keyDate="yes" encoding="iso8601">
-                <xsl:value-of select="normalize-space()"/>
-            </mods:dateIssued>
-        </mods:originInfo>
-    </xsl:template>
-
-    <!-- ### ShelfMarkSource ### -->
-    <xsl:template match="kitodo:metadata[@name='shelfmarksource']">
-        <mods:location>
-            <mods:shelfLocator>
-                <xsl:value-of select="normalize-space()"/>
-            </mods:shelfLocator>
-        </mods:location>
-    </xsl:template>
-
-    <!-- ### FormatSourcePrint ### -->
-    <xsl:template match="kitodo:metadata[@name='FormatSourcePrint']">
         <mods:physicalDescription>
             <mods:extent>
-                <xsl:value-of select="normalize-space()"/>
+                <xsl:value-of select="$physicalDescription"/>
             </mods:extent>
         </mods:physicalDescription>
-    </xsl:template>
 
-    <!-- ### CatalogIDDigital ### -->
-    <xsl:template match="kitodo:metadata[@name='CatalogIDDigital']">
-        <mods:recordInfo>
-            <mods:recordIdentifier>
-                <xsl:value-of select="normalize-space()"/>
-            </mods:recordIdentifier>
-        </mods:recordInfo>
-    </xsl:template>
-
-    <!-- ### slub_link, slub_linktext ### -->
-    <xsl:template match="kitodo:metadata[@name='slub_link']">
         <mods:location>
+            <mods:shelfLocator>
+                <xsl:value-of select="$shelfLocator"/>
+            </mods:shelfLocator>
             <mods:url>
-                <xsl:value-of select="normalize-space()"/>
+                <xsl:value-of select="$url"/>
             </mods:url>
         </mods:location>
+
+        <mods:recordInfo>
+            <mods:recordIdentifier>
+                <xsl:value-of select="$recordIdentifier"/>
+            </mods:recordIdentifier>
+        </mods:recordInfo>
     </xsl:template>
 
     <!-- pass-through rule -->

--- a/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
+++ b/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mets="http://www.loc.gov/METS/"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:kitodo="http://meta.kitodo.org/v1/"
+>
+    <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="/">
+        <mods:mods>
+            <xsl:apply-templates/>
+        </mods:mods>
+    </xsl:template>
+
+    <!-- ### TitleDocMain ### -->
+    <xsl:template match="kitodo:metadata[@name='TitleDocMain']">
+        <mods:titleInfo>
+            <mods:title>
+                <xsl:value-of select="normalize-space()"/>
+            </mods:title>
+        </mods:titleInfo>
+    </xsl:template>
+
+    <!-- ### Author, slub_Recipient ### -->
+    <xsl:template match="kitodo:metadataGroup[@name='Person']">
+        <xsl:variable name="role" select="../kitodo:metadata[@name='Role']"/>
+        <xsl:variable name="last_name" select="../kitodo:metadata[@name='lastName']"/>
+        <xsl:variable name="first_name" select="../kitodo:metadata[@name='firstName']"/>
+        <xsl:choose>
+            <xsl:when test="$role='author'">
+                <mods:name>
+                    <mods:namePart type="family">
+                        <xsl:value-of select="$last_name"/>
+                    </mods:namePart>
+                    <mods:namePart type="given">
+                        <xsl:value-of select="$first_name"/>
+                    </mods:namePart>
+                    <mods:displayForm>
+                        <xsl:value-of select="$last_name"/>,
+                        <xsl:value-of select="$first_name"/>
+                    </mods:displayForm>
+                    <mods:role>
+                        <mods:roleTerm type="code" authority="marcrelator">
+                            aut
+                        </mods:roleTerm>
+                        <mods:roleTerm type="text" authority="marcrelator">
+                            Author
+                        </mods:roleTerm>
+                    </mods:role>
+                </mods:name>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- ### PlaceOfPublication ### -->
+    <xsl:template match="kitodo:metadata[@name='PlaceOfPublication']">
+        <mods:originInfo eventType="publication">
+            <mods:place>
+                <mods:placeTerm type="text">
+                    <xsl:value-of select="normalize-space()"/>
+                </mods:placeTerm>
+            </mods:place>
+        </mods:originInfo>
+    </xsl:template>
+
+    <!-- ### PublisherName ### -->
+    <xsl:template match="kitodo:metadata[@name='PublisherName']">
+        <mods:originInfo eventType="publication">
+            <mods:publisher>
+                <xsl:value-of select="normalize-space()"/>
+            </mods:publisher>
+        </mods:originInfo>
+    </xsl:template>
+
+    <!-- ### PublicationYear ### -->
+    <xsl:template match="kitodo:metadata[@name='PublicationYear']">
+        <mods:originInfo eventType="publication">
+            <mods:dateIssued keyDate="yes" encoding="iso8601">
+                <xsl:value-of select="normalize-space()"/>
+            </mods:dateIssued>
+        </mods:originInfo>
+    </xsl:template>
+
+    <!-- ### ShelfMarkSource ### -->
+    <xsl:template match="kitodo:metadata[@name='shelfmarksource']">
+        <mods:location>
+            <mods:shelfLocator>
+                <xsl:value-of select="normalize-space()"/>
+            </mods:shelfLocator>
+        </mods:location>
+    </xsl:template>
+
+    <!-- ### FormatSourcePrint ### -->
+    <xsl:template match="kitodo:metadata[@name='FormatSourcePrint']">
+        <mods:physicalDescription>
+            <mods:extent>
+                <xsl:value-of select="normalize-space()"/>
+            </mods:extent>
+        </mods:physicalDescription>
+    </xsl:template>
+
+    <!-- ### CatalogIDDigital ### -->
+    <xsl:template match="kitodo:metadata[@name='CatalogIDDigital']">
+        <mods:recordInfo>
+            <mods:recordIdentifier>
+                <xsl:value-of select="normalize-space()"/>
+            </mods:recordIdentifier>
+        </mods:recordInfo>
+    </xsl:template>
+
+    <!-- ### slub_link, slub_linktext ### -->
+    <xsl:template match="kitodo:metadata[@name='slub_link']">
+        <mods:location>
+            <mods:url>
+                <xsl:value-of select="normalize-space()"/>
+            </mods:url>
+        </mods:location>
+    </xsl:template>
+
+    <!-- pass-through rule -->
+    <xsl:template match="@*|node()">
+        <xsl:apply-templates select="@*|node()"/>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Script contains all obligatory fields for DFG Viewer. Names of kitodo metadata elements are based on ruleset https://github.com/kitodo/kitodo-production/blob/master/Kitodo/rulesets/subhh.xml .

@solth and @sebastian-meyer : it would be nice if you could leave here your reviews :)