### PR TITLE
Remove outdated comment

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
@@ -261,7 +261,6 @@ public class WorkflowForm extends BaseForm {
     }
 
     private void saveWorkflow() {
-        // TODO: Erik needs to make field invisible in the editor
         try {
             ServiceManager.getWorkflowService().save(this.workflow);
         } catch (DataException e) {


### PR DESCRIPTION
We used to have a distinct filename field in the editor. It was removed by @Beacze in https://github.com/kitodo/kitodo-production/commit/01ec7d24154b0591f551504a9d9aa5a7f9a268bb so I have nothing left to do! 👍 