### PR TITLE
reload template

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
@@ -149,8 +149,9 @@ public class TemplateForm extends TemplateBaseForm {
 
             try {
                 ServiceManager.getTemplateService().save(this.template);
+                template = ServiceManager.getTemplateService().getById(this.template.getId());
                 new WorkflowControllerService().activateNextTasks(template.getTasks());
-            } catch (DataException | IOException e) {
+            } catch (DataException | IOException | DAOException e) {
                 Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.TEMPLATE.getTranslationSingular() },
                     logger, e);
                 return this.stayOnCurrentPage;


### PR DESCRIPTION
The template needs to be reloaded after save because dependencies (expecially tasks) are not connected to the session anymore.
This fixes the error with multiple Scanning tasks