### PR TITLE
Bump xmlbeans from 2.4.0 to 3.1.0

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -398,7 +398,7 @@
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>2.4.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
Bumps xmlbeans from 2.4.0 to 3.1.0.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>