### PR TITLE
Element names

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -203,7 +203,7 @@ public enum ParameterCore implements ParameterInterface {
 
     /**
      * Sorting of images.
-     * 
+     *
      * <p>
      * Numeric sorting of images. 1 is lesser then 002, compares the number of
      * image names, characters other than digits are not supported.
@@ -336,6 +336,12 @@ public enum ParameterCore implements ParameterInterface {
      * Separators available for double page pagination modes.
      */
     PAGE_SEPARATORS(new Parameter<>("metsEditor.pageSeparators", "\" \"")),
+
+    /**
+     # Priority list of metadata keys used to display title information in the metadata editors structure and gallery
+     panels.
+     */
+    TITLE_KEYS(new Parameter<>("metsEditor.titleMetadata", "")),
 
     /*
      * backup of metadata configuration

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -36,6 +36,8 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.MediaUnit;
@@ -56,6 +58,7 @@ import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.interfaces.RulesetSetupInterface;
 import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.dataeditor.DataEditorService;
 import org.primefaces.PrimeFaces;
 
 @Named("DataEditorForm")
@@ -674,5 +677,29 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             includedStructuralElement.getViews().removeFirstOccurrence(view);
         }
         view.getMediaUnit().getIncludedStructuralElements().remove(includedStructuralElement);
+    }
+
+    /**
+     * Retrieve and return 'title' value of given Object 'dataObject' if Object is instance of
+     * 'IncludedStructuralElement' and if it does have a title. Uses a configurable list of metadata keys to determine
+     * which metadata keys should be considered.
+     * Return empty string otherwise.
+     *
+     * @param dataObject
+     *          StructureTreeNode containing the IncludedStructuralElement whose title is returned
+     * @return 'title' value of the IncludedStructuralElement contained in the given StructureTreeNode 'treeNode'
+     */
+    public String getStructureElementTitle(Object dataObject) {
+        if (dataObject instanceof IncludedStructuralElement) {
+            IncludedStructuralElement element = (IncludedStructuralElement) dataObject;
+            List<Metadata> titleMetadata = element.getMetadata().stream()
+                    .filter(m -> DataEditorService.getTitleKeys().contains(m.getKey())).collect(Collectors.toList());
+            for (Metadata metadata : titleMetadata) {
+                if (metadata instanceof MetadataEntry) {
+                    return " - " + ((MetadataEntry) metadata).getValue();
+                }
+            }
+        }
+        return "";
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryStripe.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryStripe.java
@@ -84,7 +84,12 @@ public class GalleryStripe {
         return medias;
     }
 
-    IncludedStructuralElement getStructure() {
+    /**
+     * Returns the structure of the stripe.
+     *
+     * @return structure
+     */
+    public IncludedStructuralElement getStructure() {
         return structure;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -446,15 +446,14 @@ public class StructurePanel implements Serializable {
         }
 
         if (Boolean.FALSE.equals(this.isSeparateMedia())) {
-            String page = Helper.getTranslation("page").concat(" ");
             for (View view : structure.getViews()) {
                 if (!viewsShowingOnAChild.contains(view) && Objects.nonNull(view.getMediaUnit())) {
+                    String order = view.getMediaUnit().getOrder() + " : ";
                     if (Objects.nonNull(view.getMediaUnit().getOrderlabel())) {
-                        addTreeNode(page.concat(view.getMediaUnit().getOrderlabel()), false, false, view, parent);
+                        addTreeNode(order + view.getMediaUnit().getOrderlabel(), false, false, view, parent);
                     } else {
-                        addTreeNode(page, false, false, view, parent);
+                        addTreeNode(order + "uncounted", false, false, view, parent);
                     }
-
                     viewsShowingOnAChild.add(view);
                 }
             }

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
@@ -61,7 +61,7 @@ public class DataEditorService {
      * @return list of title metadata keys
      */
     public static List<String> getTitleKeys() {
-        return Arrays.stream(ConfigCore.getParameter(ParameterCore.TITLE_KEYS).split(","))
+        return Arrays.stream(ConfigCore.getParameter(ParameterCore.TITLE_KEYS, "").split(","))
                 .map(String::trim).collect(Collectors.toList());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
@@ -14,6 +14,9 @@ package org.kitodo.production.services.dataeditor;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.kitodo.api.dataeditor.DataEditorInterface;
 import org.kitodo.config.ConfigCore;
@@ -49,5 +52,16 @@ public class DataEditorService {
 
     private String getXsltFolder() {
         return ConfigCore.getParameter(ParameterCore.DIR_XSLT);
+    }
+
+    /**
+     * Retrieve and return list of metadata keys that are used for displaying title information in the metadata editors
+     * structure and gallery panels from the Kitodo configuration file.
+     *
+     * @return list of title metadata keys
+     */
+    public static List<String> getTitleKeys() {
+        return Arrays.stream(ConfigCore.getParameter(ParameterCore.TITLE_KEYS).split(","))
+                .map(String::trim).collect(Collectors.toList());
     }
 }

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -252,6 +252,8 @@ metsEditor.displayFileManipulation=true
 # Defaults to one single white space:
 metsEditor.pageSeparators=" "
 
+# Priority list of metadata keys used to display title information in the metadata editors structure and gallery panels
+metsEditor.titleMetadata=TitleDocMain
 
 # -----------------------------------
 # backup of metadata configuration

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1084,7 +1084,7 @@ h3#headerText {
 .kitodoScript button {
     margin: 0 0 5px 5px;
 }
-    
+
 /*----------------------------------------------------------------------
 Metadata Editor
 ----------------------------------------------------------------------*/
@@ -1838,6 +1838,8 @@ Column content
     color: var(--pure-white);
     padding: 5px;
     border-top: solid var(--contrast-border-width) var(--blue);
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 #imagePreviewForm\:structuredPages ul {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -73,7 +73,7 @@
                                 styleClass="pageList"
                                 binding="#{currentElement}">
                         <!-- Index 0 of stripes is used to identify the logical root element. -->
-                        <h:outputText value="#{stripe.label}"
+                        <h:outputText value="#{stripe.label} #{DataEditorForm.getStructureElementTitle(stripe.structure)}"
                                       style="font-weight: bold;"
                                       rendered="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe) ne 0}"/>
                         <p:outputPanel deferred="true"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -56,6 +56,7 @@
                 <!--@elvariable id="logicalElementType" type="java.lang.String"-->
                 <ui:param name="logicalElementType" value="#{logicalNode.label}"/>
                 <h:outputText value="#{empty logicalElementType ? msgs['dataEditor.unknownType'] : logicalElementType}" style="#{logicalNode.undefined ? 'background-color: gold' : ''}"/>
+                <h:outputText value="#{DataEditorForm.getStructureElementTitle(logicalNode.dataObject)}"/>
                 <h:outputText value="#{DataEditorForm.structurePanel.getMultipleAssignmentsIndex(logicalNode) + 1}"
                               rendered="#{logicalNode.assignedSeveralTimes}"
                               styleClass="assigned-several-times"/>


### PR DESCRIPTION
Update labels for pages and structure elements in metadata editor:
- show `ORDER` and `ORDER_LABEL` in structure tree (similar to thumbnail overlays in gallery)
- show structure element title or name in structure tree and gallery
- configure eligible metadata types for title information in `kitodo_config.properties`