### PR TITLE
#2785 Fix JAI ImageIO TIFF metadata loading by using no metadata for thumbnails

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -1694,8 +1694,12 @@ public class Metadaten {
                                 Helper.setFehlerMeldung("formularOrdner:TifFolders", "", "image " + this.myBild + " does not exist in folder "
                                         + this.currentTifFolder + ", using image from " + new SafeFile(this.myProzess.getImagesTifDirectory(true)).getName());
                             }
-                            this.imagehelper.scaleFile(tiffconverterpfad, myPfad + mySession, this.myBildGroesse, this.myImageRotation);
-                            logger.trace("scaleFile");
+
+                            // scaleFile() uses contentserver which uses an old TIFF library with a bug reading some big TIFF metadata tags
+                            //this.imagehelper.scaleFile(tiffconverterpfad, myPfad + mySession, this.myBildGroesse, this.myImageRotation);
+                            //logger.trace("scaleFile");
+                            // ...instead use createImageThumbnail() without external dependencies
+                            this.imagehelper.createImageThumbnail(tiffconverterpfad, myPfad + mySession, this.myBildGroesse);
                         } catch (Exception e) {
                             Helper.setFehlerMeldung("could not find image folder", e);
                             logger.error(e);


### PR DESCRIPTION
To avoid exceptions in metadata loading as described in #2785 I added a simple method to create thumbnails without reading the metadata. This works for our images and should for everyone else too. The old method still exists for compatibility.

Tested with AdoptOpenJDK 8.