### PR TITLE
Raise Apache POI version to 3.17 and cleanup dependency usage

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -327,48 +327,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- it still uses log4j -->
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-contrib</artifactId>
-            <version>${poi.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>${poi.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.xmlbeans</groupId>
-                    <artifactId>xmlbeans</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
             <version>${poi.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlbeans</groupId>
-            <artifactId>xmlbeans</artifactId>
-            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <joda-time.version>2.10.4</joda-time.version>
         <myfaces.version>2.3.4</myfaces.version>
         <mysql.version>5.1.38</mysql.version>
-        <poi.version>3.6</poi.version>
+        <poi.version>3.17</poi.version>
         <primefaces.version>7.0.2</primefaces.version>
         <saxon.version>9.0.0.4</saxon.version>
         <log4j.version>2.12.1</log4j.version>


### PR DESCRIPTION
Replace version from 2006 with latest available and compile-compatible version from 2017.