### PR TITLE
Hide 'Unstructured gallery view' button in metadata editor

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -45,6 +45,7 @@
                                      icon="fa fa-th-large"
                                      oncomplete="destruct()"
                                      title="#{msgs['dataEditor.galleryUnstructuredView']}"
+                                     rendered="false"
                                      styleClass="#{DataEditorForm.galleryPanel.galleryViewMode eq 'grid' ? 'active' : 'inactive'}">
                         <f:setPropertyActionListener value="grid" target="#{DataEditorForm.galleryPanel.galleryViewMode}"/>
                     </p:commandButton>


### PR DESCRIPTION
Because that gallery view is not required at the moment.