### PR TITLE
Bump commons-net from 3.2 to 3.6

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>3.2</version>
+            <version>3.6</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>


### PR DESCRIPTION
Bumps commons-net from 3.2 to 3.6.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>