### PR TITLE
Fix doctype journal children

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/InsertionPositionSelectionTreeNode.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/InsertionPositionSelectionTreeNode.java
@@ -22,6 +22,7 @@ public class InsertionPositionSelectionTreeNode extends DefaultTreeNode {
     private int itemIndex;
     private String label;
     private boolean possibleInsertionPosition;
+    private String tooltip;
 
     /**
      * Creates a new node for a radio button.
@@ -46,10 +47,11 @@ public class InsertionPositionSelectionTreeNode extends DefaultTreeNode {
      * @param label
      *            label for the included structural element
      */
-    InsertionPositionSelectionTreeNode(TreeNode parent, String label) {
+    InsertionPositionSelectionTreeNode(TreeNode parent, String label, String tooltip) {
         super(null, parent);
         this.label = label;
         this.possibleInsertionPosition = false;
+        this.tooltip = tooltip;
         super.setData(this);
         setExpanded(true);
     }
@@ -70,6 +72,15 @@ public class InsertionPositionSelectionTreeNode extends DefaultTreeNode {
      */
     public String getLabel() {
         return label;
+    }
+
+    /**
+     * Returns the tooltip for an existing included structural element.
+     *
+     * @return the tooltip
+     */
+    public String getTooltip() {
+        return tooltip;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -14,6 +14,7 @@ package org.kitodo.production.forms.createprocess;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -182,6 +183,7 @@ public class TitleRecordLinkTab {
             RulesetManagementInterface ruleset, List<LanguageRange> priorityList) throws IOException, DAOException {
 
         String type;
+        String tooltip = "";
         if (Objects.isNull(currentIncludedStructuralElement.getLink())) {
             type = currentIncludedStructuralElement.getType();
         } else {
@@ -189,13 +191,14 @@ public class TitleRecordLinkTab {
             int linkedProcessUri = processService.processIdFromUri(currentIncludedStructuralElement.getLink().getUri());
             Process linkedProcess = processService.getById(linkedProcessUri);
             type = processService.getBaseType(linkedProcess);
+            tooltip = Helper.getTranslation("tooltip", Arrays.asList(Integer.toString(linkedProcessUri)));
         }
 
         StructuralElementViewInterface currentIncludedStructuralElementView = ruleset.getStructuralElementView(type,
             createProcessForm.getAcquisitionStage(), priorityList);
 
         TreeNode includedStructuralElementNode = new InsertionPositionSelectionTreeNode(parentNode,
-                currentIncludedStructuralElementView.getLabel());
+                currentIncludedStructuralElementView.getLabel(), tooltip);
 
         boolean linkingAllowedHere = Objects.isNull(currentIncludedStructuralElement.getLink())
                 && currentIncludedStructuralElementView.getAllowedSubstructuralElements()

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -132,7 +132,10 @@ public class TitleRecordLinkTab {
      * @throws IOException
      *             if the METS file cannot be read
      */
-    private void createInsertionPositionSelectionTree() throws DAOException, IOException {
+    public void createInsertionPositionSelectionTree() throws DAOException, IOException {
+        if (Objects.isNull(titleRecordProcess)) {
+            return;
+        }
         URI uri = ServiceManager.getProcessService().getMetadataFileUri(titleRecordProcess);
         Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(uri);
 

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -877,6 +877,7 @@ timeoutWarningDMS=W\u00E4hrend des Exports m\u00FCssen viele Daten in das Pr\u00
 title=Titel
 titleRecordLink=Titelsatzverkn\u00FCpfung
 to=bis
+tooltip=Nr. {0}
 hits=Treffer
 tsl=TSL
 typ=Typ

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -876,6 +876,7 @@ timeoutWarningDMS=During import a lot of data needs to be transferred to the pre
 title=Title
 titleRecordLink=Title record link
 to=to
+tooltip=No. {0}
 hits=Hits
 tsl=TSL
 typ=Type

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
@@ -42,7 +42,9 @@
                                    var="step"
                                    itemLabel="#{step.localizedLabel}"
                                    itemValue="#{step.title}"/>
-                    <p:ajax event="change" update="editForm:processFromTemplateTabView:metadataTable"/>
+                    <p:ajax event="change"
+                            listener="#{CreateProcessForm.titleRecordLinkTab.createInsertionPositionSelectionTree()}"
+                            update="editForm:processFromTemplateTabView:metadataTable,editForm:processFromTemplateTabView:insertionTree"/>
                 </p:selectOneMenu>
             </div>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/titleRecordLink.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/titleRecordLink.xhtml
@@ -83,8 +83,11 @@
                         <h:outputLabel for="insertionPositionRadioButton"
                                        value="#{msgs.insertHere}"
                                        rendered="#{node.possibleInsertionPosition}"/>
-                        <h:outputText value="#{node.label}"
-                                      rendered="#{not node.possibleInsertionPosition}"/>
+                        <h:outputText value="#{node.label}" id="treeNodeText"
+                                       rendered="#{not node.possibleInsertionPosition}"/>
+                        <p:tooltip id="treeNodeTooltip" for="treeNodeText" value="#{node.tooltip}"
+                                       position="right" showEffect="clip" hideEffect="explode"
+                                       rendered="#{not node.possibleInsertionPosition and not empty node.tooltip}"/>
                     </p:treeNode>
                 </p:tree>
             </h:panelGroup>


### PR DESCRIPTION
Fixes:
- Insertion position tree is updated on media type change
- Cannot save if no insertion position is selected, error shows again
- Tooltip to see number of linked process (on mouse over). Example:

![Tooltip](https://user-images.githubusercontent.com/3040657/72982523-8ebd6680-3ddf-11ea-9c04-fc1e632cce8f.png)
