### PR TITLE
Repair login name check againts internal blacklist

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -13,12 +13,12 @@ package org.kitodo.production.services.data;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -277,7 +277,7 @@ public class UserService extends ClientSearchDatabaseService<User, UserDAO> impl
     private boolean isLoginAllowed(String login) {
         KitodoConfigFile blacklist = KitodoConfigFile.LOGIN_BLACKLIST;
         // If user defined blacklist doesn't exists, use default one
-        try (InputStream inputStream = blacklist.exists() ? new FileInputStream(blacklist.getFile())
+        try (InputStream inputStream = blacklist.exists() ? Files.newInputStream(blacklist.getFile().toPath())
                 : Thread.currentThread().getContextClassLoader().getResourceAsStream(blacklist.getName());
                 InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
                 BufferedReader reader = new BufferedReader(inputStreamReader)) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -275,22 +275,10 @@ public class UserService extends ClientSearchDatabaseService<User, UserDAO> impl
     }
 
     private boolean isLoginAllowed(String login) {
+        KitodoConfigFile blacklist = KitodoConfigFile.LOGIN_BLACKLIST;
         // If user defined blacklist doesn't exists, use default one
-        if (!KitodoConfigFile.LOGIN_BLACKLIST.exists()) {
-            ClassLoader classloader = Thread.currentThread().getContextClassLoader();
-            try (InputStream inputStream = classloader.getResourceAsStream(KitodoConfigFile.LOGIN_BLACKLIST.getName());
-                    InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                    BufferedReader reader = new BufferedReader(inputStreamReader)) {
-                if (isLoginFoundOnBlackList(reader, login)) {
-                    return false;
-                }
-            } catch (IOException e) {
-                Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
-                return false;
-            }
-        }
-        // Go through the user defined blacklist file line by line and compare with login
-        try (FileInputStream inputStream = new FileInputStream(KitodoConfigFile.LOGIN_BLACKLIST.getFile());
+        try (InputStream inputStream = blacklist.exists() ? new FileInputStream(blacklist.getFile())
+                : Thread.currentThread().getContextClassLoader().getResourceAsStream(blacklist.getName());
                 InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
                 BufferedReader reader = new BufferedReader(inputStreamReader)) {
             if (isLoginFoundOnBlackList(reader, login)) {
@@ -303,6 +291,10 @@ public class UserService extends ClientSearchDatabaseService<User, UserDAO> impl
         return true;
     }
 
+    /**
+     * Go through the user defined blacklist file line by line and compare with
+     * login.
+     */
     private boolean isLoginFoundOnBlackList(BufferedReader reader, String login) throws IOException {
         String notAllowedLogin;
         while ((notAllowedLogin = reader.readLine()) != null) {


### PR DESCRIPTION
Yesterday we had the problem that a user could not be edited with the error message that the login is on the blacklist or contains invalid characters. We noticed the following logic error: If no blacklist was found in the configuration directory, the internal file in the jar file was queried. Then the method was not terminated, but still tried to open the non-existent file and returned the `IOException` as `false` (i.e. invalid user name). This is fixed hereby. If the file does not exist, no attempt will be made to open it.