### PR TITLE
Native JSF websocket implementation

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.faces.push.Push;
+import javax.faces.push.PushContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.json.Json;
@@ -33,8 +35,6 @@ import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.index.IndexingService;
-import org.omnifaces.cdi.Push;
-import org.omnifaces.cdi.PushContext;
 import org.omnifaces.util.Ajax;
 
 @Named

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexAllThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexAllThread.java
@@ -11,9 +11,10 @@
 
 package org.kitodo.production.services.index;
 
+import javax.faces.push.PushContext;
+
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
-import org.omnifaces.cdi.PushContext;
 
 public class IndexAllThread extends Thread {
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.faces.push.PushContext;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
@@ -43,7 +44,6 @@ import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.IndexWorker;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.SearchService;
-import org.omnifaces.cdi.PushContext;
 
 public class IndexingService {
 
@@ -78,7 +78,7 @@ public class IndexingService {
     private IndexStates currentState = IndexStates.NO_STATE;
 
     private Thread indexerThread = null;
-    
+
     private static IndexRestClient indexRestClient = IndexRestClient.getInstance();
 
     /**

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/indexing.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/indexing.xhtml
@@ -12,10 +12,10 @@
 -->
 
 <ui:composition
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-        xmlns:p="http://primefaces.org/ui"
-        xmlns:o="http://omnifaces.org/ui">
+        xmlns:p="http://primefaces.org/ui">
     <p:importEnum type="org.kitodo.production.enums.IndexStates" allSuffix="ALL_ENUM_VALUES"/>
     <p:importEnum type="org.kitodo.production.enums.ObjectType" var="objectTypeEnum"/>
     <p:panel id="listWrapper">
@@ -152,7 +152,7 @@
                 </p:panel>
                 <p:commandButton class="refreshTable" update="indexingTable" style="visibility: hidden;"/>
                 <p:poll widgetVar="progressPoll" update="indexingTable" interval="1" autoStart="false"/>
-                <o:socket channel="togglePollingChannel" onmessage="toggleProgressPolling" />
+                <f:websocket channel="togglePollingChannel" onmessage="toggleProgressPolling" />
             </ui:fragment>
         </h:form>
     </p:panel>

--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -63,7 +63,7 @@
     </context-param>
 
     <context-param>
-        <param-name>org.omnifaces.SOCKET_ENDPOINT_ENABLED</param-name>
+        <param-name>javax.faces.ENABLE_WEBSOCKET_ENDPOINT</param-name>
         <param-value>true</param-value>
     </context-param>
 


### PR DESCRIPTION
After [updating to JSF 2.3 ](https://github.com/kitodo/kitodo-production/pull/2834) we don't need the Omnifaces implementation of websockets anymore and can use the native JSF implementation instead.