### PR TITLE
2.x: Prevent Null Pointer Exception if meta data value is null

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/RenderableLineEdit.java
+++ b/Goobi/src/de/sub/goobi/metadaten/RenderableLineEdit.java
@@ -74,10 +74,14 @@ public class RenderableLineEdit extends RenderableMetadatum implements Renderabl
      */
     @Override
     public void addContent(Metadata data) {
+        String metadataValue = data.getValue();
+        if (metadataValue == null) {
+            metadataValue = "";
+        }
         if (value == null) {
-            value = new ArrayList<String>(Arrays.asList(data.getValue().split(METADATA_LINE_SEPARATOR)));
+            value = new ArrayList<String>(Arrays.asList(metadataValue.split(METADATA_LINE_SEPARATOR)));
         } else {
-            value.addAll(Arrays.asList(data.getValue().split(METADATA_LINE_SEPARATOR)));
+            value.addAll(Arrays.asList(metadataValue.split(METADATA_LINE_SEPARATOR)));
         }
     }
 


### PR DESCRIPTION
Fix for issue #2809 

If a meta data element is added to a meta data group after a process is created a null pointer exception is thrown:

```
java.lang.NullPointerException
    at de.sub.goobi.metadaten.RenderableLineEdit.addContent(RenderableLineEdit.java:78)
    at de.sub.goobi.metadaten.RenderableLineEdit.<init>(RenderableLineEdit.java:62)
    at de.sub.goobi.metadaten.RenderableMetadatum.create(RenderableMetadatum.java:152)
    at de.sub.goobi.metadaten.RenderableMetadataGroup.createMembers(RenderableMetadataGroup.java:246)
    at de.sub.goobi.metadaten.RenderableMetadataGroup.<init>(RenderableMetadataGroup.java:156)
    at de.sub.goobi.metadaten.Metadaten.getMyGroups(Metadaten.java:3109)
    at sun.reflect.GeneratedMethodAccessor1338.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
...
```

The new meta data element did not exist in the meta data file and will be `null` after initialisation and using this `null` value on a String class `split` method will cause the null pointer exception in the log and a white page inside the meta data editor.