### PR TITLE
Bump commons-discovery from 0.4 to 0.5

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>commons-discovery</groupId>
             <artifactId>commons-discovery</artifactId>
-            <version>0.4</version>
+            <version>0.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>


### PR DESCRIPTION
Bumps commons-discovery from 0.4 to 0.5.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>