### PR TITLE
2.x: Delete old temporary images

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/LoginForm.java
+++ b/Goobi/src/de/sub/goobi/forms/LoginForm.java
@@ -213,7 +213,7 @@ public class LoginForm {
         FilenameFilter filter = new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
-                return name.endsWith(".png");
+                return name.endsWith(".jpg");
             }
         };
         File dir = new File(myPfad);


### PR DESCRIPTION
After merging #2813 temporary created image files are not deleted any more because file extension was changed from `.png` to `.jpg`. This pull request is fixing this.