### PR TITLE
Bump jaxb.version from 2.3.0 to 2.3.0.1

### DIFF
--- a/Kitodo-DataEditor/pom.xml
+++ b/Kitodo-DataEditor/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>kitodo-data-editor</artifactId>
 
     <properties>
-        <jaxb.version>2.3.0</jaxb.version>
+        <jaxb.version>2.3.0.1</jaxb.version>
         <maxAllowedViolations>4</maxAllowedViolations>
     </properties>
 


### PR DESCRIPTION
Bumps `jaxb.version` from 2.3.0 to 2.3.0.1.

Updates `jaxb-impl` from 2.3.0 to 2.3.0.1

Updates `jaxb-core` from 2.3.0 to 2.3.0.1

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>