### PR TITLE
Rename boundbook to physSequence

### DIFF
--- a/Kitodo-DataEditor/src/test/resources/testmetaOldFormat.xml
+++ b/Kitodo-DataEditor/src/test/resources/testmetaOldFormat.xml
@@ -88,7 +88,7 @@
         </mets:div>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
             <mets:div ID="PHYS_0001" ORDER="1" ORDERLABEL="uncounted" TYPE="page">
                 <mets:fptr FILEID="FILE_0001"/>
             </mets:div>

--- a/Kitodo-DataFormat/src/test/resources/meta.xml
+++ b/Kitodo-DataFormat/src/test/resources/meta.xml
@@ -1678,7 +1678,7 @@
     </mets:div>
   </mets:structMap>
   <mets:structMap TYPE="PHYSICAL">
-    <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook">
+    <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
       <mets:div ID="PHYS_0001" ORDER="1" ORDERLABEL="uncounted" TYPE="page">
         <mets:fptr FILEID="FILE_0001"/>
       </mets:div>

--- a/Kitodo/src/main/java/org/goobi/production/cli/helper/CopyProcess.java
+++ b/Kitodo/src/main/java/org/goobi/production/cli/helper/CopyProcess.java
@@ -169,7 +169,7 @@ public class CopyProcess extends ProzesskopieForm {
                 logger.error(e.getMessage(), e);
             }
         }
-        if (field.getDocStruct().equals("boundbook")) {
+        if (field.getDocStruct().equals("physSequence")) {
             myTempStruct = myRdf.getDigitalDocument().getPhysicalDocStruct();
         }
         return myTempStruct;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProzesskopieForm.java
@@ -85,7 +85,7 @@ import org.primefaces.PrimeFaces;
 public class ProzesskopieForm extends BaseForm {
     private static final Logger logger = LogManager.getLogger(ProzesskopieForm.class);
     private static final String OPAC_CONFIG = "configurationOPAC";
-    private static final String BOUND_BOOK = "boundbook";
+    private static final String PHYS_SEQUENCE = "physSequence";
     private static final String FIRST_CHILD = "firstchild";
     private static final String LIST_OF_CREATORS = "ListOfCreators";
 
@@ -421,7 +421,7 @@ public class ProzesskopieForm extends BaseForm {
         if (field.getDocStruct().equals(FIRST_CHILD)) {
             docStruct = digitalDocument.getLogicalDocStruct().getAllChildren().get(0);
         }
-        if (field.getDocStruct().equals(BOUND_BOOK)) {
+        if (field.getDocStruct().equals(PHYS_SEQUENCE)) {
             docStruct = digitalDocument.getPhysicalDocStruct();
         }
         return docStruct;
@@ -612,7 +612,7 @@ public class ProzesskopieForm extends BaseForm {
                 Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
             }
         }
-        if (fieldDocStruct.equals(BOUND_BOOK)) {
+        if (fieldDocStruct.equals(PHYS_SEQUENCE)) {
             tempStruct = this.rdf.getDigitalDocument().getPhysicalDocStruct();
         }
         // which Metadata

--- a/Kitodo/src/main/resources/kitodo_projects.xml
+++ b/Kitodo/src/main/resources/kitodo_projects.xml
@@ -114,7 +114,7 @@
                 <item from="vorlage" isdoctype="monograph" ughbinding="true" docstruct="topstruct"
                       metadata="PublisherName">Verlag
                 </item>
-                <item from="vorlage" ughbinding="true" docstruct="boundbook" metadata="shelfmarksource">Signatur</item>
+                <item from="vorlage" ughbinding="true" docstruct="physSequence" metadata="shelfmarksource">Signatur</item>
                 <processtitle isdoctype="multivolume">ATS+TSL+'_'+PPN digital f-Satz+'_'+Nummer (Benennung)
                 </processtitle>
                 <processtitle isdoctype="monograph">ATS+TSL+'_'+PPN digital a-Satz</processtitle>

--- a/Kitodo/src/test/resources/metadata/2/meta.xml
+++ b/Kitodo/src/test/resources/metadata/2/meta.xml
@@ -32,7 +32,7 @@
         <mets:div DMDID="DMDLOG_0000" ID="LOG_0000" TYPE="Monograph"/>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook"/>
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence"/>
     </mets:structMap>
     <mets:structLink>
         <mets:smLink xlink:to="PHYS_0000" xlink:from="LOG_0000" xmlns:xlink="http://www.w3.org/1999/xlink"/>

--- a/Kitodo/src/test/resources/metadata/4/meta.xml
+++ b/Kitodo/src/test/resources/metadata/4/meta.xml
@@ -32,7 +32,7 @@
         <mets:div DMDID="DMDLOG_0000" ID="LOG_0000" TYPE="Monograph"/>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook"/>
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence"/>
     </mets:structMap>
     <mets:structLink>
         <mets:smLink xlink:to="PHYS_0000" xlink:from="LOG_0000" xmlns:xlink="http://www.w3.org/1999/xlink"/>

--- a/Kitodo/src/test/resources/metadata/5/meta.xml
+++ b/Kitodo/src/test/resources/metadata/5/meta.xml
@@ -32,7 +32,7 @@
         <mets:div DMDID="DMDLOG_0000" ID="LOG_0000" TYPE="Monograph"/>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook"/>
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence"/>
     </mets:structMap>
     <mets:structLink>
         <mets:smLink xlink:to="PHYS_0000" xlink:from="LOG_0000" xmlns:xlink="http://www.w3.org/1999/xlink"/>

--- a/Kitodo/src/test/resources/metadata/7/meta.xml
+++ b/Kitodo/src/test/resources/metadata/7/meta.xml
@@ -32,7 +32,7 @@
         <mets:div DMDID="DMDLOG_0000" ID="LOG_0000" TYPE="Monograph"/>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook"/>
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence"/>
     </mets:structMap>
     <mets:structLink>
         <mets:smLink xlink:to="PHYS_0000" xlink:from="LOG_0000" xmlns:xlink="http://www.w3.org/1999/xlink"/>

--- a/Kitodo/src/test/resources/metadata/9/meta.xml
+++ b/Kitodo/src/test/resources/metadata/9/meta.xml
@@ -32,7 +32,7 @@
         <mets:div DMDID="DMDLOG_0000" ID="LOG_0000" TYPE="Monograph"/>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook"/>
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence"/>
     </mets:structMap>
     <mets:structLink>
         <mets:smLink xlink:to="PHYS_0000" xlink:from="LOG_0000" xmlns:xlink="http://www.w3.org/1999/xlink"/>

--- a/Kitodo/src/test/resources/metadata/testmeta.xml
+++ b/Kitodo/src/test/resources/metadata/testmeta.xml
@@ -72,7 +72,7 @@
         </mets:div>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
             <mets:div ID="PHYS_0001" ORDER="1" ORDERLABEL="uncounted" TYPE="page">
                 <mets:fptr FILEID="FILE_0001"/>
             </mets:div>

--- a/Kitodo/src/test/resources/metadata/testmetaOldFormat.xml
+++ b/Kitodo/src/test/resources/metadata/testmetaOldFormat.xml
@@ -103,7 +103,7 @@
         </mets:div>
     </mets:structMap>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="BoundBook">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
             <mets:div ID="PHYS_0001" ORDER="1" ORDERLABEL="uncounted" TYPE="page">
                 <mets:fptr FILEID="FILE_0001"/>
             </mets:div>


### PR DESCRIPTION
METS **requires** the root structure of the physical structure-tree to be named `physSequence`.