### PR TITLE
Replace org.joda.time with java.time

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/DateUtils.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/DateUtils.java
@@ -11,25 +11,22 @@
 
 package org.kitodo.production.helper;
 
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.TreeSet;
 
-import org.joda.time.DateTimeConstants;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
 /**
  * The class DateUtils contains an omnium-gatherum of functions that work on
- * calendar dates. All functionality is realized using the org.joda.time.*
- * library.
+ * calendar dates.
  */
 public class DateUtils {
     /**
      * The field DATE_FORMATTER provides a DateTimeFormatter that is used to
      * convert between LocalDate objects and String in common German notation.
      */
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("dd.MM.yyyy");
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
     /**
      * Private constructor to hide the implicit public one.
@@ -55,7 +52,7 @@ public class DateUtils {
      * @return the last month which can be found up to the end of that year
      */
     public static int lastMonthForYear(TreeSet<LocalDate> data, int year) {
-        return data.headSet(new LocalDate(year, DateTimeConstants.DECEMBER, 31), true).last().getMonthOfYear();
+        return data.headSet(LocalDate.of(year, Month.DECEMBER, 31), true).last().getMonthValue();
     }
 
     /**
@@ -74,7 +71,7 @@ public class DateUtils {
         if (!sameYear(compared, comparee)) {
             return false;
         }
-        return compared.getMonthOfYear() == comparee.getMonthOfYear();
+        return compared.getMonthValue() == comparee.getMonthValue();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Block.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Block.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.production.model.bibliography.course;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,8 +20,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormatter;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;
 
 /**
@@ -559,11 +559,11 @@ public class Block {
     public String toString(DateTimeFormatter dateConverter) {
         StringBuilder result = new StringBuilder();
         if (Objects.nonNull(firstAppearance)) {
-            result.append(dateConverter.print(firstAppearance));
+            result.append(dateConverter.format(firstAppearance));
         }
         result.append(" − ");
         if (Objects.nonNull(lastAppearance)) {
-            result.append(dateConverter.print(lastAppearance));
+            result.append(dateConverter.format(lastAppearance));
         }
         return result.toString();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
@@ -12,6 +12,10 @@
 package org.kitodo.production.model.bibliography.course;
 
 import java.io.IOException;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,10 +34,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.joda.time.DateTimeConstants;
-import org.joda.time.LocalDate;
-import org.joda.time.MonthDay;
-import org.joda.time.format.DateTimeFormat;
 import org.kitodo.production.helper.XMLUtils;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;
 import org.kitodo.production.model.bibliography.course.metadata.RecoveredMetadata;
@@ -251,7 +251,7 @@ public class Course extends ArrayList<Block> {
     /**
      * January the 1ˢᵗ.
      */
-    public static final MonthDay FIRST_OF_JANUARY = new MonthDay(1, 1);
+    public static final MonthDay FIRST_OF_JANUARY = MonthDay.of(1, 1);
 
     private static final int WEEKDAY_PAGES = 40;
     private static final int SUNDAY_PAGES = 240;
@@ -273,7 +273,7 @@ public class Course extends ArrayList<Block> {
     /**
      * The first day of the year.
      */
-    private MonthDay yearStart = new MonthDay(1, 1);
+    private MonthDay yearStart = MonthDay.of(1, 1);
 
     /**
      * Default constructor, creates an empty course. Must be made explicit since
@@ -301,8 +301,8 @@ public class Course extends ArrayList<Block> {
         Element rootNode = XMLUtils.getFirstChildWithTagName(xml, ELEMENT_COURSE);
         String yearBegin = rootNode.getAttribute(ATTRIBUTE_YEAR_BEGIN);
         if (!yearBegin.isEmpty()) {
-            LocalDate dateTime = DateTimeFormat.forPattern("--MM-dd").parseLocalDate(yearBegin);
-            yearStart = new MonthDay(dateTime.getMonthOfYear(), dateTime.getDayOfMonth());
+            LocalDate dateTime = LocalDate.parse(yearBegin, DateTimeFormatter.ofPattern("--MM-dd").withLocale(DateTimeFormatter.ISO_DATE.getLocale()));
+            yearStart = MonthDay.of(dateTime.getMonthValue(), dateTime.getDayOfMonth());
         }
         yearName = rootNode.getAttribute(ATTRIBUTE_YEAR_TERM);
         Element processesNode = XMLUtils.getFirstChildWithTagName(rootNode, ELEMENT_PROCESSES);
@@ -642,7 +642,7 @@ public class Course extends ArrayList<Block> {
             for (LocalDate day = block.getFirstAppearance(); !day.isAfter(lastAppearance); day = day.plusDays(1)) {
                 for (Issue issue : block.getIssues()) {
                     if (issue.isMatch(day)) {
-                        totalNumberOfPages += day.getDayOfWeek() != DateTimeConstants.SUNDAY ? WEEKDAY_PAGES
+                        totalNumberOfPages += day.getDayOfWeek() != DayOfWeek.SUNDAY ? WEEKDAY_PAGES
                                 : SUNDAY_PAGES;
                     }
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/CourseToGerman.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/CourseToGerman.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.production.model.bibliography.course;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -18,8 +20,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.joda.time.DateTimeConstants;
-import org.joda.time.LocalDate;
 import org.kitodo.production.helper.DateUtils;
 
 /**
@@ -111,7 +111,7 @@ public class CourseToGerman {
             Issue issue = issueIterator.next();
             result.append("an allen ");
             int daysOfWeekCount = 0;
-            for (int dayOfWeek = DateTimeConstants.MONDAY; dayOfWeek <= DateTimeConstants.SUNDAY; dayOfWeek++) {
+            for (int dayOfWeek = DayOfWeek.MONDAY.getValue(); dayOfWeek <= DayOfWeek.SUNDAY.getValue(); dayOfWeek++) {
                 if (issue.isDayOfWeek(dayOfWeek)) {
                     result.append(DAYS_OF_WEEK_NAMES[dayOfWeek]);
                     result.append("en");
@@ -221,7 +221,7 @@ public class CourseToGerman {
 
             if (!nextInSameMonth) {
                 buffer.append(' ');
-                buffer.append(MONTH_NAMES[current.getMonthOfYear()]);
+                buffer.append(MONTH_NAMES[current.getMonthValue()]);
             }
 
             if (!DateUtils.sameYear(current, next)) {
@@ -240,7 +240,7 @@ public class CourseToGerman {
                 }
             } else if (next != null) {
                 if (nextInSameMonth && nextBothInSameMonth
-                        || !nextInSameMonth && next.getMonthOfYear() != lastMonthOfYear) {
+                        || !nextInSameMonth && next.getMonthValue() != lastMonthOfYear) {
                     buffer.append(", ");
                 } else {
                     buffer.append(" und ");
@@ -265,7 +265,7 @@ public class CourseToGerman {
     private static void appendDate(StringBuilder buffer, LocalDate date) {
         buffer.append(date.getDayOfMonth());
         buffer.append(". ");
-        buffer.append(MONTH_NAMES[date.getMonthOfYear()]);
+        buffer.append(MONTH_NAMES[date.getMonthValue()]);
         buffer.append(' ');
         buffer.append(date.getYear());
     }

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Granularity.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Granularity.java
@@ -11,8 +11,9 @@
 
 package org.kitodo.production.model.bibliography.course;
 
-import org.joda.time.LocalDate;
-import org.joda.time.format.ISODateTimeFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.kitodo.exceptions.NotImplementedException;
 
 /**
@@ -65,16 +66,16 @@ public enum Granularity {
     public String format(LocalDate date) {
         switch (this) {
             case DAYS:
-                return ISODateTimeFormat.date().print(date);
+                return DateTimeFormatter.ISO_LOCAL_DATE.format(date);
             case MONTHS:
-                return ISODateTimeFormat.yearMonth().print(date);
+                return DateTimeFormatter.ofPattern("yyyy-MM").format(date);
             case QUARTERS:
-                return ISODateTimeFormat.year().print(date) + "/Q"
-                        + ((date.getMonthOfYear() - 1) / 3) + 1;
+                return DateTimeFormatter.ofPattern("yyyy").format(date) + "/Q"
+                        + ((date.getMonthValue() - 1) / 3) + 1;
             case WEEKS:
-                return ISODateTimeFormat.weekyearWeek().print(date);
+                return DateTimeFormatter.ofPattern("yyyy-'W'ww").format(date);
             case YEARS:
-                return ISODateTimeFormat.year().print(date);
+                return DateTimeFormatter.ofPattern("yyyy").format(date);
             default:
                 throw new NotImplementedException();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
@@ -11,6 +11,10 @@
 
 package org.kitodo.production.model.bibliography.course;
 
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -18,10 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.joda.time.LocalDate;
-import org.joda.time.MonthDay;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.kitodo.exceptions.UnreachableCodeException;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;
 
@@ -35,25 +35,25 @@ public class IndividualIssue {
      * The constant DAY holds a DateTimeFormatter used to get the a two-digit
      * day (01—31) from the newspaper’s date.
      */
-    private static final DateTimeFormatter DAY = DateTimeFormat.forPattern("dd");
+    private static final DateTimeFormatter DAY = DateTimeFormatter.ofPattern("dd");
 
     /**
      * The constant MONTH holds a DateTimeFormatter used to get the a two-digit
      * month (01—12) from the newspaper’s date.
      */
-    private static final DateTimeFormatter MONTH = DateTimeFormat.forPattern("MM");
+    private static final DateTimeFormatter MONTH = DateTimeFormatter.ofPattern("MM");
 
     /**
      * The constant YEAR2 holds a DateTimeFormatter used to get the a four-digit
      * year of era (00—99, always positive) from the newspaper’s date.
      */
-    private static final DateTimeFormatter YEAR2 = DateTimeFormat.forPattern("YY");
+    private static final DateTimeFormatter YEAR2 = DateTimeFormatter.ofPattern("YY");
 
     /**
      * The constant YEAR4 holds a DateTimeFormatter used to get the a four-digit
      * year of era (0001—9999, always positive) from the newspaper’s date.
      */
-    private static final DateTimeFormatter YEAR4 = DateTimeFormat.forPattern("YYYY");
+    private static final DateTimeFormatter YEAR4 = DateTimeFormatter.ofPattern("YYYY");
 
     /**
      * Metadata key to store the sorting number.
@@ -119,11 +119,11 @@ public class IndividualIssue {
             case DAYS:
                 return date.hashCode();
             case WEEKS:
-                return prime * getFirstYear(yearStart) + date.getWeekOfWeekyear();
+                return prime * getFirstYear(yearStart) + date.get(WeekFields.ISO.weekOfWeekBasedYear()); // TODO Weekfields.ISO correct?
             case MONTHS:
-                return prime * getFirstYear(yearStart) + date.getMonthOfYear();
+                return prime * getFirstYear(yearStart) + date.getMonthValue();
             case QUARTERS:
-                return prime * getFirstYear(yearStart) + (date.getMonthOfYear() - 1) / 3;
+                return prime * getFirstYear(yearStart) + (date.getMonthValue() - 1) / 3;
             case YEARS:
                 return getFirstYear(yearStart);
             default:
@@ -140,7 +140,7 @@ public class IndividualIssue {
      */
     private int getFirstYear(MonthDay yearStart) {
         int year = date.getYear();
-        return date.compareTo(yearStart.toLocalDate(year)) < 0 ? year - 1 : year;
+        return date.compareTo(yearStart.atYear(year)) < 0 ? year - 1 : year;
     }
 
     /**
@@ -200,7 +200,7 @@ public class IndividualIssue {
         int length = heading.length();
         String upperCase = heading.toUpperCase();
         String lowerCase = heading.toLowerCase();
-        genericFields.put("#DAY", DAY.print(date));
+        genericFields.put("#DAY", DAY.format(date));
         genericFields.put("#I", length > 1 ? upperCase.substring(0, 1) : upperCase);
         genericFields.put("#i", length > 1 ? lowerCase.substring(0, 1) : lowerCase);
         genericFields.put("#IS", length > 2 ? upperCase.substring(0, 2) : upperCase);
@@ -210,9 +210,9 @@ public class IndividualIssue {
         genericFields.put("#ISSU", length > 4 ? upperCase.substring(0, 4) : upperCase);
         genericFields.put("#issu", length > 4 ? lowerCase.substring(0, 4) : lowerCase);
         genericFields.put("#Issue", heading);
-        genericFields.put("#MONTH", MONTH.print(date));
-        genericFields.put("#YEAR", YEAR4.print(date));
-        genericFields.put("#YR", YEAR2.print(date));
+        genericFields.put("#MONTH", MONTH.format(date));
+        genericFields.put("#YEAR", YEAR4.format(date));
+        genericFields.put("#YR", YEAR2.format(date));
         return genericFields;
     }
 
@@ -229,7 +229,7 @@ public class IndividualIssue {
      *         the value
      */
     public Iterable<Pair<String, String>> getMetadata(int monthOfYear, int dayOfMonth) {
-        return getMetadata(new MonthDay(monthOfYear, dayOfMonth));
+        return getMetadata(MonthDay.of(monthOfYear, dayOfMonth));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
@@ -11,12 +11,12 @@
 
 package org.kitodo.production.model.bibliography.course;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import org.joda.time.DateTimeConstants;
-import org.joda.time.LocalDate;
 
 /**
  * The class Issue represents the regular appearance of one (or the) issue of a
@@ -128,8 +128,8 @@ public class Issue {
      *            An int representing the day of week (1 = monday … 7 = sunday)
      * @return true if the Set was changed
      */
-    private boolean addDayOfWeek(int dayOfWeek) {
-        boolean modified = daysOfWeek.add(dayOfWeek);
+    private boolean addDayOfWeek(DayOfWeek dayOfWeek) {
+        boolean modified = daysOfWeek.add(dayOfWeek.getValue());
         if (modified) {
             course.clearProcesses();
         }
@@ -154,7 +154,7 @@ public class Issue {
      * @return true if the set was changed
      */
     public boolean addMonday() {
-        return addDayOfWeek(DateTimeConstants.MONDAY);
+        return addDayOfWeek(DayOfWeek.MONDAY);
     }
 
     /**
@@ -163,7 +163,7 @@ public class Issue {
      * @return true if the set was changed
      */
     public boolean addTuesday() {
-        return addDayOfWeek(DateTimeConstants.TUESDAY);
+        return addDayOfWeek(DayOfWeek.TUESDAY);
     }
 
     /**
@@ -172,7 +172,7 @@ public class Issue {
      * @return true if the set was changed
      */
     public boolean addWednesday() {
-        return addDayOfWeek(DateTimeConstants.WEDNESDAY);
+        return addDayOfWeek(DayOfWeek.WEDNESDAY);
     }
 
     /**
@@ -181,7 +181,7 @@ public class Issue {
      * @return true if the set was changed
      */
     public boolean addThursday() {
-        return addDayOfWeek(DateTimeConstants.THURSDAY);
+        return addDayOfWeek(DayOfWeek.THURSDAY);
     }
 
     /**
@@ -190,7 +190,7 @@ public class Issue {
      * @return true if the set was changed
      */
     public boolean addFriday() {
-        return addDayOfWeek(DateTimeConstants.FRIDAY);
+        return addDayOfWeek(DayOfWeek.FRIDAY);
     }
 
     /**
@@ -199,7 +199,7 @@ public class Issue {
      * @return true if the set was changed
      */
     public boolean addSaturday() {
-        return addDayOfWeek(DateTimeConstants.SATURDAY);
+        return addDayOfWeek(DayOfWeek.SATURDAY);
     }
 
     /**
@@ -208,7 +208,7 @@ public class Issue {
      * @return true if the set was changed
      */
     public boolean addSunday() {
-        return addDayOfWeek(DateTimeConstants.SUNDAY);
+        return addDayOfWeek(DayOfWeek.SUNDAY);
     }
 
     /**
@@ -319,7 +319,7 @@ public class Issue {
      * @return true, if the issue regularly appears on Mondays.
      */
     public boolean isMonday() {
-        return daysOfWeek.contains(DateTimeConstants.MONDAY);
+        return daysOfWeek.contains(DayOfWeek.MONDAY.getValue());
     }
 
     /**
@@ -329,7 +329,7 @@ public class Issue {
      * @return true, if the issue regularly appears on Tuesdays.
      */
     public boolean isTuesday() {
-        return daysOfWeek.contains(DateTimeConstants.TUESDAY);
+        return daysOfWeek.contains(DayOfWeek.TUESDAY.getValue());
     }
 
     /**
@@ -339,7 +339,7 @@ public class Issue {
      * @return true, if the issue regularly appears on Wednesdays.
      */
     public boolean isWednesday() {
-        return daysOfWeek.contains(DateTimeConstants.WEDNESDAY);
+        return daysOfWeek.contains(DayOfWeek.WEDNESDAY.getValue());
     }
 
     /**
@@ -349,7 +349,7 @@ public class Issue {
      * @return true, if the issue regularly appears on Thursdays.
      */
     public boolean isThursday() {
-        return daysOfWeek.contains(DateTimeConstants.THURSDAY);
+        return daysOfWeek.contains(DayOfWeek.THURSDAY.getValue());
     }
 
     /**
@@ -359,7 +359,7 @@ public class Issue {
      * @return true, if the issue regularly appears on Fridays.
      */
     public boolean isFriday() {
-        return daysOfWeek.contains(DateTimeConstants.FRIDAY);
+        return daysOfWeek.contains(DayOfWeek.FRIDAY.getValue());
     }
 
     /**
@@ -369,7 +369,7 @@ public class Issue {
      * @return true, if the issue regularly appears on Saturdays.
      */
     public boolean isSaturday() {
-        return daysOfWeek.contains(DateTimeConstants.SATURDAY);
+        return daysOfWeek.contains(DayOfWeek.SATURDAY.getValue());
     }
 
     /**
@@ -379,7 +379,7 @@ public class Issue {
      * @return true, if the issue regularly appears on Sundays.
      */
     public boolean isSunday() {
-        return daysOfWeek.contains(DateTimeConstants.SUNDAY);
+        return daysOfWeek.contains(DayOfWeek.SUNDAY.getValue());
     }
 
     /**
@@ -399,17 +399,17 @@ public class Issue {
         Set<LocalDate> remainingExclusions = new HashSet<>();
 
         @SuppressWarnings("unchecked")
-        HashSet<LocalDate>[][] subsets = new HashSet[DateTimeConstants.SUNDAY][APPEARED + 1];
-        for (int dayOfWeek = DateTimeConstants.MONDAY; dayOfWeek <= DateTimeConstants.SUNDAY; dayOfWeek++) {
+        HashSet<LocalDate>[][] subsets = new HashSet[DayOfWeek.SUNDAY.getValue()][APPEARED + 1];
+        for (int dayOfWeek = DayOfWeek.MONDAY.getValue(); dayOfWeek <= DayOfWeek.SUNDAY.getValue(); dayOfWeek++) {
             subsets[dayOfWeek - 1][NOT_APPEARED] = new HashSet<>();
             subsets[dayOfWeek - 1][APPEARED] = new HashSet<>();
         }
 
         for (LocalDate day = firstAppearance; !day.isAfter(lastAppearance); day = day.plusDays(1)) {
-            subsets[day.getDayOfWeek() - 1][isMatch(day) ? APPEARED : NOT_APPEARED].add(day);
+            subsets[day.getDayOfWeek().getValue() - 1][isMatch(day) ? APPEARED : NOT_APPEARED].add(day);
         }
 
-        for (int dayOfWeek = DateTimeConstants.MONDAY; dayOfWeek <= DateTimeConstants.SUNDAY; dayOfWeek++) {
+        for (int dayOfWeek = DayOfWeek.MONDAY.getValue(); dayOfWeek <= DayOfWeek.SUNDAY.getValue(); dayOfWeek++) {
             if (subsets[dayOfWeek - 1][APPEARED].size() > subsets[dayOfWeek - 1][NOT_APPEARED].size()) {
                 daysOfWeek.add(dayOfWeek);
                 remainingExclusions.addAll(subsets[dayOfWeek - 1][NOT_APPEARED]);
@@ -443,8 +443,8 @@ public class Issue {
      *            An int representing the day of week (1 = monday … 7 = sunday)
      * @return true if the Set was changed
      */
-    private boolean removeDayOfWeek(int dayOfWeek) {
-        boolean modified = daysOfWeek.remove(dayOfWeek);
+    private boolean removeDayOfWeek(DayOfWeek dayOfWeek) {
+        boolean modified = daysOfWeek.remove(dayOfWeek.getValue());
         if (modified) {
             course.clearProcesses();
         }
@@ -469,7 +469,7 @@ public class Issue {
      * @return true if the Set was changed
      */
     public boolean removeMonday() {
-        return removeDayOfWeek(DateTimeConstants.MONDAY);
+        return removeDayOfWeek(DayOfWeek.MONDAY);
     }
 
     /**
@@ -478,7 +478,7 @@ public class Issue {
      * @return true if the Set was changed
      */
     public boolean removeTuesday() {
-        return removeDayOfWeek(DateTimeConstants.TUESDAY);
+        return removeDayOfWeek(DayOfWeek.TUESDAY);
     }
 
     /**
@@ -487,7 +487,7 @@ public class Issue {
      * @return true if the Set was changed
      */
     public boolean removeWednesday() {
-        return removeDayOfWeek(DateTimeConstants.WEDNESDAY);
+        return removeDayOfWeek(DayOfWeek.WEDNESDAY);
     }
 
     /**
@@ -496,7 +496,7 @@ public class Issue {
      * @return true if the Set was changed
      */
     public boolean removeThursday() {
-        return removeDayOfWeek(DateTimeConstants.THURSDAY);
+        return removeDayOfWeek(DayOfWeek.THURSDAY);
     }
 
     /**
@@ -505,7 +505,7 @@ public class Issue {
      * @return true if the Set was changed
      */
     public boolean removeFriday() {
-        return removeDayOfWeek(DateTimeConstants.FRIDAY);
+        return removeDayOfWeek(DayOfWeek.FRIDAY);
     }
 
     /**
@@ -514,7 +514,7 @@ public class Issue {
      * @return true if the Set was changed
      */
     public boolean removeSaturday() {
-        return removeDayOfWeek(DateTimeConstants.SATURDAY);
+        return removeDayOfWeek(DayOfWeek.SATURDAY);
     }
 
     /**
@@ -523,7 +523,7 @@ public class Issue {
      * @return true if the Set was changed
      */
     public boolean removeSunday() {
-        return removeDayOfWeek(DateTimeConstants.SUNDAY);
+        return removeDayOfWeek(DayOfWeek.SUNDAY);
     }
 
     /**
@@ -552,13 +552,13 @@ public class Issue {
         StringBuilder result = new StringBuilder();
         result.append(heading);
         result.append(" (");
-        result.append(daysOfWeek.contains(DateTimeConstants.MONDAY) ? 'M' : '-');
-        result.append(daysOfWeek.contains(DateTimeConstants.TUESDAY) ? 'T' : '-');
-        result.append(daysOfWeek.contains(DateTimeConstants.WEDNESDAY) ? 'W' : '-');
-        result.append(daysOfWeek.contains(DateTimeConstants.THURSDAY) ? 'T' : '-');
-        result.append(daysOfWeek.contains(DateTimeConstants.FRIDAY) ? 'F' : '-');
-        result.append(daysOfWeek.contains(DateTimeConstants.SATURDAY) ? 'S' : '-');
-        result.append(daysOfWeek.contains(DateTimeConstants.SUNDAY) ? 'S' : '-');
+        result.append(daysOfWeek.contains(DayOfWeek.MONDAY.getValue()) ? 'M' : '-');
+        result.append(daysOfWeek.contains(DayOfWeek.TUESDAY.getValue()) ? 'T' : '-');
+        result.append(daysOfWeek.contains(DayOfWeek.WEDNESDAY.getValue()) ? 'W' : '-');
+        result.append(daysOfWeek.contains(DayOfWeek.THURSDAY.getValue()) ? 'T' : '-');
+        result.append(daysOfWeek.contains(DayOfWeek.FRIDAY.getValue()) ? 'F' : '-');
+        result.append(daysOfWeek.contains(DayOfWeek.SATURDAY.getValue()) ? 'S' : '-');
+        result.append(daysOfWeek.contains(DayOfWeek.SUNDAY.getValue()) ? 'S' : '-');
         result.append(") +");
         if (additions.size() <= 5) {
             result.append(additions.toString());

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadata.java
@@ -11,13 +11,12 @@
 
 package org.kitodo.production.model.bibliography.course.metadata;
 
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.joda.time.LocalDate;
-import org.joda.time.MonthDay;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.ISODateTimeFormat;
 import org.kitodo.production.helper.metadata.pagination.Paginator;
 import org.kitodo.production.model.bibliography.course.Block;
 import org.kitodo.production.model.bibliography.course.Granularity;
@@ -168,7 +167,7 @@ public class CountableMetadata {
             }
         }
         throw new IllegalStateException("Issue “" + selectedIssue.getRight().getHeading() + "” not found on "
-                + DateTimeFormat.mediumDate().print(selectedIssue.getLeft()));
+                + DateTimeFormatter.ISO_LOCAL_DATE.format(selectedIssue.getLeft()));
     }
 
     /**
@@ -235,21 +234,21 @@ public class CountableMetadata {
     /**
      * Returns a human-readable concise description of this countable metadata.
      *
-     * @retun a human-readable description of this metadata
+     * @return a human-readable description of this metadata
      */
     @Override
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(startValue);
         stringBuilder.append(" from ");
-        stringBuilder.append(ISODateTimeFormat.date().print(create.getLeft()));
+        stringBuilder.append(DateTimeFormatter.ISO_DATE.format(create.getLeft()));
         stringBuilder.append(", ");
         stringBuilder.append(create.getRight().getHeading());
         if (delelte == null) {
             stringBuilder.append(" infinitely");
         } else {
             stringBuilder.append(" to ");
-            stringBuilder.append(ISODateTimeFormat.date().print(delelte.getLeft()));
+            stringBuilder.append(DateTimeFormatter.ISO_DATE.format(delelte.getLeft()));
             stringBuilder.append(", ");
             stringBuilder.append(delelte.getRight().getHeading());
         }

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/IssueComparator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/IssueComparator.java
@@ -11,10 +11,10 @@
 
 package org.kitodo.production.model.bibliography.course.metadata;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.joda.time.LocalDate;
 import org.kitodo.production.model.bibliography.course.Block;
 import org.kitodo.production.model.bibliography.course.Issue;
 

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/RecoveredMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/RecoveredMetadata.java
@@ -11,7 +11,8 @@
 
 package org.kitodo.production.model.bibliography.course.metadata;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
+
 import org.kitodo.production.model.bibliography.course.Granularity;
 
 /**

--- a/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
@@ -16,7 +16,9 @@ import de.unigoettingen.sub.search.opac.ConfigOpacDoctype;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.LocalDate;
 import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,9 +34,6 @@ import javax.naming.ConfigurationException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
@@ -538,15 +537,14 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         if (PATTERN_DOUBLE_YEAR.equals(scheme)) {
             int firstYear = date.getYear();
             MonthDay yearBegin = yearSimpleMetadataView.getYearBegin();
-            LocalDate yearStartThisYear = new LocalDate(firstYear, yearBegin.getMonthValue(),
-                    yearBegin.getDayOfMonth());
+            LocalDate yearStartThisYear = LocalDate.of(firstYear, yearBegin.getMonth(), yearBegin.getDayOfMonth());
             if (date.isBefore(yearStartThisYear)) {
                 firstYear--;
             }
             return String.format("%04d/%04d", firstYear, firstYear + 1);
         } else {
-            DateTimeFormatter yearFormatter = DateTimeFormat.forPattern(scheme);
-            return yearFormatter.print(date);
+            DateTimeFormatter yearFormatter = DateTimeFormatter.ofPattern(scheme);
+            return yearFormatter.format(date);
         }
     }
 

--- a/Kitodo/src/test/java/org/kitodo/NewspaperCourse.java
+++ b/Kitodo/src/test/java/org/kitodo/NewspaperCourse.java
@@ -11,9 +11,9 @@
 
 package org.kitodo;
 
+import java.time.LocalDate;
 import java.util.Objects;
 
-import org.joda.time.LocalDate;
 import org.kitodo.production.model.bibliography.course.Block;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.model.bibliography.course.Issue;
@@ -47,134 +47,134 @@ public class NewspaperCourse {
 
     private static void addFirstBlock(Course course) {
         Block block = new Block(course);
-        block.setPublicationPeriod(new LocalDate(1703, 8, 8), new LocalDate(1703, 12, 31));
+        block.setPublicationPeriod(LocalDate.of(1703, 8, 8), LocalDate.of(1703, 12, 31));
         Issue issue = new Issue(course);
         issue.addMonday();
         issue.addThursday();
-        issue.addAddition(new LocalDate(1703, 8, 8));
-        issue.addExclusion(new LocalDate(1703, 8, 9));
-        issue.addExclusion(new LocalDate(1703, 8, 16));
-        issue.addAddition(new LocalDate(1703, 8, 17));
-        issue.addExclusion(new LocalDate(1703, 8, 30));
-        issue.addAddition(new LocalDate(1703, 8, 31));
-        issue.addAddition(new LocalDate(1703, 9, 6));
+        issue.addAddition(LocalDate.of(1703, 8, 8));
+        issue.addExclusion(LocalDate.of(1703, 8, 9));
+        issue.addExclusion(LocalDate.of(1703, 8, 16));
+        issue.addAddition(LocalDate.of(1703, 8, 17));
+        issue.addExclusion(LocalDate.of(1703, 8, 30));
+        issue.addAddition(LocalDate.of(1703, 8, 31));
+        issue.addAddition(LocalDate.of(1703, 9, 6));
         block.addIssue(issue);
         course.add(block);
     }
 
     private static void addSecondBlock(Course course) {
         Block block = new Block(course);
-        block.setPublicationPeriod(new LocalDate(1704, 12, 31), new LocalDate(1713, 7, 22));
+        block.setPublicationPeriod(LocalDate.of(1704, 12, 31), LocalDate.of(1713, 7, 22));
         Issue issue = new Issue(course);
         issue.addWednesday();
         issue.addSaturday();
-        issue.addAddition(new LocalDate(1705, 1, 27));
-        issue.addExclusion(new LocalDate(1705, 1, 28));
-        issue.addAddition(new LocalDate(1705, 4, 8));
-        issue.addExclusion(new LocalDate(1705, 4, 7));
-        issue.addAddition(new LocalDate(1705, 11, 10));
-        issue.addExclusion(new LocalDate(1705, 11, 11));
-        issue.addAddition(new LocalDate(1706, 3, 16));
-        issue.addExclusion(new LocalDate(1706, 3, 17));
-        issue.addExclusion(new LocalDate(1706, 5, 1));
-        issue.addAddition(new LocalDate(1706, 5, 2));
-        issue.addExclusion(new LocalDate(1707, 7, 27));
-        issue.addAddition(new LocalDate(1707, 7, 29));
-        issue.addExclusion(new LocalDate(1708, 9, 19));
-        issue.addAddition(new LocalDate(1708, 9, 21));
-        issue.addExclusion(new LocalDate(1709, 5, 25));
-        issue.addExclusion(new LocalDate(1711, 5, 23));
-        issue.addExclusion(new LocalDate(1711, 5, 27));
-        issue.addExclusion(new LocalDate(1711, 5, 30));
-        issue.addExclusion(new LocalDate(1711, 6, 24));
-        issue.addExclusion(new LocalDate(1711, 6, 27));
-        issue.addExclusion(new LocalDate(1712, 6, 11));
-        issue.addAddition(new LocalDate(1712, 6, 14));
-        issue.addExclusion(new LocalDate(1712, 9, 10));
-        issue.addExclusion(new LocalDate(1712, 9, 14));
-        issue.addExclusion(new LocalDate(1712, 12, 31));
-        issue.addExclusion(new LocalDate(1713, 1, 21));
-        issue.addAddition(new LocalDate(1713, 1, 22));
-        issue.addExclusion(new LocalDate(1713, 2, 22));
-        issue.addExclusion(new LocalDate(1713, 2, 25));
-        issue.addExclusion(new LocalDate(1713, 4, 12));
-        issue.addAddition(new LocalDate(1713, 4, 13));
+        issue.addAddition(LocalDate.of(1705, 1, 27));
+        issue.addExclusion(LocalDate.of(1705, 1, 28));
+        issue.addAddition(LocalDate.of(1705, 4, 8));
+        issue.addExclusion(LocalDate.of(1705, 4, 7));
+        issue.addAddition(LocalDate.of(1705, 11, 10));
+        issue.addExclusion(LocalDate.of(1705, 11, 11));
+        issue.addAddition(LocalDate.of(1706, 3, 16));
+        issue.addExclusion(LocalDate.of(1706, 3, 17));
+        issue.addExclusion(LocalDate.of(1706, 5, 1));
+        issue.addAddition(LocalDate.of(1706, 5, 2));
+        issue.addExclusion(LocalDate.of(1707, 7, 27));
+        issue.addAddition(LocalDate.of(1707, 7, 29));
+        issue.addExclusion(LocalDate.of(1708, 9, 19));
+        issue.addAddition(LocalDate.of(1708, 9, 21));
+        issue.addExclusion(LocalDate.of(1709, 5, 25));
+        issue.addExclusion(LocalDate.of(1711, 5, 23));
+        issue.addExclusion(LocalDate.of(1711, 5, 27));
+        issue.addExclusion(LocalDate.of(1711, 5, 30));
+        issue.addExclusion(LocalDate.of(1711, 6, 24));
+        issue.addExclusion(LocalDate.of(1711, 6, 27));
+        issue.addExclusion(LocalDate.of(1712, 6, 11));
+        issue.addAddition(LocalDate.of(1712, 6, 14));
+        issue.addExclusion(LocalDate.of(1712, 9, 10));
+        issue.addExclusion(LocalDate.of(1712, 9, 14));
+        issue.addExclusion(LocalDate.of(1712, 12, 31));
+        issue.addExclusion(LocalDate.of(1713, 1, 21));
+        issue.addAddition(LocalDate.of(1713, 1, 22));
+        issue.addExclusion(LocalDate.of(1713, 2, 22));
+        issue.addExclusion(LocalDate.of(1713, 2, 25));
+        issue.addExclusion(LocalDate.of(1713, 4, 12));
+        issue.addAddition(LocalDate.of(1713, 4, 13));
         block.addIssue(issue);
         course.add(block);
     }
 
     private static void addThirdBlock(Course course) {
         Block block = new Block(course);
-        block.setPublicationPeriod(new LocalDate(1713, 9, 13), new LocalDate(1714, 2, 17));
+        block.setPublicationPeriod(LocalDate.of(1713, 9, 13), LocalDate.of(1714, 2, 17));
         Issue issue = new Issue(course);
         issue.addWednesday();
         issue.addSaturday();
-        issue.addAddition(new LocalDate(1713, 10, 17));
-        issue.addExclusion(new LocalDate(1713, 10, 18));
+        issue.addAddition(LocalDate.of(1713, 10, 17));
+        issue.addExclusion(LocalDate.of(1713, 10, 18));
         block.addIssue(issue);
         course.add(block);
     }
 
     private static void addFourthBlock(Course course) {
         Block block = new Block(course);
-        block.setPublicationPeriod(new LocalDate(1714, 4, 28), new LocalDate(1714, 10, 19));
+        block.setPublicationPeriod(LocalDate.of(1714, 4, 28), LocalDate.of(1714, 10, 19));
         Issue issue = new Issue(course);
-        issue.addAddition(new LocalDate(1714, 4, 28));
-        issue.addAddition(new LocalDate(1714, 5, 2));
-        issue.addAddition(new LocalDate(1714, 5, 19));
-        issue.addAddition(new LocalDate(1714, 5, 23));
-        issue.addAddition(new LocalDate(1714, 6, 2));
-        issue.addAddition(new LocalDate(1714, 6, 6));
-        issue.addAddition(new LocalDate(1714, 6, 9));
-        issue.addAddition(new LocalDate(1714, 6, 23));
-        issue.addAddition(new LocalDate(1714, 6, 27));
-        issue.addAddition(new LocalDate(1714, 6, 30));
-        issue.addAddition(new LocalDate(1714, 7, 4));
-        issue.addAddition(new LocalDate(1714, 7, 11));
-        issue.addAddition(new LocalDate(1714, 7, 14));
-        issue.addAddition(new LocalDate(1714, 7, 21));
-        issue.addAddition(new LocalDate(1714, 8, 22));
-        issue.addAddition(new LocalDate(1714, 8, 25));
-        issue.addAddition(new LocalDate(1714, 9, 1));
-        issue.addAddition(new LocalDate(1714, 9, 4));
-        issue.addAddition(new LocalDate(1714, 9, 8));
-        issue.addAddition(new LocalDate(1714, 10, 19));
+        issue.addAddition(LocalDate.of(1714, 4, 28));
+        issue.addAddition(LocalDate.of(1714, 5, 2));
+        issue.addAddition(LocalDate.of(1714, 5, 19));
+        issue.addAddition(LocalDate.of(1714, 5, 23));
+        issue.addAddition(LocalDate.of(1714, 6, 2));
+        issue.addAddition(LocalDate.of(1714, 6, 6));
+        issue.addAddition(LocalDate.of(1714, 6, 9));
+        issue.addAddition(LocalDate.of(1714, 6, 23));
+        issue.addAddition(LocalDate.of(1714, 6, 27));
+        issue.addAddition(LocalDate.of(1714, 6, 30));
+        issue.addAddition(LocalDate.of(1714, 7, 4));
+        issue.addAddition(LocalDate.of(1714, 7, 11));
+        issue.addAddition(LocalDate.of(1714, 7, 14));
+        issue.addAddition(LocalDate.of(1714, 7, 21));
+        issue.addAddition(LocalDate.of(1714, 8, 22));
+        issue.addAddition(LocalDate.of(1714, 8, 25));
+        issue.addAddition(LocalDate.of(1714, 9, 1));
+        issue.addAddition(LocalDate.of(1714, 9, 4));
+        issue.addAddition(LocalDate.of(1714, 9, 8));
+        issue.addAddition(LocalDate.of(1714, 10, 19));
         block.addIssue(issue);
         course.add(block);
     }
 
     private static void addFifthBlock(Course course) {
         Block block = new Block(course);
-        block.setPublicationPeriod(new LocalDate(1715, 6, 1), new LocalDate(1715, 7, 13));
+        block.setPublicationPeriod(LocalDate.of(1715, 6, 1), LocalDate.of(1715, 7, 13));
         Issue issue = new Issue(course);
         issue.addWednesday();
         issue.addSaturday();
-        issue.addExclusion(new LocalDate(1715, 6, 8));
-        issue.addExclusion(new LocalDate(1715, 6, 15));
-        issue.addExclusion(new LocalDate(1715, 6, 26));
-        issue.addExclusion(new LocalDate(1715, 6, 29));
+        issue.addExclusion(LocalDate.of(1715, 6, 8));
+        issue.addExclusion(LocalDate.of(1715, 6, 15));
+        issue.addExclusion(LocalDate.of(1715, 6, 26));
+        issue.addExclusion(LocalDate.of(1715, 6, 29));
         block.addIssue(issue);
         course.add(block);
     }
 
     private static void addSixthBlock(Course course) {
         Block block = new Block(course);
-        block.setPublicationPeriod(new LocalDate(1716, 8, 8), new LocalDate(1716, 12, 26));
+        block.setPublicationPeriod(LocalDate.of(1716, 8, 8), LocalDate.of(1716, 12, 26));
         Issue issue = new Issue(course);
         issue.addWednesday();
         issue.addSaturday();
-        issue.addExclusion(new LocalDate(1715, 8, 22));
+        issue.addExclusion(LocalDate.of(1715, 8, 22));
         block.addIssue(issue);
         course.add(block);
     }
 
     private static void addSeventhBlock(Course course) {
         Block block = new Block(course);
-        block.setPublicationPeriod(new LocalDate(1719, 1, 1), new LocalDate(1720, 12, 31));
+        block.setPublicationPeriod(LocalDate.of(1719, 1, 1), LocalDate.of(1720, 12, 31));
         Issue issue = new Issue(course);
         issue.addWednesday();
         issue.addSaturday();
-        issue.addExclusion(new LocalDate(1719, 9, 9));
+        issue.addExclusion(LocalDate.of(1719, 9, 9));
         block.addIssue(issue);
         course.add(block);
     }


### PR DESCRIPTION
Replaces the `org.joda.time package` with the `java.time` package for all usages regarding newspapers.

@matthias-ronge can you please review this refactoring?