### PR TITLE
Bump selenium.version from 3.12.0 to 3.141.59

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <parent.basedir>${basedir}/../</parent.basedir>
         <maxAllowedViolations>30</maxAllowedViolations>
-        <selenium.version>3.12.0</selenium.version>
+        <selenium.version>3.141.59</selenium.version>
         <cargo.plugin.version>1.6.8</cargo.plugin.version>
     </properties>
 


### PR DESCRIPTION
Bumps `selenium.version` from 3.12.0 to 3.141.59.

Updates `selenium-firefox-driver` from 3.12.0 to 3.141.59
- [Release notes](https://github.com/SeleniumHQ/selenium/releases)
- [Commits](https://github.com/SeleniumHQ/selenium/compare/selenium-3.12.0...selenium-3.141.59)

Updates `selenium-chrome-driver` from 3.12.0 to 3.141.59
- [Release notes](https://github.com/SeleniumHQ/selenium/releases)
- [Commits](https://github.com/SeleniumHQ/selenium/compare/selenium-3.12.0...selenium-3.141.59)

Updates `selenium-support` from 3.12.0 to 3.141.59
- [Release notes](https://github.com/SeleniumHQ/selenium/releases)
- [Commits](https://github.com/SeleniumHQ/selenium/compare/selenium-3.12.0...selenium-3.141.59)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>