### PR TITLE
Bump jandex from 2.0.5.Final to 2.1.1.Final

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
-            <version>2.0.5.Final</version>
+            <version>2.1.1.Final</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
Bumps jandex from 2.0.5.Final to 2.1.1.Final.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>