### PR TITLE
Bump activemq-core from 5.5.1 to 5.7.0

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -314,7 +314,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-core</artifactId>
-            <version>5.5.1</version>
+            <version>5.7.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Bumps activemq-core from 5.5.1 to 5.7.0.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>