### PR TITLE
Metadata Editor fixes

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -744,7 +744,8 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             List<Metadata> titleMetadata = element.getMetadata().stream()
                     .filter(m -> DataEditorService.getTitleKeys().contains(m.getKey())).collect(Collectors.toList());
             for (Metadata metadata : titleMetadata) {
-                if (metadata instanceof MetadataEntry) {
+                if (metadata instanceof MetadataEntry && Objects.nonNull(((MetadataEntry) metadata).getValue())
+                        && !((MetadataEntry) metadata).getValue().isEmpty()) {
                     return " - " + ((MetadataEntry) metadata).getValue();
                 }
             }

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1490,13 +1490,32 @@ Column content
     bottom: 64px;
 }
 
+.ui-tree .ui-treenode.linked .ui-treenode-label::after {
+    content: '🔗';
+    margin-left: var(--default-half-size);
+}
+
+.ui-tree .ui-treenode.undefined .ui-treenode-label::after {
+    content: '⚠️';
+    margin-left: var(--default-half-size);
+}
+
+.ui-tree .ui-treenode.undefined.linked .ui-treenode-label::after {
+    content: '⚠️🔗';
+    margin-left: var(--default-half-size);
+}
+
 .ui-tree .ui-treenode.linked {
     background: transparent;
     cursor: not-allowed;
 }
 
-.ui-tree .ui-treenode.linked span {
+.ui-tree .ui-treenode.linked span span {
     pointer-events: none;
+}
+
+.ui-tree .ui-treenode.undefined .ui-treenode-label span {
+    background-color: gold;
 }
 
 #structureTreeForm .ui-treenode-label .assigned-several-times {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1490,6 +1490,15 @@ Column content
     bottom: 64px;
 }
 
+.ui-tree .ui-treenode.linked {
+    background: transparent;
+    cursor: not-allowed;
+}
+
+.ui-tree .ui-treenode.linked span {
+    pointer-events: none;
+}
+
 #structureTreeForm .ui-treenode-label .assigned-several-times {
     margin-left: 5px;
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -54,16 +54,15 @@
                     listener="#{DataEditorForm.structurePanel.onNodeExpand}"/>
             <p:treeNode expandedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-expanded'}"
                         collapsedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-collapsed'}"
-                        styleClass="#{logicalNode.linked ? 'linked' : ''}">
+                        styleClass="#{logicalNode.linked ? 'linked' : ''} #{logicalNode.undefined ? 'undefined' : ''}">
                 <!--@elvariable id="logicalElementType" type="java.lang.String"-->
                 <ui:param name="logicalElementType" value="#{logicalNode.label}"/>
-                <h:outputText value="#{empty logicalElementType ? msgs['dataEditor.unknownType'] : logicalElementType}" style="#{logicalNode.undefined ? 'background-color: gold' : ''}"/>
+                <h:outputText value="#{empty logicalElementType ? msgs['dataEditor.unknownType'] : logicalElementType}"
+                              title="#{logicalNode.undefined ? msgs['dataEditor.undefinedStructure'] : ''}"/>
                 <h:outputText value="#{DataEditorForm.getStructureElementTitle(logicalNode.dataObject)}"/>
                 <h:outputText value="#{DataEditorForm.structurePanel.getMultipleAssignmentsIndex(logicalNode) + 1}"
                               rendered="#{logicalNode.assignedSeveralTimes}"
                               styleClass="assigned-several-times"/>
-                <h:outputText value=" 🔗" rendered="#{logicalNode.linked}"/>
-                <h:outputText value=" ⚠️" rendered="#{logicalNode.undefined}" style="background-color: gold;" title="#{msgs['dataEditor.undefinedStructure']}"/>
             </p:treeNode>
         </p:tree>
         <p:contextMenu for="logicalTree" id="contextMenuLogicalTree">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -53,7 +53,8 @@
             <p:ajax event="expand"
                     listener="#{DataEditorForm.structurePanel.onNodeExpand}"/>
             <p:treeNode expandedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-expanded'}"
-                        collapsedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-collapsed'}">
+                        collapsedIcon="#{logicalNode.dataObject['class'].simpleName eq 'View' ? 'ui-icon-document' : 'ui-icon-folder-collapsed'}"
+                        styleClass="#{logicalNode.linked ? 'linked' : ''}">
                 <!--@elvariable id="logicalElementType" type="java.lang.String"-->
                 <ui:param name="logicalElementType" value="#{logicalNode.label}"/>
                 <h:outputText value="#{empty logicalElementType ? msgs['dataEditor.unknownType'] : logicalElementType}" style="#{logicalNode.undefined ? 'background-color: gold' : ''}"/>


### PR DESCRIPTION
- disable click for structure nodes linking to other processes
- fix disappearing link symbols in structure tree when element is added
- prevent display of "null" in gallery and structure when element has no title