### PR TITLE
Add possibility for migrating template tasks to workflow

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/migration/TemplateConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/migration/TemplateConverter.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.migration;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.URI;
+import java.util.Comparator;
+import java.util.List;
+
+import org.kitodo.config.ConfigCore;
+import org.kitodo.data.database.beans.Task;
+import org.kitodo.data.database.beans.Template;
+import org.kitodo.production.services.ServiceManager;
+
+public class TemplateConverter {
+
+    /**
+     * Convert given template to workflow file.
+     * 
+     * @param template
+     *            for conversion
+     */
+    public void convertTemplateToWorkflowFile(Template template) throws IOException {
+        String workflow = createWorkflow(template.getTitle(), template.getTasks());
+        saveFile(template.getTitle(), workflow);
+    }
+
+    /**
+     * Convert given tasks to workflow file.
+     * 
+     * @param title
+     *            for workflow
+     * @param tasks
+     *            for conversion
+     */
+    public void convertTemplateToWorkflowFile(String title, List<Task> tasks) throws IOException {
+        String workflow = createWorkflow(title, tasks);
+        saveFile(title, workflow);
+    }
+
+    private String createWorkflow(String title, List<Task> tasks) {
+        tasks.sort(Comparator.comparing(Task::getOrdering));
+
+        StringBuilder xmlDiagram = new StringBuilder(
+                "<bpmn2:definitions xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "                   xmlns:bpmn2=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"\n"
+                        + "                   xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\"\n"
+                        + "                   xmlns:dc=\"http://www.omg.org/spec/DD/20100524/DC\"\n"
+                        + "                   xmlns:di=\"http://www.omg.org/spec/DD/20100524/DI\"\n"
+                        + "                   xmlns:template=\"http://www.kitodo.org/template\" id=\"sample-diagram\"\n"
+                        + "                   targetNamespace=\"http://bpmn.io/schema/bpmn\"\n"
+                        + "                   xsi:schemaLocation=\"http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd\">\n"
+                        + "    <bpmn2:process id=\"" + title + "\" name=\"" + title + "\" isExecutable=\"false\"\n"
+                        + "                   template:outputName=\"" + title + "\">\n"
+                        + "        <bpmn2:startEvent id=\"StartEvent_1\">\n"
+                        + "            <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>\n"
+                        + "        </bpmn2:startEvent>\n");
+
+        convertTasksToXmlWorkflow(xmlDiagram, tasks);
+        XmlGenerator.generateEndEvent(xmlDiagram, tasks.size());
+
+        XmlGenerator.generateBpmnDiagram(xmlDiagram, title);
+        convertTasksToWorkflowCoordinates(xmlDiagram, tasks);
+        XmlGenerator.generateCloseBpmnDiagram(xmlDiagram);
+
+        return xmlDiagram.toString();
+    }
+
+    private void convertTasksToXmlWorkflow(StringBuilder diagram, List<Task> tasks) {
+        for (Task task : tasks) {
+            if (task.getOrdering().equals(1)) {
+                diagram.append(XmlGenerator.generateTask(task, "StartEvent_1", "Task_" + task.getOrdering()));
+            } else {
+                diagram.append(XmlGenerator.generateTask(task));
+            }
+        }
+    }
+
+    private void convertTasksToWorkflowCoordinates(StringBuilder diagram, List<Task> tasks) {
+        int xAxe = 498;
+
+        for (Task task : tasks) {
+            diagram.append(XmlGenerator.generateTaskShape(task.getOrdering(), xAxe));
+            xAxe = xAxe + 150;
+        }
+
+        XmlGenerator.generateBpmnEndEvent(diagram, xAxe);
+    }
+
+    private void saveFile(String title, String fileContent) throws IOException {
+        URI xmlDiagramURI = new File(ConfigCore.getKitodoDiagramDirectory() + title + ".bpmn20.xml").toURI();
+
+        try (OutputStream outputStream = ServiceManager.getFileService().write(xmlDiagramURI);
+                BufferedWriter bufferedWriter = new BufferedWriter(new OutputStreamWriter(outputStream))) {
+            bufferedWriter.write(fileContent);
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/migration/XmlGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/migration/XmlGenerator.java
@@ -1,0 +1,250 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.migration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kitodo.data.database.beans.Role;
+import org.kitodo.data.database.beans.Task;
+
+class XmlGenerator {
+
+    private static final String END_LINE = "\">\n";
+    private static final String SLASH_END_LINE = "\"/>\n";
+    private static final String QUOTES = "\" ";
+    private static final String OPEN_LABEL = "                <bpmndi:BPMNLabel>\n";
+    private static final String CLOSE_LABEL = "                </bpmndi:BPMNLabel>\n";
+    private static final String CLOSE_SHAPE = "            </bpmndi:BPMNShape>\n";
+
+    private XmlGenerator() {
+        // private constructor for static class
+    }
+
+    /**
+     * Generate task.
+     * 
+     * @param task
+     *            for generating
+     * @return generated task
+     */
+    static String generateTask(Task task) {
+        return generateTask(task, "Task_" + (task.getOrdering() - 1), "Task_" + task.getOrdering());
+    }
+
+    /**
+     * Generate task.
+     * 
+     * @param task
+     *            for generating
+     * @param sourceReference
+     *            for sequence flow
+     * @param targetReference
+     *            for sequence flow
+     * @return generated task
+     */
+    static String generateTask(Task task, String sourceReference, String targetReference) {
+        StringBuilder taskBuilder = new StringBuilder();
+
+        openTask(taskBuilder, task);
+
+        taskBuilder.append("id=\"Task_");
+        taskBuilder.append(task.getOrdering());
+        taskBuilder.append(QUOTES);
+
+        taskBuilder.append("name=\"");
+        taskBuilder.append(task.getTitle());
+        taskBuilder.append(QUOTES);
+
+        generateTemplateTaskProperty(taskBuilder, "editType", task.getEditType().getValue());
+        generateTemplateTaskProperty(taskBuilder, "processingStatus", task.getProcessingStatus().getValue());
+        generateTemplateTaskProperty(taskBuilder, "concurrent", task.isConcurrent());
+        generateTemplateTaskProperty(taskBuilder, "typeMetadata", task.isTypeMetadata());
+        generateTemplateTaskProperty(taskBuilder, "separateStructure", task.isSeparateStructure());
+        generateTemplateTaskProperty(taskBuilder, "typeAutomatic", task.isTypeAutomatic());
+        generateTemplateTaskProperty(taskBuilder, "typeExportDMS", task.isTypeExportDMS());
+        generateTemplateTaskProperty(taskBuilder, "typeImagesRead", task.isTypeImagesRead());
+        generateTemplateTaskProperty(taskBuilder, "typeImagesWrite", task.isTypeImagesRead());
+        generateTemplateTaskProperty(taskBuilder, "typeAcceptClose", task.isTypeAcceptClose());
+        generateTemplateTaskProperty(taskBuilder, "typeCloseVerify", task.isTypeCloseVerify());
+        generateTemplateTaskProperty(taskBuilder, "batchStep", task.isBatchStep());
+        generateTemplateTaskProperty(taskBuilder, "repeatOnCorrection", task.isRepeatOnCorrection());
+
+        if (!task.getRoles().isEmpty()) {
+            taskBuilder.append("template:permittedUserRole=\"");
+            for (Role role : task.getRoles()) {
+                taskBuilder.append(role.getId());
+                taskBuilder.append(",");
+            }
+            taskBuilder.deleteCharAt(taskBuilder.length() - 1);
+            taskBuilder.append(QUOTES);
+        }
+
+        if (StringUtils.isNotBlank(task.getScriptName()) || StringUtils.isNotBlank(task.getScriptPath())) {
+            generateTemplateTaskProperty(taskBuilder, "scriptName", task.getScriptName());
+            generateTemplateTaskProperty(taskBuilder, "scriptPath", task.getScriptPath());
+        }
+
+        taskBuilder.append(">\n");
+
+        generateSequences(taskBuilder, task.getOrdering());
+        closeTask(taskBuilder, task);
+        generateSequenceFlow(taskBuilder, task.getOrdering(), sourceReference, targetReference);
+
+        return taskBuilder.toString();
+    }
+
+    static void generateEndEvent(StringBuilder diagram, int tasksSize) {
+        diagram.append("<bpmn2:endEvent id=\"EndEvent_1\">\n");
+        diagram.append("            <bpmn2:incoming>SequenceFlow_");
+        diagram.append(tasksSize + 1);
+        diagram.append("</bpmn2:incoming>\n");
+        diagram.append("        </bpmn2:endEvent>\n");
+        diagram.append("<bpmn2:sequenceFlow id=\"SequenceFlow_");
+        diagram.append(tasksSize + 1);
+        diagram.append("\" sourceRef=\"Task_");
+        diagram.append(tasksSize);
+        diagram.append("\" targetRef=\"EndEvent_1\"/>\n");
+        diagram.append("    </bpmn2:process>\n");
+    }
+
+    private static void openTask(StringBuilder taskBuilder, Task task) {
+        if (StringUtils.isNotBlank(task.getScriptName()) || StringUtils.isNotBlank(task.getScriptPath())) {
+            taskBuilder.append("        <bpmn2:scriptTask ");
+        } else {
+            taskBuilder.append("        <bpmn2:task ");
+        }
+    }
+
+    private static void closeTask(StringBuilder taskBuilder, Task task) {
+        if (StringUtils.isNotBlank(task.getScriptName()) || StringUtils.isNotBlank(task.getScriptPath())) {
+            taskBuilder.append("        </bpmn2:scriptTask>\n");
+        } else {
+            taskBuilder.append("        </bpmn2:task>\n");
+        }
+    }
+
+    private static void generateTemplateTaskProperty(StringBuilder taskBuilder, String propertyName, Object propertyValue) {
+        taskBuilder.append("template:");
+        taskBuilder.append(propertyName);
+        taskBuilder.append("=\"");
+        taskBuilder.append(propertyValue);
+        taskBuilder.append(QUOTES);
+    }
+
+    private static void generateSequences(StringBuilder taskBuilder, Integer ordering) {
+        taskBuilder.append("            <bpmn2:incoming>SequenceFlow_");
+        taskBuilder.append(ordering);
+        taskBuilder.append("</bpmn2:incoming>\n");
+        taskBuilder.append("            <bpmn2:outgoing>SequenceFlow_");
+        taskBuilder.append(ordering + 1);
+        taskBuilder.append("</bpmn2:outgoing>\n");
+    }
+
+    private static void generateSequenceFlow(StringBuilder taskBuilder, Integer ordering, String sourceReference, String targetReference) {
+        taskBuilder.append("        <bpmn2:sequenceFlow id=\"SequenceFlow_");
+        taskBuilder.append(ordering);
+        taskBuilder.append("\" sourceRef=\"");
+        taskBuilder.append(sourceReference);
+        taskBuilder.append("\" targetRef=\"");
+        taskBuilder.append(targetReference);
+        taskBuilder.append(SLASH_END_LINE);
+    }
+
+    /**
+     * Generate task shape to display in workflow editor.
+     * 
+     * @param taskOrdering
+     *            order of task for which task shape should be generated
+     * @param xAxe
+     *            reference coordinate
+     * @return task shape to display in workflow editor
+     */
+    static String generateTaskShape(Integer taskOrdering, int xAxe) {
+        StringBuilder taskBuilder = new StringBuilder();
+
+        final int yAxe = 218;
+
+        taskBuilder.append("            <bpmndi:BPMNShape id=\"Task_");
+        taskBuilder.append(taskOrdering);
+        taskBuilder.append("_di\" bpmnElement=\"Task_");
+        taskBuilder.append(taskOrdering);
+        taskBuilder.append(END_LINE);
+        generateBounds(taskBuilder, xAxe, yAxe, 100, 80);
+        taskBuilder.append(CLOSE_SHAPE);
+        taskBuilder.append("            <bpmndi:BPMNEdge id=\"SequenceFlow_");
+        taskBuilder.append(taskOrdering + 1);
+        taskBuilder.append("_di\" bpmnElement=\"SequenceFlow_");
+        taskBuilder.append(taskOrdering + 1);
+        taskBuilder.append(END_LINE);
+        generateWayPoint(taskBuilder, xAxe + 100, yAxe + 40);
+        generateWayPoint(taskBuilder, xAxe + 150, yAxe + 40);
+        taskBuilder.append(OPEN_LABEL);
+        generateBounds(taskBuilder, xAxe + 125, yAxe + 29, 0, 12);
+        taskBuilder.append(CLOSE_LABEL);
+        taskBuilder.append("            </bpmndi:BPMNEdge>\n");
+
+        return taskBuilder.toString();
+    }
+
+    static void generateBpmnDiagram(StringBuilder diagram, String title) {
+        final int xAxe = 498;
+
+        diagram.append("    <bpmndi:BPMNDiagram id=\"BPMNDiagram_1\">\n");
+        diagram.append("        <bpmndi:BPMNPlane id=\"BPMNPlane_1\" bpmnElement=\"");
+        diagram.append(title);
+        diagram.append(END_LINE);
+        diagram.append("            <bpmndi:BPMNShape id=\"_BPMNShape_StartEvent_1\" bpmnElement=\"StartEvent_1\">\n");
+        generateBounds(diagram, 412, 240, 36, 36);
+        diagram.append(CLOSE_SHAPE);
+        diagram.append("            <bpmndi:BPMNEdge id=\"SequenceFlow_1_di\" bpmnElement=\"SequenceFlow_1\">\n");
+        generateWayPoint(diagram, xAxe - 50, 258);
+        generateWayPoint(diagram, xAxe, 258);
+        diagram.append(OPEN_LABEL);
+        generateBounds(diagram, xAxe - 25, 237, 0, 12);
+        diagram.append(CLOSE_LABEL);
+        diagram.append("            </bpmndi:BPMNEdge>\n");
+    }
+
+    static void generateBpmnEndEvent(StringBuilder diagram, int xAxe) {
+        diagram.append("            <bpmndi:BPMNShape id=\"EndEvent_1_di\" bpmnElement=\"EndEvent_1\">\n");
+        generateBounds(diagram, xAxe, 240, 36, 36);
+        diagram.append(OPEN_LABEL);
+        generateBounds(diagram, xAxe + 18, 280, 0, 12);
+        diagram.append(CLOSE_LABEL);
+        diagram.append(CLOSE_SHAPE);
+    }
+
+    static void generateCloseBpmnDiagram(StringBuilder diagram) {
+        diagram.append("        </bpmndi:BPMNPlane>\n");
+        diagram.append("    </bpmndi:BPMNDiagram>\n");
+        diagram.append("</bpmn2:definitions>");
+    }
+
+    private static void generateBounds(StringBuilder diagram, int xAxe, int yAxe, int width, int height) {
+        diagram.append("                <dc:Bounds x=\"");
+        diagram.append(xAxe);
+        diagram.append("\" y=\"");
+        diagram.append(yAxe);
+        diagram.append("\" width=\"");
+        diagram.append(width);
+        diagram.append("\" height=\"");
+        diagram.append(height);
+        diagram.append(SLASH_END_LINE);
+    }
+
+    private static void generateWayPoint(StringBuilder diagram, int xAxe, int yAxe) {
+        diagram.append("                <di:waypoint x=\"");
+        diagram.append(xAxe);
+        diagram.append("\" y=\"");
+        diagram.append(yAxe);
+        diagram.append(SLASH_END_LINE);
+    }
+}

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -174,6 +174,7 @@ confirmDeleteRole=Rolle l\u00F6schen?
 confirmDeleteWorkflow=Workflow l\u00F6schen?
 confirmNewPassword=Neues Passwort best\u00E4tigen
 confirmRelease=Abgeben best\u00E4tigen
+convertTemplateToWorkflow=Vorlage in Workflow konvertieren
 copy=Kopie
 copyRolesToClient=Rollen zum Mandanten hinzuf\u00FCgen
 copyTemplates=Projekt inkl. Templates kopieren

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -174,6 +174,7 @@ confirmDeleteRole=Delete role?
 confirmDeleteWorkflow=Delete workflow?
 confirmNewPassword=Confirm new password
 confirmRelease=Confirm release
+convertTemplateToWorkflow=Convert template to workflow
 copy=copy
 copyRolesToClient=Copy roles to client
 copyTemplates=Copy Project including Templates

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
@@ -75,6 +75,13 @@
                                    message="#{msgs.confirmDeleteTemplate}"
                                    icon="ui-icon-alert"/>
                     </p:commandLink>
+
+                    <h:commandLink action="#{TemplateForm.convertTemplateToWorkflow()}" immediate="true"
+                                   title="#{msgs.convertTemplateToWorkflow}"
+                                   rendered="#{SecurityAccessController.hasAuthorityToAddWorkflow() and item.workflow.title eq ''}">
+                        <f:setPropertyActionListener value="#{item.id}" target="#{TemplateForm.templateById}"/>
+                        <h:outputText><i class="fa fa-random fa-lg"/></h:outputText>
+                    </h:commandLink>
                 </h:form>
             </h:outputText>
         </p:column>

--- a/Kitodo/src/test/java/org/kitodo/production/migration/TemplateConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/migration/TemplateConverterIT.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.migration;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.config.ConfigCore;
+import org.kitodo.data.database.beans.Template;
+import org.kitodo.production.services.ServiceManager;
+
+public class TemplateConverterIT {
+
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertProcessesFull();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldConvertTemplateToWorkflowFile() throws Exception {
+        Template template = ServiceManager.getTemplateService().getById(1);
+
+        TemplateConverter templateConverter = new TemplateConverter();
+        templateConverter.convertTemplateToWorkflowFile(template);
+
+        File xmlDiagram = new File(ConfigCore.getKitodoDiagramDirectory() + template.getTitle() + ".bpmn20.xml");
+        assertTrue("Template was not converted to xml file!", xmlDiagram.exists());
+
+        assertTrue(FileUtils.readFileToString(xmlDiagram, StandardCharsets.UTF_8)
+                .contains("<bpmn2:process id=\"First template\" name=\"First template\" isExecutable=\"false\"\n"
+                        + "                   template:outputName=\"First template\">"));
+
+        FileUtils.forceDelete(xmlDiagram);
+    }
+
+    @Test
+    public void shouldConvertTasksToWorkflowFile() throws Exception {
+        Template template = ServiceManager.getTemplateService().getById(1);
+
+        TemplateConverter templateConverter = new TemplateConverter();
+        templateConverter.convertTemplateToWorkflowFile(template.getTitle(), template.getTasks());
+
+        File xmlDiagram = new File(ConfigCore.getKitodoDiagramDirectory() + template.getTitle() + ".bpmn20.xml");
+        assertTrue("Template was not converted to xml file!", xmlDiagram.exists());
+
+        assertTrue(FileUtils.readFileToString(xmlDiagram, StandardCharsets.UTF_8)
+                .contains("<bpmn2:process id=\"First template\" name=\"First template\" isExecutable=\"false\"\n"
+                        + "                   template:outputName=\"First template\">"));
+
+        FileUtils.forceDelete(xmlDiagram);
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/migration/XmlGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/migration/XmlGeneratorIT.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.migration;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.Task;
+import org.kitodo.data.database.beans.Template;
+import org.kitodo.production.services.ServiceManager;
+
+public class XmlGeneratorIT {
+
+    private static Template template;
+
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertProcessesFull();
+
+        template = ServiceManager.getTemplateService().getById(1);
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Test
+    public void shouldGenerateTaskWithoutSourceTarget() {
+        Task task = template.getTasks().stream().filter(x -> x.getOrdering().equals(2)).findAny().orElse(null);
+
+        String taskString = XmlGenerator.generateTask(task);
+        String expected = "        <bpmn2:scriptTask id=\"Task_2\" name=\"Blocking\" template:editType=\"1\" "
+                + "template:processingStatus=\"3\" template:concurrent=\"false\" template:typeMetadata=\"false\" "
+                + "template:separateStructure=\"false\" template:typeAutomatic=\"false\" template:typeExportDMS=\"false\" "
+                + "template:typeImagesRead=\"false\" template:typeImagesWrite=\"false\" template:typeAcceptClose=\"false\" "
+                + "template:typeCloseVerify=\"false\" template:batchStep=\"false\" template:repeatOnCorrection=\"false\" "
+                + "template:permittedUserRole=\"1\" template:scriptName=\"scriptName\" "
+                + "template:scriptPath=\"../type/automatic/script/path\" >\n"
+                + "            <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>\n"
+                + "            <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>\n"
+                + "        </bpmn2:scriptTask>\n"
+                + "        <bpmn2:sequenceFlow id=\"SequenceFlow_2\" sourceRef=\"Task_1\" targetRef=\"Task_2\"/>\n";
+
+        assertEquals("Generate task is incorrect!", expected, taskString);
+    }
+
+    @Test
+    public void shouldGenerateTaskWithSourceTarget() {
+        Task task = template.getTasks().stream().filter(x -> x.getOrdering().equals(1)).findAny().orElse(null);
+
+        String taskString = XmlGenerator.generateTask(task, "StartEvent_1", "Task_1");
+        String expected = "        <bpmn2:task id=\"Task_1\" name=\"Finished\" template:editType=\"3\" "
+                + "template:processingStatus=\"3\" template:concurrent=\"false\" template:typeMetadata=\"false\" "
+                + "template:separateStructure=\"false\" template:typeAutomatic=\"false\" template:typeExportDMS=\"false\" "
+                + "template:typeImagesRead=\"false\" template:typeImagesWrite=\"false\" template:typeAcceptClose=\"false\" "
+                + "template:typeCloseVerify=\"false\" template:batchStep=\"false\" template:repeatOnCorrection=\"false\" "
+                + "template:permittedUserRole=\"1\" >\n"
+                + "            <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>\n"
+                + "            <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>\n"
+                + "        </bpmn2:task>\n"
+                + "        <bpmn2:sequenceFlow id=\"SequenceFlow_1\" sourceRef=\"StartEvent_1\" targetRef=\"Task_1\"/>\n";
+
+        assertEquals("Generate task is incorrect!", expected, taskString);
+    }
+
+    @Test
+    public void shouldGenerateTaskShape() {
+        String taskString = XmlGenerator.generateTaskShape(1, 498);
+
+        String expected = "            <bpmndi:BPMNShape id=\"Task_1_di\" bpmnElement=\"Task_1\">\n"
+                + "                <dc:Bounds x=\"498\" y=\"218\" width=\"100\" height=\"80\"/>\n"
+                + "            </bpmndi:BPMNShape>\n"
+                + "            <bpmndi:BPMNEdge id=\"SequenceFlow_2_di\" bpmnElement=\"SequenceFlow_2\">\n"
+                + "                <di:waypoint x=\"598\" y=\"258\"/>\n"
+                + "                <di:waypoint x=\"648\" y=\"258\"/>\n"
+                + "                <bpmndi:BPMNLabel>\n"
+                + "                <dc:Bounds x=\"623\" y=\"247\" width=\"0\" height=\"12\"/>\n"
+                + "                </bpmndi:BPMNLabel>\n"
+                + "            </bpmndi:BPMNEdge>\n";
+
+        assertEquals("Generate task shaped is incorrect!", expected, taskString);
+    }
+}


### PR DESCRIPTION
Idea:

- user with authority for adding workflow can see icon for converting template to workflow (icon appears only when template doesn't have yet workflow)
- after user click icon, new workflow is created (workflow xml file is create and workflow is inserted to database as draft) and user is redirect to workflow edit page, there he can check if everything is ok and set workflow as active

![kitodo](https://user-images.githubusercontent.com/9614459/60345990-82dd0380-99ba-11e9-8486-8572baa7a0db.png)
![kitodo2](https://user-images.githubusercontent.com/9614459/60345991-82dd0380-99ba-11e9-95f8-a93011f69bc8.png)

