### PR TITLE
Improve XSLT handling in XML Schema Converter

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormatConversion.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormatConversion.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.schemaconverter;
+
+public enum MetadataFormatConversion {
+    MODS_2_KITODO("mods2kitodo.xsl", null),
+    MARC_2_MODS("marc21slim2mods.xsl", "https://www.loc.gov/standards/mods/v3/MARC21slim2MODS3-4.xsl");
+
+    private String fileName;
+    private String source;
+
+    /**
+     * Constructor setting filename and source URI for the XSL transformation file.
+     * @param filename Filename including suffix without any path.
+     * @param source Remote source where the file can be retrieved from if it is not yet available in Kitodo.
+     */
+    MetadataFormatConversion(String filename, String source) {
+        this.fileName = filename;
+        this.source = source;
+    }
+
+    /**
+     * Get fileName.
+     *
+     * @return value of fileName
+     */
+    public String getFileName() {
+        return fileName;
+    }
+
+    /**
+     * Get source.
+     *
+     * @return value of source
+     */
+    public String getSource() {
+        return source;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/SchemaConverterInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/SchemaConverterInterface.java
@@ -13,6 +13,7 @@ package org.kitodo.api.schemaconverter;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 /** Enables the conversion of a DataRecord from one format to another. */
 public interface SchemaConverterInterface {
@@ -27,7 +28,7 @@ public interface SchemaConverterInterface {
      * @return The result of the conversion as a DataRecord.
      */
     DataRecord convert(DataRecord record, MetadataFormat targetMetadataFormat, FileFormat targetFileFormat,
-                       File mappingFile) throws IOException;
+                       File mappingFile) throws IOException, URISyntaxException;
 
     /**
      * Check and return whether the current SchemaConverter supports the given MetadataFormat as a target format or not.

--- a/Kitodo-XML-SchemaConverter/pom.xml
+++ b/Kitodo-XML-SchemaConverter/pom.xml
@@ -46,26 +46,6 @@
     <build>
         <plugins>
             <plugin>
-                <!--Download xslt for marc to mods-->
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <version>1.3.0</version>
-                <executions>
-                    <execution>
-                        <id>mets</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>https://www.loc.gov/standards/mods/v3/MARC21slim2MODS3-4.xsl</url>
-                            <outputFileName>marc21slim2mods3-4.xsl</outputFileName>
-                            <outputDirectory>${project.build.directory}/downloaded-sources/xslt</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar-plugin.version}</version>

--- a/Kitodo-XML-SchemaConverter/src/test/java/org/kitodo/xmlschemaconverter/XmlSchemaConverterTest.java
+++ b/Kitodo-XML-SchemaConverter/src/test/java/org/kitodo/xmlschemaconverter/XmlSchemaConverterTest.java
@@ -14,8 +14,10 @@ package org.kitodo.xmlschemaconverter;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -24,6 +26,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.kitodo.api.schemaconverter.DataRecord;
@@ -41,8 +44,16 @@ public class XmlSchemaConverterTest {
     private static final String MODS_TEST_FILE_PATH = "src/test/resources/modsXmlTestRecord.xml";
     private static final String MARC_TEST_FILE_PATH = "src/test/resources/marcXmlTestRecord.xml";
 
+    @AfterClass
+    public static void tearDown() {
+        File xslt = new File ("src/main/resources/xslt/marc21slim2mods.xsl");
+        if (xslt.exists()) {
+            xslt.delete();
+        }
+    }
+
     @Test
-    public void shouldConvertModsToInternalFormat() throws IOException, ParserConfigurationException, SAXException {
+    public void shouldConvertModsToInternalFormat() throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
         DataRecord testRecord = new DataRecord();
         testRecord.setMetadataFormat(MetadataFormat.MODS);
         testRecord.setFileFormat(FileFormat.XML);
@@ -89,7 +100,7 @@ public class XmlSchemaConverterTest {
     }
 
     @Test
-    public void shouldConvertMarcToInternalFormat() throws IOException, ParserConfigurationException, SAXException {
+    public void shouldConvertMarcToInternalFormat() throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
         DataRecord testRecord = new DataRecord();
         testRecord.setMetadataFormat(MetadataFormat.MARC);
         testRecord.setFileFormat(FileFormat.XML);

--- a/Kitodo-XML-SchemaConverter/src/test/resources/kitodo_config.properties
+++ b/Kitodo-XML-SchemaConverter/src/test/resources/kitodo_config.properties
@@ -1,0 +1,1 @@
+directory.xslt=src/main/resources/xslt/


### PR DESCRIPTION
XSLT files are now expected to be located in the directory configured in `directory.xslt`.
The `marc21slim2mods.xslt` is now downloaded during runtime when it does not exist in the directory configured in `directory.xslt`.