### PR TITLE
Bump cargo-maven2-plugin from 1.6.8 to 1.7.7

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -32,7 +32,7 @@
         <parent.basedir>${basedir}/../</parent.basedir>
         <maxAllowedViolations>30</maxAllowedViolations>
         <selenium.version>3.141.59</selenium.version>
-        <cargo.plugin.version>1.6.8</cargo.plugin.version>
+        <cargo.plugin.version>1.7.7</cargo.plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bumps cargo-maven2-plugin from 1.6.8 to 1.7.7.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>