### PR TITLE
Copy all nodes from kitodo xml to mets-mods xml

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -561,6 +561,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${com.h2database.h2.version}</version>

--- a/Kitodo/src/main/java/org/kitodo/export/XsltHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/export/XsltHelper.java
@@ -36,11 +36,14 @@ public class XsltHelper {
     /**
      * Transforms a xml file by xslt and returns the result as string.
      *
-     * @param source  The xml file to transform.
-     * @param xslFile The xsl file.
+     * @param source
+     *            The xml file to transform.
+     * @param xslFile
+     *            The xsl file.
      * @return The Result of the transformation as String object.
      */
-    static ByteArrayOutputStream transformXmlByXslt(StreamSource source, URI xslFile) throws TransformerException, IOException {
+    static ByteArrayOutputStream transformXmlByXslt(StreamSource source, URI xslFile)
+            throws TransformerException, IOException {
         StreamSource xsltSource = new StreamSource(xslFile.getPath());
         TransformerFactory factory = TransformerFactory.newInstance();
         Transformer transformer = factory.newTransformer(xsltSource);

--- a/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
+++ b/Kitodo/src/main/resources/xslt/kitodo2mods.xsl
@@ -14,7 +14,6 @@
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:mets="http://www.loc.gov/METS/"
                 xmlns:mods="http://www.loc.gov/mods/v3"
                 xmlns:kitodo="http://meta.kitodo.org/v1/"
 >
@@ -22,9 +21,7 @@
     <xsl:strip-space elements="*"/>
 
     <xsl:template match="/">
-        <mods:mods>
-            <xsl:apply-templates/>
-        </mods:mods>
+        <xsl:apply-templates/>
     </xsl:template>
 
     <xsl:template match="kitodo:kitodo">
@@ -45,95 +42,102 @@
 
         <xsl:variable name="recordIdentifier" select="kitodo:metadata[@name='CatalogIDDigital']"/>
 
-        <xsl:if test="$title">
-            <mods:titleInfo>
-                <mods:title>
-                    <xsl:value-of select="$title"/>
-                </mods:title>
-            </mods:titleInfo>
-        </xsl:if>
-
-        <xsl:choose>
-            <xsl:when test="$role='author'">
-                <mods:name>
-                    <mods:namePart type="family">
-                        <xsl:value-of select="$last_name"/>
-                    </mods:namePart>
-                    <mods:namePart type="given">
-                        <xsl:value-of select="$first_name"/>
-                    </mods:namePart>
-                    <mods:displayForm>
-                        <xsl:value-of select="$last_name"/>,
-                        <xsl:value-of select="$first_name"/>
-                    </mods:displayForm>
-                    <mods:role>
-                        <mods:roleTerm type="code" authority="marcrelator">
-                            aut
-                        </mods:roleTerm>
-                        <mods:roleTerm type="text" authority="marcrelator">
-                            Author
-                        </mods:roleTerm>
-                    </mods:role>
-                </mods:name>
-            </xsl:when>
-        </xsl:choose>
-
-        <xsl:if test="$place or $publisher or $dateIssued">
-            <mods:originInfo eventType="publication">
-                <mods:place>
-                    <xsl:if test="$place">
-                        <mods:placeTerm type="text">
-                            <xsl:value-of select="$place"/>
-                        </mods:placeTerm>
-                    </xsl:if>
-                    <xsl:if test="$publisher">
-                        <mods:publisher>
-                            <xsl:value-of select="$publisher"/>
-                        </mods:publisher>
-                    </xsl:if>
-                    <xsl:if test="$dateIssued">
-                        <mods:dateIssued keyDate="yes" encoding="iso8601">
-                            <xsl:value-of select="$dateIssued"/>
-                        </mods:dateIssued>
-                    </xsl:if>
-                </mods:place>
-            </mods:originInfo>
-        </xsl:if>
-
-        <xsl:if test="$physicalDescription">
-            <mods:physicalDescription>
-                <mods:extent>
-                    <xsl:value-of select="$physicalDescription"/>
-                </mods:extent>
-            </mods:physicalDescription>
-        </xsl:if>
-
-        <xsl:if test="$shelfLocator or $url">
-            <mods:location>
-                <xsl:if test="$shelfLocator">
-                    <mods:shelfLocator>
-                        <xsl:value-of select="$shelfLocator"/>
-                    </mods:shelfLocator>
+        <xsl:if test="$title or $role or $place or $publisher or $dateIssued or $physicalDescription or $shelfLocator or $url or $recordIdentifier">
+            <mods:mods>
+                <xsl:if test="$title">
+                    <mods:titleInfo>
+                        <mods:title>
+                            <xsl:value-of select="$title"/>
+                        </mods:title>
+                    </mods:titleInfo>
                 </xsl:if>
-                <xsl:if test="$url">
-                    <mods:url>
-                        <xsl:value-of select="$url"/>
-                    </mods:url>
+
+                <xsl:choose>
+                    <xsl:when test="$role='author'">
+                        <mods:name>
+                            <mods:namePart type="family">
+                                <xsl:value-of select="$last_name"/>
+                            </mods:namePart>
+                            <mods:namePart type="given">
+                                <xsl:value-of select="$first_name"/>
+                            </mods:namePart>
+                            <mods:displayForm>
+                                <xsl:value-of select="$last_name"/>,
+                                <xsl:value-of select="$first_name"/>
+                            </mods:displayForm>
+                            <mods:role>
+                                <mods:roleTerm type="code" authority="marcrelator">
+                                    aut
+                                </mods:roleTerm>
+                                <mods:roleTerm type="text" authority="marcrelator">
+                                    Author
+                                </mods:roleTerm>
+                            </mods:role>
+                        </mods:name>
+                    </xsl:when>
+                </xsl:choose>
+
+                <xsl:if test="$place or $publisher or $dateIssued">
+                    <mods:originInfo eventType="publication">
+                        <mods:place>
+                            <xsl:if test="$place">
+                                <mods:placeTerm type="text">
+                                    <xsl:value-of select="$place"/>
+                                </mods:placeTerm>
+                            </xsl:if>
+                            <xsl:if test="$publisher">
+                                <mods:publisher>
+                                    <xsl:value-of select="$publisher"/>
+                                </mods:publisher>
+                            </xsl:if>
+                            <xsl:if test="$dateIssued">
+                                <mods:dateIssued keyDate="yes" encoding="iso8601">
+                                    <xsl:value-of select="$dateIssued"/>
+                                </mods:dateIssued>
+                            </xsl:if>
+                        </mods:place>
+                    </mods:originInfo>
                 </xsl:if>
-            </mods:location>
+
+                <xsl:if test="$physicalDescription">
+                    <mods:physicalDescription>
+                        <mods:extent>
+                            <xsl:value-of select="$physicalDescription"/>
+                        </mods:extent>
+                    </mods:physicalDescription>
+                </xsl:if>
+
+                <xsl:if test="$shelfLocator or $url">
+                    <mods:location>
+                        <xsl:if test="$shelfLocator">
+                            <mods:shelfLocator>
+                                <xsl:value-of select="$shelfLocator"/>
+                            </mods:shelfLocator>
+                        </xsl:if>
+                        <xsl:if test="$url">
+                            <mods:url>
+                                <xsl:value-of select="$url"/>
+                            </mods:url>
+                        </xsl:if>
+                    </mods:location>
+                </xsl:if>
+
+                <xsl:if test="$recordIdentifier">
+                    <mods:recordInfo>
+                        <mods:recordIdentifier>
+                            <xsl:value-of select="$recordIdentifier"/>
+                        </mods:recordIdentifier>
+                    </mods:recordInfo>
+                </xsl:if>
+            </mods:mods>
         </xsl:if>
 
-        <xsl:if test="$recordIdentifier">
-            <mods:recordInfo>
-                <mods:recordIdentifier>
-                    <xsl:value-of select="$recordIdentifier"/>
-                </mods:recordIdentifier>
-            </mods:recordInfo>
-        </xsl:if>
     </xsl:template>
 
     <!-- pass-through rule -->
-    <xsl:template match="@*|node()">
-        <xsl:apply-templates select="@*|node()"/>
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
     </xsl:template>
 </xsl:stylesheet>

--- a/Kitodo/src/test/java/org/kitodo/export/XsltHelperTest.java
+++ b/Kitodo/src/test/java/org/kitodo/export/XsltHelperTest.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.export;
+
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.transform.stream.StreamSource;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.xmlunit.matchers.CompareMatcher;
+
+public class XsltHelperTest {
+
+    @Test
+    public void shouldTransformKitodoToMods() throws Exception {
+        final String path = "src/test/resources/";
+
+        ByteArrayOutputStream outputStream = XsltHelper.transformXmlByXslt(
+            new StreamSource(path + "metadata/2/meta.xml"), URI.create(path + "xslt/kitodo2mods.xsl"));
+
+        File expected = new File(path + "metsFromKitodo.xml");
+        File result = new File(path + "mets.xml");
+        FileUtils.writeStringToFile(result, outputStream.toString(), StandardCharsets.UTF_8);
+
+        assertThat(result, CompareMatcher.isIdenticalTo(expected).ignoreWhitespace());
+
+        FileUtils.deleteQuietly(result);
+    }
+}

--- a/Kitodo/src/test/resources/metsFromKitodo.xml
+++ b/Kitodo/src/test/resources/metsFromKitodo.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/mods.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/v10 http://www.loc.gov/standards/mix/mix10/mix10.xsd">
+    <mets:metsHdr CREATEDATE="2018-09-14T07:45:17">
+        <mets:agent OTHERTYPE="SOFTWARE" ROLE="CREATOR" TYPE="OTHER">
+            <mets:name>Kitodo - kitodo-ugh-3.0-SNAPSHOT - 18-April-2018 13:20:13</mets:name>
+            <mets:note>Kitodo</mets:note>
+        </mets:agent>
+    </mets:metsHdr>
+    <mets:dmdSec ID="DMDLOG_0000">
+        <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData>
+                <mods:mods xmlns:mods="http://www.loc.gov/mods/v3"
+                           xmlns:kitodo="http://meta.kitodo.org/v1/">
+                    <mods:titleInfo>
+                        <mods:title>Second process</mods:title>
+                    </mods:titleInfo>
+                </mods:mods>
+            </mets:xmlData>
+        </mets:mdWrap>
+    </mets:dmdSec>
+    <mets:dmdSec ID="DMDPHYS_0000">
+        <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData/>
+        </mets:mdWrap>
+    </mets:dmdSec>
+    <mets:structMap TYPE="LOGICAL">
+        <mets:div DMDID="DMDLOG_0000" ID="LOG_0000" TYPE="Monograph"/>
+    </mets:structMap>
+    <mets:structMap TYPE="PHYSICAL">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook"/>
+    </mets:structMap>
+    <mets:structLink>
+        <mets:smLink xmlns:xlink="http://www.w3.org/1999/xlink"
+                     xlink:to="PHYS_0000"
+                     xlink:from="LOG_0000"/>
+    </mets:structLink>
+</mets:mets>

--- a/Kitodo/src/test/resources/xslt/kitodo2mods.xsl
+++ b/Kitodo/src/test/resources/xslt/kitodo2mods.xsl
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:kitodo="http://meta.kitodo.org/v1/"
+>
+    <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="kitodo:kitodo">
+        <xsl:variable name="title" select="kitodo:metadata[@name='TitleDocMain']"/>
+
+        <xsl:variable name="role" select="kitodo:metadataGroup[@name='Person']/kitodo:metadata[@name='Role']"/>
+        <xsl:variable name="last_name" select="kitodo:metadataGroup[@name='Person']/kitodo:metadata[@name='lastName']"/>
+        <xsl:variable name="first_name" select="kitodo:metadataGroup[@name='Person']/kitodo:metadata[@name='firstName']"/>
+
+        <xsl:variable name="place" select="kitodo:metadata[@name='PlaceOfPublication']"/>
+        <xsl:variable name="publisher" select="kitodo:metadata[@name='PublisherName']"/>
+        <xsl:variable name="dateIssued" select="kitodo:metadata[@name='PublicationYear']"/>
+
+        <xsl:variable name="physicalDescription" select="kitodo:metadata[@name='FormatSourcePrint']"/>
+
+        <xsl:variable name="shelfLocator" select="kitodo:metadata[@name='shelfmarksource']"/>
+        <xsl:variable name="url" select="kitodo:metadata[@name='slub_link']"/>
+
+        <xsl:variable name="recordIdentifier" select="kitodo:metadata[@name='CatalogIDDigital']"/>
+
+        <xsl:if test="$title or $role or $place or $publisher or $dateIssued or $physicalDescription or $shelfLocator or $url or $recordIdentifier">
+            <mods:mods>
+                <xsl:if test="$title">
+                    <mods:titleInfo>
+                        <mods:title>
+                            <xsl:value-of select="$title"/>
+                        </mods:title>
+                    </mods:titleInfo>
+                </xsl:if>
+
+                <xsl:choose>
+                    <xsl:when test="$role='author'">
+                        <mods:name>
+                            <mods:namePart type="family">
+                                <xsl:value-of select="$last_name"/>
+                            </mods:namePart>
+                            <mods:namePart type="given">
+                                <xsl:value-of select="$first_name"/>
+                            </mods:namePart>
+                            <mods:displayForm>
+                                <xsl:value-of select="$last_name"/>,
+                                <xsl:value-of select="$first_name"/>
+                            </mods:displayForm>
+                            <mods:role>
+                                <mods:roleTerm type="code" authority="marcrelator">
+                                    aut
+                                </mods:roleTerm>
+                                <mods:roleTerm type="text" authority="marcrelator">
+                                    Author
+                                </mods:roleTerm>
+                            </mods:role>
+                        </mods:name>
+                    </xsl:when>
+                </xsl:choose>
+
+                <xsl:if test="$place or $publisher or $dateIssued">
+                    <mods:originInfo eventType="publication">
+                        <mods:place>
+                            <xsl:if test="$place">
+                                <mods:placeTerm type="text">
+                                    <xsl:value-of select="$place"/>
+                                </mods:placeTerm>
+                            </xsl:if>
+                            <xsl:if test="$publisher">
+                                <mods:publisher>
+                                    <xsl:value-of select="$publisher"/>
+                                </mods:publisher>
+                            </xsl:if>
+                            <xsl:if test="$dateIssued">
+                                <mods:dateIssued keyDate="yes" encoding="iso8601">
+                                    <xsl:value-of select="$dateIssued"/>
+                                </mods:dateIssued>
+                            </xsl:if>
+                        </mods:place>
+                    </mods:originInfo>
+                </xsl:if>
+
+                <xsl:if test="$physicalDescription">
+                    <mods:physicalDescription>
+                        <mods:extent>
+                            <xsl:value-of select="$physicalDescription"/>
+                        </mods:extent>
+                    </mods:physicalDescription>
+                </xsl:if>
+
+                <xsl:if test="$shelfLocator or $url">
+                    <mods:location>
+                        <xsl:if test="$shelfLocator">
+                            <mods:shelfLocator>
+                                <xsl:value-of select="$shelfLocator"/>
+                            </mods:shelfLocator>
+                        </xsl:if>
+                        <xsl:if test="$url">
+                            <mods:url>
+                                <xsl:value-of select="$url"/>
+                            </mods:url>
+                        </xsl:if>
+                    </mods:location>
+                </xsl:if>
+
+                <xsl:if test="$recordIdentifier">
+                    <mods:recordInfo>
+                        <mods:recordIdentifier>
+                            <xsl:value-of select="$recordIdentifier"/>
+                        </mods:recordIdentifier>
+                    </mods:recordInfo>
+                </xsl:if>
+            </mods:mods>
+        </xsl:if>
+
+    </xsl:template>
+
+    <!-- pass-through rule -->
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
PR #2685 has added file for converting Kitodo Intern format to MODS, but without copying the whole METS structure. This PR copies all existing nodes and includes previously added kitodo-mods conversion.