### PR TITLE
MariaDB support

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -260,11 +260,13 @@
                                 <groupId>mysql</groupId>
                                 <artifactId>mysql-connector-java</artifactId>
                                 <version>${mysql.version}</version>
+                                <scope>runtime</scope>
                             </dependency>
                             <dependency>
                                 <groupId>org.mariadb.jdbc</groupId>
                                 <artifactId>mariadb-java-client</artifactId>
                                 <version>${mariadb-java-client.version}</version>
+                                <scope>runtime</scope>
                             </dependency>
                         </dependencies>
                         <executions>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -261,6 +261,11 @@
                                 <artifactId>mysql-connector-java</artifactId>
                                 <version>${mysql.version}</version>
                             </dependency>
+                            <dependency>
+                                <groupId>org.mariadb.jdbc</groupId>
+                                <artifactId>mariadb-java-client</artifactId>
+                                <version>${mariadb-java-client.version}</version>
+                            </dependency>
                         </dependencies>
                         <executions>
                             <execution>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -163,6 +163,11 @@
             <version>${mysql.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>${mariadb-java-client.version}</version>
+        </dependency>
+        <dependency>
             <groupId>net.sf.barcode4j</groupId>
             <artifactId>barcode4j-fop-ext</artifactId>
             <version>2.1</version>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -161,11 +161,13 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>${mariadb-java-client.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.barcode4j</groupId>

--- a/docs/gettingstarted/use_mariadb.md
+++ b/docs/gettingstarted/use_mariadb.md
@@ -1,0 +1,31 @@
+# Use MariaDB instead of MySQL
+
+* Kitodo.Production application must be built with a connector for MariaDB
+* Hibernate and Flyway configuration must be adjusted to use MariaDB
+
+## Hibernate configuration
+
+* modifications must be done in file `hibernate.cfg.xml`
+
+### hibernate.dialect
+
+* for correct dialect look at https://stackoverflow.com/a/51734560 or Hibernate JavaDoc.
+* f.e. use `org.hibernate.dialect.MariaDB10Dialect` if your MariaDB server is in version 10.1.x
+
+### hibernate.connection.driver_class
+
+* instead of `com.mysql.jdbc.Driver` use `org.mariadb.jdbc.Driver`
+* maybe this is not needed anymore as in normal cases connection driver class is detected correct by Hibernate
+
+### hibernate.connection.url
+
+* instead of `jdbc:mysql://...` use `jdbc:mariadb://...`
+
+## Flyway configuration
+
+* only needed if you want to migrate your database with help of Flyway
+* modification must be done in file `flyway.properties`
+
+### flyway.url
+
+* instead of `jdbc:mysql://...` use `jdbc:mariadb://...`

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <spring.security.version>4.2.13.RELEASE</spring.security.version>
         <flyway-maven-plugin.version>5.1.4</flyway-maven-plugin.version>
         <pitest.version>1.4.10</pitest.version>
+        <mariadb-java-client.version>2.4.4</mariadb-java-client.version>
     </properties>
 
     <repositories>
@@ -270,6 +271,11 @@
                                 <groupId>mysql</groupId>
                                 <artifactId>mysql-connector-java</artifactId>
                                 <version>${mysql.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.mariadb.jdbc</groupId>
+                                <artifactId>mariadb-java-client</artifactId>
+                                <version>${mariadb-java-client.version}</version>
                             </dependency>
                         </dependencies>
                         <executions>


### PR DESCRIPTION
Add basically support for MariaDB (Community fork of MySQL) for usage and flyway based migration. Which files must be adjusted and how is described inside the added documentation.

notes:
* Switching from MySQL to MariaDB should work on the fly if you change the hibernate configuration
* flyway based migration until MariaDB version 10.3 should work
* default flyway migration on running tests is still using MySQL. I don't think that it is possible to run two database instances at once on Travis.

well known issue:
* for MariaDB version 10.4 and newer flyway must be updated to 6.0-beta or 6.0.6 (current version at Oct 14th 2019, [PR for 6.0.4](https://github.com/kitodo/kitodo-production/pull/2905)) to run the flyway migration. Normal usage through hibernate should work.
