### PR TITLE
Bump commons-beanutils from 1.7.0 to 1.9.4

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.7.0</version>
+            <version>1.9.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>


### PR DESCRIPTION
Bumps commons-beanutils from 1.7.0 to 1.9.4.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>