### PR TITLE
Validate metadata on task closing instead of metadata editor saving

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -284,13 +284,11 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     public String save() {
         metadataPanel.preserve();
         structurePanel.preserve();
-        if (validate()) {
-            try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
-                ServiceManager.getMetsService().save(workpiece, out);
-                return close();
-            } catch (IOException e) {
-                Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
-            }
+        try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
+            ServiceManager.getMetsService().save(workpiece, out);
+            return close();
+        } catch (IOException e) {
+            Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
         PrimeFaces.current().executeScript("PF('sticky-notifications').removeAll();");
         PrimeFaces.current().ajax().update("notifications");

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -43,7 +43,6 @@ import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Comment;
 import org.kitodo.data.database.beans.Process;
-import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.beans.WorkflowCondition;
@@ -143,10 +142,12 @@ public class WorkflowControllerService {
     }
 
     private boolean validateMetadata(Task task) throws IOException, DataException {
-        URI metaXMLURI = ServiceManager.getProcessService().getMetadataFileUri(task.getProcess());
-        Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metaXMLURI);
+        URI metadataFileUri = ServiceManager.getProcessService().getMetadataFileUri(task.getProcess());
+        Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metadataFileUri);
         RulesetManagementInterface ruleset = ServiceManager.getRulesetManagementService().getRulesetManagement();
-        ruleset.load(new File(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_RULESETS), task.getProcess().getRuleset().getFile()).toString()));
+        ruleset.load(new File(Paths.get(
+                ConfigCore.getParameter(ParameterCore.DIR_RULESETS),
+                task.getProcess().getRuleset().getFile()).toString()));
         ValidationResult validationResult = ServiceManager.getMetadataValidationService().validate(workpiece, ruleset);
         if (State.ERROR.equals(validationResult.getState())) {
             Helper.setErrorMessage(Helper.getTranslation("dataEditor.validation.state.error"));

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -34,9 +35,14 @@ import javax.xml.xpath.XPathFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.command.CommandResult;
+import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
+import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.api.validation.State;
+import org.kitodo.api.validation.ValidationResult;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Comment;
+import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.User;
@@ -136,6 +142,21 @@ public class WorkflowControllerService {
         }
     }
 
+    private boolean validateMetadata(Task task) throws IOException, DataException {
+        URI metaXMLURI = ServiceManager.getProcessService().getMetadataFileUri(task.getProcess());
+        Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metaXMLURI);
+        RulesetManagementInterface ruleset = ServiceManager.getRulesetManagementService().getRulesetManagement();
+        ruleset.load(new File(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_RULESETS), task.getProcess().getRuleset().getFile()).toString()));
+        ValidationResult validationResult = ServiceManager.getMetadataValidationService().validate(workpiece, ruleset);
+        if (State.ERROR.equals(validationResult.getState())) {
+            Helper.setErrorMessage(Helper.getTranslation("dataEditor.validation.state.error"));
+            for (String message : validationResult.getResultMessages()) {
+                Helper.setErrorMessage(message);
+            }
+        }
+        return !validationResult.getState().equals(State.ERROR);
+    }
+
     /**
      * Close method task called by user action.
      *
@@ -149,8 +170,8 @@ public class WorkflowControllerService {
             // metadata validation
             if (task.isTypeMetadata()
                     && ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.USE_META_DATA_VALIDATION)
-                    && !ServiceManager.getMetadataValidationService().validate(task.getProcess())) {
-                return;
+                    && !validateMetadata(task)) {
+                throw new DataException("Error on metadata validation!");
             }
 
             // image validation
@@ -158,8 +179,7 @@ public class WorkflowControllerService {
                 ImageHelper mih = new ImageHelper();
                 URI imageFolder = ServiceManager.getProcessService().getImagesOriginDirectory(false, task.getProcess());
                 if (!mih.checkIfImagesValid(task.getProcess().getTitle(), imageFolder)) {
-                    Helper.setErrorMessage("Error on image validation!");
-                    return;
+                    throw new DataException("Error on image validation!");
                 }
             }
         }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/baseEditView.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/baseEditView.xhtml
@@ -24,7 +24,7 @@
                         <h3>Kitodo.Production</h3>
                     </ui:insert>
                 </p:panel>
-                <p:messages id="error-messages">
+                <p:messages id="error-messages" showIcon="false" closable="true">
                     <p:autoUpdate/>
                 </p:messages>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/baseListView.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/baseListView.xhtml
@@ -25,7 +25,7 @@
                     <h3>Kitodo.Production</h3>
                 </ui:insert>
             </p:panel>
-            <p:messages id="error-messages">
+            <p:messages id="error-messages" showIcon="false" closable="true">
                 <p:autoUpdate/>
             </p:messages>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -120,7 +120,7 @@
                     <!-- Close button -->
                     <p:commandLink id="close" action="#{CurrentTaskForm.closeTaskByUser}" title="#{msgs.closeTask}">
                         <h:graphicImage value="/pages/images/buttons/ok.gif" alt="ok"
-                                        style="margin-right:3px;vertical-align:middle"/>
+                                        style="margin-right:3px; vertical-align: middle;"/>
                         <h:outputText value="#{msgs.closeTask}"/>
                         <p:confirm header="#{msgs.confirmClose}" message="#{msgs.closeTask}" icon="ui-icon-alert"/>
                     </p:commandLink>

--- a/Kitodo/src/main/webapp/pages/currentTasksEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/currentTasksEdit.xhtml
@@ -14,7 +14,6 @@
 <ui:composition
         template="/WEB-INF/templates/baseListView.xhtml"
         xmlns:f="http://xmlns.jcp.org/jsf/core"
-        xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:p="http://primefaces.org/ui">
 


### PR DESCRIPTION
Metadata validation is now triggered when closing tasks with `typeMetadata` and `typeCloseVerify` set to `true` instead of during saving in the metadata editor. The option to validate in the editor by using the dedicated `Validate` button still exists.