### PR TITLE
Remove duplicate smLinks

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -115,12 +115,33 @@ public class DivXmlElementAccess extends IncludedStructuralElement {
         Set<FileXmlElementAccess> fileXmlElementAccesses = mediaUnitsMap.get(div.getID());
         if (Objects.nonNull(fileXmlElementAccesses)) {
             for (FileXmlElementAccess fileXmlElementAccess : fileXmlElementAccesses) {
-                if (Objects.nonNull(fileXmlElementAccess)) {
+                if (Objects.nonNull(fileXmlElementAccess)
+                    && !fileXmlElementAccessIsLinkedToChildren(fileXmlElementAccess, div.getDiv(), mediaUnitsMap)) {
                     super.getViews().add(new AreaXmlElementAccess(fileXmlElementAccess).getView());
                 }
             }
         }
         super.setLink(MptrXmlElementAccess.getLinkFromDiv(div));
+    }
+
+    private boolean fileXmlElementAccessIsLinkedToChildren(FileXmlElementAccess fileXmlElementAccess,
+                                                           List<DivType> divs,
+                                                           Map<String, Set<FileXmlElementAccess>> mediaUnitsMap) {
+        if (divs.size() == 0) {
+            return false;
+        }
+        boolean test = false;
+        for (DivType div : divs) {
+            Set<FileXmlElementAccess> fileXmlElementAccesses = mediaUnitsMap.get(div.getID());
+            if (Objects.nonNull(fileXmlElementAccesses) && fileXmlElementAccesses.contains(fileXmlElementAccess)) {
+                return true;
+            }
+            if (div.getDiv().size() > 0
+                    && fileXmlElementAccessIsLinkedToChildren(fileXmlElementAccess, div.getDiv(), mediaUnitsMap)) {
+                test = true;
+            }
+        }
+        return test;
     }
 
     /**

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -56,8 +56,8 @@ public class MetsXmlElementAccessIT {
         // METS file has 183 associated images
         assertEquals(183, workpiece.getMediaUnits().size());
 
-        // all pages are linked to the root element
-        assertEquals(workpiece.getMediaUnits().size(), workpiece.getRootElement().getViews().size());
+        // METS file has 17 unstructured images
+        assertEquals(17, workpiece.getRootElement().getViews().size());
 
         // root node has 16 children
         assertEquals(16, workpiece.getRootElement().getChildren().size());
@@ -233,7 +233,9 @@ public class MetsXmlElementAccessIT {
             assertEquals(2, mediaUnit.getMediaFiles().size());
         }
         IncludedStructuralElement includedStructuralElementRoot = reread.getRootElement();
-        assertEquals(4, includedStructuralElementRoot.getViews().size());
+        assertEquals(1, includedStructuralElementRoot.getChildren().get(0).getViews().size());
+        assertEquals(2, includedStructuralElementRoot.getChildren().get(1).getViews().size());
+        assertEquals(1, includedStructuralElementRoot.getChildren().get(2).getViews().size());
         assertEquals(3, includedStructuralElementRoot.getChildren().size());
         assertEquals(1, includedStructuralElementRoot.getMetadata().size());
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -36,8 +36,8 @@ public class MetsServiceIT {
         // METS file has 183 associated images
         assertEquals(183, workpiece.getMediaUnits().size());
 
-        // all pages are linked to the root element
-        assertEquals(workpiece.getMediaUnits().size(), workpiece.getRootElement().getViews().size());
+        // METS file has 17 unstructured images
+        assertEquals(17, workpiece.getRootElement().getViews().size());
 
         // root node has 16 children
         assertEquals(16, workpiece.getRootElement().getChildren().size());


### PR DESCRIPTION
Loading the meta.xml in the metadata editor will now check if the smLink is linking the same physical node like another smLink on a deeper level. All smLinks except the lowest for each physical element are not added to the workpiece.
Saving the metadata editor will remove the smLinks from the meta.xml. 