### PR TITLE
Fix query for distinct values from ES index

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
@@ -28,6 +28,7 @@ import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.enums.TaskStatus;
+import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.dto.ProjectDTO;
 import org.kitodo.production.enums.FilterString;
@@ -107,7 +108,7 @@ public class SearchForm {
         try {
             workpiecePropertiesTitlesDistinct = ServiceManager.getPropertyService()
                     .findWorkpiecePropertiesTitlesDistinct();
-        } catch (DataException e) {
+        } catch (DataException | DAOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
         this.masterpiecePropertyTitles = workpiecePropertiesTitlesDistinct;
@@ -136,7 +137,7 @@ public class SearchForm {
         List<String> processPropertiesTitlesDistinct = new ArrayList<>();
         try {
             processPropertiesTitlesDistinct = ServiceManager.getPropertyService().findProcessPropertiesTitlesDistinct();
-        } catch (DataException e) {
+        } catch (DataException | DAOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
         this.processPropertyTitles = processPropertiesTitlesDistinct;
@@ -156,7 +157,7 @@ public class SearchForm {
         List<String> taskTitles = new ArrayList<>();
         try {
             taskTitles = ServiceManager.getTaskService().findTaskTitlesDistinct();
-        } catch (DataException e) {
+        } catch (DataException | DAOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
         this.stepTitles = taskTitles;
@@ -170,7 +171,7 @@ public class SearchForm {
         try {
             templatePropertiesTitlesDistinct = ServiceManager.getPropertyService()
                     .findTemplatePropertiesTitlesDistinct();
-        } catch (DataException e) {
+        } catch (DataException | DAOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
         this.templatePropertyTitles = templatePropertiesTitlesDistinct;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -115,7 +115,7 @@ public class PropertyService extends TitleSearchService<Property, PropertyDTO, P
      *
      * @return a list of titles.
      */
-    public List<String> findWorkpiecePropertiesTitlesDistinct() throws DataException {
+    public List<String> findWorkpiecePropertiesTitlesDistinct() throws DataException, DAOException {
         return findDistinctTitles("workpiece");
     }
 
@@ -124,7 +124,7 @@ public class PropertyService extends TitleSearchService<Property, PropertyDTO, P
      *
      * @return a list of titles.
      */
-    public List<String> findTemplatePropertiesTitlesDistinct() throws DataException {
+    public List<String> findTemplatePropertiesTitlesDistinct() throws DataException, DAOException {
         return findDistinctTitles("template");
     }
 
@@ -133,12 +133,12 @@ public class PropertyService extends TitleSearchService<Property, PropertyDTO, P
      *
      * @return a list of titles.
      */
-    public List<String> findProcessPropertiesTitlesDistinct() throws DataException {
+    public List<String> findProcessPropertiesTitlesDistinct() throws DataException, DAOException {
         return findDistinctTitles("process");
     }
 
-    private List<String> findDistinctTitles(String type) throws DataException {
-        return findDistinctValues(getQueryForType(type), "title.keyword", true);
+    private List<String> findDistinctTitles(String type) throws DataException, DAOException {
+        return findDistinctValues(getQueryForType(type), "title.keyword", true, countDatabaseRows());
     }
 
     private QueryBuilder getQueryForType(String type) {
@@ -221,7 +221,7 @@ public class PropertyService extends TitleSearchService<Property, PropertyDTO, P
 
     /**
      * Transfer property for duplication.
-     * 
+     *
      * @param property
      *            as Property object
      * @return duplicated property as Property object

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -259,8 +259,8 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
      *
      * @return a list of titles
      */
-    public List<String> findTaskTitlesDistinct() throws DataException {
-        return findDistinctValues(QueryBuilders.matchAllQuery(), "title.keyword", true);
+    public List<String> findTaskTitlesDistinct() throws DataException, DAOException {
+        return findDistinctValues(QueryBuilders.matchAllQuery(), "title.keyword", true, countDatabaseRows());
     }
 
     @Override
@@ -482,7 +482,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
 
     /**
      * Make the necessary changes when performing an automatic task.
-     * 
+     *
      * @param task
      *            ongoing task
      * @param automatic
@@ -760,7 +760,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
     /**
      * The function determines, from projects, the folders whose contents can be
      * generated automatically.
-     * 
+     *
      * <p>
      * This feature is needed once by the task in the template to determine
      * which folders show buttons in the interface to turn content creation on
@@ -768,7 +768,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
      * to determine if there is at least one folder to be created in the task,
      * because then action links for generating are displayed, and not
      * otherwise.
-     * 
+     *
      * <p>
      * To create content automatically, a folder must be defined as the template
      * folder in the project. The templates serve to create the contents in the
@@ -777,7 +777,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
      * after a reconfiguration, this is still set as otherwise they would
      * overwrite themselves. Also, contents can not be created in folders where
      * nothing is configured. The folders that are left over can be created.
-     * 
+     *
      * @param projects
      *            an object stream of projects that may have folders defined
      *            whose contents can be auto-generated
@@ -791,7 +791,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
 
     /**
      * Only lets projects pass where a source folder is selected.
-     * 
+     *
      * @param projects
      *            the unpurified stream of projects
      * @return a stream only of projects that define a source to generate images
@@ -819,7 +819,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
     /**
      * Removes all folders to generate which do not have anything to generate
      * configured.
-     * 
+     *
      * @param folders
      *            a stream of folders
      * @return a stream only of those folders where an image generation module

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -777,13 +777,16 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      *            by which aggregation is going to be performed
      * @param sort
      *            asc true or false
+     * @param size
+     *            number of rows returned by query
      * @return sorted list of distinct values
      */
-    protected List<String> findDistinctValues(QueryBuilder query, String field, boolean sort) throws DataException {
+    protected List<String> findDistinctValues(QueryBuilder query, String field, boolean sort, long size) throws DataException {
         List<String> distinctValues = new ArrayList<>();
         try {
             Aggregations jsonObject = searcher.aggregateDocuments(query,
-                AggregationBuilders.terms(field).field(field).order(Terms.Order.aggregation("_term", sort)));
+                AggregationBuilders.terms(field).field(field).order(Terms.Order.aggregation("_term", sort))
+                        .size(Math.toIntExact(size)));
             ParsedStringTerms stringTerms = jsonObject.get(field);
             List<? extends Terms.Bucket> buckets = stringTerms.getBuckets();
             for (Terms.Bucket bucket : buckets) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.kitodo.data.database.beans.BaseBean;
@@ -784,15 +785,12 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     protected List<String> findDistinctValues(QueryBuilder query, String field, boolean sort, long size) throws DataException {
         List<String> distinctValues = new ArrayList<>();
         try {
-            Aggregations jsonObject;
+            TermsAggregationBuilder termsAggregation = AggregationBuilders.terms(field).field(field)
+                    .order(Terms.Order.aggregation("_term", sort));
             if (size > 0) {
-                jsonObject = searcher.aggregateDocuments(query,
-                        AggregationBuilders.terms(field).field(field).order(Terms.Order.aggregation("_term", sort))
-                                .size(Math.toIntExact(size)));
-            } else {
-                jsonObject = searcher.aggregateDocuments(query,
-                        AggregationBuilders.terms(field).field(field).order(Terms.Order.aggregation("_term", sort)));
+                termsAggregation.size(Math.toIntExact(size));
             }
+            Aggregations jsonObject = searcher.aggregateDocuments(query, termsAggregation);
             ParsedStringTerms stringTerms = jsonObject.get(field);
             List<? extends Terms.Bucket> buckets = stringTerms.getBuckets();
             for (Terms.Bucket bucket : buckets) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -784,9 +784,15 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     protected List<String> findDistinctValues(QueryBuilder query, String field, boolean sort, long size) throws DataException {
         List<String> distinctValues = new ArrayList<>();
         try {
-            Aggregations jsonObject = searcher.aggregateDocuments(query,
-                AggregationBuilders.terms(field).field(field).order(Terms.Order.aggregation("_term", sort))
-                        .size(Math.toIntExact(size)));
+            Aggregations jsonObject;
+            if (size > 0) {
+                jsonObject = searcher.aggregateDocuments(query,
+                        AggregationBuilders.terms(field).field(field).order(Terms.Order.aggregation("_term", sort))
+                                .size(Math.toIntExact(size)));
+            } else {
+                jsonObject = searcher.aggregateDocuments(query,
+                        AggregationBuilders.terms(field).field(field).order(Terms.Order.aggregation("_term", sort)));
+            }
             ParsedStringTerms stringTerms = jsonObject.get(field);
             List<? extends Terms.Bucket> buckets = stringTerms.getBuckets();
             for (Terms.Bucket bucket : buckets) {


### PR DESCRIPTION
Query for distinct values in `SearchService` would only return the first 10 elements of a type (for example `Task`) which wasn't noticed because most workflows right now have less than 10 tasks. This change sets the size of the result set to the number of corresponding objects in the database.