### PR TITLE
Bump junit.version from 5.4.1 to 5.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <primefaces.version>7.0</primefaces.version>
         <saxon.version>9.0.0.4</saxon.version>
         <log4j.version>2.12.1</log4j.version>
-        <junit.version>5.4.1</junit.version>
+        <junit.version>5.5.2</junit.version>
         <elasticsearch.version>5.6.5</elasticsearch.version>
         <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>


### PR DESCRIPTION
Bumps `junit.version` from 5.4.1 to 5.5.2.

Updates `junit-jupiter-engine` from 5.4.1 to 5.5.2
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.4.1...r5.5.2)

Updates `junit-vintage-engine` from 5.4.1 to 5.5.2
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.4.1...r5.5.2)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>