### PR TITLE
Fix randomly failing selenium test

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UserEditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UserEditPage.java
@@ -140,32 +140,34 @@ public class UserEditPage extends EditPage<UserEditPage> {
     public void addUserToRole(String roleTitle) throws Exception {
         switchToTabByIndex(TabIndex.USER_ROLES.getIndex());
         addUserToRoleButton.click();
+		
+        await("Wait for visible role selection dialog").atMost(5, TimeUnit.SECONDS).ignoreExceptions()
+                .untilTrue(new AtomicBoolean(selectRoleTable.isDisplayed()));
+
         List<WebElement> tableRows = Browser.getRowsOfTable(selectRoleTable);
-        try {
-            addRow(tableRows, roleTitle, addToRoleDialog);
-        } catch (StaleElementReferenceException e) {
-            tableRows = Browser.getRowsOfTable(Browser.getDriver().findElement(By.id("roleForm:selectRoleTable_data")));
-            addToRoleDialog = Browser.getDriver().findElement(By.id("addRoleDialog"));
-            addRow(tableRows, roleTitle, addToRoleDialog);
-        }
+        addRow(tableRows, roleTitle, addToRoleDialog);
+        
     }
 
     public void addUserToClient(String clientName) throws Exception {
         switchToTabByIndex(TabIndex.USER_CLIENT_LIST.getIndex());
         addUserToClientButton.click();
+		
+        await("Wait for visible client selection dialog").atMost(5, TimeUnit.SECONDS).ignoreExceptions()
+                .untilTrue(new AtomicBoolean(selectClientTable.isDisplayed()));
+
         List<WebElement> tableRows = Browser.getRowsOfTable(selectClientTable);
-        try {
-            addRow(tableRows, clientName, addToClientDialog);
-        } catch (StaleElementReferenceException e) {
-            tableRows = Browser.getRowsOfTable(Browser.getDriver().findElement(By.id("userClientForm:selectClientTable_data")));
-            addToClientDialog = Browser.getDriver().findElement(By.id("addClientDialog"));
-            addRow(tableRows, clientName, addToClientDialog);
-        }
+		addRow(tableRows, clientName, addToClientDialog);
+        
     }
 
     public UserEditPage addUserToProject(String projectName) throws Exception {
         switchToTabByIndex(TabIndex.USER_PROJECT_LIST.getIndex());
         addUserToProjectButton.click();
+		
+        await("Wait for visible project selection dialog").atMost(5, TimeUnit.SECONDS).ignoreExceptions()
+     .untilTrue(new AtomicBoolean(selectProjectTable.isDisplayed()));
+		
         List<WebElement> tableRows = Browser.getRowsOfTable(selectProjectTable);
         addRow(tableRows, projectName, addToProjectDialog);
         return this;

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UserEditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UserEditPage.java
@@ -140,9 +140,9 @@ public class UserEditPage extends EditPage<UserEditPage> {
     public void addUserToRole(String roleTitle) throws Exception {
         switchToTabByIndex(TabIndex.USER_ROLES.getIndex());
         addUserToRoleButton.click();
-		
+
         await("Wait for visible role selection dialog").atMost(5, TimeUnit.SECONDS).ignoreExceptions()
-                .untilTrue(new AtomicBoolean(selectRoleTable.isDisplayed()));
+        .untilTrue(new AtomicBoolean(selectRoleTable.isDisplayed()));
 
         List<WebElement> tableRows = Browser.getRowsOfTable(selectRoleTable);
         addRow(tableRows, roleTitle, addToRoleDialog);
@@ -152,22 +152,22 @@ public class UserEditPage extends EditPage<UserEditPage> {
     public void addUserToClient(String clientName) throws Exception {
         switchToTabByIndex(TabIndex.USER_CLIENT_LIST.getIndex());
         addUserToClientButton.click();
-		
+
         await("Wait for visible client selection dialog").atMost(5, TimeUnit.SECONDS).ignoreExceptions()
-                .untilTrue(new AtomicBoolean(selectClientTable.isDisplayed()));
+        .untilTrue(new AtomicBoolean(selectClientTable.isDisplayed()));
 
         List<WebElement> tableRows = Browser.getRowsOfTable(selectClientTable);
-		addRow(tableRows, clientName, addToClientDialog);
+        addRow(tableRows, clientName, addToClientDialog);
         
     }
 
     public UserEditPage addUserToProject(String projectName) throws Exception {
         switchToTabByIndex(TabIndex.USER_PROJECT_LIST.getIndex());
         addUserToProjectButton.click();
-		
+
         await("Wait for visible project selection dialog").atMost(5, TimeUnit.SECONDS).ignoreExceptions()
-     .untilTrue(new AtomicBoolean(selectProjectTable.isDisplayed()));
-		
+        .untilTrue(new AtomicBoolean(selectProjectTable.isDisplayed()));
+
         List<WebElement> tableRows = Browser.getRowsOfTable(selectProjectTable);
         addRow(tableRows, projectName, addToProjectDialog);
         return this;
@@ -186,7 +186,7 @@ public class UserEditPage extends EditPage<UserEditPage> {
 
     private void openUserConfig() {
         await("Wait for visible user menu button").atMost(20, TimeUnit.SECONDS).ignoreExceptions()
-                .untilTrue(new AtomicBoolean(userMenuButton.isDisplayed()));
+        .untilTrue(new AtomicBoolean(userMenuButton.isDisplayed()));
 
         hoverWebElement(userMenuButton);
         hoverWebElement(userConfigButton);


### PR DESCRIPTION
I ran the selenium tests locally and discovered that the try-catch-block in these methods was always called. Without them the test `addUserTest()` would fail completely.

My guess is that the webdriver tries to act on these elements although they are not ready by a tiny fraction of a second. So it works sometimes but not always.

Therefore, `addUserTest()` seemingly fails at random. Subsequent tests will fail as well because the browser throws an alert to warn you about unsaved input when leaving the page.

![Screenshot 2019-06-28 at 14 55 09](https://user-images.githubusercontent.com/180686/60371543-d15dc280-99f9-11e9-98aa-95eecde79f3a.png)

This change fixes the test for me reliably.*





*Now something different will break in Travis when I publish this PR. 😝
