### PR TITLE
Add children’s views to parents when exporting

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
@@ -253,18 +253,6 @@ public class EditPagesDialog {
     }
 
     /**
-     * This method is invoked if the user clicks on the take pages from children
-     * btn command button.
-     */
-    public void takePagesFromChildren() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
-            MetadataEditor.assignViewsFromChildren(dataEditor.getSelectedStructure().get());
-            dataEditor.refreshStructurePanel();
-            prepare();
-        }
-    }
-
-    /**
      * This method is invoked if the user clicks on the remove page btn command
      * button.
      */

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -240,7 +240,10 @@ public class MetadataEditor {
      *            structure to add all views of all children to
      */
     public static void assignViewsFromChildren(IncludedStructuralElement structure) {
-        structure.getViews().addAll(getViewsFromChildrenRecursive(structure));
+        Collection<View> viewsToAdd = getViewsFromChildrenRecursive(structure);
+        Collection<View> assignedViews = structure.getViews();
+        viewsToAdd.removeAll(assignedViews);
+        assignedViews.addAll(viewsToAdd);
     }
 
     private static Collection<View> getViewsFromChildrenRecursive(IncludedStructuralElement structure) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -34,6 +34,7 @@ import org.kitodo.production.helper.VariableReplacer;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyInnerPhysicalDocStructHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
+import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.model.Subfolder;
 import org.kitodo.production.services.ServiceManager;
 
@@ -84,6 +85,26 @@ public class SchemaService {
         convertChildrenLinksForExport(workpiece, workpiece.getRootElement(), prefs);
         if (Objects.nonNull(process.getParent())) {
             addParentLinkForExport(prefs, workpiece, process.getParent());
+        }
+
+        assignViewsFromChildrenRecursive(workpiece.getRootElement());
+    }
+
+    /**
+     * At all levels, assigns the views of the children to the included
+     * structural elements.
+     *
+     * @param includedStructuralElement
+     *            included structural element on which the recursion is
+     *            performed
+     */
+    private void assignViewsFromChildrenRecursive(IncludedStructuralElement includedStructuralElement) {
+        List<IncludedStructuralElement> children = includedStructuralElement.getChildren();
+        if (!children.isEmpty()) {
+            for (IncludedStructuralElement child : children) {
+                assignViewsFromChildrenRecursive(child);
+            }
+            MetadataEditor.assignViewsFromChildren(includedStructuralElement);
         }
     }
 

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -694,7 +694,6 @@ searchOPAC=OPAC durchsuchen
 searchPlaceholder=Suche nach Projekten, Vorg\u00E4ngen, Aufgaben oder Benutzern
 searchResult=Suchergebnis
 searchResultFor=Suchergebnis f\u00FCr:
-seitenVonUnterelementenZuweisen=Seiten von Unterelementen zuweisen
 pageAllocation=Seitenzuordnung
 pageAssign=Seiten zuweisen
 pageCount=Seitenz\u00E4hlung

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -693,7 +693,6 @@ searchOPAC=Search OPAC
 searchPlaceholder=Search for projects, processes, tasks or users
 searchResult=Search result
 searchResultFor=Search result for:
-seitenVonUnterelementenZuweisen=Assign pages of subelements
 pageAllocation=Page allocation
 pageAssign=Assign pages
 pageCount=Page counting

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/editPages.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/editPages.xhtml
@@ -56,12 +56,6 @@
 
                     <h:panelGroup layout="block"
                                   styleClass="dialogButtonWrapper">
-                        <p:commandButton id="takePagesFromChildrenBtn"
-                                         value="#{msgs.seitenVonUnterelementenZuweisen}"
-                                         action="#{DataEditorForm.editPagesDialog.takePagesFromChildren}"
-                                         styleClass="secondary"
-                                         style="margin-left: var(--default-double-size);"
-                                         update="structureTreeForm,paginationSubSelection"/>
                         <p:commandButton id="setPageStartAndEndBtn"
                                          value="#{msgs.pageAssign}"
                                          styleClass="secondary"


### PR DESCRIPTION
The feature to add the views from the children to the parents has been fixed and integrated into the export. The button for manually triggering the function has been removed.