### PR TITLE
Display metadata groups not defined in the rule set

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
@@ -45,12 +45,12 @@ public class ProcessBooleanMetadata extends ProcessSimpleMetadata implements Ser
      *            data to display
      */
     ProcessBooleanMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings, MetadataEntry data) {
-        super(container, settings);
+        super(container, settings, settings.getLabel());
         this.active = Objects.nonNull(data);
     }
 
     private ProcessBooleanMetadata(ProcessBooleanMetadata template) {
-        super(template.container, template.settings);
+        super(template.container, template.settings, template.label);
         this.active = template.active;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -62,7 +62,7 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
 
     ProcessSelectMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings,
             Collection<MetadataEntry> selected) {
-        super(container, settings);
+        super(container, settings, settings.getLabel());
         this.items = toItems(settings.getSelectItems());
         for (MetadataEntry entry : selected) {
             selectedItems.add(entry.getValue());
@@ -73,7 +73,7 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     }
 
     private ProcessSelectMetadata(ProcessSelectMetadata template) {
-        super(template.container, template.settings);
+        super(template.container, template.settings, template.label);
         this.items = template.items;
         this.selectedItems = new ArrayList<>(template.selectedItems);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -13,6 +13,7 @@ package org.kitodo.production.forms.createprocess;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
@@ -32,8 +33,9 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
      * @param settings
      *            the ruleset settings for this field.
      */
-    protected ProcessSimpleMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings) {
-        super(container, settings.getLabel());
+    protected ProcessSimpleMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings,
+            String label) {
+        super(container, label);
         this.settings = settings;
     }
 
@@ -62,16 +64,16 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
      * @return whether the field is editable
      */
     public boolean isEditable() {
-        return settings.isEditable();
+        return Objects.isNull(settings) || settings.isEditable();
     }
 
     @Override
     public boolean isUndefined() {
-        return settings.isUndefined();
+        return Objects.isNull(settings) || settings.isUndefined();
     }
 
     public boolean isRequired() {
-        return settings.getMinOccurs() > 0;
+        return Objects.nonNull(settings) && settings.getMinOccurs() > 0;
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
+import org.kitodo.api.dataeditor.rulesetmanagement.InputType;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
@@ -37,14 +38,14 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
     private Date date;
 
     ProcessTextMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings, MetadataEntry value) {
-        super(container, settings);
+        super(container, settings, Objects.isNull(settings) ? value.getKey() : settings.getLabel());
         if (Objects.nonNull(value)) {
             this.value = value.getValue();
         }
     }
 
     private ProcessTextMetadata(ProcessTextMetadata template) {
-        super(template.container, template.settings);
+        super(template.container, template.settings, template.label);
         this.value = template.value;
         this.date = Objects.isNull(template.date) ? null : new Date(template.date.getTime());
     }
@@ -61,7 +62,8 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
 
     @Override
     public String getInput() {
-        switch (settings.getInputType()) {
+        InputType inputType = Objects.isNull(settings) ? InputType.ONE_LINE_TEXT : settings.getInputType();
+        switch (inputType) {
             case DATE:
                 return "calendar";
             case INTEGER:


### PR DESCRIPTION
Metadata groups in the data that are not defined in the ruleset caused the following exception: _Got complex metadata entry with key "…" which isn't declared as substructured key in the rule set._ The page was not built. This change fixes this so that now unknown metadata groups are also displayed.