### PR TITLE
2.x: Fix JDOMException

### DIFF
--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/GetOpac.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/GetOpac.java
@@ -239,6 +239,7 @@ class GetOpac {
         try {
             Document doc = sb.build(new StringReader(opacResponse));
             XPath numberOfHitsPath = XPath.newInstance("//srw:numberOfRecords");
+            numberOfHitsPath.addNamespace("srw", "http://www.loc.gov/zing/srw/");
             Element numberOfHitsElement = (Element) numberOfHitsPath.selectSingleNode(doc);
             numberOfHits = Integer.parseInt(numberOfHitsElement.getText());
         } catch (JDOMException | IOException e) {

--- a/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/GetOpac.java
+++ b/Goobi/plugins/opac/ModsPlugin/org/kitodo/production/plugin/CataloguePlugin/ModsPlugin/GetOpac.java
@@ -147,7 +147,7 @@ class GetOpac {
         try {
             return retrieveDataFromOPAC(SRU_VERSION + SEARCH_URL_BEFORE_QUERY + queryURL + RECORD_SCHEMA_MODS, timeout);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn(e.getLocalizedMessage(), e);
             return null;
         }
     }
@@ -243,7 +243,7 @@ class GetOpac {
             Element numberOfHitsElement = (Element) numberOfHitsPath.selectSingleNode(doc);
             numberOfHits = Integer.parseInt(numberOfHitsElement.getText());
         } catch (JDOMException | IOException e) {
-            e.printStackTrace();
+            logger.warn(e.getLocalizedMessage(), e);
         }
 
         return numberOfHits;


### PR DESCRIPTION
Log of Tomcat (8.5) contains following output after using the MODS SRU import plugin:

```
org.jdom.JDOMException: XPath error while evaluating "//srw:numberOfRecords": XPath expression uses unbound namespace prefix srw: XPath expression uses unbound namespace prefix srw
        at org.jdom.xpath.JaxenXPath.selectSingleNode(JaxenXPath.java:156)
        at org.kitodo.production.plugin.CataloguePlugin.ModsPlugin.GetOpac.retrieveNumberOfHitsFromOpacResponse(GetOpac.java:245)
        at org.kitodo.production.plugin.CataloguePlugin.ModsPlugin.GetOpac.performQuery(GetOpac.java:132)
        at org.kitodo.production.plugin.CataloguePlugin.ModsPlugin.GetOpac.getNumberOfHits(GetOpac.java:102)
        at org.kitodo.production.plugin.CataloguePlugin.ModsPlugin.ModsPlugin.find(ModsPlugin.java:311)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.goobi.production.plugin.UnspecificPlugin.invokeQuietly(UnspecificPlugin.java:469)
        at org.goobi.production.plugin.CataloguePlugin.CataloguePlugin.find(CataloguePlugin.java:237)
        at de.sub.goobi.forms.ProzesskopieForm.OpacAuswerten(ProzesskopieForm.java:487)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
...
```