### PR TITLE
Improve selection in gallery

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -261,7 +261,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     public String close() {
         metadataPanel.clear();
         structurePanel.clear();
-        galleryPanel.clear();
         workpiece = null;
         mainFileUri = null;
         ruleset = null;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -740,8 +740,7 @@ public class GalleryPanel {
             return;
         }
 
-        Pair<MediaUnit, IncludedStructuralElement> firstSelectedMediaPair =
-                dataEditor.getSelectedMedia().get(dataEditor.getSelectedMedia().size() - 1);
+        Pair<MediaUnit, IncludedStructuralElement> firstSelectedMediaPair = dataEditor.getSelectedMedia().get(0);
         Pair<MediaUnit, IncludedStructuralElement> lastSelectedMediaPair =
                 new ImmutablePair<>(currentSelection.getView().getMediaUnit(), parentStripe.getStructure());
 

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1780,6 +1780,12 @@ Column content
     width: 75px;
 }
 
+.thumbnail-container > .ui-widget-content {
+    height: 100%;
+    padding: 0;
+    width: 100%;
+}
+
 .thumbnail-container .assigned-several-times {
     bottom: 5px;
     color: var(--pure-white);

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1607,6 +1607,15 @@ Column content
     color: var(--orange);
 }
 
+#imagePreviewForm {
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Old versions of Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Non-prefixed version, currently supported by Chrome, Opera and Firefox */
+}
+
 #imagePreviewForm\:tifFoldersLabel {
     color: var(--pure-white);
     line-height: var(--input-height);

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -9,17 +9,44 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-var metadataEditor = {};
-
-metadataEditor.select = {
-
-    selectionType(event) {
-        if (event.metaKey || event.ctrlKey) {
-            select([{name: "page", value: event.currentTarget.dataset.order},{name: "selectionType", value: "multi"}]);
-        } else if (event.shiftKey) {
-            select([{name: "page", value: event.currentTarget.dataset.order},{name: "selectionType", value: "range"}]);
+var metadataEditor = {
+    dragging: false,
+    handleMouseDown(event) {
+        if (event.currentTarget.querySelectorAll(".active").length === 0) {
+            this.select(event);
+        }
+    },
+    handleMouseUp(event) {
+        this.dragdrop.removeDragAmountIcon();
+        if (this.dragging) {
+            this.dragging = false;
         } else {
-            select([{name: "page", value: event.currentTarget.dataset.order},{name: "selectionType", value: "default"}]);
+            this.select(event);
+        }
+    },
+    handleDragStart(event) {
+        this.dragging = true;
+        this.dragdrop.addDragAmountIcon(event);
+    },
+    select(event) {
+        if (event.metaKey || event.ctrlKey) {
+            select([
+                {name: "page", value: event.currentTarget.dataset.order},
+                {name: "stripe", value: event.currentTarget.dataset.stripe},
+                {name: "selectionType", value: "multi"}
+            ]);
+        } else if (event.shiftKey) {
+            select([
+                {name: "page", value: event.currentTarget.dataset.order},
+                {name: "stripe", value: event.currentTarget.dataset.stripe},
+                {name: "selectionType", value: "range"}
+            ]);
+        } else {
+            select([
+                {name: "page", value: event.currentTarget.dataset.order},
+                {name: "stripe", value: event.currentTarget.dataset.stripe},
+                {name: "selectionType", value: "default"}
+            ]);
         }
     }
 };

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -25,7 +25,14 @@
         <h:form id="imagePreviewForm" style="height: 100%;">
             <p:graphicImage id="mediaViewData" value="#{DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).mediaViewData}" style="display: none;"/>
 
-            <p:remoteCommand name="select" action="#{DataEditorForm.galleryPanel.setSelectionType}"/>
+            <p:remoteCommand name="select"
+                             action="#{DataEditorForm.galleryPanel.select}"
+                             update="@(.thumbnail)
+                                    galleryHeadingWrapper
+                                    imagePreviewForm:mediaViewData
+                                    structureTreeForm:logicalTree
+                                    structureTreeForm:physicalTree
+                                    metadataAccordion:logicalMetadataWrapperPanel"/>
 
             <p:panelGrid id="imageControlPanel" columns="3"
                          style="right: 47px; top: 0; position: absolute;">
@@ -90,10 +97,12 @@
                                          rendered="#{not editImages}"
                                          styleClass="page-drop-area"/>
                                 <p:panel id="structuredPagePanel"
-                                         a:ondragstart="metadataEditor.dragdrop.addDragAmountIcon(event);"
-                                         a:onmouseup="metadataEditor.dragdrop.removeDragAmountIcon(event);">
-                                    <h:panelGroup onmouseup="metadataEditor.select.selectionType(event);"
-                                                  a:data-order="#{media.order}">
+                                         a:ondragstart="metadataEditor.handleDragStart(event)"
+                                         a:onmousedown="metadataEditor.handleMouseDown(event)"
+                                         a:onmouseup="metadataEditor.handleMouseUp(event)"
+                                         a:data-order="#{media.order}"
+                                         a:data-stripe="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe)}">
+                                    <h:panelGroup>
                                         <h:panelGroup class="thumbnail-container">
                                                 <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
                                                                 class="thumbnail #{DataEditorForm.galleryPanel.isSelected(media, stripe) ? 'active' : ''}"
@@ -107,13 +116,6 @@
                                                     #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
                                                 </h:panelGroup>
                                         </h:panelGroup>
-                                        <p:ajax event="click"
-                                                listener="#{DataEditorForm.galleryPanel.select(media, stripe)}"
-                                                update="@(.thumbnail)
-                                                       structureTreeForm:logicalTree
-                                                       structureTreeForm:physicalTree
-                                                       metadataAccordion:logicalMetadataWrapperPanel"
-                                                oncomplete="scrollToSelectedTreeNode();"/>
                                     </h:panelGroup>
                                 </p:panel>
                                 <ui:fragment rendered="#{not editImages}">
@@ -176,11 +178,12 @@
                                          rendered="#{editImages}"
                                          styleClass="page-drop-area"/>
                                 <p:panel id="unstructuredMediaPanel"
-                                         a:ondragstart="metadataEditor.dragdrop.addDragAmountIcon(event);"
-                                         a:onmouseup="metadataEditor.dragdrop.removeDragAmountIcon(event);">
-                                    <h:panelGroup id="updateSelectedUnstructuredMediaLink"
-                                                  onmouseup="metadataEditor.select.selectionType(event);"
-                                                  a:data-order="#{media.order}">
+                                         a:ondragstart="metadataEditor.handleDragStart(event)"
+                                         a:onmousedown="metadataEditor.handleMouseDown(event)"
+                                         a:onmouseup="metadataEditor.handleMouseUp(event)"
+                                         a:data-order="#{media.order}"
+                                         a:data-stripe="0">
+                                <h:panelGroup id="updateSelectedUnstructuredMediaLink">
                                         <h:panelGroup styleClass="thumbnail-container">
                                                 <!-- only render those pages that are not assigned to a stripe (structure) here! -->
                                                 <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
@@ -193,14 +196,6 @@
                                                     #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
                                                 </h:panelGroup>
                                         </h:panelGroup>
-                                        <p:ajax event="click"
-                                                listener="#{DataEditorForm.galleryPanel.select(media, DataEditorForm.galleryPanel.stripes.get(0))}"
-                                                update="@this
-                                                        @(.thumbnail)
-                                                        structureTreeForm:logicalTree
-                                                        structureTreeForm:physicalTree
-                                                        metadataAccordion:logicalMetadataWrapperPanel"
-                                                oncomplete="scrollToSelectedTreeNode();"/>
                                     </h:panelGroup>
                                 </p:panel>
                                 <ui:fragment rendered="#{editImages}">
@@ -253,13 +248,10 @@
                                var="media">
                         <p:outputPanel deferred="true"
                                        deferredMode="visible">
-                            <p:commandLink action="#{DataEditorForm.galleryPanel.select(media, null)}"
-                                           update="@this
-                                                   @(.active.thumbnail)
-                                                   structureTreeForm:logicalTree
-                                                   structureTreeForm:physicalTree
-                                                   imagePreviewForm:mapWrapper"
-                                           oncomplete="scrollToSelectedTreeNode();">
+                            <p:panel a:onmousedown="metadataEditor.handleMouseDown(event)"
+                                     a:ondragstart="metadataEditor.handleDragStart(event)"
+                                     a:onmouseup="metadataEditor.handleMouseUp(event)"
+                                     a:data-order="#{media.order}">
                                 <h:panelGroup layout="block" styleClass="thumbnail-container">
                                         <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
                                                         class="thumbnail #{DataEditorForm.galleryPanel.isSelected(media, null) ? 'active' : ''}"
@@ -271,7 +263,7 @@
                                         #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
                                     </h:panelGroup>
                                 </h:panelGroup>
-                            </p:commandLink>
+                            </p:panel>
                         </p:outputPanel>
                     </ui:repeat>
                 </div>
@@ -292,14 +284,11 @@
                                     <p:outputPanel deferred="true"
                                                    deferredMode="visible">
                                         <h:panelGroup layout="block">
-                                            <p:commandLink action="#{DataEditorForm.galleryPanel.select(media, null)}"
-                                                           update="@(.thumbnail)
-                                                                   galleryHeadingWrapper
-                                                                   imagePreviewForm:mediaViewData
-                                                                   structureTreeForm:logicalTree
-                                                                   structureTreeForm:physicalTree"
-                                                           oncomplete="checkScrollPosition();initializeImage();scrollToSelectedTreeNode();">
-                                                <h:panelGroup layout="block" styleClass="thumbnail-container">
+                                                <p:panel layout="block"
+                                                         styleClass="thumbnail-container"
+                                                         a:onmousedown="metadataEditor.handleMouseDown(event)"
+                                                         a:onmouseup="metadataEditor.handleMouseUp(event)"
+                                                         a:data-order="#{media.order}">
                                                         <h:outputText><p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
                                                                                       class="thumbnail #{DataEditorForm.galleryPanel.isSelected(media, null) ? 'active' : ''}"
                                                                                       rendered="#{media.showingInPreview}">
@@ -308,8 +297,7 @@
                                                         <h:panelGroup layout="block" styleClass="thumbnail-overlay">
                                                             #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
                                                         </h:panelGroup>
-                                                </h:panelGroup>
-                                            </p:commandLink>
+                                                </p:panel>
                                         </h:panelGroup>
                                     </p:outputPanel>
                                 </ui:repeat>


### PR DESCRIPTION
- added range selection to detail view
- multiple successive range selections now keep the same first index and just change the last index
- drag & drop can now happen in the same `mousedown` event like the selection 