### PR TITLE
Support defaultDisplay on metadata groups

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -3132,23 +3132,22 @@ public class Metadaten {
         }
         for (Entry<String, List<MetadataGroup>> entry : displayGroups.entrySet()) {
             records = entry.getValue();
-            if (records != null) {
-                if (records.size() > 0) {
-                    for (MetadataGroup record : records) {
-                        result.add(new RenderableMetadataGroup(record, this, language, projectName));
-                    }
-                } else {
-                    for (MetadataGroupType groupType : myDocStruct.getType().getAllMetadataGroupTypes()) {
-                        if (groupType.getName().equals(entry.getKey())) {
-                            RenderableMetadataGroup newMetadataGroup = new RenderableMetadataGroup(groupType, language, projectName);
-                            result.add(newMetadataGroup);
-                            try {
-                                myDocStruct.addMetadataGroup(newMetadataGroup.toMetadataGroup());
-                            } catch (DocStructHasNoTypeException | MetadataTypeNotAllowedException e) {
-                                throw new IllegalStateException(e.getMessage(), e);
-                            }
-                            break;
+            if (records != null && records.size() > 0) {
+                for (MetadataGroup record : records) {
+                    result.add(new RenderableMetadataGroup(record, this, language, projectName));
+                }
+            } else if (records != null) {
+                for (MetadataGroupType groupType : myDocStruct.getType().getAllMetadataGroupTypes()) {
+                    if (groupType.getName().equals(entry.getKey())) {
+                        RenderableMetadataGroup newMetadataGroup = new RenderableMetadataGroup(groupType, language,
+                                projectName);
+                        result.add(newMetadataGroup);
+                        try {
+                            myDocStruct.addMetadataGroup(newMetadataGroup.toMetadataGroup());
+                        } catch (DocStructHasNoTypeException | MetadataTypeNotAllowedException e) {
+                            throw new IllegalStateException(e.getMessage(), e);
                         }
+                        break;
                     }
                 }
             }

--- a/Goobi/src/de/sub/goobi/metadaten/RenderableLineEdit.java
+++ b/Goobi/src/de/sub/goobi/metadaten/RenderableLineEdit.java
@@ -42,7 +42,7 @@ public class RenderableLineEdit extends RenderableMetadatum implements Renderabl
     /**
      * Holds the content lines of the edit box.
      */
-    private List<String> value;
+    private List<String> value = new ArrayList<String>();
 
     /**
      * Constructor. Creates a RenderableLineEdit.

--- a/Goobi/src/de/sub/goobi/metadaten/RenderableMetadataGroup.java
+++ b/Goobi/src/de/sub/goobi/metadaten/RenderableMetadataGroup.java
@@ -158,6 +158,34 @@ public class RenderableMetadataGroup extends RenderableMetadatum {
     }
 
     /**
+     * Creates a RenderableMetadataGroup instance for a default display metadata
+     * group that still can be added to the currently selected level of the
+     * document structure hierarchy.
+     *
+     * @param type
+     *            type of metadata group
+     * @param language
+     *            display language to use
+     * @param projectName
+     *            project that the act whose metadata group is to edit belongs
+     *            to
+     * @throws ConfigurationException
+     *             if a single value metadata field is configured to show a
+     *             multi-select input
+     */
+    public RenderableMetadataGroup(MetadataGroupType type, String language, String projectName)
+            throws ConfigurationException {
+        super(type.getAllLanguages(), null);
+        this.possibleTypes = Collections.emptyMap();
+        this.type = type;
+        this.projectName = projectName;
+        this.metadataGroup = null;
+        this.container = null;
+        updateMembers(type);
+        setLanguage(language);
+    }
+
+    /**
      * Protected constructor for classes extending RenderableMetadataGroup,
      * creates a new RenderableMetadataGroup with exactly one type.
      *


### PR DESCRIPTION
The `defaultDisplay` attribute on metadata groups was not supported by the front-end. This is hereby fixed.