### PR TITLE
Check Optional<?> for existence before invoking get()

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
@@ -23,6 +23,7 @@ import java.util.Locale.LanguageRange;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.kitodo.api.dataeditor.rulesetmanagement.DatesSimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
@@ -241,10 +242,11 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
          * tests can be combined with each other, then all conditions must
          * apply.
          */
-        if (!universal.getPattern().isPresent()) {
+        Optional<Pattern> optionalPattern = universal.getPattern();
+        if (!optionalPattern.isPresent()) {
             return true;
         }
-        return universal.getPattern().get().matcher(value).matches();
+        return optionalPattern.get().matcher(value).matches();
     }
 
     void setScheme(String scheme) {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
@@ -153,8 +153,9 @@ public class RulesetManagement implements RulesetManagementInterface {
      */
     private void initializeNamespaces(List<Key> keys, File home) throws IOException {
         for (Key key : keys) {
-            if (key.getNamespace().isPresent()) {
-                String namespaceURI = key.getNamespace().get();
+            Optional<String> optionalNamespace = key.getNamespace();
+            if (optionalNamespace.isPresent()) {
+                String namespaceURI = optionalNamespace.get();
                 File file = new File(home, namespaceURI.replaceFirst("^.*?/([^/]*?)[#/]?$", "$1").concat(".xml"));
                 if (file.isFile()) {
                     try {

--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/LongTermPreservationValidationConfigParameter.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/LongTermPreservationValidationConfigParameter.java
@@ -98,7 +98,7 @@ enum LongTermPreservationValidationConfigParameter implements ParameterInterface
     /**
      * Returns the name of the long term preservation validation config
      * parameter.
-     * 
+     *
      * @return the name
      */
     @Override
@@ -108,7 +108,7 @@ enum LongTermPreservationValidationConfigParameter implements ParameterInterface
 
     /**
      * Retrieves the parameter interface element for a validation result state.
-     * 
+     *
      * @param state
      *            input status
      * @return one of the above possibilities
@@ -118,7 +118,8 @@ enum LongTermPreservationValidationConfigParameter implements ParameterInterface
                 .of(LongTermPreservationValidationConfigParameter.values()).parallel();
         String result = state.toString().replace(TernaryValue.MAYBE.toString(), UNDETERMINED).replace('/', '.');
         LongTermPreservationValidationConfigParameter constant = constants
-                .filter(member -> member.getName().endsWith(result)).findFirst().get();
+                .filter(member -> member.getName().endsWith(result)).findFirst()
+                .orElseThrow(IllegalStateException::new);
         return constant;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -144,9 +145,10 @@ public class AddDocStrucTypeDialog {
      * submit btn command button.
      */
     private void addMultiDocStruc() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
             MetadataEditor.addMultipleStructures(elementsToAddSpinnerValue, docStructAddTypeSelectionSelectedItem,
-                dataEditor.getWorkpiece(), dataEditor.getSelectedStructure().get(),
+                dataEditor.getWorkpiece(), selectedStructure.get(),
                 docStructPositionSelectionSelectedItem, selectAddableMetadataTypesSelectedItem,
                     inputMetaDataValue);
             dataEditor.refreshStructurePanel();
@@ -158,9 +160,10 @@ public class AddDocStrucTypeDialog {
      * submit btn command button.
      */
     private void addSingleDocStruc(boolean selectViews) {
-        if (dataEditor.getSelectedStructure().isPresent()) {
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
             IncludedStructuralElement newStructure = MetadataEditor.addStructure(docStructAddTypeSelectionSelectedItem,
-                    dataEditor.getWorkpiece(), dataEditor.getSelectedStructure().get(),
+                    dataEditor.getWorkpiece(), selectedStructure.get(),
                     docStructPositionSelectionSelectedItem, getViewsToAdd());
             dataEditor.getSelectedMedia().clear();
             if (selectViews) {
@@ -391,8 +394,9 @@ public class AddDocStrucTypeDialog {
      * Prepare popup dialog by retrieving available insertion positions and doc struct types for selected element.
      */
     public void prepare() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
-            this.parents = MetadataEditor.getAncestorsOfStructure(dataEditor.getSelectedStructure().get(),
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
+            this.parents = MetadataEditor.getAncestorsOfStructure(selectedStructure.get(),
                 dataEditor.getWorkpiece().getRootElement());
             prepareDocStructPositionSelectionItems(parents.isEmpty());
             prepareSelectAddableMetadataTypesItems(true);
@@ -409,8 +413,9 @@ public class AddDocStrucTypeDialog {
      * currently selected position.
      */
     public void prepareDocStructTypes() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
-            this.parents = MetadataEditor.getAncestorsOfStructure(dataEditor.getSelectedStructure().get(),
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
+            this.parents = MetadataEditor.getAncestorsOfStructure(selectedStructure.get(),
                     dataEditor.getWorkpiece().getRootElement());
             if (parents.isEmpty()) {
                 docStructAddTypeSelectionItemsForParent = Collections.emptyList();
@@ -545,10 +550,11 @@ public class AddDocStrucTypeDialog {
     }
 
     private StructuralElementViewInterface getStructuralElementView() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
             return dataEditor.getRuleset()
                     .getStructuralElementView(
-                            dataEditor.getSelectedStructure().get().getType(),
+                            selectedStructure.get().getType(),
                             dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
         } else {
             TreeNode selectedLogicalNode = dataEditor.getStructurePanel().getSelectedLogicalNode();
@@ -591,7 +597,7 @@ public class AddDocStrucTypeDialog {
                 }
             }
         }
-        preselectedViews.sort(Comparator.comparingInt(v -> v.getMediaUnit().getOrder()));
+        preselectedViews.sort(Comparator.comparingInt(view -> view.getMediaUnit().getOrder()));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddMediaUnitDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddMediaUnitDialog.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.faces.model.SelectItem;
 
@@ -46,9 +47,10 @@ public class AddMediaUnitDialog {
      * Add a new MediaUnit.
      */
     public void addMediaUnit() {
-        if (dataEditor.getSelectedMediaUnit().isPresent()) {
+        Optional<MediaUnit> selectedMediaUnit = dataEditor.getSelectedMediaUnit();
+        if (selectedMediaUnit.isPresent()) {
             MediaUnit mediaUnit = MetadataEditor.addMediaUnit(selectedType, dataEditor.getWorkpiece(),
-                    dataEditor.getSelectedMediaUnit().get(),
+                    selectedMediaUnit.get(),
                     selectedPosition);
             dataEditor.refreshStructurePanel();
             dataEditor.getStructurePanel().selectMediaUnit(mediaUnit);
@@ -71,13 +73,14 @@ public class AddMediaUnitDialog {
     }
 
     private void preparePossiblePositions() {
-        if (dataEditor.getSelectedMediaUnit().isPresent()) {
+        Optional<MediaUnit> selectedMediaUnit = dataEditor.getSelectedMediaUnit();
+        if (selectedMediaUnit.isPresent()) {
             possiblePositions = new ArrayList<>();
             possiblePositions.add(new SelectItem(InsertionPosition.FIRST_CHILD_OF_CURRENT_ELEMENT,
                     Helper.getTranslation("dataEditor.position.asFirstChildOfCurrentElement")));
             possiblePositions.add(new SelectItem(InsertionPosition.LAST_CHILD_OF_CURRENT_ELEMENT,
                     Helper.getTranslation("dataEditor.position.asLastChildOfCurrentElement")));
-            List<MediaUnit> parents = MetadataEditor.getAncestorsOfMediaUnit(dataEditor.getSelectedMediaUnit().get(),
+            List<MediaUnit> parents = MetadataEditor.getAncestorsOfMediaUnit(selectedMediaUnit.get(),
                     dataEditor.getWorkpiece().getMediaUnit());
             if (parents.size() > 0) {
                 possiblePositions.add(new SelectItem(InsertionPosition.BEFORE_CURRENT_ELEMENT,
@@ -95,13 +98,14 @@ public class AddMediaUnitDialog {
     public void preparePossibleTypes() {
         possibleTypes = new ArrayList<>();
 
-        if (dataEditor.getSelectedMediaUnit().isPresent()) {
+        Optional<MediaUnit> selectedMediaUnit = dataEditor.getSelectedMediaUnit();
+        if (selectedMediaUnit.isPresent()) {
             StructuralElementViewInterface divisionView = null;
 
             if (InsertionPosition.FIRST_CHILD_OF_CURRENT_ELEMENT.equals(selectedPosition)
                     || InsertionPosition.LAST_CHILD_OF_CURRENT_ELEMENT.equals(selectedPosition)) {
                 divisionView = dataEditor.getRuleset().getStructuralElementView(
-                        dataEditor.getSelectedMediaUnit().orElseThrow(IllegalStateException::new).getType(),
+                    selectedMediaUnit.orElseThrow(IllegalStateException::new).getType(),
                         dataEditor.getAcquisitionStage(),
                         dataEditor.getPriorityList()
                 );
@@ -109,7 +113,7 @@ public class AddMediaUnitDialog {
             } else if (InsertionPosition.BEFORE_CURRENT_ELEMENT.equals(selectedPosition)
                     || InsertionPosition.AFTER_CURRENT_ELEMENT.equals(selectedPosition)) {
                 LinkedList<MediaUnit> parents = MetadataEditor.getAncestorsOfMediaUnit(
-                        dataEditor.getSelectedMediaUnit().get(),
+                    selectedMediaUnit.get(),
                         dataEditor.getWorkpiece().getMediaUnit());
                 if (!parents.isEmpty()) {
                     divisionView = dataEditor.getRuleset().getStructuralElementView(

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -543,8 +543,9 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
      * @return boolean representing selection status
      */
     public boolean isStripeSelected(IncludedStructuralElement structure) {
-        if (Objects.nonNull(getSelectedStructure()) && getSelectedStructure().isPresent()) {
-            return Objects.equals(structure, getSelectedStructure().get());
+        Optional<IncludedStructuralElement> selectedStructure = structurePanel.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
+            return Objects.equals(structure, selectedStructure.get());
         } else {
             return false;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
@@ -15,12 +15,14 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.faces.model.SelectItem;
 
+import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.MediaUnit;
 import org.kitodo.api.dataformat.View;
 import org.kitodo.production.metadata.MetadataEditor;
@@ -81,9 +83,10 @@ public class EditPagesDialog {
      * button.
      */
     public void addPage() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
             for (View viewToAdd : getViewsToAdd(paginationSelectionSelectedItems)) {
-                dataEditor.assignView(dataEditor.getSelectedStructure().get(), viewToAdd, -1);
+                dataEditor.assignView(selectedStructure.get(), viewToAdd, -1);
             }
             dataEditor.refreshStructurePanel();
             prepare();
@@ -211,9 +214,10 @@ public class EditPagesDialog {
      * btn command button.
      */
     public void setPageStartAndEnd() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
             for (View viewToAdd : getViewsToAdd(selectFirstPageSelectedItem, selectLastPageSelectedItem)) {
-                dataEditor.assignView(dataEditor.getSelectedStructure().get(), viewToAdd, -1);
+                dataEditor.assignView(selectedStructure.get(), viewToAdd, -1);
             }
             dataEditor.refreshStructurePanel();
             prepare();
@@ -238,8 +242,9 @@ public class EditPagesDialog {
             Integer id = i;
             SelectItem selectItem = new SelectItem(id, label);
             selectPageItems.add(selectItem);
-            boolean assigned = dataEditor.getSelectedStructure().isPresent()
-                    && dataEditor.getSelectedStructure().get().getViews().contains(view);
+            Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+            boolean assigned = selectedStructure.isPresent()
+                    && selectedStructure.get().getViews().contains(view);
             (assigned ? paginationSubSelectionItems : paginationSelectionItems).add(selectItem);
             (assigned ? assigneds : unassigneds).add(id);
         }
@@ -260,9 +265,10 @@ public class EditPagesDialog {
      * button.
      */
     public void removePage() {
-        if (dataEditor.getSelectedStructure().isPresent()) {
+        Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
+        if (selectedStructure.isPresent()) {
             for (View viewToRemove : getViewsToAdd(paginationSubSelectionSelectedItems)) {
-                dataEditor.unassignView(dataEditor.getSelectedStructure().get(), viewToRemove, false);
+                dataEditor.unassignView(selectedStructure.get(), viewToRemove, false);
             }
             dataEditor.refreshStructurePanel();
             prepare();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -414,11 +414,11 @@ public class GalleryPanel {
 
     private static MediaVariant getMediaVariant(Folder folderSettings, List<MediaUnit> mediaUnits) {
         String use = folderSettings.getFileGroup();
-        Optional<MediaVariant> maybeMediaVariant = mediaUnits.parallelStream().map(MediaUnit::getMediaFiles)
+        Optional<MediaVariant> optionalMediaVariant = mediaUnits.parallelStream().map(MediaUnit::getMediaFiles)
                 .flatMap(mediaFiles -> mediaFiles.entrySet().parallelStream()).map(Entry::getKey)
                 .filter(mediaVariant -> use.equals(mediaVariant.getUse())).findAny();
-        if (maybeMediaVariant.isPresent()) {
-            return maybeMediaVariant.get();
+        if (optionalMediaVariant.isPresent()) {
+            return optionalMediaVariant.get();
         } else {
             MediaVariant mediaVariant = new MediaVariant();
             mediaVariant.setMimeType(folderSettings.getMimeType());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.faces.model.SelectItem;
 
@@ -287,11 +288,10 @@ public class PaginationPanel {
 
     private void preparePaginationSelectionSelectedItem() {
         MediaUnit selectedMediaUnit = null;
-        if (dataEditor.getStructurePanel().isSeparateMedia()
-                && Objects.nonNull(dataEditor.getSelectedMediaUnit())
-                && dataEditor.getSelectedMediaUnit().isPresent()
-                && "page".equals(dataEditor.getSelectedMediaUnit().get().getType())) {
-            selectedMediaUnit = dataEditor.getSelectedMediaUnit().get();
+        Optional<MediaUnit> optionalSelectedMediaUnit = dataEditor.getSelectedMediaUnit();
+        if (dataEditor.getStructurePanel().isSeparateMedia() && Objects.nonNull(optionalSelectedMediaUnit)
+                && optionalSelectedMediaUnit.isPresent() && "page".equals(optionalSelectedMediaUnit.get().getType())) {
+            selectedMediaUnit = optionalSelectedMediaUnit.get();
         } else if (Objects.nonNull(dataEditor.getStructurePanel().getSelectedLogicalNode())) {
             StructureTreeNode structureTreeNode = (StructureTreeNode) dataEditor.getStructurePanel().getSelectedLogicalNode().getData();
             if (structureTreeNode.getDataObject() instanceof View) {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
@@ -164,8 +164,9 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
         List<MetadataViewWithValuesInterface<Metadata>> entryViews = divisionView
                 .getSortedVisibleMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList());
         for (MetadataViewWithValuesInterface<Metadata> entryView : entryViews) {
-            if (entryView.getMetadata().isPresent()) {
-                MetadataViewInterface key = entryView.getMetadata().get();
+            Optional<MetadataViewInterface> optionalMetadata = entryView.getMetadata();
+            if (optionalMetadata.isPresent()) {
+                MetadataViewInterface key = optionalMetadata.get();
                 for (Metadata value : entryView.getValues()) {
                     if (value instanceof MetadataEntry) {
                         allMetadata.add(new LegacyMetadataHelper(null, new LegacyMetadataTypeHelper(key),
@@ -187,7 +188,8 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
                 .getSortedVisibleMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList());
         for (MetadataViewWithValuesInterface<Metadata> entryView : entryViews) {
             if (entryView.getMetadata().isPresent()) {
-                MetadataViewInterface key = entryView.getMetadata().get();
+                Optional<MetadataViewInterface> optionalMetadata = entryView.getMetadata();
+                MetadataViewInterface key = optionalMetadata.get();
                 if (key.getId().equals(metadataType.getName())) {
                     for (Metadata value : entryView.getValues()) {
                         if (value instanceof MetadataEntry) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -1048,19 +1048,20 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
      * @return
      *      the only Entry's value as java.lang.String
      */
-    String parsePrimeFacesFilter(Map filters) {
-        if (Objects.nonNull(filters) && filters.entrySet().size() == 1) {
-            Map.Entry filter = (Map.Entry) filters.entrySet().stream().findAny().get();
-            if (filter.getValue() instanceof String) {
-                return (String) filter.getValue();
-            } else {
-                logger.warn("Given filter is not a String. Ignoring filter.");
+    String parsePrimeFacesFilter(Map<?, ?> filters) {
+        if (Objects.nonNull(filters)) {
+            int count = filters.size();
+            if (count == 1) {
+                Object value = filters.entrySet().iterator().next().getValue();
+                if (value instanceof String) {
+                    return (String) value;
+                } else {
+                    logger.warn("Given filter is not a String. Ignoring filter.");
+                }
+            } else if (count > 1) {
+                logger.warn("Filter map contains too many entries (only 0 or 1 allowed). Ignoring filter map.");
             }
-        } else if (Objects.nonNull(filters) && filters.entrySet().size() > 1) {
-            logger.warn("Filter map contains to many entries (only 0 or 1 allowed). Ignoring filter map.");
         }
         return "";
     }
-
-
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/image/MissingOrDamagedImagesFilterPredicate.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/image/MissingOrDamagedImagesFilterPredicate.java
@@ -67,7 +67,7 @@ public class MissingOrDamagedImagesFilterPredicate implements Predicate<Subfolde
      * and can be validated. The name of the file results from the settings of
      * the folder passed into the {@link #test(Subfolder)} function, and the
      * canonical name part and the variables.
-     * 
+     *
      * @param canonical
      *            the canonical part of the file name
      */
@@ -81,7 +81,7 @@ public class MissingOrDamagedImagesFilterPredicate implements Predicate<Subfolde
      * canonical name part and the variables passed in the constructor. If there
      * is such a file, the long time preservation validation interface is
      * queried to check if the file is valid.
-     * 
+     *
      * @param folder
      *            folder where to find the file
      * @return true, if the picture needs to be generated
@@ -92,23 +92,22 @@ public class MissingOrDamagedImagesFilterPredicate implements Predicate<Subfolde
         if (!imageURI.isPresent()) {
             logger.info(IMAGE_MISSING, canonical, folder);
             return true;
-        } else {
-            Optional<FileType> fileType = folder.getFileFormat().getFileType();
-            if (fileType.isPresent()) {
-                LongTermPreservationValidationService serviceLoader = new LongTermPreservationValidationService();
-                ValidationResult validated = serviceLoader.validate(imageURI.get(), fileType.get());
-                if (validated.getState().equals(State.SUCCESS)) {
-                    logger.info(VALIDATION_SUCCESS, canonical, folder, validated.getState());
-                    return false;
-                } else {
-                    logger.info(VALIDATION_NO_SUCCESS, canonical, folder, validated.getState());
-                    validated.getResultMessages().forEach(logger::debug);
-                    return true;
-                }
+        }
+        Optional<FileType> fileType = folder.getFileFormat().getFileType();
+        if (fileType.isPresent()) {
+            LongTermPreservationValidationService serviceLoader = new LongTermPreservationValidationService();
+            ValidationResult validated = serviceLoader.validate(imageURI.get(), fileType.get());
+            if (validated.getState().equals(State.SUCCESS)) {
+                logger.info(VALIDATION_SUCCESS, canonical, folder, validated.getState());
+                return false;
             } else {
-                logger.warn(NO_VALIDATOR_CONFIGURED, canonical, folder);
+                logger.info(VALIDATION_NO_SUCCESS, canonical, folder, validated.getState());
+                validated.getResultMessages().forEach(logger::debug);
                 return true;
             }
+        } else {
+            logger.warn(NO_VALIDATOR_CONFIGURED, canonical, folder);
+            return true;
         }
     }
 }


### PR DESCRIPTION
The pattern criticized by Sonarcloud was mainly that an optional value was retrieved fro a getter, checked for existence, and then retrieved again by invoking the getter again. This is hypothetically unsafe because getters could return different values on multiple invocations. It is more correct to store the value of the getter in a local variable and to check and access both places from there.