### PR TITLE
Bump javax.json from 1.1.2 to 1.1.4

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>


### PR DESCRIPTION
Bumps javax.json from 1.1.2 to 1.1.4.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>