### PR TITLE
Bugfix: Disable parallel processing in smLink generation

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -223,7 +223,7 @@ public class DivXmlElementAccess extends IncludedStructuralElement {
         div.setLABEL(super.getLabel());
         div.setORDERLABEL(super.getOrderlabel());
         div.setTYPE(super.getType());
-        smLinkData.addAll(super.getViews().parallelStream().map(View::getMediaUnit).map(mediaUnitIDs::get)
+        smLinkData.addAll(super.getViews().stream().map(View::getMediaUnit).map(mediaUnitIDs::get)
                 .map(mediaUnitId -> Pair.of(metsReferrerId, mediaUnitId)).collect(Collectors.toList()));
 
         Optional<MdSecType> optionalDmdSec = createMdSec(super.getMetadata(), MdSec.DMD_SEC);


### PR DESCRIPTION
Parallel processing may mess up the order of smLink elements if the CPU decides to do so.