### PR TITLE
Fix duplicate scrollbars in Firefox

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1506,6 +1506,12 @@ Column content
     position: absolute;
 }
 
+/* This fixes duplicate scrollbars in Firefox */
+#metadataAccordion\:metadata\:addMetadataButton + table,
+#metadataAccordion\:physicalMetadata\:addMetadataButton + table {
+    margin-top: 0 !important;
+}
+
 #metadata input {
     width: 100%;
 }


### PR DESCRIPTION
Fixes duplicate scrollbars in the metadata editor's metadata column.