### PR TITLE
Switch from trusty to xenial distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,13 @@ cache:
     - $HOME/.m2
   timeout: 1000
 
-dist: trusty
+dist: xenial
 
 jdk:
-  - oraclejdk8
   - openjdk8
 
 addons:
   chrome: stable
-  apt:
-      sources:
-        - mysql-5.7-trusty
-      packages:
-        - mysql-server
 
 env: DB=mysql
 
@@ -27,7 +21,7 @@ services:
   - mysql
 
 script:
-  - mvn clean install -B -Pall-tests,flyway,checkstyle,findbugs,!development && mvn clean install -B -Pselenium,!development
+  - mvn clean install -B '-Pall-tests,flyway,checkstyle,findbugs,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
 
 # install: true is deactivating the separate install-step, which runs before the script
 install: true
@@ -44,7 +38,4 @@ before_script:
   - mysql -u root -e "GRANT ALL ON kitodo.* TO 'kitodo'@'localhost';"
   - mysql -u root kitodo < Kitodo/setup/schema.sql
   - mysql -u root kitodo < Kitodo/setup/default.sql
-  - export DISPLAY=:99.0
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
   - export MAVEN_OPTS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
This pull request will change the Travis build environment from Trusty to Xenial like in #2770 

The same disadvantage is here: Xenial did not support OracleJDK8 any more and so tests would not executed against this JDK.

Obsolete:
An other disadvantage currently is that one selenium test suite is failing every time: `RemovingST`. I could not find the reason for this failing as this not happing on my local development system. Output from Travis:

```
[ERROR] removeRoleTest  Time elapsed: 12.048 s  <<< ERROR!
org.openqa.selenium.ElementClickInterceptedException: 
element click intercepted: Element <li class="ui-tabs-header ui-state-default ui-corner-top ui-tabs-selected ui-state-active" role="tab" aria-expanded="true" aria-selected="true" aria-label="" data-index="1" tabindex="0">...</li> is not clickable at point (167, 143). Other element would receive the click: <div id="loadingScreen" style="">...</div>
  (Session info: chrome=75.0.3770.142)
Build info: version: '3.12.0', revision: '7c6e0b3', time: '2018-05-08T14:04:26.12Z'
System info: host: 'travis-job-273e925a-a5ec-49da-9e91-87857cd0bb3f', ip: '127.0.1.1', os.name: 'Linux', os.arch: 'amd64', os.version: '4.15.0-1028-gcp', java.version: '1.8.0_191'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Capabilities {acceptInsecureCerts: false, browserName: chrome, browserVersion: 75.0.3770.142, chrome: {chromedriverVersion: 75.0.3770.140 (2d9f97485c7b..., userDataDir: /tmp/.com.google.Chrome.QYUbfV}, goog:chromeOptions: {debuggerAddress: localhost:46453}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, proxy: Proxy(), setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify}
Session ID: adb3f3bc3c543f8b0412854b6aeb3f16
	at org.kitodo.selenium.RemovingST.removeRoleTest(RemovingST.java:77)
```

Maybe someone else can fetch this kind of error and use this pull request as a base for this solution. 