### PR TITLE
Bump commons-jxpath from 1.2 to 1.3

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>commons-jxpath</groupId>
             <artifactId>commons-jxpath</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
             <exclusions>
                 <exclusion>
                     <artifactId>*</artifactId>


### PR DESCRIPTION
Bumps commons-jxpath from 1.2 to 1.3.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>