### PR TITLE
Add ORDER to logical structure

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/IncludedStructuralElement.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/IncludedStructuralElement.java
@@ -45,6 +45,11 @@ public class IncludedStructuralElement implements Parent<IncludedStructuralEleme
     private Collection<Metadata> metadata = new HashSet<>();
 
     /**
+     * Order of IncludedStructuralElements in relation to Views assigned to the parent.
+     */
+    private int order;
+
+    /**
      * The order label of this included structural element, used to store the
      * machine-readable value if the label contains a human-readable value that
      * can be mapped to a machine-readable value.
@@ -95,6 +100,7 @@ public class IncludedStructuralElement implements Parent<IncludedStructuralEleme
         label = source.label;
         link = source.link;
         metadata = source.metadata;
+        order = source.order;
         orderlabel = source.orderlabel;
         subincludedStructuralElements = source.subincludedStructuralElements;
         type = source.type;
@@ -157,6 +163,24 @@ public class IncludedStructuralElement implements Parent<IncludedStructuralEleme
      */
     public Collection<Metadata> getMetadata() {
         return metadata;
+    }
+
+    /**
+     * Get order.
+     *
+     * @return value of order
+     */
+    public int getOrder() {
+        return order;
+    }
+
+    /**
+     * Set order.
+     *
+     * @param order as int
+     */
+    public void setOrder(int order) {
+        this.order = order;
     }
 
     /**

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -112,15 +112,15 @@ public class DivXmlElementAccess extends IncludedStructuralElement {
         metsReferrerId = div.getID();
         BigInteger order = div.getORDER();
         if (Objects.nonNull(order) && order.intValue() > 0) {
-            super.setOrder(order.intValue());
+            setOrder(order.intValue());
         } else if (parentOrder > 0) {
-            super.setOrder(parentOrder);
+            setOrder(parentOrder);
         } else {
-            super.setOrder(1);
+            setOrder(1);
         }
         super.setOrderlabel(div.getORDERLABEL());
         for (DivType child : div.getDiv()) {
-            super.getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, super.getOrder()));
+            getChildren().add(new DivXmlElementAccess(child, mets, mediaUnitsMap, getOrder()));
         }
         super.setType(div.getTYPE());
         List<FileXmlElementAccess> fileXmlElementAccesses = mediaUnitsMap.get(div.getID());
@@ -234,8 +234,8 @@ public class DivXmlElementAccess extends IncludedStructuralElement {
         DivType div = new DivType();
         div.setID(metsReferrerId);
         div.setLABEL(super.getLabel());
-        if (super.getOrder() > 0) {
-            div.setORDER(BigInteger.valueOf(super.getOrder()));
+        if (getOrder() > 0) {
+            div.setORDER(BigInteger.valueOf(getOrder()));
         }
         div.setORDERLABEL(super.getOrderlabel());
         div.setTYPE(super.getType());

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -145,7 +145,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
             }
         }
         workpiece.setRootElement(getStructMapsStreamByType(mets, "LOGICAL")
-                .map(structMap -> new DivXmlElementAccess(structMap.getDiv(), mets, mediaUnitsMap)).collect(Collectors.toList())
+                .map(structMap -> new DivXmlElementAccess(structMap.getDiv(), mets, mediaUnitsMap, 1)).collect(Collectors.toList())
                 .iterator().next());
     }
 


### PR DESCRIPTION
Adds the ORDER attribute to the divs of the logical structMap. This is the basis for ordering the logical and physical nodes in the combined tree.