### PR TITLE
Deactivated action icons in list views

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2026,7 +2026,8 @@ footer {
 }
 
 .ui-datatable tr td.actionsColumn > a,
-.ui-datatable tr td.actionsColumn > form > a  {
+.ui-datatable tr td.actionsColumn > form > a,
+.ui-datatable tr td.actionsColumn > form > span {
     margin-right: 10px;
 }
 

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -76,9 +76,14 @@ a.ui-state-hover i {
     color: var(--focused-blue);
 }
 
-a.disabled i {
+a.disabled i,
+span.disabled i {
     color: var(--medium-gray);
     cursor: default;
+}
+
+span.disabled {
+    pointer-events: auto;
 }
 
 .ui-state-error {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -284,7 +284,8 @@ a.plain.ui-state-disabled,
 .ui-button.ui-state-disabled,
 .ui-commandlink:disabled,
 .ui-commandlink.disabled,
-.ui-commandlink.ui-state-disabled {
+.ui-commandlink.ui-state-disabled,
+.actionsColumn span.ui-state-disabled {
     color: var(--medium-gray);
     cursor: default;
     opacity: initial;

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
@@ -41,25 +41,37 @@
         <p:column headerText="#{msgs.actions}" styleClass="actionsColumn">
             <h:outputText>
                 <h:form>
-                    <h:link id="viewWorkflow" outcome="workflowEdit" title="#{msgs.view}"
-                            rendered="#{(SecurityAccessController.hasAuthorityToViewWorkflow() and not SecurityAccessController.hasAuthorityToEditWorkflow()) or (SecurityAccessController.hasAuthorityToEditWorkflow() and item.status eq 'active')}">
-                        <i class="fa fa-eye fa-lg"/>
+                    <h:link id="viewWorkflow"
+                            outcome="workflowEdit"
+                            title="#{msgs.view}"
+                            disabled="#{item.status ne 'active'}"
+                            styleClass="#{item.status ne 'active' ? 'ui-state-disabled' : ''}"
+                            rendered="#{(SecurityAccessController.hasAuthorityToViewWorkflow() and not SecurityAccessController.hasAuthorityToEditWorkflow()) or (SecurityAccessController.hasAuthorityToEditWorkflow())}">
+                        <h:outputText><i class="fa fa-eye fa-lg"/></h:outputText>
                         <f:param name="id" value="#{item.id}"/>
                     </h:link>
 
-                    <h:link id="editWorkflow" outcome="workflowEdit" title="#{msgs.edit}"
-                            rendered="#{SecurityAccessController.hasAuthorityToEditWorkflow() and item.status eq 'draft'}">
-                        <i class="fa fa-pencil-square-o fa-lg"/>
+                    <h:link id="editWorkflow"
+                            outcome="workflowEdit"
+                            title="#{msgs.edit}"
+                            disabled="#{item.status ne 'draft'}"
+                            styleClass="#{item.status ne 'draft' ? 'ui-state-disabled' : ''}"
+                            rendered="#{SecurityAccessController.hasAuthorityToEditWorkflow()}">
+                        <h:outputText><i class="fa fa-pencil-square-o fa-lg"/></h:outputText>
                         <f:param name="id" value="#{item.id}"/>
                     </h:link>
 
-                    <h:commandLink action="#{WorkflowForm.duplicate(item.id)}" title="#{msgs.duplicateWorkflow}"
+                    <h:commandLink action="#{WorkflowForm.duplicate(item.id)}"
+                                   title="#{msgs.duplicateWorkflow}"
                                    rendered="#{SecurityAccessController.hasAuthorityToAddWorkflow()}">
                         <h:outputText><i class="fa fa-clone fa-lg"/></h:outputText>
                     </h:commandLink>
 
-                    <p:commandLink id="archiveWorkflow" action="#{WorkflowForm.archive}" title="#{msgs.archive}"
-                                   rendered="#{SecurityAccessController.hasAuthorityToEditWorkflow() and item.status eq 'active'}"
+                    <p:commandLink id="archiveWorkflow"
+                                   action="#{WorkflowForm.archive}"
+                                   title="#{msgs.archive}"
+                                   disabled="#{item.status ne 'active'}"
+                                   rendered="#{SecurityAccessController.hasAuthorityToEditWorkflow()}"
                                    update="projectsTabView:workflowTable">
                         <h:outputText><i class="fa fa-archive"/></h:outputText>
                         <f:setPropertyActionListener value="#{item.id}" target="#{WorkflowForm.workflowById}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
@@ -45,7 +45,7 @@
                             outcome="workflowEdit"
                             title="#{msgs.view}"
                             disabled="#{item.status ne 'active'}"
-                            styleClass="#{item.status ne 'active' ? 'ui-state-disabled' : ''}"
+                            styleClass="#{item.status ne 'active' ? 'disabled' : ''}"
                             rendered="#{(SecurityAccessController.hasAuthorityToViewWorkflow() and not SecurityAccessController.hasAuthorityToEditWorkflow()) or (SecurityAccessController.hasAuthorityToEditWorkflow())}">
                         <h:outputText><i class="fa fa-eye fa-lg"/></h:outputText>
                         <f:param name="id" value="#{item.id}"/>
@@ -55,7 +55,7 @@
                             outcome="workflowEdit"
                             title="#{msgs.edit}"
                             disabled="#{item.status ne 'draft'}"
-                            styleClass="#{item.status ne 'draft' ? 'ui-state-disabled' : ''}"
+                            styleClass="#{item.status ne 'draft' ? 'disabled' : ''}"
                             rendered="#{SecurityAccessController.hasAuthorityToEditWorkflow()}">
                         <h:outputText><i class="fa fa-pencil-square-o fa-lg"/></h:outputText>
                         <f:param name="id" value="#{item.id}"/>
@@ -71,9 +71,10 @@
                                    action="#{WorkflowForm.archive}"
                                    title="#{msgs.archive}"
                                    disabled="#{item.status ne 'active'}"
+                                   styleClass="#{item.status ne 'active' ? 'disabled' : ''}"
                                    rendered="#{SecurityAccessController.hasAuthorityToEditWorkflow()}"
                                    update="projectsTabView:workflowTable">
-                        <h:outputText><i class="fa fa-archive"/></h:outputText>
+                        <h:outputText title="#{msgs.archive}"><i class="fa fa-archive"/></h:outputText>
                         <f:setPropertyActionListener value="#{item.id}" target="#{WorkflowForm.workflowById}"/>
                         <p:confirm header="#{msgs.confirmArchive}" message="#{msgs.confirmArchiveWorkflow}"
                                    icon="ui-icon-alert"/>


### PR DESCRIPTION
To clean up the list views in Kitodo.Production, action icons are now always displayed if the current user generally has the authority to perform the corresponding action. It is now deactivated instead of hidden if the state of the list item prohibits the action at the moment, though.

Currently the only example for this is the workflow list where - among others - the `edit` symbol is deactivated for workflows that are already in use.

![deactivated_symbols](https://user-images.githubusercontent.com/19183925/68326452-c7488080-00cb-11ea-8003-7181f77535a0.png)
