### PR TITLE
Fix IT tests

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/CreateProcessFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/CreateProcessFormIT.java
@@ -86,7 +86,10 @@ public class CreateProcessFormIT {
     public void shouldCreateNewProcess() throws Exception {
         CreateProcessForm underTest = new CreateProcessForm();
         underTest.getProcessDataTab().setDocType("Monograph");
-        underTest.setProcesses(new LinkedList<>(Collections.singletonList(new TempProcess(new Process(), new Workpiece()))));
+        Process newProcess = new Process();
+        Workpiece newWorkPiece = new Workpiece();
+        TempProcess tempProcess = new TempProcess(newProcess, newWorkPiece);
+        underTest.setProcesses(new LinkedList<>(Collections.singletonList(tempProcess)));
         underTest.getMainProcess().setProject(ServiceManager.getProjectService().getById(1));
         underTest.getMainProcess().setRuleset(ServiceManager.getRulesetService().getById(1));
         underTest.getMainProcess().setTitle("title");
@@ -98,6 +101,10 @@ public class CreateProcessFormIT {
         ExecutionPermission.setNoExecutePermission(script);
         long after = processService.count();
         assertEquals("No process was created!", before + 1, after);
-        processService.remove((int) (after - 1));
+
+        // clean up database, index and file system
+        Integer processId = newProcess.getId();
+        processService.remove(processId);
+        fileService.delete(URI.create(processId.toString()));
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/CreateProcessFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/CreateProcessFormIT.java
@@ -58,15 +58,8 @@ public class CreateProcessFormIT {
         MockDatabase.insertProcessesFull();
         MockDatabase.insertProcessesForHierarchyTests();
         MockDatabase.setUpAwaitility();
-        fileService.createDirectory(URI.create(""), "1");
         SecurityTestUtils.addUserDataToSecurityContext(ServiceManager.getUserService().getById(1), 1);
-        if (System.getProperty("java.class.path").contains("eclipse")) {
-            while (Objects.isNull(processService.findByTitle(firstProcess))) {
-                Thread.sleep(50);
-            }
-        } else {
-            await().untilTrue(new AtomicBoolean(Objects.nonNull(processService.findByTitle(firstProcess))));
-        }
+        await().untilTrue(new AtomicBoolean(Objects.nonNull(processService.findByTitle(firstProcess))));
     }
 
     /**
@@ -76,7 +69,6 @@ public class CreateProcessFormIT {
     public static void cleanDatabase() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
-        fileService.delete(URI.create("1"));
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/TitleRecordLinkTabIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/TitleRecordLinkTabIT.java
@@ -15,7 +15,6 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.net.URI;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -31,10 +30,8 @@ import org.kitodo.production.forms.createprocess.CreateProcessForm;
 import org.kitodo.production.forms.createprocess.TitleRecordLinkTab;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ProcessService;
-import org.kitodo.production.services.file.FileService;
 
 public class TitleRecordLinkTabIT {
-    private static FileService fileService = new FileService();
     private static final ProcessService processService = ServiceManager.getProcessService();
 
     private static final String firstProcess = "First process";
@@ -48,15 +45,8 @@ public class TitleRecordLinkTabIT {
         MockDatabase.insertProcessesFull();
         MockDatabase.insertProcessesForHierarchyTests();
         MockDatabase.setUpAwaitility();
-        fileService.createDirectory(URI.create(""), "1");
         SecurityTestUtils.addUserDataToSecurityContext(ServiceManager.getUserService().getById(1), 1);
-        if (System.getProperty("java.class.path").contains("eclipse")) {
-            while (Objects.isNull(processService.findByTitle(firstProcess))) {
-                Thread.sleep(50);
-            }
-        } else {
-            await().untilTrue(new AtomicBoolean(Objects.nonNull(processService.findByTitle(firstProcess))));
-        }
+        await().untilTrue(new AtomicBoolean(Objects.nonNull(processService.findByTitle(firstProcess))));
     }
 
     /**
@@ -66,7 +56,6 @@ public class TitleRecordLinkTabIT {
     public static void cleanDatabase() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
-        fileService.delete(URI.create("1"));
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/production/helper/tasks/NewspaperMigrationTaskIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/tasks/NewspaperMigrationTaskIT.java
@@ -15,15 +15,19 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.kitodo.ExecutionPermission;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
 import org.kitodo.TreeDeleter;
 import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.config.ConfigCore;
+import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Batch;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Ruleset;
@@ -41,8 +45,15 @@ public class NewspaperMigrationTaskIT {
     private static final BatchService batchService = ServiceManager.getBatchService();
     private static final ProcessService processService = ServiceManager.getProcessService();
 
+    private static final File script = new File(ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_DIR_META));
+
     @BeforeClass
     public static void prepareDatabase() throws Exception {
+
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            ExecutionPermission.setExecutePermission(script);
+        }
+
         moveOriginMetadataDirectoryAside();
         FileUtils.copyDirectory(TEST_DATAFILES_DIRECTORY, METADATA_DIRECTORY);
         MockDatabase.startNode();
@@ -123,6 +134,10 @@ public class NewspaperMigrationTaskIT {
         MockDatabase.cleanDatabase();
         restoreMetadataDirectoryContents();
         SecurityTestUtils.cleanSecurityContext();
+
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            ExecutionPermission.setNoExecutePermission(script);
+        }
     }
 
     private static void restoreMetadataDirectoryContents() throws Exception {

--- a/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
@@ -15,7 +15,6 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
@@ -31,10 +30,8 @@ import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ProcessService;
-import org.kitodo.production.services.file.FileService;
 
 public class MetadataEditorIT {
-    private static FileService fileService = new FileService();
     private static final ProcessService processService = ServiceManager.getProcessService();
 
     private static final String firstProcess = "First process";
@@ -48,15 +45,8 @@ public class MetadataEditorIT {
         MockDatabase.insertProcessesFull();
         MockDatabase.insertProcessesForHierarchyTests();
         MockDatabase.setUpAwaitility();
-        fileService.createDirectory(URI.create(""), "1");
         SecurityTestUtils.addUserDataToSecurityContext(ServiceManager.getUserService().getById(1), 1);
-        if (System.getProperty("java.class.path").contains("eclipse")) {
-            while (Objects.isNull(processService.findByTitle(firstProcess))) {
-                Thread.sleep(50);
-            }
-        } else {
-            await().untilTrue(new AtomicBoolean(Objects.nonNull(processService.findByTitle(firstProcess))));
-        }
+        await().untilTrue(new AtomicBoolean(Objects.nonNull(processService.findByTitle(firstProcess))));
     }
 
     /**
@@ -66,7 +56,6 @@ public class MetadataEditorIT {
     public static void cleanDatabase() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
-        fileService.delete(URI.create("1"));
     }
 
     @Rule

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -20,6 +20,7 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.awaitility.Awaitility;
 import org.junit.AfterClass;
@@ -92,6 +93,11 @@ public class NewspaperProcessesGeneratorIT {
      */
     @Test
     public void shouldGenerateNewspaperProcesses() throws Exception {
+        // create backup of meta data file as this file is modified inside test
+        File metaFile = new File("src/test/resources/metadata/10/meta.xml");
+        File backupFile = new File("src/test/resources/metadata/10/meta.xml.1");
+        FileUtils.copyFile(metaFile, backupFile);
+
         Process completeEdition = ServiceManager.getProcessService().getById(10);
         Course course = NewspaperCourse.getCourse();
         course.splitInto(Granularity.DAYS);
@@ -101,6 +107,10 @@ public class NewspaperProcessesGeneratorIT {
         }
         Assert.assertEquals("The newspaper processes generator has not been completed!", underTest.getNumberOfSteps(),
             underTest.getProgress());
+
+        // restore backuped meta data file
+        FileUtils.deleteQuietly(metaFile);
+        FileUtils.moveFile(backupFile, metaFile);
         cleanUp();
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -84,6 +84,10 @@ public class NewspaperProcessesGeneratorIT {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
         KitodoConfigFile.PROJECT_CONFIGURATION.getFile().delete();
+
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            ExecutionPermission.setNoExecutePermission(script);
+        }
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -13,7 +13,6 @@ package org.kitodo.production.process;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,10 +42,8 @@ import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.model.bibliography.course.Granularity;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ProcessService;
-import org.kitodo.production.services.file.FileService;
 
 public class NewspaperProcessesGeneratorIT {
-    private static final FileService fileService = new FileService();
     private static final ProcessService processService = ServiceManager.getProcessService();
 
     private static final String firstProcess = "First process";
@@ -71,7 +68,6 @@ public class NewspaperProcessesGeneratorIT {
         MockDatabase.insertProcessesFull();
         MockDatabase.insertProcessForCalendarHierarchyTests();
         MockDatabase.setUpAwaitility();
-        fileService.createDirectory(URI.create(""), "1");
         SecurityTestUtils.addUserDataToSecurityContext(ServiceManager.getUserService().getById(1), 1);
         Awaitility.await().untilTrue(new AtomicBoolean(Objects.nonNull(processService.findByTitle(firstProcess))));
     }

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -155,6 +155,10 @@ public class KitodoScriptServiceIT {
     @Test
     public void shouldGenerateDerivativeImages() throws Exception {
 
+        // Delete created and still running taskmanager tasks from other test suites because
+        // this test is assuming that there are no other taskmanager tasks running!
+        TaskManager.stopAndDeleteAllTasks();
+
         Folder generatorSource = new Folder();
         generatorSource.setMimeType("image/tiff");
         generatorSource.setPath("images/(processtitle)_media");

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -77,6 +77,10 @@ public class KitodoScriptServiceIT {
 
         assertTrue(max + ": There is no such directory!", max.isDirectory());
 
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            ExecutionPermission.setNoExecutePermission(scriptCreateDirMeta);
+        }
+
         TreeDeleter.deltree(processHome);
     }
 


### PR DESCRIPTION
Running integration tests multiple times on a Linux system results in 

* modified files and directories inside the repo
* created background tasks which are not cleaned up which causing failing tests

While checking and cleaning up this tests some other needless calls are removed which are introduced by copy and pasting from other test suites.
