### PR TITLE
Lazy hit model

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/externaldatamanagement/ExternalDataImportInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/externaldatamanagement/ExternalDataImportInterface.java
@@ -54,6 +54,25 @@ public interface ExternalDataImportInterface {
     SearchResult search(String catalogId, String field, String term, int rows);
 
     /**
+     * Perform search in catalog with given ID 'catalogId' with given search fields
+     * 'field' and term 'term'. The parameter rows controls how many records should
+     * be returned. The parameter 'start' controls the index of the first hit.
+     *
+     * @param catalogId
+     *            ID of the catalog that will be queried.
+     * @param field
+     *            search field that will be queried
+     * @param term
+     *            value of search field that will be queried
+     * @param rows
+     *            number of records to be returned
+     * @param start
+     *            index of the first record to be returned
+     * @return Search result of performed query.
+     */
+    SearchResult search(String catalogId, String field, String term, int start, int rows);
+
+    /**
      * Searches for Data in a given source by term and field.
      *
      * @param ids

--- a/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/SRUImport.java
+++ b/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/SRUImport.java
@@ -119,9 +119,11 @@ public class SRUImport implements ExternalDataImportInterface {
 
             try {
                 URI queryURL = createQueryURI(queryParameters);
-                return performQuery(
-                        queryURL.toString()
-                                + "&startRecord=" + start
+                String queryString = queryURL.toString();
+                if (start > 0 ) {
+                    queryString += ("&startRecord=" + start);
+                }
+                return performQuery(queryString
                                 + "&maximumRecords=" + numberOfRecords
                                 + "&query=" + createSearchFieldString(searchFieldMap));
             } catch (URISyntaxException | UnsupportedEncodingException e) {

--- a/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/SRUImport.java
+++ b/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/SRUImport.java
@@ -121,7 +121,7 @@ public class SRUImport implements ExternalDataImportInterface {
                 URI queryURL = createQueryURI(queryParameters);
                 String queryString = queryURL.toString();
                 if (start > 0 ) {
-                    queryString += ("&startRecord=" + start);
+                    queryString += "&startRecord=" + start;
                 }
                 return performQuery(queryString
                                 + "&maximumRecords=" + numberOfRecords

--- a/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/SRUImport.java
+++ b/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/SRUImport.java
@@ -93,11 +93,18 @@ public class SRUImport implements ExternalDataImportInterface {
         loadOPACConfiguration(catalogId);
         HashMap<String, String> searchFields = new HashMap<>();
         searchFields.put(field, term);
-        return search(catalogId, searchFields, rows);
+        return search(catalogId, searchFields, 1, rows);
     }
 
-    private SearchResult search(String catalogId, Map<String, String> searchParameters, int numberOfRecords) {
-        // TODO: check how the fields of hits from SRU interfaces can be configured via CQL (need only title and id!)
+    @Override
+    public SearchResult search(String catalogId, String field, String term, int start, int rows) {
+        loadOPACConfiguration(catalogId);
+        HashMap<String, String> searchFields = new HashMap<>();
+        searchFields.put(field, term);
+        return search(catalogId, searchFields, start, rows);
+    }
+
+    private SearchResult search(String catalogId, Map<String, String> searchParameters, int start, int numberOfRecords) {
         loadOPACConfiguration(catalogId);
         if (searchFieldMapping.keySet().containsAll(searchParameters.keySet())) {
 
@@ -114,6 +121,7 @@ public class SRUImport implements ExternalDataImportInterface {
                 URI queryURL = createQueryURI(queryParameters);
                 return performQuery(
                         queryURL.toString()
+                                + "&startRecord=" + start
                                 + "&maximumRecords=" + numberOfRecords
                                 + "&query=" + createSearchFieldString(searchFieldMap));
             } catch (URISyntaxException | UnsupportedEncodingException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -299,7 +299,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
      *
      * @return true if process was prepared, otherwise false
      */
-    public boolean prepareProcess(int templateId, int projectId) {
+    private boolean prepareProcess(int templateId, int projectId) {
         ProcessGenerator processGenerator = new ProcessGenerator();
         try {
             boolean generated = processGenerator.generateProcess(templateId, projectId);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
@@ -18,6 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.faces.context.FacesContext;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.logging.log4j.LogManager;
@@ -26,9 +27,6 @@ import org.kitodo.api.externaldatamanagement.SingleHit;
 import org.kitodo.exceptions.NoRecordFoundException;
 import org.kitodo.exceptions.UnsupportedFormatException;
 import org.kitodo.production.helper.Helper;
-import javax.annotation.PostConstruct;
-import javax.faces.context.FacesContext;
-
 import org.kitodo.production.model.LazyHitModel;
 import org.kitodo.production.services.ServiceManager;
 import org.omnifaces.util.Ajax;
@@ -51,7 +49,7 @@ public class ImportTab implements Serializable {
     private static final String ID_PARAMETER_NAME = "ID";
     private static final String FORM_CLIENTID = "editForm";
     private static final String KITODO_STRING = "kitodo";
-    private static final String HITLIST_TABLE_NAME = "hitlistDialogForm:hitlistDialogTable";
+    private static final String HITSTABLE_NAME = "hitlistDialogForm:hitlistDialogTable";
     private DataTable hitsTable;
 
     /**
@@ -62,12 +60,6 @@ public class ImportTab implements Serializable {
     ImportTab(CreateProcessForm createProcessForm) {
         this.createProcessForm = createProcessForm;
     }
-
-    @PostConstruct
-    private void initializeHitsTable() {
-        hitsTable = (DataTable) FacesContext.getCurrentInstance().getViewRoot().findComponent(HITLIST_TABLE_NAME);
-    }
-
 
     /**
      * Get list of catalogs.
@@ -107,13 +99,14 @@ public class ImportTab implements Serializable {
     public void search() {
         try {
             int pageSize = ServiceManager.getUserService().getAuthenticatedUser().getTableSize();
+            this.hitsTable = (DataTable) FacesContext.getCurrentInstance().getViewRoot().findComponent(HITSTABLE_NAME);
             this.hitModel.load(
                     (this.hitsTable.getPage() + 1) * pageSize,
                     pageSize,
                     "",
                     SortOrder.ASCENDING,
                     null);
-            PrimeFaces.current().executeScript("PF('hitlist').show()");
+            PrimeFaces.current().executeScript("PF('hitlistDialog').show()");
         } catch (IllegalArgumentException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
@@ -32,7 +32,6 @@ import org.kitodo.production.services.ServiceManager;
 import org.omnifaces.util.Ajax;
 import org.primefaces.PrimeFaces;
 import org.primefaces.component.datatable.DataTable;
-import org.primefaces.model.SortOrder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -50,7 +49,6 @@ public class ImportTab implements Serializable {
     private static final String FORM_CLIENTID = "editForm";
     private static final String KITODO_STRING = "kitodo";
     private static final String HITSTABLE_NAME = "hitlistDialogForm:hitlistDialogTable";
-    private DataTable hitsTable;
 
     /**
      * Standard constructor.
@@ -98,14 +96,8 @@ public class ImportTab implements Serializable {
      */
     public void search() {
         try {
-            int pageSize = ServiceManager.getUserService().getAuthenticatedUser().getTableSize();
-            this.hitsTable = (DataTable) FacesContext.getCurrentInstance().getViewRoot().findComponent(HITSTABLE_NAME);
-            this.hitModel.load(
-                    (this.hitsTable.getPage() + 1) * pageSize,
-                    pageSize,
-                    "",
-                    SortOrder.ASCENDING,
-                    null);
+            DataTable hits = (DataTable) FacesContext.getCurrentInstance().getViewRoot().findComponent(HITSTABLE_NAME);
+            hits.reset();
             PrimeFaces.current().executeScript("PF('hitlistDialog').show()");
         } catch (IllegalArgumentException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
@@ -122,20 +114,6 @@ public class ImportTab implements Serializable {
             return this.hitModel.getHits();
         } else {
             return new LinkedList<>();
-        }
-    }
-
-    /**
-     * Get total number of hits for performed query. Returns 0 if searchResult
-     * instance is null.
-     *
-     * @return total number of hits
-     */
-    public int getNumberOfHits() {
-        if (Objects.nonNull(this.hitModel)) {
-            return this.hitModel.getRowCount();
-        } else {
-            return 0;
         }
     }
 
@@ -170,11 +148,12 @@ public class ImportTab implements Serializable {
         }
     }
 
+    /**
+     * Get LazyHitModel.
+     *
+     * @return LazyHitModel of this ImportTab
+     */
     public LazyHitModel getHitModel() {
         return this.hitModel;
-    }
-
-    public void printPageNumber() {
-        System.out.println("Current page number: " + this.hitsTable.getPage());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.kitodo.api.externaldatamanagement.SingleHit;
+import org.kitodo.api.externaldatamanagement.SearchResult;
+import org.kitodo.production.services.ServiceManager;
+import org.primefaces.model.LazyDataModel;
+import org.primefaces.model.SortOrder;
+
+public class LazyHitModel extends LazyDataModel<Object> {
+
+    private String selectedCatalog = "";
+    private String selectedField = "";
+    private String searchTerm = "";
+
+    private SearchResult searchResult = null;
+
+    @Override
+    public Object getRowData(String rowKey) {
+        return null;
+    }
+
+    @Override
+    public Object getRowKey(Object inObject) {
+        return null;
+    }
+
+    @Override
+    public int getRowCount() {
+        if (Objects.nonNull(this.searchResult)) {
+            return this.searchResult.getNumberOfHits();
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public List<Object> load(int first, int resultSize, String sortField, SortOrder sortOrder, Map filters) {
+
+        searchResult = ServiceManager.getImportService().performSearch(
+                this.selectedField, this.searchTerm, this.selectedCatalog, first, resultSize);
+
+        return searchResult.getHits().stream().map(r -> (Object)r).collect(Collectors.toList());
+    }
+
+    /**
+     * Get list of hits from last search result.
+     *
+     * @return list of hits
+     */
+    public List<SingleHit> getHits() {
+        if (Objects.nonNull(this.searchResult)) {
+            return this.searchResult.getHits();
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Getter for selectedCatalog.
+     *
+     * @return value of selectedCatalog
+     */
+    public String getSelectedCatalog() {
+        return selectedCatalog;
+    }
+
+    /**
+     * Setter for selectedCatalog.
+     *
+     * @param catalog as java.lang.String
+     */
+    public void setSelectedCatalog(String catalog) {
+        this.selectedCatalog = catalog;
+    }
+
+    /**
+     * Get searchTerm.
+     *
+     * @return value of searchTerm
+     */
+    public String getSearchTerm() {
+        return this.searchTerm;
+    }
+
+    /**
+     * Set searchTerm.
+     *
+     * @param searchTerm as java.lang.String
+     */
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    /**
+     * Get selectedField.
+     *
+     * @return value of selectedField
+     */
+    public String getSelectedField() {
+        return this.selectedField;
+    }
+
+    /**
+     * Set selectedField.
+     *
+     * @param field as java.lang.String
+     */
+    public void setSelectedField(String field) {
+        this.selectedField = field;
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.kitodo.api.externaldatamanagement.SingleHit;
 import org.kitodo.api.externaldatamanagement.SearchResult;
+import org.kitodo.api.externaldatamanagement.SingleHit;
 import org.kitodo.production.services.ServiceManager;
 import org.primefaces.model.LazyDataModel;
 import org.primefaces.model.SortOrder;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -69,6 +69,15 @@ public class ImportService {
         return localReference;
     }
 
+    private void loadOpacConfiguration(String catalogName) {
+        try {
+            OPACConfig.getOPACConfiguration(catalogName);
+        } catch (IllegalArgumentException e) {
+            logger.error(e.getLocalizedMessage());
+            throw new IllegalArgumentException("Error: OPAC '" + catalogName + "' is not supported!");
+        }
+    }
+
     /**
      * Load ExternalDataImportInterface implementation with KitodoServiceLoader and perform given query string
      * with loaded module.
@@ -80,13 +89,25 @@ public class ImportService {
      */
     public SearchResult performSearch(String searchField, String searchTerm, String catalogName) {
         importModule = initializeImportModule();
-        try {
-            OPACConfig.getOPACConfiguration(catalogName);
-        } catch (IllegalArgumentException e) {
-            logger.error(e.getLocalizedMessage());
-            throw new IllegalArgumentException("Error: OPAC '" + catalogName + "' is not supported!");
-        }
+        loadOpacConfiguration(catalogName);
         return importModule.search(catalogName, searchField, searchTerm, 10);
+    }
+
+    /**
+     * Load ExternalDataImportInterface implementation with KitodoServiceLoader and perform given query string
+     * with loaded module.
+     *
+     * @param searchField field to query
+     * @param searchTerm  given search term
+     * @param catalogName catalog to search
+     * @param start index of first record returned
+     * @param rows number of records returned
+     * @return search result
+     */
+    public SearchResult performSearch(String searchField, String searchTerm, String catalogName, int start, int rows) {
+        importModule = initializeImportModule();
+        loadOpacConfiguration(catalogName);
+        return importModule.search(catalogName, searchField, searchTerm, start, rows);
     }
 
     private ExternalDataImportInterface initializeImportModule() {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/hitlistDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/hitlistDialog.xhtml
@@ -16,7 +16,7 @@
         xmlns:p="http://primefaces.org/ui"
         xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
-    <p:dialog widgetVar="hitlist"
+    <p:dialog widgetVar="hitlistDialog"
               id="hitlist"
               width="700px"
               modal="true"
@@ -26,7 +26,7 @@
         <h3>#{msgs.hitlist} (#{CreateProcessForm.importTab.numberOfHits} #{msgs.hits})</h3>
         <h:form id="hitlistDialogForm">
             <p:dataTable id="hitlistDialogTable"
-                         value="#{CreateProcessForm.importTab.hits}"
+                         value="#{CreateProcessForm.importTab.hitModel}"
                          var="hit"
                          rows="#{LoginForm.loggedUser.tableSize}"
                          paginatorPosition="bottom"
@@ -39,7 +39,7 @@
                     <p:commandLink id="selectRecord"
                                    value="#{hit.title}"
                                    title="#{hit.title}"
-                                   onclick="PF('hitlist').hide()"
+                                   onclick="PF('hitlistDialog').hide()"
                                    update="editForm"
                                    immediate="true"
                                    action="#{CreateProcessForm.importTab.getSelectedRecord()}">
@@ -50,7 +50,7 @@
             <h:panelGroup layout="block"
                           styleClass="dialogButtonWrapper">
                 <p:commandButton id="cancel"
-                                 onclick="PF('hitlist').hide();"
+                                 onclick="PF('hitlistDialog').hide();"
                                  value="#{msgs.cancel}"
                                  icon="fa fa-times fa-lg"
                                  iconPos="right"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/hitlistDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/hitlistDialog.xhtml
@@ -31,8 +31,10 @@
                          rows="#{LoginForm.loggedUser.tableSize}"
                          paginatorPosition="bottom"
                          paginator="true"
+                         lazy="true"
                          paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {NextPageLink} {LastPageLink}"
                          currentPageReportTemplate="#{msgs.currentPageReportTemplate}">
+                <p:ajax event="page" listener="#{CreateProcessForm.importTab.printPageNumber()}"/>
                 <p:column headerText="#{msgs.hits}">
                     <p:commandLink id="selectRecord"
                                    value="#{hit.title}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/hitlistDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/hitlistDialog.xhtml
@@ -23,7 +23,7 @@
               resizable="false"
               showHeader="false"
               dynamic="true">
-        <h3>#{msgs.hitlist} (#{CreateProcessForm.importTab.numberOfHits} #{msgs.hits})</h3>
+        <h3>#{msgs.hitlist}</h3>
         <h:form id="hitlistDialogForm">
             <p:dataTable id="hitlistDialogTable"
                          value="#{CreateProcessForm.importTab.hitModel}"
@@ -34,8 +34,7 @@
                          lazy="true"
                          paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {NextPageLink} {LastPageLink}"
                          currentPageReportTemplate="#{msgs.currentPageReportTemplate}">
-                <p:ajax event="page" listener="#{CreateProcessForm.importTab.printPageNumber()}"/>
-                <p:column headerText="#{msgs.hits}">
+                <p:column headerText="#{CreateProcessForm.importTab.hitModel.rowCount} #{msgs.hits}">
                     <p:commandLink id="selectRecord"
                                    value="#{hit.title}"
                                    title="#{hit.title}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/import.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/import.xhtml
@@ -24,7 +24,7 @@
             <p:selectOneMenu id="catalogueSelectMenu"
                              required="#{not empty param['editForm:processFromTemplateTabView:performCatalogSearch']}"
                              immediate="true"
-                             value="#{CreateProcessForm.importTab.selectedCatalog}">
+                             value="#{CreateProcessForm.importTab.hitModel.selectedCatalog}">
                 <f:selectItem itemValue="#{null}" itemLabel="-- #{msgs.selectCatalog} --" noSelectionOption="true"/>
                 <f:selectItems value="#{CreateProcessForm.importTab.catalogs}" var="step" itemLabel="#{step}"
                                itemValue="#{step}"/>
@@ -37,11 +37,11 @@
                       id="catalogSearchField">
             <p:outputLabel for="fieldSelectMenu"
                            value="#{msgs.field}"
-                           rendered="#{CreateProcessForm.importTab.selectedCatalog ne null}"/>
+                           rendered="#{CreateProcessForm.importTab.hitModel.selectedCatalog ne null}"/>
             <p:selectOneMenu id="fieldSelectMenu"
-                             rendered="#{CreateProcessForm.importTab.selectedCatalog ne null}"
+                             rendered="#{CreateProcessForm.importTab.hitModel.selectedCatalog ne null}"
                              required="#{not empty param['editForm:processFromTemplateTabView:performCatalogSearch']}"
-                             value="#{CreateProcessForm.importTab.selectedField}">
+                             value="#{CreateProcessForm.importTab.hitModel.selectedField}">
                 <f:selectItem itemValue="#{null}"
                               itemLabel="-- #{msgs.selectSearchField} --"
                               noSelectionOption="true"/>
@@ -51,19 +51,19 @@
         <h:panelGroup layout="block"
                       id="catalogSearchTerm">
             <p:outputLabel for="searchTerm"
-                           rendered="#{CreateProcessForm.importTab.selectedCatalog ne null}"
+                           rendered="#{CreateProcessForm.importTab.hitModel.selectedCatalog ne null}"
                            value="#{msgs.value}"/>
             <p:inputText id="searchTerm"
                          onkeypress="if (event.keyCode === 13) { document.getElementById('editForm:processFromTemplateTabView:performCatalogSearch').click(); return false; }"
-                         rendered="#{CreateProcessForm.importTab.selectedCatalog ne null}"
-                         value="#{CreateProcessForm.importTab.searchTerm}"
+                         rendered="#{CreateProcessForm.importTab.hitModel.selectedCatalog ne null}"
+                         value="#{CreateProcessForm.importTab.hitModel.searchTerm}"
                          class="input"
                          required="#{not empty param['editForm:processFromTemplateTabView:performCatalogSearch']}"/>
         </h:panelGroup>
         <h:panelGroup layout="block"
                       id="catalogSearchButton">
             <p:commandButton id="performCatalogSearch"
-                             rendered="#{CreateProcessForm.importTab.selectedCatalog ne null}"
+                             rendered="#{CreateProcessForm.importTab.hitModel.selectedCatalog ne null}"
                              action="#{CreateProcessForm.importTab.search}"
                              value="#{msgs.searchOPAC}"
                              title="#{msgs.searchOPAC}"


### PR DESCRIPTION
- enable pagination in OPAC search result list popup dialog
- add lazy loading of SRU search result hit list data sets (only load data records for currently displayed hit list page and load additional data sets from SRU interface on demand)