### PR TITLE
2.x: Fix NPE while adding first process property

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -1927,7 +1927,8 @@ public class ProzessverwaltungForm extends BasisForm {
                 Helper.setFehlerMeldung(value);
                 return;
             }
-            if (this.processProperty.getProzesseigenschaft() == null) {
+            if (this.processProperty.getProzesseigenschaft() == null
+                    || this.processProperty.getProzesseigenschaft().getProzess() == null) {
                 Prozesseigenschaft pe = new Prozesseigenschaft();
                 pe.setProzess(this.myProzess);
                 this.processProperty.setProzesseigenschaft(pe);


### PR DESCRIPTION
Fix a null pointer exception while adding first process property of a process.