### PR TITLE
2.x: Switch to xenial release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 # Travis continuous integration for Kitodo.Production
 
-dist: trusty
+dist: xenial
 
 language: java
 
 jdk:
-  - oraclejdk8
   - openjdk8
 
 addons:


### PR DESCRIPTION
This pull request will change the Travis build infrastructure from Trusty to Xenial. 

Disadvantage of Xenial is lack of support for OracleJDK8 so test execution would not run against this JDK. This can lead to breaks if some OpenJDK-only specific code is inserted which did not exists on OracleJDK. But there is no other way as the support for Trusty has ended in April 2019 and default distribution is on Travis Xenial already.

It is up to the maintainers to accept or reject this pull request.
