### PR TITLE
Prevent correction comments in parallel tasks

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CommentForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CommentForm.java
@@ -297,7 +297,7 @@ public class CommentForm extends BaseForm {
      * @return whether there are concurrent tasks in work or not
      */
     public boolean isConcurrentTaskInWork() {
-        return this.currentTask.getId() < 0 || !getConcurrentTasksInWork().isEmpty();
+        return !getConcurrentTasksInWork().isEmpty();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.SessionScoped;
+import javax.faces.context.FacesContext;
 import javax.inject.Named;
 
 import org.apache.logging.log4j.LogManager;
@@ -185,8 +186,12 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             openProcesses.put(process.getId(), user);
         } catch (IOException | DAOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
-            // TODO: redirect to referrer!
-            //FacesContext.getCurrentInstance().getExternalContext().redirect(referringView);
+            try {
+                FacesContext.getCurrentInstance().getExternalContext().redirect(referringView);
+            } catch (IOException ex) {
+                logger.error("Unable to redirect to referrer '" + referringView + "'. (" + ex.getLocalizedMessage()
+                        + ")");
+            }
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -598,7 +598,10 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     public int getFallbackTaskID(int processID) {
         try {
             Process process = ServiceManager.getProcessService().getById(processID);
-            return process.getTasks().get(0).getId();
+            if (!process.getTasks().isEmpty()) {
+                return process.getTasks().get(0).getId();
+            }
+            return -1;
         } catch (DAOException e) {
             Helper.setErrorMessage("errorLoadingOne", new Object[] {ObjectType.PROCESS.getTranslationSingular(),
                 processID}, logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -39,6 +39,7 @@ import org.kitodo.api.dataformat.View;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.MetadataEditor;
+import org.kitodo.production.security.SecurityUserDetails;
 import org.kitodo.production.services.ServiceManager;
 import org.primefaces.event.NodeCollapseEvent;
 import org.primefaces.event.NodeExpandEvent;
@@ -1010,9 +1011,33 @@ public class StructurePanel implements Serializable {
         show();
     }
 
+    /**
+     * Check and return whether the metadata of a process should be displayed in separate logical and physical
+     * structure trees or in one unified structure tree.
+     * Returns true if the current task in the metadata editor is
+     * - non null
+     * - assigned to the current user
+     * - type metadata
+     * - separate structure flag = true
+     *
+     * @return
+     *          whether metadata structure should be displayed in separate structure trees or not
+     */
     public boolean isSeparateMedia() {
-        return Objects.nonNull(this.dataEditor.getCurrentTask())
-                && this.dataEditor.getCurrentTask().isSeparateStructure();
+        if (Objects.nonNull(this.dataEditor.getCurrentTask())
+                && this.dataEditor.getCurrentTask().isTypeMetadata()
+                && this.dataEditor.getCurrentTask().isSeparateStructure()) {
+            SecurityUserDetails authenticatedUser = ServiceManager.getUserService().getAuthenticatedUser();
+            if (Objects.nonNull(authenticatedUser)) {
+                int userID = authenticatedUser.getId();
+                return Objects.nonNull(this.dataEditor.getCurrentTask().getProcessingUser())
+                        && Objects.equals(this.dataEditor.getCurrentTask().getProcessingUser().getId(), userID);
+            } else {
+                return true;
+            }
+        } else {
+            return false;
+        }
     }
 
     private void expandNode(TreeNode node) {

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -213,6 +213,7 @@ currentPageReportTemplate={currentPage} von {totalPages}
 currentRepresentative=Aktueller Repr\u00E4sentant\:
 dataCopier.runtimeException=Fehler beim Kopieren der Daten\:
 dataEditor.childNotContainedError=Elternelement von Struktur {0} enth\u00E4lt die Struktur nicht!
+dataEditor.comment.parallelTaskInWorkText=Sie k\u00F6nnen f\u00FCr die aktuelle Aufgabe keinen Korrekturkommentar schreiben, da sich eine parallele Aufgabe ({0}) derzeit durch Benutzer {1} in Bearbeitung befindet.
 dataEditor.comment.role.archivist=Archivar/in
 dataEditor.comment.role.creator=Sch\u00F6pfer/in
 dataEditor.comment.role.custodian=Verwalter/in

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -213,6 +213,7 @@ currentPageReportTemplate={currentPage} of {totalPages}
 currentRepresentative=Current representative\:
 dataCopier.runtimeException=Copying the data failed\:
 dataEditor.childNotContainedError=Parents of structure {0} do not contain structure!
+dataEditor.comment.parallelTaskInWorkText=Correction comments are disabled while parallel task {0} is in work by user {1}.
 dataEditor.comment.role.archivist=archivist
 dataEditor.comment.role.creator=creator
 dataEditor.comment.role.custodian=custodian

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/newCommentDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/newCommentDialog.xhtml
@@ -54,7 +54,8 @@
                         <p:outputLabel value="#{msgs.correctionMessage}" for="correctionMessageSwitch"/>
                         <p:selectBooleanCheckbox id="correctionMessageSwitch"
                                                  value="#{CommentForm.correctionComment}"
-                                                 disabled="#{CommentForm.sizeOfPreviousStepsForProblemReporting lt 1}"
+                                                 disabled="#{CommentForm.sizeOfPreviousStepsForProblemReporting lt 1 || CommentForm.concurrentTaskInWork}"
+                                                 title="#{CommentForm.concurrentTaskInWorkTooltip}"
                                                  immediate="true"
                                                  styleClass="switch input">
                             <p:ajax event="change" update="@form"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -84,13 +84,14 @@
                     </h:commandLink>
 
                     <!-- Metadaten-button -->
-                    <h:commandLink id="readXml"
-                                   rendered="#{task.typeMetadata and process.blockedUser == null}"
-                                   actionListener="#{DataEditorForm.setCurrentTask(task)}"
-                                   action="#{DataEditorForm.open(process.id, 'currentTasksEdit.jsf?id='.concat(task.id))}"
-                                   title="#{msgs.metadataEdit}">
+                    <h:link id="readXml"
+                            outcome="/pages/metadataEditor?faces-redirect=true"
+                            rendered="#{task.typeMetadata and process.blockedUser == null}"
+                            title="#{msgs.metadataEdit}">
+                        <f:param name="taskId" value="#{task.id}"/>
+                        <f:param name="referrer" value="#{'currentTasksEdit.jsf?id='.concat(task.id)}"/>
                         <h:outputText><i class="fa fa-file-o"/> #{msgs.metadataEdit}</h:outputText>
-                    </h:commandLink>
+                    </h:link>
 
                     <!-- Re-generate all images action link -->
                     <h:commandLink id="generateAllImages"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
@@ -55,15 +55,14 @@
                     <h:outputText><i class="fa fa-file-o"/></h:outputText>
                 </p:commandLink>
                 <!-- else, open metadata editor directly -->
-                <h:commandLink id="readXML"
-                               action="#{DataEditorForm.open(process.id, 'desktop')}"
-                               title="#{msgs.metadataEdit}"
-                               actionListener="#{CommentForm.setProcessId(process.id)}"
-                               rendered="#{SecurityAccessController.hasAuthorityToOpenMetadataEditor() and taskOptions.size() le 1}">
-                    <f:setPropertyActionListener value="#{taskOptions.size() eq 1 ? taskOptions.get(0) : null}"
-                                                 target="#{DataEditorForm.currentTask}"/>
+                <h:link id="readXML"
+                        outcome="/pages/metadataEditor?faces-redirect=true"
+                        title="#{msgs.metadataEdit}"
+                        rendered="#{SecurityAccessController.hasAuthorityToOpenMetadataEditor() and taskOptions.size() le 1}">
+                    <f:param name="taskId" value="#{taskOptions.size() eq 1 ? taskOptions.get(0).getId() : DataEditorForm.getFallbackTaskID(process.id)}"/>
+                    <f:param name="referrer" value="#{'desktop'}"/>
                     <h:outputText><i class="fa fa-file-o"/></h:outputText>
-                </h:commandLink>
+                </h:link>
 
                 <p:commandLink id="download" action="#{ProcessForm.downloadToHome}" title="#{msgs.linkHomeDirectory}"
                                rendered="#{SecurityAccessController.hasAuthorityToEditProcessImages()}">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/tasksWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/tasksWidget.xhtml
@@ -52,7 +52,6 @@
                 </p:commandLink>
                 <!-- assign task -->
                 <h:commandLink id="take" action="#{CurrentTaskForm.takeOverTask}"
-                               actionListener="#{CommentForm.setProcessId(task.process.id)}"
                                rendered="#{(task.processingStatus == 'OPEN' and !task.batchStep) || (task.processingStatus == 'OPEN' and task.batchStep and !task.batchAvailable)}"
                                title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}" icon="fa fa-bell-o">
                     <h:outputText><i class="fa fa-bell-o"/></h:outputText>
@@ -60,7 +59,6 @@
                 </h:commandLink>
                 <!-- already assigned task (this user) -->
                 <h:commandLink id="editOwnTask" action="#{CurrentTaskForm.editTask}"
-                               actionListener="#{CommentForm.setProcessId(task.process.id)}"
                                rendered="#{(task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and !task.batchStep) || (task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and task.batchStep and !task.batchAvailable)}"
                                title="#{msgs.inBearbeitungDurch}: #{task.processingUser!=null and task.processingUser.id!=0 ? task.processingUser.fullName:''}">
                     <h:outputText><i class="fa fa-bell"/></h:outputText>
@@ -69,7 +67,6 @@
                 </h:commandLink>
                 <!-- already assigned task (different user) -->
                 <h:commandLink id="editOtherTask" action="#{CurrentTaskForm.editTask}"
-                               actionListener="#{CommentForm.setProcessId(task.process.id)}"
                                rendered="#{task.processingStatus == 'INWORK' and task.processingUser.id != LoginForm.loggedUser.id and (!task.batchStep || !task.batchAvailable)}"
                                title="#{msgs.inBearbeitungDurch}: #{(task.processingUser!=null and task.processingUser.id!=0 ? task.processingUser.fullName : '')}">
                     <h:outputText><i class="fa fa-bell-slash"/></h:outputText>
@@ -78,7 +75,6 @@
 
                 <!-- take over batch -->
                 <h:commandLink id="batch" action="#{CurrentTaskForm.takeOverBatchTasks}"
-                               actionListener="#{CommentForm.setProcessId(task.process.id)}"
                                rendered="#{task.processingStatus == 'OPEN' and task.batchStep and task.batchAvailable}"
                                title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
                     <h:graphicImage value="/pages/images/buttons/admin3a.gif" alt="edit"/>
@@ -87,7 +83,6 @@
 
                 <!-- edit batch step (this user) -->
                 <h:commandLink id="batchInWork" action="#{CurrentTaskForm.editBatchTasks}"
-                               actionListener="#{CommentForm.setProcessId(task.process.id)}"
                                rendered="#{task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and task.batchStep and task.batchAvailable}"
                                title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
                     <h:graphicImage value="/pages/images/buttons/admin3.gif" alt="edit"/>
@@ -96,7 +91,6 @@
 
                 <!-- edit batch step (different user) -->
                 <h:commandLink id="batchInWorkOther" action="#{CurrentTaskForm.editBatchTasks}"
-                               actionListener="#{CommentForm.setProcessId(task.process.id)}"
                                rendered="#{task.processingStatus == 'INWORK' and task.processingUser.id != LoginForm.loggedUser.id and task.batchStep and task.batchAvailable}"
                                title="#{msgs.inBearbeitungDurch}: #{(task.processingUser!=null and task.processingUser.id!=0 ? task.processingUser.fullName : '')}">
                     <h:graphicImage value="/pages/images/buttons/admin3c.gif" alt="edit"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/selectCurrentTask.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/selectCurrentTask.xhtml
@@ -33,8 +33,12 @@
                 <h:panelGroup styleClass="select-selector" layout="block">
                     <p>
                         <p:selectOneMenu id="currentTaskMenu"
+                                         required="true"
                                          converter="#{taskConverter}"
                                          value="#{DataEditorForm.currentTask}">
+                            <f:selectItem itemValue="#{null}"
+                                          itemLabel="#{msgs['dataEditor.selectMetadataTask']}"
+                                          noSelectionOption="true"/>
                             <f:selectItems value="#{DataEditorForm.getCurrentTaskOptions(DataEditorForm.process.id)}"
                                            var="task"
                                            itemLabel="#{task.title}"
@@ -44,8 +48,7 @@
                     <p:panelGrid>
                         <p:row>
                             <p:commandButton id="setCurrentTaskButton"
-                                             action="#{DataEditorForm.open(DataEditorForm.process.id, view.viewId)}"
-                                             actionListener="#{CommentForm.setProcessId(DataEditorForm.process.id)}"
+                                             action="#{DataEditorForm.selectCurrentTask(view.viewId)}"
                                              onclick="PF('selectCurrentTaskDialog').hide();"
                                              styleClass="primary right"
                                              iconPos="right"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
@@ -23,8 +23,8 @@
                                     SecurityAccessController.hasAuthorityToEditProcessStructureData()}"/>
     <p:panel styleClass="content-header">
         <h3 id="headerText">
-            <h:outputText value="#{DataEditorForm.processTitle} - #{msgs.metadataEdit}"
-                          title="#{DataEditorForm.processTitle} - #{msgs.metadataEdit}"/>
+            <h:outputText value="#{DataEditorForm.processTitle} - #{msgs.metadataEdit} (Task: '#{DataEditorForm.currentTask.title}')"
+                          title="#{DataEditorForm.processTitle} - #{msgs.metadataEdit} (Task: '#{DataEditorForm.currentTask.title}')"/>
         </h3>
         <p:commandButton id="save"
                          widgetVar="save"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -81,15 +81,14 @@
                     <h:outputText><i class="fa fa-file-o"/></h:outputText>
                 </p:commandLink>
                 <!-- else, open metadata editor directly -->
-                <h:commandLink id="readXML"
-                               action="#{DataEditorForm.open(process.id, 'processes')}"
-                               title="#{msgs.metadataEdit}"
-                               actionListener="#{CommentForm.setProcessId(process.id)}"
-                               rendered="#{SecurityAccessController.hasAuthorityToOpenMetadataEditor() and taskOptions.size() le 1}">
-                    <f:setPropertyActionListener value="#{taskOptions.size() eq 1 ? taskOptions.get(0) : null}"
-                                                 target="#{DataEditorForm.currentTask}"/>
+                <h:link id="readXML"
+                        outcome="/pages/metadataEditor?faces-redirect=true"
+                        title="#{msgs.metadataEdit}"
+                        rendered="#{SecurityAccessController.hasAuthorityToOpenMetadataEditor() and taskOptions.size() le 1}">
+                    <f:param name="taskId" value="#{taskOptions.size() eq 1 ? taskOptions.get(0).getId() : DataEditorForm.getFallbackTaskID(process.id)}"/>
+                    <f:param name="referrer" value="#{'processes'}"/>
                     <h:outputText><i class="fa fa-file-o"/></h:outputText>
-                </h:commandLink>
+                </h:link>
 
                 <p:commandLink id="download" action="#{ProcessForm.downloadToHome}" title="#{msgs.linkHomeDirectory}"
                                rendered="#{SecurityAccessController.hasAuthorityToEditProcessImages()}">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -89,7 +89,6 @@
             <p:column headerText="#{msgs.actions}">
                 <!-- assign task -->
                 <h:commandLink id="take"
-                               actionListener="#{CommentForm.setProcessId(item.process.id)}"
                                action="#{CurrentTaskForm.takeOverTask}"
                                rendered="#{(item.processingStatus == 'OPEN' and !item.batchStep) || (item.processingStatus == 'OPEN' and item.batchStep and !item.batchAvailable)}"
                                title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
@@ -98,7 +97,6 @@
                 </h:commandLink>
                 <!-- already assigned task (this user) -->
                 <h:commandLink id="editOwnTask" action="#{CurrentTaskForm.editTask}"
-                               actionListener="#{CommentForm.setProcessId(item.process.id)}"
                                rendered="#{(item.processingStatus == 'INWORK' and item.processingUser.id == LoginForm.loggedUser.id and !item.batchStep) || (item.processingStatus == 'INWORK' and item.processingUser.id == LoginForm.loggedUser.id and item.batchStep and !item.batchAvailable)}"
                                title="#{msgs.inBearbeitungDurch}: #{item.processingUser!=null and item.processingUser.id!=0 ? item.processingUser.fullName:''}">
                     <i class="fa fa-bell"/>
@@ -106,7 +104,6 @@
                 </h:commandLink>
                 <!-- already assigned task (different user) -->
                 <h:commandLink id="editOtherTask" action="#{CurrentTaskForm.editTask}"
-                               actionListener="#{CommentForm.setProcessId(item.process.id)}"
                                rendered="#{item.processingStatus == 'INWORK' and item.processingUser.id != LoginForm.loggedUser.id and (!item.batchStep || !item.batchAvailable)}"
                                title="#{msgs.inBearbeitungDurch}: #{(item.processingUser!=null and item.processingUser.id!=0 ? item.processingUser.fullName : '')}">
                     <i class="fa fa-bell-slash"/>
@@ -115,7 +112,6 @@
 
                 <!-- take over batch -->
                 <h:commandLink id="batch" action="#{CurrentTaskForm.takeOverBatchTasks}"
-                               actionListener="#{CommentForm.setProcessId(item.process.id)}"
                                rendered="#{item.processingStatus == 'OPEN' and item.batchStep and item.batchAvailable}"
                                title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
                     <h:graphicImage value="/pages/images/buttons/admin3a.gif" alt="edit"/>
@@ -124,7 +120,6 @@
 
                 <!-- edit batch step (this user) -->
                 <h:commandLink id="batchInWork" action="#{CurrentTaskForm.editBatchTasks}"
-                               actionListener="#{CommentForm.setProcessId(item.process.id)}"
                                rendered="#{item.processingStatus == 'INWORK' and item.processingUser.id == LoginForm.loggedUser.id and item.batchStep and item.batchAvailable}"
                                title="#{msgs.bearbeitungDiesesSchrittsUebernehmen}">
                     <h:graphicImage value="/pages/images/buttons/admin3.gif" alt="edit"/>
@@ -133,7 +128,6 @@
 
                 <!-- edit batch step (different user) -->
                 <h:commandLink id="batchInWorkOther" action="#{CurrentTaskForm.editBatchTasks}"
-                               actionListener="#{CommentForm.setProcessId(item.process.id)}"
                                rendered="#{item.processingStatus == 'INWORK' and item.processingUser.id != LoginForm.loggedUser.id and item.batchStep and item.batchAvailable}"
                                title="#{msgs.inBearbeitungDurch}: #{(item.processingUser!=null and item.processingUser.id!=0 ? item.processingUser.fullName : '')}">
                     <h:graphicImage value="/pages/images/buttons/admin3c.gif" alt="edit"/>

--- a/Kitodo/src/main/webapp/pages/currentTasksEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/currentTasksEdit.xhtml
@@ -18,8 +18,10 @@
         xmlns:p="http://primefaces.org/ui">
 
     <f:metadata>
+        <!--@elvariable id="id" type="int"-->
         <f:viewParam name="id"/>
         <f:viewAction action="#{CurrentTaskForm.loadTaskById(id)}"/>
+        <f:viewAction action="#{CommentForm.setCurrentTaskById(id)}"/>
     </f:metadata>
 
     <ui:define name="contentHeader">

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -13,10 +13,21 @@
 
 <ui:composition
         template="/WEB-INF/templates/base.xhtml"
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:a="http://xmlns.jcp.org/jsf/passthrough"
         xmlns:p="http://primefaces.org/ui">
+
+    <f:metadata>
+        <!--@elvariable id="taskId" type="int"-->
+        <f:viewParam name="taskId"/>
+        <!--@elvariable id="referrer" type="java.lang.String"-->
+        <f:viewParam name="referrer"/>
+        <f:viewAction action="#{DataEditorForm.open(taskId, referrer)}"/>
+        <f:viewAction action="#{CommentForm.setCurrentTaskById(taskId)}"/>
+    </f:metadata>
+
     <ui:define name="content">
 
         <!--@elvariable id="viewStructure" type="boolean"-->

--- a/Kitodo/src/main/webapp/pages/searchResult.xhtml
+++ b/Kitodo/src/main/webapp/pages/searchResult.xhtml
@@ -75,15 +75,14 @@
                     <h:outputText><i class="fa fa-file-o"/></h:outputText>
                 </p:commandLink>
                 <!-- else, open metadata editor directly -->
-                <h:commandLink id="readXML"
-                               action="#{DataEditorForm.open(process.id, 'processes')}"
-                               title="#{msgs.metadataEdit}"
-                               actionListener="#{CommentForm.setProcessId(process.id)}"
-                               rendered="#{SecurityAccessController.hasAuthorityToOpenMetadataEditor() and taskOptions.size() le 1}">
-                    <f:setPropertyActionListener value="#{taskOptions.size() eq 1 ? taskOptions.get(0) : null}"
-                                                 target="#{DataEditorForm.currentTask}"/>
+                <h:link id="readXML"
+                        outcome="/pages/metadataEditor?faces-redirect=true"
+                        title="#{msgs.metadataEdit}"
+                        rendered="#{SecurityAccessController.hasAuthorityToOpenMetadataEditor() and taskOptions.size() le 1}">
+                    <f:param name="taskId" value="#{taskOptions.size() eq 1 ? taskOptions.get(0).getId() : DataEditorForm.getFallbackTaskID(process.id)}"/>
+                    <f:param name="referrer" value="#{'searchResult'}"/>
                     <h:outputText><i class="fa fa-file-o"/></h:outputText>
-                </h:commandLink>
+                </h:link>
 
                 <p:commandLink id="download" action="#{ProcessForm.downloadToHome}" title="#{msgs.linkHomeDirectory}"
                                rendered="#{SecurityAccessController.hasAuthorityToEditProcessImages()}">


### PR DESCRIPTION
The option to create parallel tasks with the new workflow editor mostly renders the previous function to determine the one `currentTask` that is `INWORK` useless. 
Since now mutliple parallel tasks can be `INWORK` at the same time, the option to write a correction comment (which closes all tasks that come after a selected "correction task" in the workflow) needs to be deactivated if separate tasks are currently in work by different users.

The changes in this Pull Request perform this check and deactivate the switch for correction comments, adding a tooltip to the deactivated switch informing the user which other parallel task is in work by which user.

Additionaly, this Pull Request changes the way the MetadataEditor is opened. Instead of setting the ID of a process to load in the backend, the task for which the metadata is opened is passed as an URL parameter. This way, the Metadata Editor can be opened with appropriate URL parameters (e.g. `taskId=41` etc.) and does not rely on specific states in the backend, e.g. it becomes "bookmarkable".

<img width="1438" alt="Bildschirmfoto 2019-07-19 um 10 27 31" src="https://user-images.githubusercontent.com/19183925/61522412-9bb56380-aa12-11e9-90f3-9537c867cac5.png">
