### PR TITLE
Link media to multiple structural elements

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
@@ -72,6 +72,19 @@ public class MediaUnit implements Parent<MediaUnit> {
     private String metsDivReferrerId;
 
     /**
+     * List of IncludedStructuralElements this view is assigned to.
+     */
+    private List<IncludedStructuralElement> includedStructuralElements;
+
+    /**
+     * Creates a new MediaUnit.
+     */
+    public MediaUnit() {
+        includedStructuralElements = new LinkedList<>();
+    }
+
+
+    /**
      * Returns the subordinate media units associated with this media unit.
      *
      * @return the subordinate media units
@@ -177,6 +190,15 @@ public class MediaUnit implements Parent<MediaUnit> {
      */
     public void setDivId(String divId) {
         this.metsDivReferrerId = divId;
+    }
+
+    /**
+     * Get includedStructuralElements.
+     *
+     * @return value of includedStructuralElements
+     */
+    public List<IncludedStructuralElement> getIncludedStructuralElements() {
+        return includedStructuralElements;
     }
 
     @Override

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -118,6 +118,7 @@ public class DivXmlElementAccess extends IncludedStructuralElement {
                 if (Objects.nonNull(fileXmlElementAccess)
                     && !fileXmlElementAccessIsLinkedToChildren(fileXmlElementAccess, div.getDiv(), mediaUnitsMap)) {
                     super.getViews().add(new AreaXmlElementAccess(fileXmlElementAccess).getView());
+                    fileXmlElementAccess.getMediaUnit().getIncludedStructuralElements().add(this);
                 }
             }
         }

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -128,6 +128,7 @@ public class MetsXmlElementAccessIT {
             View view = new View();
             view.setMediaUnit(page);
             workpiece.getRootElement().getViews().add(view);
+            page.getIncludedStructuralElements().add(workpiece.getRootElement());
         }
 
         IncludedStructuralElement frontCover = new IncludedStructuralElement();
@@ -136,6 +137,7 @@ public class MetsXmlElementAccessIT {
         View view = new View();
         view.setMediaUnit(pages.get(0));
         frontCover.getViews().add(view);
+        view.getMediaUnit().getIncludedStructuralElements().add(frontCover);
         workpiece.getRootElement().getChildren().add(frontCover);
 
         IncludedStructuralElement inside = new IncludedStructuralElement();
@@ -144,9 +146,11 @@ public class MetsXmlElementAccessIT {
         view = new View();
         view.setMediaUnit(pages.get(1));
         inside.getViews().add(view);
+        view.getMediaUnit().getIncludedStructuralElements().add(inside);
         view = new View();
         view.setMediaUnit(pages.get(2));
         inside.getViews().add(view);
+        view.getMediaUnit().getIncludedStructuralElements().add(inside);
         workpiece.getRootElement().getChildren().add(inside);
 
         IncludedStructuralElement backCover = new IncludedStructuralElement();
@@ -155,6 +159,7 @@ public class MetsXmlElementAccessIT {
         view = new View();
         view.setMediaUnit(pages.get(3));
         backCover.getViews().add(view);
+        view.getMediaUnit().getIncludedStructuralElements().add(backCover);
         workpiece.getRootElement().getChildren().add(backCover);
 
         // add metadata

--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -203,6 +203,7 @@ public enum ParameterCore implements ParameterInterface {
 
     /**
      * Sorting of images.
+     * 
      * <p>
      * Numeric sorting of images. 1 is lesser then 002, compares the number of
      * image names, characters other than digits are not supported.

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -230,6 +230,10 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     private void init() {
         final long begin = System.nanoTime();
 
+        List<MediaUnit> severalAssignments = new LinkedList<>();
+        initSeveralAssignments(workpiece.getMediaUnit(), severalAssignments);
+        structurePanel.getSeveralAssignments().addAll(severalAssignments);
+
         structurePanel.show();
         structurePanel.getSelectedLogicalNode().setSelected(true);
         structurePanel.getSelectedPhysicalNode().setSelected(true);
@@ -318,6 +322,15 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         PrimeFaces.current().executeScript("PF('sticky-notifications').removeAll();");
         PrimeFaces.current().ajax().update("notifications");
         return null;
+    }
+
+    private void initSeveralAssignments(MediaUnit mediaUnit, List<MediaUnit> severalAssignments) {
+       if (mediaUnit.getIncludedStructuralElements().size() > 1) {
+           severalAssignments.add(mediaUnit);
+       }
+       for (MediaUnit child : mediaUnit.getChildren()) {
+           initSeveralAssignments(child, severalAssignments);
+       }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -657,4 +657,14 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         return "/pages/metadataEditor?faces-redirect=true&taskId=" + this.getCurrentTask().getId()
                 + "&referrer=" + referrer;
     }
+
+    void assignView(IncludedStructuralElement includedStructuralElement, View view) {
+        includedStructuralElement.getViews().add(view);
+        view.getMediaUnit().getIncludedStructuralElements().add(includedStructuralElement);
+    }
+
+    void unassignView(IncludedStructuralElement includedStructuralElement, View view) {
+        includedStructuralElement.getViews().remove(view);
+        view.getMediaUnit().getIncludedStructuralElements().remove(includedStructuralElement);
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -325,12 +325,12 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     }
 
     private void initSeveralAssignments(MediaUnit mediaUnit, List<MediaUnit> severalAssignments) {
-       if (mediaUnit.getIncludedStructuralElements().size() > 1) {
-           severalAssignments.add(mediaUnit);
-       }
-       for (MediaUnit child : mediaUnit.getChildren()) {
-           initSeveralAssignments(child, severalAssignments);
-       }
+        if (mediaUnit.getIncludedStructuralElements().size() > 1) {
+            severalAssignments.add(mediaUnit);
+        }
+        for (MediaUnit child : mediaUnit.getChildren()) {
+            initSeveralAssignments(child, severalAssignments);
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
@@ -82,7 +82,9 @@ public class EditPagesDialog {
      */
     public void addPage() {
         if (dataEditor.getSelectedStructure().isPresent()) {
-            dataEditor.getSelectedStructure().get().getViews().addAll(getViewsToAdd(paginationSelectionSelectedItems));
+            for (View viewToAdd : getViewsToAdd(paginationSelectionSelectedItems)) {
+                dataEditor.assignView(dataEditor.getSelectedStructure().get(), viewToAdd);
+            }
             dataEditor.refreshStructurePanel();
             prepare();
         }
@@ -210,8 +212,9 @@ public class EditPagesDialog {
      */
     public void setPageStartAndEnd() {
         if (dataEditor.getSelectedStructure().isPresent()) {
-            dataEditor.getSelectedStructure().get().getViews()
-                    .addAll(getViewsToAdd(selectFirstPageSelectedItem, selectLastPageSelectedItem));
+            for (View viewToAdd : getViewsToAdd(selectFirstPageSelectedItem, selectLastPageSelectedItem)) {
+                dataEditor.assignView(dataEditor.getSelectedStructure().get(), viewToAdd);
+            }
             dataEditor.refreshStructurePanel();
             prepare();
         }
@@ -258,8 +261,9 @@ public class EditPagesDialog {
      */
     public void removePage() {
         if (dataEditor.getSelectedStructure().isPresent()) {
-            dataEditor.getSelectedStructure().get().getViews()
-                    .removeAll(getViewsToAdd(paginationSubSelectionSelectedItems));
+            for (View viewToRemove : getViewsToAdd(paginationSubSelectionSelectedItems)) {
+                dataEditor.unassignView(dataEditor.getSelectedStructure().get(), viewToRemove);
+            }
             dataEditor.refreshStructurePanel();
             prepare();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryMediaContent.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryMediaContent.java
@@ -210,4 +210,16 @@ public class GalleryMediaContent {
     public View getView() {
         return view;
     }
+
+    /**
+     * Check if the GalleryMediaContent's MediaUnit is assigned to several IncludedStructuralElements.
+     *
+     * @return {@code true} when the MediaUnit is assigned to more than one logical element
+     */
+    public boolean isAssignedSeveralTimes() {
+        if (Objects.nonNull(view) && Objects.nonNull(view.getMediaUnit())) {
+            return view.getMediaUnit().getIncludedStructuralElements().size() > 1;
+        }
+        return false;
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -602,7 +602,7 @@ public class GalleryPanel {
         }
     }
 
-    /*
+    /**
      * Get the index of this GalleryMediaContent's MediaUnit out of all MediaUnits
      * which are assigned to more than one IncludedStructuralElement.
      *

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -601,4 +601,18 @@ public class GalleryPanel {
             dataEditor.getSelectedMedia().add(selectedMediaPair);
         }
     }
+
+    /*
+     * Get the index of this GalleryMediaContent's MediaUnit out of all MediaUnits
+     * which are assigned to more than one IncludedStructuralElement.
+     *
+     * @param galleryMediaContent object to find the index for
+     * @return index of the GalleryMediaContent's MediaUnit if present in the List of several assignments, or -1 if not present in the list.
+     */
+    public int getSeveralAssignmentsIndex(GalleryMediaContent galleryMediaContent) {
+        if (Objects.nonNull(galleryMediaContent.getView()) && Objects.nonNull(galleryMediaContent.getView().getMediaUnit())) {
+            return dataEditor.getStructurePanel().getSeveralAssignments().indexOf(galleryMediaContent.getView().getMediaUnit());
+        }
+        return -1;
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1174,7 +1174,8 @@ public class StructurePanel implements Serializable {
                 int logicalNodeIndex = logicalNodeSiblings.indexOf(selectedLogicalNode.getParent());
                 List<TreeNode> viewSiblbings = selectedLogicalNode.getParent().getChildren();
                 // check for selected node's positions and siblings after selected node's parent
-                if (viewSiblbings.indexOf(selectedLogicalNode) == viewSiblbings.size() - 1 && logicalNodeSiblings.size() > logicalNodeIndex + 1) {
+                if (viewSiblbings.indexOf(selectedLogicalNode) == viewSiblbings.size() - 1
+                        && logicalNodeSiblings.size() > logicalNodeIndex + 1) {
                     TreeNode nextSibling = logicalNodeSiblings.get(logicalNodeIndex + 1);
                     if (nextSibling.getData() instanceof StructureTreeNode) {
                         StructureTreeNode structureTreeNodeSibling = (StructureTreeNode) nextSibling.getData();
@@ -1217,7 +1218,8 @@ public class StructurePanel implements Serializable {
             if (selectedLogicalNode.getParent().getData() instanceof StructureTreeNode) {
                 StructureTreeNode structureTreeNodeParent = (StructureTreeNode) selectedLogicalNode.getParent().getData();
                 if (structureTreeNodeParent.getDataObject() instanceof IncludedStructuralElement) {
-                    IncludedStructuralElement includedStructuralElement = (IncludedStructuralElement) structureTreeNodeParent.getDataObject();
+                    IncludedStructuralElement includedStructuralElement =
+                            (IncludedStructuralElement) structureTreeNodeParent.getDataObject();
                     dataEditor.unassignView(includedStructuralElement, view);
                     if (view.getMediaUnit().getIncludedStructuralElements().size() <= 1) {
                         severalAssignments.remove(view.getMediaUnit());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1138,7 +1138,7 @@ public class StructurePanel implements Serializable {
      * @return index of the StructureTreeNode's MediaUnit if present in the List of several assignments, or -1 if not present in the list.
      */
     public int getMultipleAssignmentsIndex(StructureTreeNode treeNode) {
-        if (Objects.nonNull(treeNode.getDataObject()) && treeNode.getDataObject() instanceof View
+        if (treeNode.getDataObject() instanceof View
                 && Objects.nonNull(((View) treeNode.getDataObject()).getMediaUnit())) {
             return severalAssignments.indexOf(((View) treeNode.getDataObject()).getMediaUnit());
         }
@@ -1153,7 +1153,7 @@ public class StructurePanel implements Serializable {
     public boolean isAssignedSeveralTimes() {
         if (Objects.nonNull(selectedLogicalNode) && selectedLogicalNode.getData() instanceof  StructureTreeNode) {
             StructureTreeNode structureTreeNode = (StructureTreeNode) selectedLogicalNode.getData();
-            if (Objects.nonNull(structureTreeNode.getDataObject()) && structureTreeNode.getDataObject() instanceof View) {
+            if (structureTreeNode.getDataObject() instanceof View) {
                 View view = (View) structureTreeNode.getDataObject();
                 return view.getMediaUnit().getIncludedStructuralElements().size() > 1;
             }
@@ -1168,8 +1168,7 @@ public class StructurePanel implements Serializable {
     public boolean isAssignableSeveralTimes() {
         if (Objects.nonNull(selectedLogicalNode) && selectedLogicalNode.getData() instanceof  StructureTreeNode) {
             StructureTreeNode structureTreeNode = (StructureTreeNode) selectedLogicalNode.getData();
-            if (Objects.nonNull(structureTreeNode.getDataObject())
-                    && structureTreeNode.getDataObject() instanceof View) {
+            if (structureTreeNode.getDataObject() instanceof View) {
                 List<TreeNode> logicalNodeSiblings = selectedLogicalNode.getParent().getParent().getChildren();
                 int logicalNodeIndex = logicalNodeSiblings.indexOf(selectedLogicalNode.getParent());
                 List<TreeNode> viewSiblbings = selectedLogicalNode.getParent().getChildren();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -91,6 +91,11 @@ public class StructurePanel implements Serializable {
     private HashMap<IncludedStructuralElement, Boolean> previousExpansionStatesPhysicalTree;
 
     /**
+     * List of all mediaUnits assigned to multiple IncludedStructuralElements.
+     */
+    private List<MediaUnit> severalAssignments = new LinkedList<>();
+
+    /**
      * Creates a new structure panel.
      *
      * @param dataEditor
@@ -111,6 +116,7 @@ public class StructurePanel implements Serializable {
         previouslySelectedLogicalNode = null;
         previouslySelectedPhysicalNode = null;
         structure = null;
+        severalAssignments = new LinkedList<>();
     }
 
     void deleteSelectedStructure() {
@@ -1116,5 +1122,117 @@ public class StructurePanel implements Serializable {
             }
         }
         return null;
+    }
+
+    /**
+     * Get List of MediaUnits assigned to multiple IncludedStructuralElements.
+     *
+     * @return value of severalAssignments
+     */
+    List<MediaUnit> getSeveralAssignments() {
+        return severalAssignments;
+    }
+
+
+    /**
+     * Get the index of this StructureTreeNode's MediaUnit out of all MediaUnits
+     * which are assigned to more than one IncludedStructuralElement.
+     *
+     * @param treeNode object to find the index for
+     * @return index of the StructureTreeNode's MediaUnit if present in the List of several assignments, or -1 if not present in the list.
+     */
+    public int getMultipleAssignmentsIndex(StructureTreeNode treeNode) {
+        if (Objects.nonNull(treeNode.getDataObject()) && treeNode.getDataObject() instanceof View
+                && Objects.nonNull(((View) treeNode.getDataObject()).getMediaUnit())) {
+            return severalAssignments.indexOf(((View) treeNode.getDataObject()).getMediaUnit());
+        }
+        return -1;
+    }
+
+    /**
+     * Check if the selected Node's MediaUnit is assigned to several IncludedStructuralElements.
+     *
+     * @return {@code true} when the MediaUnit is assigned to more than one logical element
+     */
+    public boolean isAssignedSeveralTimes() {
+        if (Objects.nonNull(selectedLogicalNode) && selectedLogicalNode.getData() instanceof  StructureTreeNode) {
+            StructureTreeNode structureTreeNode = (StructureTreeNode) selectedLogicalNode.getData();
+            if (Objects.nonNull(structureTreeNode.getDataObject()) && structureTreeNode.getDataObject() instanceof View) {
+                View view = (View) structureTreeNode.getDataObject();
+                return view.getMediaUnit().getIncludedStructuralElements().size() > 1;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if the selected Node's MediaUnit can be assigned to the next logical element in addition to the current assignment.
+     * @return {@code true} if the MediaUnit can be assigned to the next IncludedStructuralElement
+     */
+    public boolean isAssignableSeveralTimes() {
+        if (Objects.nonNull(selectedLogicalNode) && selectedLogicalNode.getData() instanceof  StructureTreeNode) {
+            StructureTreeNode structureTreeNode = (StructureTreeNode) selectedLogicalNode.getData();
+            if (Objects.nonNull(structureTreeNode.getDataObject())
+                    && structureTreeNode.getDataObject() instanceof View) {
+                List<TreeNode> logicalNodeSiblings = selectedLogicalNode.getParent().getParent().getChildren();
+                int logicalNodeIndex = logicalNodeSiblings.indexOf(selectedLogicalNode.getParent());
+                List<TreeNode> viewSiblbings = selectedLogicalNode.getParent().getChildren();
+                // check for selected node's positions and siblings after selected node's parent
+                if (viewSiblbings.indexOf(selectedLogicalNode) == viewSiblbings.size() - 1 && logicalNodeSiblings.size() > logicalNodeIndex + 1) {
+                    TreeNode nextSibling = logicalNodeSiblings.get(logicalNodeIndex + 1);
+                    if (nextSibling.getData() instanceof StructureTreeNode) {
+                        StructureTreeNode structureTreeNodeSibling = (StructureTreeNode) nextSibling.getData();
+                        return structureTreeNodeSibling.getDataObject() instanceof IncludedStructuralElement;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Assign selected Node's MediaUnit to the next IncludedStructuralElement.
+     */
+    public void assign() {
+        if (isAssignableSeveralTimes()) {
+            View view = (View) ((StructureTreeNode) selectedLogicalNode.getData()).getDataObject();
+            List<TreeNode> logicalNodeSiblings = selectedLogicalNode.getParent().getParent().getChildren();
+            int logicalNodeIndex = logicalNodeSiblings.indexOf(selectedLogicalNode.getParent());
+            TreeNode nextSibling = logicalNodeSiblings.get(logicalNodeIndex + 1);
+            StructureTreeNode structureTreeNodeSibling = (StructureTreeNode) nextSibling.getData();
+            IncludedStructuralElement includedStructuralElement = (IncludedStructuralElement) structureTreeNodeSibling.getDataObject();
+            includedStructuralElement.getViews().add(view);
+            view.getMediaUnit().getIncludedStructuralElements().add(includedStructuralElement);
+            severalAssignments.add(view.getMediaUnit());
+            preserveLogical();
+            show();
+            dataEditor.getGalleryPanel().updateStripes();
+        }
+    }
+
+    /**
+     * Unassign the selected Node's MediaUnit from the IncludedStructuralElement parent at the selected position.
+     * This does not remove it from other IncludedStructuralElements.
+     */
+    public void unassign() {
+        if (isAssignedSeveralTimes()) {
+            StructureTreeNode structureTreeNode = (StructureTreeNode) selectedLogicalNode.getData();
+            View view = (View) structureTreeNode.getDataObject();
+            if (selectedLogicalNode.getParent().getData() instanceof StructureTreeNode) {
+                StructureTreeNode structureTreeNodeParent = (StructureTreeNode) selectedLogicalNode.getParent().getData();
+                if (structureTreeNodeParent.getDataObject() instanceof IncludedStructuralElement) {
+                    IncludedStructuralElement includedStructuralElement = (IncludedStructuralElement) structureTreeNodeParent.getDataObject();
+                    includedStructuralElement.getViews().remove(view);
+                    view.getMediaUnit().getIncludedStructuralElements().remove(includedStructuralElement);
+                    if (view.getMediaUnit().getIncludedStructuralElements().size() <= 1) {
+                        severalAssignments.remove(view.getMediaUnit());
+                    }
+                    preserveLogical();
+                    show();
+                    dataEditor.getGalleryPanel().updateStripes();
+                }
+            }
+        }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -959,12 +959,8 @@ public class StructurePanel implements Serializable {
      */
     void moveViews(IncludedStructuralElement toElement, List<Pair<View, IncludedStructuralElement>> elementsToBeMoved) {
         for (Pair<View, IncludedStructuralElement> elementToBeMoved : elementsToBeMoved) {
-            elementToBeMoved.getValue().getViews().remove(elementToBeMoved.getKey());
-            toElement.getViews().add(elementToBeMoved.getKey());
-            if (Objects.nonNull(elementToBeMoved.getKey().getMediaUnit())) {
-                elementToBeMoved.getKey().getMediaUnit().getIncludedStructuralElements().remove(elementToBeMoved.getValue());
-                elementToBeMoved.getKey().getMediaUnit().getIncludedStructuralElements().add(toElement);
-            }
+            dataEditor.unassignView(elementToBeMoved.getValue(), elementToBeMoved.getKey());
+            dataEditor.assignView(toElement, elementToBeMoved.getKey());
         }
     }
 
@@ -1202,8 +1198,7 @@ public class StructurePanel implements Serializable {
             TreeNode nextSibling = logicalNodeSiblings.get(logicalNodeIndex + 1);
             StructureTreeNode structureTreeNodeSibling = (StructureTreeNode) nextSibling.getData();
             IncludedStructuralElement includedStructuralElement = (IncludedStructuralElement) structureTreeNodeSibling.getDataObject();
-            includedStructuralElement.getViews().add(view);
-            view.getMediaUnit().getIncludedStructuralElements().add(includedStructuralElement);
+            dataEditor.assignView(includedStructuralElement, view);
             severalAssignments.add(view.getMediaUnit());
             preserveLogical();
             show();
@@ -1223,8 +1218,7 @@ public class StructurePanel implements Serializable {
                 StructureTreeNode structureTreeNodeParent = (StructureTreeNode) selectedLogicalNode.getParent().getData();
                 if (structureTreeNodeParent.getDataObject() instanceof IncludedStructuralElement) {
                     IncludedStructuralElement includedStructuralElement = (IncludedStructuralElement) structureTreeNodeParent.getDataObject();
-                    includedStructuralElement.getViews().remove(view);
-                    view.getMediaUnit().getIncludedStructuralElements().remove(includedStructuralElement);
+                    dataEditor.unassignView(includedStructuralElement, view);
                     if (view.getMediaUnit().getIncludedStructuralElements().size() <= 1) {
                         severalAssignments.remove(view.getMediaUnit());
                     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -953,8 +953,12 @@ public class StructurePanel implements Serializable {
      */
     void moveViews(IncludedStructuralElement toElement, List<Pair<View, IncludedStructuralElement>> elementsToBeMoved) {
         for (Pair<View, IncludedStructuralElement> elementToBeMoved : elementsToBeMoved) {
-            toElement.getViews().add(elementToBeMoved.getKey());
             elementToBeMoved.getValue().getViews().remove(elementToBeMoved.getKey());
+            toElement.getViews().add(elementToBeMoved.getKey());
+            if (Objects.nonNull(elementToBeMoved.getKey().getMediaUnit())) {
+                elementToBeMoved.getKey().getMediaUnit().getIncludedStructuralElements().remove(elementToBeMoved.getValue());
+                elementToBeMoved.getKey().getMediaUnit().getIncludedStructuralElements().add(toElement);
+            }
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructureTreeNode.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructureTreeNode.java
@@ -12,9 +12,11 @@
 package org.kitodo.production.forms.dataeditor;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.MediaUnit;
+import org.kitodo.api.dataformat.View;
 
 public class StructureTreeNode implements Serializable {
 
@@ -81,5 +83,22 @@ public class StructureTreeNode implements Serializable {
         } else {
             return "";
         }
+    }
+
+    /**
+     * Check if the StructureTreeNode's MediaUnit is assigned to several IncludedStructuralElements.
+     *
+     * @return {@code true} when the MediaUnit is assigned to more than one logical element
+     */
+    public boolean isAssignedSeveralTimes() {
+        if (Objects.nonNull(this.dataObject)) {
+            if (this.dataObject instanceof View) {
+                View view = (View) this.dataObject;
+                return Objects.nonNull(view.getMediaUnit()) && view.getMediaUnit().getIncludedStructuralElements().size() > 1;
+            } else if (this.dataObject instanceof MediaUnit) {
+                return ((MediaUnit) this.dataObject).getIncludedStructuralElements().size() > 1;
+            }
+        }
+        return false;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
@@ -127,6 +127,7 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
         LegacyInnerPhysicalDocStructHelper target = (LegacyInnerPhysicalDocStructHelper) docStruct;
         view.setMediaUnit(target.getMediaUnit());
         includedStructuralElement.getViews().add(view);
+        view.getMediaUnit().getIncludedStructuralElements().add(includedStructuralElement);
         return new LegacyReferenceHelper(target);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -217,17 +217,17 @@ public class MetadataEditor {
                 throw new IllegalStateException("complete switch");
         }
         if (Objects.nonNull(viewsToAdd) && !viewsToAdd.isEmpty()) {
-            deleteViewsFromIncludedStructuralElements(workpiece.getRootElement(), viewsToAdd);
+            for (View viewToAdd : viewsToAdd) {
+                List<IncludedStructuralElement> includedStructuralElements = viewToAdd.getMediaUnit().getIncludedStructuralElements();
+                for (IncludedStructuralElement elementToUnassign : includedStructuralElements) {
+                    elementToUnassign.getViews().remove(viewToAdd);
+                }
+                includedStructuralElements.clear();
+                includedStructuralElements.add(newStructure);
+            }
             newStructure.getViews().addAll(viewsToAdd);
         }
         return newStructure;
-    }
-
-    private static void deleteViewsFromIncludedStructuralElements(IncludedStructuralElement parent, List<View> views) {
-        parent.getViews().removeAll(views);
-        for (IncludedStructuralElement includedStructuralElement : parent.getChildren()) {
-            deleteViewsFromIncludedStructuralElements(includedStructuralElement, views);
-        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -980,6 +980,7 @@ public class FileService {
             View view = new View();
             view.setMediaUnit(mediaUnit);
             workpiece.getRootElement().getViews().add(view);
+            view.getMediaUnit().getIncludedStructuralElements().add(workpiece.getRootElement());
             canonicals.add(insertionPoint, entry.getKey());
         }
     }

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -48,6 +48,7 @@ arabic=arabisch
 archive=Archivieren
 archived=Archiviert
 assigned=Zugewiesen
+assignToNextElement=Mit n\u00E4chstem Element verkn\u00FCpfen
 ats=ATS
 ausGruppeLoeschen=Benutzer aus der Benutzergruppe l\u00F6schen
 ausgewaehltesStrukturelement=Ausgew\u00E4hltes Strukturelement
@@ -806,6 +807,7 @@ hits=Treffer
 tsl=TSL
 typ=Typ
 type=Art
+unassign=Verkn\u00FCpfung entfernen
 # unbekannt is used in TaskEditType
 unbekannt=Unbekannt
 unit=Einheit

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -48,6 +48,7 @@ arabic=Arabic
 archive=Archive
 archived=Archived
 assigned=Assigned
+assignToNextElement=Assign to next element
 ats=ATS
 ausGruppeLoeschen=Delete user from group
 ausgewaehltesStrukturelement=Selected docstruct
@@ -805,6 +806,7 @@ hits=Hits
 tsl=TSL
 typ=Type
 type=Type
+unassign=Unassign
 # unbekannt is used in TaskEditType
 unbekannt=Unknown
 unit=unit

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1434,6 +1434,16 @@ Column content
     bottom: 64px;
 }
 
+#structureTreeForm .ui-treenode-label .assigned-several-times {
+    margin-left: 5px;
+}
+
+#structureTreeForm .ui-treenode-label .assigned-several-times::before {
+    content: '\f0c1';
+    font-family: FontAwesome;
+    margin-right: 3px;
+}
+
 #structureTreeForm\:paginationPanel {
     margin-top: 5px;
     height: calc(50% - 45px);
@@ -1719,6 +1729,21 @@ Column content
 .thumbnail-container {
     position: relative;
     display: inline-block;
+}
+
+.thumbnail-container .assigned-several-times {
+    bottom: 5px;
+    color: var(--pure-white);
+    left: 5px;
+    opacity: .9;
+    position: absolute;
+    text-shadow: 0 0 3px var(--carbon-blue);
+}
+
+.thumbnail-container .assigned-several-times::before {
+    content: '\f0c1';
+    font-family: FontAwesome;
+    margin-right: 3px;
 }
 
 .thumbnail-overlay {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -445,6 +445,12 @@ button.ui-datepicker-trigger.ui-button-icon-only::before {
     background: inherit;
 }
 
+.ui-contextmenu,
+.ui-contextmenu .ui-menuitem,
+.ui-contextmenu .ui-menuitem-link {
+    width: auto;
+}
+
 .ui-inputfield,
 .ui-selectcheckboxmenu-multiple-container.ui-inputfield,
 .ui-picklist-list-wrapper,

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -101,6 +101,9 @@
                                                         rendered="#{media.showingInPreview}">
                                             <f:param name="id" value="#{media.id}" />
                                         </p:graphicImage>
+                                        <h:outputText value="#{DataEditorForm.galleryPanel.getSeveralAssignmentsIndex(media) + 1}"
+                                                      rendered="#{media.assignedSeveralTimes}"
+                                                      styleClass="assigned-several-times"/>
                                         <h:panelGroup class="thumbnail-overlay">
                                             #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
                                         </h:panelGroup>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -84,7 +84,7 @@
             <p:menuitem value="#{msgs.assignToNextElement}"
                         icon="fa fa-link fa-sm"
                         styleClass="plain"
-                        rendered="#{DataEditorForm.structurePanel.assignableSeveralTimes}"
+                        rendered="#{DataEditorForm.structurePanel.assignableSeveralTimes and not DataEditorForm.structurePanel.assignedSeveralTimes}"
                         action="#{DataEditorForm.structurePanel.assign}"
                         oncomplete="$('#loadingScreen').hide()"
                         update="structureTreeForm:logicalTree

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -36,12 +36,14 @@
             <p:ajax event="select"
                     listener="#{DataEditorForm.structurePanel.treeLogicalSelect}"
                     update="@(.thumbnail)
+                            structureTreeForm:contextMenuLogicalTree
                             structureTreeForm:physicalTree
                             metadataAccordion:logicalMetadataWrapperPanel
                             imagePreviewForm:olWrapper"/>
             <p:ajax event="dragdrop"
                     listener="#{DataEditorForm.structurePanel.onDragDrop}"
                     update="structureTreeForm:logicalTree
+                            structureTreeForm:contextMenuLogicalTree
                             metadataAccordion:logicalMetadataWrapperPanel
                             galleryWrapperPanel"/>
             <p:ajax event="collapse"
@@ -53,11 +55,14 @@
                 <!--@elvariable id="logicalElementType" type="java.lang.String"-->
                 <ui:param name="logicalElementType" value="#{logicalNode.label}"/>
                 <h:outputText value="#{empty logicalElementType ? msgs['dataEditor.unknownType'] : logicalElementType}" style="#{logicalNode.undefined ? 'background-color: gold' : ''}"/>
+                <h:outputText value="#{DataEditorForm.structurePanel.getMultipleAssignmentsIndex(logicalNode) + 1}"
+                              rendered="#{logicalNode.assignedSeveralTimes}"
+                              styleClass="assigned-several-times"/>
                 <h:outputText value=" 🔗" rendered="#{logicalNode.linked}"/>
                 <h:outputText value=" ⚠️" rendered="#{logicalNode.undefined}" style="background-color: gold;" title="#{msgs['dataEditor.undefinedStructure']}"/>
             </p:treeNode>
         </p:tree>
-        <p:contextMenu for="logicalTree">
+        <p:contextMenu for="logicalTree" id="contextMenuLogicalTree">
             <p:menuitem value="#{msgs.addElement}"
                         icon="fa fa-plus fa-sm"
                         styleClass="plain"
@@ -72,6 +77,26 @@
                         onclick="$('#loadingScreen').show()"
                         oncomplete="$('#loadingScreen').hide()"
                         action="#{DataEditorForm.deleteStructure()}"
+                        update="structureTreeForm:logicalTree
+                                paginationForm:paginationWrapperPanel
+                                metadataAccordion:logicalMetadataWrapperPanel
+                                galleryWrapperPanel"/>
+            <p:menuitem value="#{msgs.assignToNextElement}"
+                        icon="fa fa-link fa-sm"
+                        styleClass="plain"
+                        rendered="#{DataEditorForm.structurePanel.assignableSeveralTimes}"
+                        action="#{DataEditorForm.structurePanel.assign}"
+                        oncomplete="$('#loadingScreen').hide()"
+                        update="structureTreeForm:logicalTree
+                                paginationForm:paginationWrapperPanel
+                                metadataAccordion:logicalMetadataWrapperPanel
+                                galleryWrapperPanel"/>
+            <p:menuitem value="#{msgs.unassign}"
+                        icon="fa fa-chain-broken fa-sm"
+                        styleClass="plain"
+                        rendered="#{DataEditorForm.structurePanel.assignedSeveralTimes}"
+                        action="#{DataEditorForm.structurePanel.unassign}"
+                        oncomplete="$('#loadingScreen').hide()"
                         update="structureTreeForm:logicalTree
                                 paginationForm:paginationWrapperPanel
                                 metadataAccordion:logicalMetadataWrapperPanel


### PR DESCRIPTION
MediaUnits can be linked to multiple IncludedStructuralElements to represent multiple logical structures on the same media element (e.g. page).