### PR TITLE
ImageHelper error message is too vague. 

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/ImageHelper.java
@@ -40,7 +40,9 @@ public class ImageHelper {
         if (fileService.fileExist(folder)) {
             List<URI> files = fileService.getSubUris(dataFilter, folder);
             if (files.isEmpty()) {
-                Helper.setErrorMessage("[" + title + "] No objects found");
+                Helper.setErrorMessage("[" + title + "] No objects found. " +
+                        "Either no objects present, wrong file format or file name does not match your naming " +
+                        "convention. (" + ParameterCore.IMAGE_PREFIX + ")");
                 return false;
             }
 


### PR DESCRIPTION
If you don't follow the file naming convention the error message will say that no objects were found. It should describe possible reasons why no objects were found due to additional naming and format evaluation during page creation.