### PR TITLE
Update tomcat

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -624,7 +624,7 @@
                         <configuration>
                             <!-- Provide Tomcat -->
                             <container>
-                                <containerId>tomcat7x</containerId>
+                                <containerId>tomcat8x</containerId>
                                 <zipUrlInstaller>
                                     <url>
                                         https://archive.apache.org/dist/tomcat/tomcat-${tomcat.baseversion}/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip

--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -11,9 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/web-app_3_0.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <display-name>Kitodo</display-name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <maven.compiler.debug>true</maven.compiler.debug>
         <maven.compiler.debuglevel>lines,vars,source</maven.compiler.debuglevel>
         <maxAllowedViolations>1</maxAllowedViolations>
-        <tomcat.baseversion>7</tomcat.baseversion>
-        <tomcat.version>7.0.81</tomcat.version>
+        <tomcat.baseversion>8</tomcat.baseversion>
+        <tomcat.version>8.5.69</tomcat.version>
         <awaitility.version>4.0.1</awaitility.version>
         <com.h2database.h2.version>1.4.199</com.h2database.h2.version>
         <commons-codec.version>1.13</commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -216,18 +216,6 @@
             </build>
         </profile>
         <profile>
-            <id>tomcat</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.tomcat.maven</groupId>
-                        <artifactId>tomcat7-maven-plugin</artifactId>
-                        <version>2.2</version>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>flyway</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Updating Apache Tomcat to a more current version. Distribution of Apache Tomcat 7 is decreasing as many current Linux distribtions shipping at least Apache Tomcat 8.5.x. Apache Tomcat 8.0.x is already end of life since a few years.

# Note
* used version is similar to shipped version of Debian 9

# Advantage
* Servlet specification is increased from 3.0 to 3.1
* JSP specification from 2.2 to 2.3
* EL specification from 2.2 to 3.0

# Disadvantage
* Tomcat Maven Plugin is not developed any more and must be replaced or removed (PR is removing this)