### PR TITLE
Prevent npe and add tests

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/handlers/MetsKitodoHeaderHandler.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/handlers/MetsKitodoHeaderHandler.java
@@ -12,6 +12,7 @@
 package org.kitodo.dataeditor.handlers;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.kitodo.dataformat.metskitodo.Mets;
 import org.kitodo.dataformat.metskitodo.MetsType;
@@ -39,7 +40,12 @@ public class MetsKitodoHeaderHandler {
      * @return The Mets object with added note.
      */
     public static Mets addNoteToMetsHeader(String noteMessage, Mets mets) {
-        List<MetsType.MetsHdr.Agent> agents = mets.getMetsHdr().getAgent();
+        MetsType.MetsHdr metsHdr = mets.getMetsHdr();
+        if (Objects.isNull(metsHdr)) {
+            return mets;
+        }
+
+        List<MetsType.MetsHdr.Agent> agents = metsHdr.getAgent();
         if (!agents.isEmpty()) {
             agents.get(0).getNote().add(noteMessage);
         }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/handlers/MetsKitodoHeaderHandlerTest.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/handlers/MetsKitodoHeaderHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.dataeditor.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.kitodo.dataformat.metskitodo.Mets;
+import org.kitodo.dataformat.metskitodo.MetsType;
+
+public class MetsKitodoHeaderHandlerTest {
+
+    @Test
+    public void missingMetsHeaderShouldNotCreteNullPointerException() {
+        String noteMessage = "test note";
+        Mets mets = new Mets();
+
+        Mets actual = MetsKitodoHeaderHandler.addNoteToMetsHeader(noteMessage, mets);
+        Assert.assertEquals("Mets object differ.", mets, actual);
+    }
+
+    @Test
+    public void missingMetsHeaderAgentSectionDidNotChangeAnything() {
+        String noteMessage = "test note";
+        Mets mets = new Mets();
+
+        Mets actual = MetsKitodoHeaderHandler.addNoteToMetsHeader(noteMessage, mets);
+        Assert.assertEquals("Mets object differ.", mets, actual);
+    }
+
+    @Test
+    public void addNoteToExistingAgentSection() {
+        String noteMessage = "test note";
+        List<String> expectedNotes = new ArrayList<>();
+        expectedNotes.add(noteMessage);
+
+        MetsType.MetsHdr.Agent agent = new MetsType.MetsHdr.Agent();
+        agent.setName("Kitodo");
+        MetsType.MetsHdr metsHeader = new MetsType.MetsHdr();
+        metsHeader.getAgent().add(0, agent);
+        Mets mets = new Mets();
+        mets.setMetsHdr(metsHeader);
+        Mets actual = MetsKitodoHeaderHandler.addNoteToMetsHeader(noteMessage, mets);
+
+        List<String> resultNotes = actual.getMetsHdr().getAgent().get(0).getNote();
+        Assert.assertEquals("MetsHeader notes differ.", expectedNotes, resultNotes);
+    }
+}


### PR DESCRIPTION
While running migration of old meta data files this error occurs many times:

```
[ERROR] 2019-12-18 10:50:40.919 EmptyTask - null
java.lang.NullPointerException: null
        at org.kitodo.dataeditor.handlers.MetsKitodoHeaderHandler.addNoteToMetsHeader(MetsKitodoHeaderHandler.java:42) ~[kitodo-data-editor-3.0.0-beta.4-SNAPSHOT.jar:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.dataeditor.MetsKitodoConverter.convertUriToMetsFromGoobiFormat(MetsKitodoConverter.java:78) ~[kitodo-data-editor-3.0.0-beta.4-SNAPSHOT.jar:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.dataeditor.MetsKitodoConverter.convertToMetsKitodoByXslt(MetsKitodoConverter.java:63) ~[kitodo-data-editor-3.0.0-beta.4-SNAPSHOT.jar:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.dataeditor.MetsKitodoReader.readAndValidateUriToMets(MetsKitodoReader.java:103) ~[kitodo-data-editor-3.0.0-beta.4-SNAPSHOT.jar:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.dataeditor.MetsKitodoWrapper.<init>(MetsKitodoWrapper.java:116) ~[kitodo-data-editor-3.0.0-beta.4-SNAPSHOT.jar:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.dataeditor.DataEditor.readData(DataEditor.java:33) ~[kitodo-data-editor-3.0.0-beta.4-SNAPSHOT.jar:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.production.services.dataeditor.DataEditorService.readData(DataEditorService.java:39) ~[classes/:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.production.services.migration.MigrationService.migrateMetadata(MigrationService.java:79) ~[classes/:3.0.0-beta.4-SNAPSHOT]
        at org.kitodo.production.helper.tasks.MigrationTask.run(MigrationTask.java:94) ~[classes/:3.0.0-beta.4-SNAPSHOT]
```

This pull request add a prevention for this null pointer exception and add tests to this used method.