### PR TITLE
 Remove ‘order’ from hierarchical links

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/LinkedMetsResource.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/LinkedMetsResource.java
@@ -11,7 +11,6 @@
 
 package org.kitodo.api.dataformat.mets;
 
-import java.math.BigInteger;
 import java.net.URI;
 
 /**
@@ -22,11 +21,6 @@ public class LinkedMetsResource {
      * The loctype of the linked METS resource.
      */
     private String loctype;
-
-    /**
-     * The order of the linked METS resource.
-     */
-    private BigInteger order;
 
     /**
      * The URI of the linked METS resource.
@@ -50,25 +44,6 @@ public class LinkedMetsResource {
      */
     public void setLoctype(String loctype) {
         this.loctype = loctype;
-    }
-
-    /**
-     * Returns the order of the linked METS resource.
-     *
-     * @return the order
-     */
-    public BigInteger getOrder() {
-        return order;
-    }
-
-    /**
-     * Sets the order of the linked METS resource.
-     *
-     * @param order
-     *            order to set
-     */
-    public void setOrder(BigInteger order) {
-        this.order = order;
     }
 
     /**

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MptrXmlElementAccess.java
@@ -57,7 +57,6 @@ class MptrXmlElementAccess {
      *            {@code <mets:div>} to which the information is added
      */
     static void addMptrToDiv(LinkedMetsResource link, DivType div) {
-        div.setORDER(link.getOrder());
         Mptr mptr = new Mptr();
         if (AllowedLoctypeValues.contains(link.getLoctype())) {
             mptr.setLOCTYPE(link.getLoctype());
@@ -84,7 +83,6 @@ class MptrXmlElementAccess {
         Mptr mptr = div.getMptr().get(0);
         linkFromDiv.setLoctype(AllowedLoctypeValues.OTHER.toString().equals(mptr.getLOCTYPE()) ? mptr.getOTHERLOCTYPE()
                 : mptr.getLOCTYPE());
-        linkFromDiv.setOrder(div.getORDER());
         linkFromDiv.setUri(URI.create(mptr.getHref()));
         return linkFromDiv;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -18,7 +18,6 @@ import static org.kitodo.production.metadata.InsertionPosition.LAST_CHILD_OF_CUR
 import static org.kitodo.production.metadata.InsertionPosition.PARENT_OF_CURRENT_ELEMENT;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -76,7 +75,6 @@ public class AddDocStrucTypeDialog {
     private String processNumber = "";
     private Process selectedProcess;
     private List<ProcessDTO> processes = Collections.emptyList();
-    private BigInteger orderSpinnerValue;
 
     /**
      * Backing bean for the add doc struc type dialog of the metadata editor.
@@ -563,26 +561,6 @@ public class AddDocStrucTypeDialog {
     }
 
     /**
-     * Returns the value of the order spinner. The order has an influence on the
-     * order when adding links.
-     *
-     * @return the value of the order spinner
-     */
-    public BigInteger getOrderSpinnerValue() {
-        return orderSpinnerValue;
-    }
-
-    /**
-     * Sets the value of the order spinner if the user has entered a value here.
-     *
-     * @param orderSpinnerValue
-     *            value to set
-     */
-    public void setOrderSpinnerValue(BigInteger orderSpinnerValue) {
-        this.orderSpinnerValue = orderSpinnerValue;
-    }
-
-    /**
      * Adds the link when the user clicks OK.
      */
     public void addLinkButtonClick() {
@@ -599,13 +577,12 @@ public class AddDocStrucTypeDialog {
         }
         dataEditor.getCurrentChildren().add(selectedProcess);
         MetadataEditor.addLink(dataEditor.getSelectedStructure().orElseThrow(IllegalStateException::new),
-            orderSpinnerValue, selectedProcess.getId());
+            selectedProcess.getId());
         dataEditor.getStructurePanel().show(true);
         if (processNumber.trim().equals(Integer.toString(selectedProcess.getId()))) {
             alert(Helper.getTranslation("dialogAddDocStrucType.searchButtonClick.hint"));
         }
         processNumber = "";
         processes = Collections.emptyList();
-        orderSpinnerValue = null;
     }
 }

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -265,7 +265,6 @@ detailsDesSchritts=Details der Aufgabe
 detailsOfBatch=Batchdetails
 determineWhichImagesNeedToBeGenerated=\u00DCberpr\u00FCfe {0}
 closeTask=Die Bearbeitung dieser Aufgabe abschlie\u00DFen
-dialogAddDocStrucType.order=Anordnung:
 dialogAddDocStrucType.searchButton=Suchen
 dialogAddDocStrucType.searchButtonClick.empty=Sie m\u00FCssen nach etwas suchen.
 dialogAddDocStrucType.searchButtonClick.error=Die Suche lief auf einen Fehler:

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -265,7 +265,6 @@ detailsDesSchritts=Details of the task
 detailsOfBatch=batch details
 determineWhichImagesNeedToBeGenerated=Checking {0}
 closeTask=Finish this task
-dialogAddDocStrucType.order=Order:
 dialogAddDocStrucType.searchButton=Search
 dialogAddDocStrucType.searchButtonClick.empty=You have to search for something.
 dialogAddDocStrucType.searchButtonClick.error=The search ran on a mistake:

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addDocStrucType.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addDocStrucType.xhtml
@@ -171,12 +171,6 @@
                                     </p:selectOneMenu>
                                 </p:column>
                             </p:row>
-                            <p:row>
-                                <p:column><h:outputLabel for="orderSpinner" value="#{msgs['dialogAddDocStrucType.order']}"/></p:column>
-                                <p:column colspan="2">
-                                    <p:spinner id="orderSpinner" value="#{DataEditorForm.addDocStrucTypeDialog.orderSpinnerValue}"/>
-                                </p:column>
-                            </p:row>
                         </p:panelGrid>
                         <h:panelGroup layout="block">
                             <p:commandButton id="addLinkButton"


### PR DESCRIPTION
The concept of using METS `ORDER` for positioning hierarchical METS links was abandoned and is hereby removed.