### PR TITLE
Use metadata 'SpecialField' to configure parent IDs

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.Metadata;
+import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.externaldatamanagement.SingleHit;
 import org.kitodo.api.schemaconverter.ExemplarRecord;
 import org.kitodo.data.database.beans.Process;
@@ -184,7 +185,8 @@ public class ImportTab implements Serializable {
         try {
             LinkedList<TempProcess> processes = ServiceManager.getImportService().importProcessHierarchy(recordId,
                     this.hitModel.getSelectedCatalog(), this.createProcessForm.getProject().getId(),
-                    this.createProcessForm.getTemplate().getId(), this.importDepth);
+                    this.createProcessForm.getTemplate().getId(), this.importDepth,
+                    this.createProcessForm.getRuleset().getFunctionalKeys(FunctionalMetadata.HIGHERLEVEL_IDENTIFIER));
             this.createProcessForm.setProcesses(processes);
 
             // Fill metadata fields in metadata tab on successful import

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -617,6 +617,7 @@ newProcess.catalogueSearch.importSuccessfulSummary=Import erfolgreich
 newProcess.catalogueSearch.importSuccessfulDetail={0} Vorg\u00E4nge aus Katalog {1} geladen
 newProcess.catalogueSearch.linkedToExistingProcessSummary=Vorg\u00E4nge verkn\u00fcpft.
 newProcess.catalogueSearch.linkedToExistingProcessDetail=Neuer Vorgang an exisitierenden Vorgang \u201E{0}\u201C angeh\u00E4ngt.
+newProcess.catalogueSearch.parentIDMetadataMissing=Es wurde kein Metadatum zum Speichern von IDs \u00fcbergeordneter Vorg\u00E4nge ("higherlevelIdentifier") im Regelsatz gefunden. Importtiefe zur\u00fcckgesetzt auf 1!
 newProcess.titleGeneration.creationRuleNotFound=Es konnte keine Regel zur Titelgenerierung f\u00fcr Vorg\u00E4nge vom Typ \u201E{0}\u201C im Regelsatz \u201E{1}\u201C gefunden werden!
 newProject=Neues Projekt
 newRole=Neue Rolle

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -618,6 +618,7 @@ newProcess.catalogueSearch.importSuccessfulSummary=Import successful
 newProcess.catalogueSearch.importSuccessfulDetail={0} processes retrieved from {1}
 newProcess.catalogueSearch.linkedToExistingProcessSummary=Processes linked
 newProcess.catalogueSearch.linkedToExistingProcessDetail=New process linked to existing process \u201E{0}\u201C.
+newProcess.catalogueSearch.parentIDMetadataMissing=No parent ID metadata ("higherlevelIdentifier") found in ruleset! Resetting import depth to 1.
 newProcess.titleGeneration.creationRuleNotFound=No title creation rules found for docType \u201E{0}\u201C in ruleset \u201E{1}\u201C!
 newProject=New project
 newRole=New role

--- a/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/CatalogImportIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/CatalogImportIT.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.LinkedList;
 
 import org.apache.commons.io.IOUtils;
@@ -70,7 +71,8 @@ public class CatalogImportIT {
     @Test
     public void shouldImportProcessHierarchy() throws Exception {
         LinkedList<TempProcess> processes = ServiceManager.getImportService().importProcessHierarchy(CHILD_RECORD_ID,
-                OPAC_NAME, PROJECT_ID, TEMPLATE_ID, IMPORT_DEPTH);
+                OPAC_NAME, PROJECT_ID, TEMPLATE_ID, IMPORT_DEPTH,
+                Collections.singleton("CatalogIDPredecessorPeriodical"));
         Assert.assertEquals(IMPORT_DEPTH, processes.size());
     }
 


### PR DESCRIPTION
Metadata fields holding parent IDs of structure elements for hierarchical import can now be configured using the attribute `use="higherlevelIdentifier"` on a ruleset `key` definition.