### PR TITLE
Remove icu depedency

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -53,11 +53,6 @@
             <version>1.0</version>
         </dependency>
         <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>62.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.itextpdf</groupId>
             <artifactId>itextpdf</artifactId>
             <version>5.5.13</version>

--- a/Kitodo/src/main/java/org/kitodo/production/security/password/PasswordConstraintValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/password/PasswordConstraintValidator.java
@@ -11,8 +11,6 @@
 
 package org.kitodo.production.security.password;
 
-import com.ibm.icu.impl.locale.XCldrStub;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -66,7 +64,7 @@ public class PasswordConstraintValidator implements ConstraintValidator<ValidPas
         }
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(
-                XCldrStub.Joiner.on(",").join(validator.getMessages(result)))
+                String.join(",", validator.getMessages(result)))
                 .addConstraintViolation();
         return false;
     }


### PR DESCRIPTION
ICU is only used to join list of strings separated by a comma character.