### PR TITLE
Fix for deleting batches

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
@@ -281,7 +281,7 @@ public class BatchForm extends BaseForm {
         try {
             ServiceManager.getBatchService().removeAll(this.selectedBatches);
             filterAll();
-        } catch (DAOException e) {
+        } catch (DataException e) {
             Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.BATCH.getTranslationSingular() }, logger, e);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
@@ -120,9 +120,9 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
      * @param batches
      *            to remove
      */
-    public void removeAll(Iterable<Batch> batches) throws DAOException {
+    public void removeAll(Iterable<Batch> batches) throws DataException {
         for (Batch batch : batches) {
-            dao.remove(batch);
+            remove(batch);
         }
     }
 


### PR DESCRIPTION
This change fixes the deletion of batches. Previously, when deleting batches in the batch list, they would only be removed from the database, but not from the index. For that reason the index was always out of sync with the database after deleting a batch. (can be verified in master branch right now)