### PR TITLE
Bump httpclient from 4.5.6 to 4.5.10

### DIFF
--- a/Kitodo-SRU-Import/pom.xml
+++ b/Kitodo-SRU-Import/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
+            <version>4.5.10</version>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.5.6 to 4.5.10.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>