### PR TITLE
Bump mail from 1.4.4 to 1.4.7

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -301,7 +301,7 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
-            <version>1.4.4</version>
+            <version>1.4.7</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-email -->


### PR DESCRIPTION
Bumps mail from 1.4.4 to 1.4.7.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>