### PR TITLE
Bump commons-validator from 1.1.4 to 1.6

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.1.4</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>dom4j</groupId>


### PR DESCRIPTION
Bumps commons-validator from 1.1.4 to 1.6.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>