### PR TITLE
Trying to improve reliability of Selenium tests

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
@@ -93,7 +93,7 @@ public class Browser {
 
         if (!driverFile.exists()) {
             logger.debug(driverFile.getAbsolutePath() + " does not exist, providing chrome driver now");
-            WebDriverProvider.provideChromeDriver(CHROME_DRIVER_VERSION, DOWNLOAD_DIR, DRIVER_DIR);
+            WebDriverProvider.provideChromeDriver(DOWNLOAD_DIR, DRIVER_DIR);
         }
 
         ChromeDriverService service = new ChromeDriverService.Builder()

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
@@ -45,7 +45,6 @@ public class Browser {
     private static RemoteWebDriver webDriver;
     private static Actions actions;
     private static final String GECKO_DRIVER_VERSION = "0.19.1";
-    private static final String CHROME_DRIVER_VERSION = "2.40";
     private static boolean onTravis = false;
     private static BrowserType browserType = BrowserType.CHROME;
     private static final String USER_DIR = System.getProperty("user.dir");

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -35,7 +35,7 @@ public class WebDriverProvider {
     // https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
     // Please don't rely on the LATEST_RELEASE file without a version suffix.
     // It exists for backward compatibility only, and will be removed in the near future.
-    public static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_75";
+    private static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_75";
 
     private static UnArchiver zipUnArchiver = new ZipUnArchiver();
     private static UnArchiver tarGZipUnArchiver = new TarGZipUnArchiver();

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -171,7 +171,7 @@ public class WebDriverProvider {
 
     private static String fetchLatestStableChromeDriverVersion() {
 
-        String version = null;
+        String version = "";
         try {
 
             URL url = new URL(CHROME_DRIVER_LATEST_RELEASE_URL);

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -11,9 +11,12 @@
 
 package org.kitodo.selenium.testframework.helper;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URL;
+import java.net.URLConnection;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SystemUtils;
@@ -27,6 +30,12 @@ import org.kitodo.ExecutionPermission;
 public class WebDriverProvider {
 
     private static final Logger logger = LogManager.getLogger(WebDriverProvider.class);
+
+    // https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
+    // Please don't rely on the LATEST_RELEASE file without a version suffix.
+    // It exists for backward compatibility only, and will be removed in the near future.
+    public static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_75";
+
     private static UnArchiver zipUnArchiver = new ZipUnArchiver();
     private static UnArchiver tarGZipUnArchiver = new TarGZipUnArchiver();
 
@@ -50,13 +59,13 @@ public class WebDriverProvider {
             geckoDriverFileName = "geckodriver.exe";
             File geckoDriverZipFile = new File(downloadFolder + "geckodriver.zip");
             FileUtils.copyURLToFile(new URL(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-win64.zip"),
-                geckoDriverZipFile);
+                    geckoDriverZipFile);
             extractZipFileToFolder(geckoDriverZipFile, new File(extractFolder));
         } else if (SystemUtils.IS_OS_MAC_OSX) {
             geckoDriverFileName = "geckodriver";
             File geckoDriverTarFile = new File(downloadFolder + "geckodriver.tar.gz");
             FileUtils.copyURLToFile(new URL(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-macos.tar.gz"),
-                geckoDriverTarFile);
+                    geckoDriverTarFile);
             File theDir = new File(extractFolder);
             if (!theDir.exists()) {
                 theDir.mkdir();
@@ -66,7 +75,7 @@ public class WebDriverProvider {
             geckoDriverFileName = "geckodriver";
             File geckoDriverTarFile = new File(downloadFolder + "geckodriver.tar.gz");
             FileUtils.copyURLToFile(new URL(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-linux64.tar.gz"),
-                geckoDriverTarFile);
+                    geckoDriverTarFile);
             extractTarFileToFolder(geckoDriverTarFile, new File(extractFolder));
         }
         File geckoDriverFile = new File(extractFolder, geckoDriverFileName);
@@ -90,16 +99,15 @@ public class WebDriverProvider {
      * Downloads chrome driver, extracts archive file and set system property
      * "webdriver.chrome.driver". On Linux the method also sets executable
      * permission.
-     *
-     * @param chromeDriverVersion
-     *            The chrome driver version.
-     * @param downloadFolder
+     *  @param downloadFolder
      *            The folder in which the downloaded files will be put in.
-     * @param extractFolder
+     *  @param extractFolder
      *            The folder in which the extracted files will be put in.
      */
-    public static void provideChromeDriver(String chromeDriverVersion, String downloadFolder, String extractFolder)
+    public static void provideChromeDriver(String downloadFolder, String extractFolder)
             throws IOException {
+
+        String chromeDriverVersion = fetchLatestStableChromeDriverVersion();
 
         String chromeDriverUrl = "https://chromedriver.storage.googleapis.com/" + chromeDriverVersion + "/";
         String chromeDriverFileName;
@@ -158,5 +166,31 @@ public class WebDriverProvider {
     private static void extractTarFileToFolder(File file, File destinationFolder) {
         tarGZipUnArchiver.setSourceFile(file);
         tarGZipUnArchiver.extract("", destinationFolder);
+    }
+
+    private static String fetchLatestStableChromeDriverVersion() {
+
+        String version = null;
+        try {
+
+            URL url = new URL(CHROME_DRIVER_LATEST_RELEASE_URL);
+            URLConnection urlConnection = url.openConnection();
+
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
+
+            StringBuilder content = new StringBuilder();
+            content.append(bufferedReader.readLine());
+
+            bufferedReader.close();
+
+            version = content.toString();
+
+            logger.info("Latest Chrome Driver Release found: " + version);
+
+        } catch(Exception exception){
+            logger.error("Failed to fetch latest Chrome Driver Release");
+        }
+
+        return version;
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -189,7 +189,7 @@ public class WebDriverProvider {
             logger.info("Latest Chrome Driver Release found: " + version);
 
         } catch (MalformedURLException exception) {
-            logger.error("Failed to fetch latest Chrome Driver Release");
+            logger.error("URL for fetching Chrome Release is malformed.");
         } catch (IOException exception) {
             logger.error("Failed to fetch latest Chrome Driver Release");
         }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -187,7 +188,9 @@ public class WebDriverProvider {
 
             logger.info("Latest Chrome Driver Release found: " + version);
 
-        } catch(Exception exception){
+        } catch (MalformedURLException exception) {
+            logger.error("Failed to fetch latest Chrome Driver Release");
+        } catch (IOException exception) {
             logger.error("Failed to fetch latest Chrome Driver Release");
         }
 

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
@@ -13,6 +13,8 @@ package org.kitodo.selenium.testframework.pages;
 
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kitodo.selenium.testframework.Browser;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -35,6 +37,15 @@ abstract class EditPage<T> extends Page<T> {
         for (WebElement tableRow : tableRows) {
             if (Browser.getCellDataByRow(tableRow, 0).equals(title)) {
                 clickLinkOfTableRow(tableRow);
+
+                // Hold up a second…
+                try {
+                    Thread.sleep(1*1000);
+                } catch (InterruptedException e) {
+                    Logger logger = LogManager.getLogger(Browser.class);
+                    logger.error(e.getMessage());
+                }
+
                 Browser.closeDialog(dialog);
                 return;
             }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
@@ -40,7 +40,7 @@ abstract class EditPage<T> extends Page<T> {
 
                 // Hold up a second…
                 try {
-                    Thread.sleep(1*1000);
+                    Thread.sleep(1 * 1000);
                 } catch (InterruptedException e) {
                     Logger logger = LogManager.getLogger(Browser.class);
                     logger.error(e.getMessage());

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
@@ -44,7 +44,7 @@ abstract class EditPage<T> extends Page<T> {
                 try {
                     Thread.sleep(3 * 1000);
                 } catch (InterruptedException e) {
-                    Logger logger = LogManager.getLogger(Browser.class);
+                    Logger logger = LogManager.getLogger(EditPage.class);
                     logger.error(e.getMessage(), e);
                 }
 

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
@@ -20,6 +20,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 abstract class EditPage<T> extends Page<T> {
 
@@ -40,7 +42,7 @@ abstract class EditPage<T> extends Page<T> {
 
                 // Hold up a second…
                 try {
-                    Thread.sleep(1 * 1000);
+                    Thread.sleep(3 * 1000);
                 } catch (InterruptedException e) {
                     Logger logger = LogManager.getLogger(Browser.class);
                     logger.error(e.getMessage());
@@ -55,6 +57,10 @@ abstract class EditPage<T> extends Page<T> {
 
     private void clickLinkOfTableRow(WebElement tableRow) {
         WebElement link = tableRow.findElement(By.tagName("a"));
+        
+        WebDriverWait wait = new WebDriverWait(Browser.getDriver(), 5);
+        wait.until(ExpectedConditions.elementToBeClickable(link));
+
         link.click();
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
@@ -45,7 +45,7 @@ abstract class EditPage<T> extends Page<T> {
                     Thread.sleep(3 * 1000);
                 } catch (InterruptedException e) {
                     Logger logger = LogManager.getLogger(Browser.class);
-                    logger.error(e.getMessage());
+                    logger.error(e.getMessage(), e);
                 }
 
                 Browser.closeDialog(dialog);

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/EditPage.java
@@ -40,7 +40,7 @@ abstract class EditPage<T> extends Page<T> {
             if (Browser.getCellDataByRow(tableRow, 0).equals(title)) {
                 clickLinkOfTableRow(tableRow);
 
-                // Hold up a second…
+                // Hold up for some seconds…
                 try {
                     Thread.sleep(3 * 1000);
                 } catch (InterruptedException e) {
@@ -56,11 +56,10 @@ abstract class EditPage<T> extends Page<T> {
     }
 
     private void clickLinkOfTableRow(WebElement tableRow) {
-        WebElement link = tableRow.findElement(By.tagName("a"));
-        
-        WebDriverWait wait = new WebDriverWait(Browser.getDriver(), 5);
-        wait.until(ExpectedConditions.elementToBeClickable(link));
 
-        link.click();
+        WebDriverWait wait = new WebDriverWait(Browser.getDriver(), 5);
+        wait.until(ExpectedConditions.elementToBeClickable(tableRow.findElement(By.tagName("a"))));
+
+        tableRow.findElement(By.tagName("a")).click();
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UserEditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UserEditPage.java
@@ -23,6 +23,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static org.awaitility.Awaitility.await;
 import static org.kitodo.selenium.testframework.Browser.hoverWebElement;
@@ -140,32 +142,34 @@ public class UserEditPage extends EditPage<UserEditPage> {
     public void addUserToRole(String roleTitle) throws Exception {
         switchToTabByIndex(TabIndex.USER_ROLES.getIndex());
         addUserToRoleButton.click();
+
+        WebDriverWait wait = new WebDriverWait(Browser.getDriver(), 5);
+        wait.until(ExpectedConditions.elementToBeClickable(By.id(selectRoleTable.getAttribute("id"))));
+
         List<WebElement> tableRows = Browser.getRowsOfTable(selectRoleTable);
-        try {
-            addRow(tableRows, roleTitle, addToRoleDialog);
-        } catch (StaleElementReferenceException e) {
-            tableRows = Browser.getRowsOfTable(Browser.getDriver().findElement(By.id("roleForm:selectRoleTable_data")));
-            addToRoleDialog = Browser.getDriver().findElement(By.id("addRoleDialog"));
-            addRow(tableRows, roleTitle, addToRoleDialog);
-        }
+        addRow(tableRows, roleTitle, addToRoleDialog);
+
     }
 
     public void addUserToClient(String clientName) throws Exception {
         switchToTabByIndex(TabIndex.USER_CLIENT_LIST.getIndex());
         addUserToClientButton.click();
+
+        WebDriverWait wait = new WebDriverWait(Browser.getDriver(), 5);
+        wait.until(ExpectedConditions.elementToBeClickable(By.id(selectClientTable.getAttribute("id"))));
+
         List<WebElement> tableRows = Browser.getRowsOfTable(selectClientTable);
-        try {
-            addRow(tableRows, clientName, addToClientDialog);
-        } catch (StaleElementReferenceException e) {
-            tableRows = Browser.getRowsOfTable(Browser.getDriver().findElement(By.id("userClientForm:selectClientTable_data")));
-            addToClientDialog = Browser.getDriver().findElement(By.id("addClientDialog"));
-            addRow(tableRows, clientName, addToClientDialog);
-        }
+        addRow(tableRows, clientName, addToClientDialog);
+
     }
 
     public UserEditPage addUserToProject(String projectName) throws Exception {
         switchToTabByIndex(TabIndex.USER_PROJECT_LIST.getIndex());
         addUserToProjectButton.click();
+
+        WebDriverWait wait = new WebDriverWait(Browser.getDriver(), 5);
+        wait.until(ExpectedConditions.elementToBeClickable(By.id(selectProjectTable.getAttribute("id"))));
+
         List<WebElement> tableRows = Browser.getRowsOfTable(selectProjectTable);
         addRow(tableRows, projectName, addToProjectDialog);
         return this;


### PR DESCRIPTION
This PR addresses two issues with our Selenium tests.

1. Chrome WebDriver version severely outdated

There were sometimes errors in the log that the browser window could not be closed. We used the hard-coded version 2.40 of the Chrome WebDriver. This one is so old that it's not even listed on the current [release site](https://sites.google.com/a/chromium.org/chromedriver/downloads) and does not reliably support the latest Chrome release. In Travis we use the latest stable Chrome version so it makes sense to use the corresponding ChromeDriver as well. I added a call to fetch the latest release from the site and use that to download the ChromeDriver for use. Per documentation we have to make a call with the latest major release version of the Browser so when Chrome 76 is release we have to adjust that and so on. It might just work with an older version but in case Selenium tests get flaky again this would be a good place to start checking for adjustments.

2. Randomly failing test

I noticed that the test `addUserTest` is seemingly randomly failing on Travis. I could reproduce this locally as well. There seems to be some sort of race-condition or general flakiness in the test implementation.

First of all I replaced some try-catch-Blocks that were run *all the time* anyway. The `StaleElementReferenceException` is a sign that we tried to get a hold of an element that was later replaced via JS or something in the DOM and is no longer the real deal. So instead of getting an exception anyway and making a second selection, I added a waiting call to make sure the elements are ready for the test.

Nevertheless the test sometimes failed to close the dialog that pops up for selection roles/clients/projects. The following tests would fail because they would try to navigate away from the screen but the browser throws up an alert warning that changes will be lost.

![Screenshot 2019-06-28 at 14 55 09](https://user-images.githubusercontent.com/180686/60420843-f06e7700-9be8-11e9-852b-4cc5e9902f16.png)

My guess is that there's something going wrong with the dialog when a row is clicked and selected since the form has to be rebuild with updated information. That basically works but sometimes the browser tries to act too fast and gets a stale reference of the `close`-button and fails to click it. My fix is to wait a second before clicking and that seems to work. All my Travis-builds run on the first try.*





*I will get mad if this PR is not green on the first try though!