### PR TITLE
Save parent process id in index

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
@@ -30,6 +30,7 @@ public class ProcessType extends BaseType<Process> {
         String processBaseUri = process.getProcessBaseUri() != null ? process.getProcessBaseUri().getRawPath() : "";
         boolean projectActive = process.getProject() != null && process.getProject().isActive();
         int projectClientId = process.getProject() != null ? getId(process.getProject().getClient()) : 0;
+        int processParentId = Objects.nonNull(process.getParent()) ? process.getParent().getId() : 0;
 
         Map<String, Object> jsonObject = new HashMap<>();
         jsonObject.put(ProcessTypeField.TITLE.getKey(), preventNull(process.getTitle()));
@@ -53,7 +54,7 @@ public class ProcessType extends BaseType<Process> {
         jsonObject.put(ProcessTypeField.COMMENTS.getKey(), addObjectRelation(process.getComments()));
         jsonObject.put(ProcessTypeField.COMMENTS_MESSAGE.getKey(), getProcessComments(process));
         jsonObject.put(ProcessTypeField.HAS_CHILDREN.getKey(), process.getChildren().size() > 0);
-        jsonObject.put(ProcessTypeField.HAS_PARENT.getKey(), Objects.nonNull(process.getParent()));
+        jsonObject.put(ProcessTypeField.PARENT_ID.getKey(), processParentId);
         jsonObject.put(ProcessTypeField.TASKS.getKey(), addObjectRelation(process.getTasks(), true));
         jsonObject.put(ProcessTypeField.PROPERTIES.getKey(), addObjectRelation(process.getProperties(), true));
         jsonObject.put(ProcessTypeField.TEMPLATES.getKey(), addObjectRelation(process.getTemplates()));

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/ProcessTypeField.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/ProcessTypeField.java
@@ -35,7 +35,7 @@ public enum ProcessTypeField implements TypeInterface {
     COMMENTS("comments"),
     COMMENTS_MESSAGE("comments.message"),
     HAS_CHILDREN("hasChildren"),
-    HAS_PARENT("hasParent"),
+    PARENT_ID("parent.id"),
     TASKS("tasks"),
     PROPERTIES("properties"),
     TEMPLATES("templates"),

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
@@ -32,7 +32,7 @@ public class ProcessDTO extends BaseTemplateDTO {
     private String wikiField;
     private String processBaseUri;
     private String batchID;
-    private boolean hasParent;
+    private Integer parentID;
     private boolean hasChildren;
     private Integer sortHelperArticles;
     private Integer sortHelperDocstructs;
@@ -271,21 +271,21 @@ public class ProcessDTO extends BaseTemplateDTO {
     }
 
     /**
-     * Get hasParent.
+     * Get parentID.
      *
-     * @return value of hasParent
+     * @return value of parentID
      */
-    public boolean hasParent() {
-        return hasParent;
+    public Integer getParentID() {
+        return parentID;
     }
 
     /**
-     * Set hasParent.
+     * Set parentID.
      *
-     * @param hasParent as boolean
+     * @param parentID as java.lang.Integer
      */
-    public void setHasParent(boolean hasParent) {
-        this.hasParent = hasParent;
+    public void setParentID(Integer parentID) {
+        this.parentID = parentID;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -824,7 +824,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             processDTO.setSortHelperMetadata(ProcessTypeField.SORT_HELPER_METADATA.getIntValue(jsonObject));
             processDTO.setProcessBaseUri(ProcessTypeField.PROCESS_BASE_URI.getStringValue(jsonObject));
             processDTO.setHasChildren(ProcessTypeField.HAS_CHILDREN.getBooleanValue(jsonObject));
-            processDTO.setHasParent(ProcessTypeField.HAS_PARENT.getBooleanValue(jsonObject));
+            processDTO.setParentID(ProcessTypeField.PARENT_ID.getIntValue(jsonObject));
 
             if (!related) {
                 convertRelatedJSONObjects(jsonObject, processDTO);

--- a/Kitodo/src/main/resources/mapping.json
+++ b/Kitodo/src/main/resources/mapping.json
@@ -459,8 +459,12 @@
                         }
                     }
                 },
-                "hasParent": {
-                    "type": "boolean"
+                "parent": {
+                    "properties": {
+                        "id": {
+                            "type": "long"
+                        }
+                    }
                 },
                 "properties": {
                     "properties": {

--- a/Kitodo/src/test/resources/mapping.json
+++ b/Kitodo/src/test/resources/mapping.json
@@ -455,8 +455,12 @@
                         }
                     }
                 },
-                "hasParent": {
-                    "type": "boolean"
+                "parent": {
+                    "properties": {
+                        "id": {
+                            "type": "long"
+                        }
+                    }
                 },
                 "properties": {
                     "properties": {


### PR DESCRIPTION
Use the parent id instead of a boolean. This is a preparation for filtering the processes by a specific parent process.