### PR TITLE
Change from development to production project stage

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -58,11 +58,6 @@
     </context-param>
 
     <context-param>
-        <param-name>javax.faces.PROJECT_STAGE</param-name>
-        <param-value>Development</param-value>
-    </context-param>
-
-    <context-param>
         <param-name>javax.faces.ENABLE_WEBSOCKET_ENDPOINT</param-name>
         <param-value>true</param-value>
     </context-param>


### PR DESCRIPTION
Current MyFaces stage for application is set to development which is a bad for upcoming and working releases as many MyFaces security features are disabled and introducing "easy" ways to take over the application. Setting to production stage enable different security features and reduce the amount of log messages for different outputs.

Review from @solth and / or @oliver-stoehr ?