### PR TITLE
Configure loggers correctly

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
@@ -81,7 +81,7 @@ public abstract class KitodoRestClient implements RestClientInterface {
 
     /**
      * Create REST client with basic authentication.
-     * 
+     *
      * @param host
      *            default host is localhost
      * @param port
@@ -196,7 +196,11 @@ public abstract class KitodoRestClient implements RestClientInterface {
 
     protected void handleResponseException(ResponseException e) throws CustomResponseException {
         if (e.getResponse().getStatusLine().getStatusCode() == 404) {
-            logger.debug(e.getMessage(), e);
+            if (logger.isTraceEnabled()) {
+                logger.trace(e.getMessage(), e);
+            } else {
+                logger.debug(e.getMessage().replaceAll("\\p{Space}+", " "));
+            }
         } else {
             throw new CustomResponseException(e);
         }

--- a/Kitodo/src/main/resources/log4j2.xml
+++ b/Kitodo/src/main/resources/log4j2.xml
@@ -24,7 +24,13 @@
         </File>
     </Appenders>
     <Loggers>
-        <Logger name="de.unigoettingen.sub.search.opac, org.goobi, org.kitodo" level="error">
+        <Logger name="de.unigoettingen.sub.search.opac" level="error" additivity="false">
+            <AppenderRef ref="LOGFILE" level="error" />
+        </Logger>
+        <Logger name="org.goobi" level="error"  additivity="false">
+            <AppenderRef ref="LOGFILE" level="error" />
+        </Logger>
+        <Logger name="org.kitodo" level="error"  additivity="false">
             <AppenderRef ref="LOGFILE" level="error" />
         </Logger>
         <Root level="error">

--- a/Kitodo/src/test/resources/log4j2.xml
+++ b/Kitodo/src/test/resources/log4j2.xml
@@ -18,7 +18,13 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="de.unigoettingen.sub.search.opac, org.goobi, org.kitodo" level="debug">
+        <Logger name="de.unigoettingen.sub.search.opac" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.goobi" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.kitodo" level="debug" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </Logger>
         <Root level="error">

--- a/Kitodo/src/test/resources/selenium/resources/log4j2.xml
+++ b/Kitodo/src/test/resources/selenium/resources/log4j2.xml
@@ -18,7 +18,13 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="de.unigoettingen.sub.search.opac, org.goobi, org.kitodo" level="debug">
+        <Logger name="de.unigoettingen.sub.search.opac" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.goobi" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.kitodo" level="debug" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </Logger>
         <Root level="error">


### PR DESCRIPTION
Specifying multiple packages in the same XML attribute is not understood by Log4j and ignored. Setting `additivity="false"` prevents duplicate log lines from appearing.

After logging started working as it should, two spots were noticed that generated disturbing amounts of log messages (which also broke Travis’ limit):
- In the case of search engine errors, elaborately formatted JSON (half a screen full) was logged plus a stack trace (which is not needed here).
- Searching for METS files while indexing relied on stacktrace to find out if the file exists, what produced long stacktrace for each missing file.

Both were fixed in the aftermath. JSON is summarized to be in a line, and no stacktrace is displayed (the original behavior can be turned on with log level TRACE, should it be needed). File Indexing first looks for file if it exists and handles missing files. This could additionally accelerate and stabilize indexing.