### PR TITLE
Store expansion states of all nodes in structure trees before update

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -151,12 +151,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     private Task currentTask;
 
     /**
-     * Flag indicating whether the structure tree should be expanded or not. This is only true during the first
-     * initialization of the tree.
-     */
-    private boolean expandTree = true;
-
-    /**
      * Public constructor.
      */
     public DataEditorForm() {
@@ -227,8 +221,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     private void init() {
         final long begin = System.nanoTime();
 
-        expandTree = true;
-
         structurePanel.show();
         metadataPanel.showLogical(getSelectedStructure());
         metadataPanel.showPhysical(getSelectedMediaUnit());
@@ -236,8 +228,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         paginationPanel.show();
 
         editPagesDialog.prepare();
-
-        expandTree = false;
 
         if (logger.isTraceEnabled()) {
             logger.trace("Initializing editor beans took {} ms",
@@ -589,18 +579,5 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         if (Objects.nonNull(mediaUnit)) {
             galleryPanel.updateSelection(mediaUnit);
         }
-    }
-
-    boolean isExpandTree() {
-        return this.expandTree;
-    }
-
-    /**
-     * Set expandTree.
-     *
-     * @param expandTree as boolean
-     */
-    public void setExpandTree(boolean expandTree) {
-        this.expandTree = expandTree;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -70,12 +71,22 @@ public class StructurePanel implements Serializable {
     /**
      * The logical structure tree of the edited document.
      */
-    private LinkedList<DefaultTreeNode> logicalTrees;
+    private DefaultTreeNode logicalTree = null;
 
     /**
      * The physical structure tree of the edited document.
      */
     private DefaultTreeNode physicalTree = null;
+
+    /**
+     * HashMap containing the current expansion states of all TreeNodes in the logical structure tree.
+     */
+    private HashMap<String, Boolean> previousExpansionStatesLogicalTree;
+
+    /**
+     * HashMap containing the current expansion states of all TreeNodes in the physical structure tree.
+     */
+    private HashMap<String, Boolean> previousExpansionStatesPhysicalTree;
 
     /**
      * Creates a new structure panel.
@@ -91,7 +102,7 @@ public class StructurePanel implements Serializable {
      * Clear content.
      */
     public void clear() {
-        logicalTrees = null;
+        logicalTree = null;
         physicalTree = null;
         selectedLogicalNode = null;
         selectedPhysicalNode = null;
@@ -121,9 +132,7 @@ public class StructurePanel implements Serializable {
         parent.getViews().addAll(subViews);
 
         parent.getChildren().remove(selectedStructure.get());
-        this.dataEditor.setExpandTree(true);
         show();
-        this.dataEditor.setExpandTree(false);
         dataEditor.getGalleryPanel().updateStripes();
     }
 
@@ -214,7 +223,7 @@ public class StructurePanel implements Serializable {
      * @param mediaUnit
      *          MediaUnit to be selected in physical structure tree
      */
-    public void selectMediaUnit(MediaUnit mediaUnit) {
+    void selectMediaUnit(MediaUnit mediaUnit) {
         TreeNode matchingTreeNode = getMatchingTreeNode(getPhysicalTree(), mediaUnit);
         if (Objects.nonNull(matchingTreeNode)) {
             updatePhysicalNodeSelection(matchingTreeNode);
@@ -246,21 +255,12 @@ public class StructurePanel implements Serializable {
     }
 
     /**
-     * Get parentTrees.
-     *
-     * @return value of parentTrees
-     */
-    public List<DefaultTreeNode> getParentTrees() {
-        return logicalTrees.subList(0, logicalTrees.size() - 1);
-    }
-
-    /**
      * Get logicalTree.
      *
      * @return value of logicalTree
      */
     public DefaultTreeNode getLogicalTree() {
-        return logicalTrees.getLast();
+        return this.logicalTree;
     }
 
     /**
@@ -283,8 +283,8 @@ public class StructurePanel implements Serializable {
      * workpiece which is stored in the root element of the structure tree.
      */
     private void preserveLogical() {
-        if (!logicalTrees.getLast().getChildren().isEmpty()) {
-            preserveLogicalRecursive(logicalTrees.getLast().getChildren().get(0));
+        if (!this.logicalTree.getChildren().isEmpty()) {
+            preserveLogicalRecursive(this.logicalTree.getChildren().get(0));
         }
     }
 
@@ -362,9 +362,16 @@ public class StructurePanel implements Serializable {
     public void show() {
         this.structure = dataEditor.getWorkpiece().getRootElement();
         Pair<LinkedList<DefaultTreeNode>, Collection<View>> result = buildStructureTree();
-        this.logicalTrees = result.getLeft();
+
+        this.previousExpansionStatesLogicalTree = getTreeNodeExpansionStates(this.logicalTree);
+        this.logicalTree = result.getLeft().getLast();
+        updateNodeExpansionStates(this.logicalTree, this.previousExpansionStatesLogicalTree);
+
+        this.previousExpansionStatesPhysicalTree = getTreeNodeExpansionStates(this.getPhysicalTree());
         this.physicalTree = buildMediaTree(dataEditor.getWorkpiece().getMediaUnit());
-        this.selectedLogicalNode = logicalTrees.getLast().getChildren().get(0);
+        updateNodeExpansionStates(this.getPhysicalTree(), this.previousExpansionStatesPhysicalTree);
+
+        this.selectedLogicalNode = logicalTree.getChildren().get(0);
         this.selectedPhysicalNode = physicalTree.getChildren().get(0);
         this.previouslySelectedLogicalNode = selectedLogicalNode;
         this.previouslySelectedPhysicalNode = selectedPhysicalNode;
@@ -381,7 +388,7 @@ public class StructurePanel implements Serializable {
         LinkedList<DefaultTreeNode> result = new LinkedList<>();
 
         DefaultTreeNode main = new DefaultTreeNode();
-        if (this.dataEditor.isExpandTree()) {
+        if (nodeStateUnknown(this.previousExpansionStatesLogicalTree, main)) {
             main.setExpanded(true);
         }
         Collection<View> viewsShowingOnAChild = buildStructureTreeRecursively(structure, main);
@@ -419,7 +426,7 @@ public class StructurePanel implements Serializable {
          * framework. So you do not have to add the result anywhere.
          */
         DefaultTreeNode parent = new DefaultTreeNode(node, result);
-        if (this.dataEditor.isExpandTree()) {
+        if (nodeStateUnknown(this.previousExpansionStatesLogicalTree, parent)) {
             parent.setExpanded(true);
         }
 
@@ -488,7 +495,9 @@ public class StructurePanel implements Serializable {
             DefaultTreeNode parent) {
         DefaultTreeNode node = new DefaultTreeNode(new StructureTreeNode(this, label, undefined, linked, dataObject),
                 parent);
-        if (this.dataEditor.isExpandTree()) {
+        if (dataObject instanceof MediaUnit && nodeStateUnknown(this.previousExpansionStatesPhysicalTree, node)
+                || dataObject instanceof IncludedStructuralElement
+                && nodeStateUnknown(this.previousExpansionStatesLogicalTree, node)) {
             node.setExpanded(true);
         }
         return node;
@@ -515,7 +524,7 @@ public class StructurePanel implements Serializable {
         }
         URI uri = ServiceManager.getProcessService().getMetadataFileUri(parent);
         DefaultTreeNode tree = new DefaultTreeNode();
-        if (this.dataEditor.isExpandTree()) {
+        if (nodeStateUnknown(this.previousExpansionStatesLogicalTree, tree)) {
             tree.setExpanded(true);
         }
         try {
@@ -605,7 +614,7 @@ public class StructurePanel implements Serializable {
      */
     private DefaultTreeNode buildMediaTree(MediaUnit mediaRoot) {
         DefaultTreeNode rootTreeNode = new DefaultTreeNode();
-        if (this.dataEditor.isExpandTree()) {
+        if (nodeStateUnknown(this.previousExpansionStatesPhysicalTree, rootTreeNode)) {
             rootTreeNode.setExpanded(true);
         }
         buildMediaTreeRecursively(mediaRoot, rootTreeNode);
@@ -616,7 +625,7 @@ public class StructurePanel implements Serializable {
         StructuralElementViewInterface divisionView = dataEditor.getRuleset().getStructuralElementView(
                 mediaUnit.getType(), dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
         DefaultTreeNode treeNode = addTreeNode(divisionView.getLabel(), false, false, mediaUnit, parentTreeNode);
-        if (this.dataEditor.isExpandTree()) {
+        if (nodeStateUnknown(this.previousExpansionStatesPhysicalTree, treeNode)) {
             treeNode.setExpanded(true);
         }
         if (Objects.nonNull(mediaUnit.getChildren())) {
@@ -659,7 +668,7 @@ public class StructurePanel implements Serializable {
         this.updatePhysicalNodeSelection(galleryMediaContent);
     }
 
-    void updatePhysicalNodeSelection(TreeNode treeNode) {
+    private void updatePhysicalNodeSelection(TreeNode treeNode) {
         if (this.isSeparateMedia()) {
             if (Objects.nonNull(previouslySelectedPhysicalNode)) {
                 previouslySelectedPhysicalNode.setSelected(false);
@@ -692,13 +701,13 @@ public class StructurePanel implements Serializable {
         if (Objects.nonNull(selectedLogicalNode)) {
             selectedLogicalNode.setSelected(false);
         }
-        if (Objects.nonNull(logicalTrees)) {
+        if (Objects.nonNull(this.logicalTree)) {
             GalleryStripe matchingGalleryStripe = this.dataEditor.getGalleryPanel().getLogicalStructureOfMedia(galleryMediaContent);
             if (Objects.nonNull(matchingGalleryStripe) && Objects.nonNull(matchingGalleryStripe.getStructure())) {
                 if (this.isSeparateMedia()) {
                     TreeNode selectedLogicalTreeNode =
                             updateLogicalNodeSelectionRecursive(matchingGalleryStripe.getStructure(),
-                                logicalTrees.getLast());
+                                logicalTree);
                     if (Objects.nonNull(selectedLogicalTreeNode)) {
                         setSelectedLogicalNode(selectedLogicalTreeNode);
                     } else {
@@ -706,7 +715,7 @@ public class StructurePanel implements Serializable {
                     }
                 } else {
                     TreeNode selectedTreeNode = updateNodeSelectionRecursive(galleryMediaContent,
-                        logicalTrees.getLast());
+                        logicalTree);
                     if (Objects.nonNull(selectedTreeNode)) {
                         setSelectedLogicalNode(selectedTreeNode);
                     } else {
@@ -904,5 +913,43 @@ public class StructurePanel implements Serializable {
             node.setExpanded(true);
             expandNode(node.getParent());
         }
+    }
+
+    private HashMap<String, Boolean> getTreeNodeExpansionStates(DefaultTreeNode tree) {
+        if (Objects.nonNull(tree)) {
+            return getTreeNodeExpansionStatesRecursively(tree, new HashMap<>());
+        } else {
+            return new HashMap<>();
+        }
+
+    }
+
+    private HashMap<String, Boolean> getTreeNodeExpansionStatesRecursively(TreeNode treeNode, HashMap<String, Boolean> expansionStates) {
+        if (Objects.nonNull(treeNode)) {
+            expansionStates.put(treeNode.getRowKey(), treeNode.isExpanded());
+            for (TreeNode childNode : treeNode.getChildren()) {
+                expansionStates.putAll(getTreeNodeExpansionStatesRecursively(childNode, expansionStates));
+            }
+        }
+        return expansionStates;
+    }
+
+    private void updateNodeExpansionStates(DefaultTreeNode tree, HashMap<String, Boolean> expansionStates) {
+        if (Objects.nonNull(tree) && Objects.nonNull(expansionStates) && !expansionStates.isEmpty()) {
+            updateNodeExpansionStatesRecursively(tree, expansionStates);
+        }
+    }
+
+    private void updateNodeExpansionStatesRecursively(TreeNode treeNode, HashMap<String, Boolean> expansionStates) {
+        if (expansionStates.containsKey(treeNode.getRowKey())) {
+            treeNode.setExpanded(expansionStates.get(treeNode.getRowKey()));
+        }
+        for (TreeNode childNode : treeNode.getChildren()) {
+            updateNodeExpansionStatesRecursively(childNode, expansionStates);
+        }
+    }
+
+    private boolean nodeStateUnknown(HashMap<String, Boolean> expansionStates, TreeNode treeNode) {
+        return !Objects.nonNull(expansionStates) || !expansionStates.containsKey(treeNode.getRowKey());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -41,6 +41,7 @@ import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.services.ServiceManager;
 import org.primefaces.event.NodeCollapseEvent;
+import org.primefaces.event.NodeExpandEvent;
 import org.primefaces.event.TreeDragDropEvent;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
@@ -801,6 +802,19 @@ public class StructurePanel implements Serializable {
     }
 
     /**
+     * Callback function triggered on NodeExpandEvent. Sets the 'expanded' flag of the corresponding tree node to
+     * 'true' because this is not done automatically by PrimeFaces on a NodeExpandEvent.
+     *
+     * @param event
+     *          the NodeExpandEvent triggered in the corresponding structure tree
+     */
+    public void onNodeExpand(NodeExpandEvent event) {
+        if (Objects.nonNull(event) && Objects.nonNull(event.getTreeNode())) {
+            event.getTreeNode().setExpanded(true);
+        }
+    }
+
+    /**
      * Callback function triggered on TreeDragDropEvent. Checks whether performed drag'n'drop action is allowed
      * considering ruleset restrictions on structure hierarchy. In case some ruleset rules were violated by the action
      * displays a corresponding error message to the user and reverts tree to prior state.
@@ -822,7 +836,6 @@ public class StructurePanel implements Serializable {
         }
         StructureTreeNode dropNode = (StructureTreeNode) dropNodeObject;
         StructureTreeNode dragNode = (StructureTreeNode) dragNodeObject;
-
 
         try {
             if (dragNode.getDataObject() instanceof IncludedStructuralElement

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -40,6 +40,8 @@
                     update="structureTreeForm:logicalTree,metadataAccordion:logicalMetadataWrapperPanel,galleryWrapperPanel"/>
             <p:ajax event="collapse"
                     listener="#{DataEditorForm.structurePanel.onNodeCollapse}"/>
+            <p:ajax event="expand"
+                    listener="#{DataEditorForm.structurePanel.onNodeExpand}"/>
             <p:treeNode expandedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-expanded'}"
                         collapsedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-collapsed'}">
                 <!--@elvariable id="logicalElementType" type="java.lang.String"-->
@@ -93,6 +95,8 @@
                         update="structureTreeForm:physicalTree,metadataAccordion:physicalMetadataWrapperPanel,galleryWrapperPanel"/>
                 <p:ajax event="collapse"
                         listener="#{DataEditorForm.structurePanel.onNodeCollapse}"/>
+                <p:ajax event="expand"
+                        listener="#{DataEditorForm.structurePanel.onNodeExpand}"/>
                 <p:treeNode expandedIcon="#{physicalNode.dataObject.type eq 'page' ? 'ui-icon-document' : 'ui-icon-folder-expanded'}"
                             collapsedIcon="#{physicalNode.dataObject.type eq 'page' ? 'ui-icon-document' : 'ui-icon-folder-collapsed'}">
                     <!--@elvariable id="physicalElementType" type="java.lang.String"-->


### PR DESCRIPTION
Store expansion states of all TreeNodes in logical and physical structure trees. After actions that alter the structure of the trees are performed by the user - drag'n'drop, thumbnail selection in gallery etc. - the expansion states are restored when updating the trees.
On initial construction (when the metadata editor is opened with a process) all nodes are expanded by default.