### PR TITLE
Bump hibernate-validator from 5.4.2.Final to 6.0.17.Final

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.2.Final</version>
+            <version>6.0.17.Final</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml</groupId>


### PR DESCRIPTION
Bumps hibernate-validator from 5.4.2.Final to 6.0.17.Final.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>