### PR TITLE
Allow to edit an existing user without login name check

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -132,7 +132,7 @@ public class UserForm extends BaseForm {
     public String save() {
         String login = this.userObject.getLogin();
 
-        if (!isLoginValid(login)) {
+        if (Objects.isNull(userObject.getId()) && !userService.isLoginValid(login)) {
             Helper.setErrorMessage("loginNotValid", new Object[] {login });
             return this.stayOnCurrentPage;
         }
@@ -162,10 +162,6 @@ public class UserForm extends BaseForm {
             Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.USER.getTranslationSingular() }, logger, e);
             return this.stayOnCurrentPage;
         }
-    }
-
-    private boolean isLoginValid(String inLogin) {
-        return userService.isLoginValid(inLogin);
     }
 
     private boolean isMissingClient() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -132,7 +132,7 @@ public class UserForm extends BaseForm {
     public String save() {
         String login = this.userObject.getLogin();
 
-        if (Objects.isNull(userObject.getId()) && !userService.isLoginValid(login)) {
+        if (!isUserExistingOrLoginValid(login)) {
             Helper.setErrorMessage("loginNotValid", new Object[] {login });
             return this.stayOnCurrentPage;
         }
@@ -162,6 +162,10 @@ public class UserForm extends BaseForm {
             Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.USER.getTranslationSingular() }, logger, e);
             return this.stayOnCurrentPage;
         }
+    }
+
+    private boolean isUserExistingOrLoginValid(String login) {
+        return Objects.nonNull(userObject.getId()) || userService.isLoginValid(login);
     }
 
     private boolean isMissingClient() {


### PR DESCRIPTION
An existing user cannot be edited (for example, assign another project) if the login name is fails in validation. That makes no sense, because the login has already been assigned and cannot be changed anymore. This change causes that the login is only validated when a new user is created.