### PR TITLE
Move callback functions

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructureTreeNode.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructureTreeNode.java
@@ -15,19 +15,16 @@ import java.io.Serializable;
 
 import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.MediaUnit;
-import org.primefaces.event.NodeSelectEvent;
 
 public class StructureTreeNode implements Serializable {
 
     private final Object dataObject;
     private final String label;
     private final boolean linked;
-    private final StructurePanel structurePanel;
     private final boolean undefined;
 
-    StructureTreeNode(StructurePanel structurePanel, String label, boolean undefined, boolean linked,
+    StructureTreeNode(String label, boolean undefined, boolean linked,
             Object dataObject) {
-        this.structurePanel = structurePanel;
         this.label = label;
         this.undefined = undefined;
         this.linked = linked;
@@ -85,25 +82,4 @@ public class StructureTreeNode implements Serializable {
             return "";
         }
     }
-
-    /**
-     * Callback function triggered when a node is selected in the logical structure tree.
-     *
-     * @param event
-     *            NodeSelectEvent triggered by logical node being selected
-     */
-    public void treeLogicalSelect(NodeSelectEvent event) {
-        structurePanel.treeLogicalSelect(event.getTreeNode().getData());
-    }
-
-    /**
-     * Callback function triggered when a node is selected in the physical structure tree.
-     *
-     * @param event
-     *            NodeSelectEvent triggered by logical node being selected
-     */
-    public void treePhysicalSelect(NodeSelectEvent event) {
-        structurePanel.treePhysicalSelect();
-    }
-
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -33,7 +33,7 @@
                 droppable="true"
                 dragdropScope="logicalTree">
             <p:ajax event="select"
-                    listener="#{logicalNode.treeLogicalSelect}"
+                    listener="#{DataEditorForm.structurePanel.treeLogicalSelect}"
                     update="@(.thumbnail)
                             structureTreeForm:physicalTree
                             metadataAccordion:logicalMetadataWrapperPanel
@@ -96,7 +96,7 @@
                     droppable="true"
                     dragdropScope="physicalTree">
                 <p:ajax event="select"
-                        listener="#{physicalNode.treePhysicalSelect}"
+                        listener="#{DataEditorForm.structurePanel.treePhysicalSelect}"
                         update="@(.thumbnail)
                                 structureTreeForm:logicalTree
                                 metadataAccordion:physicalMetadataWrapperPanel


### PR DESCRIPTION
Move callback functions for `NodeSelect` events from `StructureNodeTree`s to `StructurePanel` to bring them in line with other callback functions and reduce redundant code.