### PR TITLE
2.x: Fix regression through other syntax

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/GoobiScript.java
+++ b/Goobi/src/de/sub/goobi/helper/GoobiScript.java
@@ -81,12 +81,15 @@ public class GoobiScript {
         StrTokenizer tokenizer = new StrTokenizer(inScript, ' ', '\"');
         while (tokenizer.hasNext()) {
             String tok = tokenizer.nextToken();
-            if (tok.indexOf(":") == -1) {
-                Helper.setFehlerMeldung("goobiScriptfield", "missing delimiter / unknown parameter: ", tok);
-            } else {
+            if (tok.contains(":")) {
                 String myKey = tok.substring(0, tok.indexOf(":"));
                 String myValue = tok.substring(tok.indexOf(":") + 1);
                 this.myParameters.put(myKey, myValue);
+            } else {
+                // action copyData has an other syntax so ignore missing colon sign(s)
+                if (this.myParameters.get("action") != null && !this.myParameters.get("action").equals("copyData")) {
+                    Helper.setFehlerMeldung("goobiScriptfield", "missing delimiter / unknown parameter: ", tok);
+                }
             }
         }
 


### PR DESCRIPTION
While reworking KitodoScript in #2710 I missed the fact that the KitodoScript action `copyData` has an other syntax. If you execute this script you get the following false error messages:

![Screenshot_2019-07-19_14-42-03](https://user-images.githubusercontent.com/2129672/61537495-9ae2f880-aa37-11e9-95aa-b7f8f075acf9.png)

One solution is to ignore the missing colon sign if chosen action is `copyData`.