### PR TITLE
Bump jersey.version from 1.19.3 to 1.19.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <hibernate.version>5.4.3.Final</hibernate.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.1.6</jaxen.version>
-        <jersey.version>1.19.3</jersey.version>
+        <jersey.version>1.19.4</jersey.version>
         <jhove.version>1.20.1</jhove.version>
         <joda-time.version>2.10</joda-time.version>
         <myfaces.version>2.2.12</myfaces.version>


### PR DESCRIPTION
Bumps `jersey.version` from 1.19.3 to 1.19.4.

Updates `jersey-server` from 1.19.3 to 1.19.4

Updates `jersey-client` from 1.19.3 to 1.19.4

Updates `jersey-json` from 1.19.3 to 1.19.4

Updates `jersey-servlet` from 1.19.3 to 1.19.4

Updates `jersey-multipart` from 1.19.3 to 1.19.4

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>