### PR TITLE
Add logging to migrations

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
@@ -99,9 +99,21 @@ public class MigrationForm extends BaseForm {
         List<Process> processList = new ArrayList<>();
         aggregatedProcesses.clear();
         for (Project project : selectedProjects) {
+            logger.trace("Listing processes from project \"{}\"...", project.getTitle());
             processList.addAll(project.getProcesses());
         }
-        for (Process process : processList) {
+        int numberOfProcesses = processList.size();
+        long lastSystemSecond = System.nanoTime() / 1_000_000_000;
+        for (int currentProcess = 0; currentProcess < processList.size(); currentProcess++) {
+            Process process = processList.get(currentProcess);
+            if (logger.isTraceEnabled()) {
+                long currentSystemSecond = System.nanoTime() / 1_000_000_000;
+                if (currentSystemSecond != lastSystemSecond) {
+                    lastSystemSecond = currentSystemSecond;
+                    logger.trace("Analyzing process {}/{} ({}% done)", currentProcess, numberOfProcesses,
+                        100 * currentProcess / numberOfProcesses);
+                }
+            }
             if (Objects.isNull(process.getTemplate())) {
                 addToAggregatedProcesses(aggregatedProcesses, process);
             }

--- a/Kitodo/src/main/java/org/kitodo/production/services/migration/MigrationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/migration/MigrationService.java
@@ -176,7 +176,11 @@ public class MigrationService {
      * @throws DataException is thrown if database access fails
      */
     public void addProcessesToTemplate(Template template, List<Process> processesToAddToTemplate) throws DataException {
-        for (Process process : processesToAddToTemplate) {
+        int numberOfProcesses = processesToAddToTemplate.size();
+        for (int currentProcess = 0; currentProcess < numberOfProcesses; currentProcess++) {
+            Process process = processesToAddToTemplate.get(currentProcess);
+            logger.trace("Assigning template \"{}\" to process \"{}\" ({}% complete)", template.getTitle(),
+                process.getTitle(), 100 * currentProcess / numberOfProcesses);
             process.setTemplate(template);
             ServiceManager.getProcessService().save(process);
         }


### PR DESCRIPTION
So that one sees in the migration tasks in the log what (if anything) happens.

MigrationForm: This will print one log line per second, **if** this should take long. I don’t know if it will actually take long or be fast with a big database, but as it took 10 seconds on my laptop (while VC was running) for 22 processes, I think it is better to log at least something here.

MigrationService: Will log every process be assigned, and percent value of progress.

Examples:
```
[TRACE] 2019-11-05 12:08:17.702 [http-nio-8080-exec-3] MigrationForm - Listing processes from project "Example Project"...
[TRACE] 2019-11-05 12:08:17.876 [http-nio-8080-exec-3] MigrationForm - Analyzing process 4/22 (18% done)

[TRACE] 2019-11-05 12:08:17.876 [http-nio-8080-exec-3] MigrationService - Assigning template "Vorlage2" to process "PineSeve_1234567X" (18% complete)
```


