### PR TITLE
Correct thumbnail size

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1770,9 +1770,9 @@ Column content
 
 .thumbnail-container {
     display: inline-block;
-    height: 80px;
+    height: 104px;
     position: relative;
-    width: 65px;
+    width: 75px;
 }
 
 .thumbnail-container .assigned-several-times {


### PR DESCRIPTION
Corrected thumbnail size to 71 pixels by 100 pixels (excluding borders of 2 pixels each). 