### PR TITLE
Remove font-awesome explicit dependency

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -580,11 +580,6 @@
             <version>2.26.3</version>
         </dependency>
         <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>font-awesome</artifactId>
-            <version>4.7.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
             <version>${jaxb2-basics-runtime.version}</version>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/head.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/head.xhtml
@@ -20,7 +20,6 @@
 
     <!-- license for raleway font is available under https://www.fontsquirrel.com/license/raleway -->
     <link href='//fonts.googleapis.com/css?family=Raleway:300,400,500'/>
-    <h:outputStylesheet library="webjars" name="font-awesome/4.7.0/css/font-awesome-jsf.css"/>
 
     <link rel="shortcut icon" href="#{resource['images/favicon.ico']}" type="image/x-icon" />
 


### PR DESCRIPTION
According to https://github.com/kitodo/kitodo-production/pull/2863#pullrequestreview-294162804 this dependency is not needed any more.

@oliver-stoehr can you please review this and confirm correct usage?