### PR TITLE
Bump hibernate.version from 5.4.3.Final to 5.4.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <commons-lang3.version>3.7</commons-lang3.version>
         <org.apache.xmlgraphics.version>2.0</org.apache.xmlgraphics.version>
         <hamcrest.version>2.1-rc3</hamcrest.version>
-        <hibernate.version>5.4.3.Final</hibernate.version>
+        <hibernate.version>5.4.4.Final</hibernate.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.1.6</jaxen.version>
         <jersey.version>1.19.4</jersey.version>


### PR DESCRIPTION
Bumps `hibernate.version` from 5.4.3.Final to 5.4.4.Final.

Updates `hibernate-c3p0` from 5.4.3.Final to 5.4.4.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/master/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.4.3...5.4.4)

Updates `hibernate-jcache` from 5.4.3.Final to 5.4.4.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/master/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.4.3...5.4.4)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>