### PR TITLE
Update checkstyle

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -214,6 +214,11 @@ public class Workpiece {
         return mediaUnits.stream().filter(m -> m.getType().equals(PAGE)).collect(Collectors.toList());
     }
 
+    /**
+     * Recursively search for all media units with type "page".
+     *
+     * @return list of all media units with type "page".
+     */
     public List<MediaUnit> getAllMediaUnits() {
         List<MediaUnit> mediaUnits = new LinkedList<>(mediaUnit.getChildren());
         for (MediaUnit mediaUnit : mediaUnit.getChildren()) {

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <parent.basedir>${basedir}/../</parent.basedir>
-        <maxAllowedViolations>16</maxAllowedViolations>
+        <maxAllowedViolations>15</maxAllowedViolations>
         <selenium.version>3.141.59</selenium.version>
         <cargo.plugin.version>1.7.7</cargo.plugin.version>
     </properties>

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportTab.java
@@ -219,6 +219,12 @@ public class ImportTab implements Serializable {
         return this.hitModel;
     }
 
+    /**
+     * Show growl message.
+     *
+     * @param summary General message
+     * @param detail Message detail
+     */
     public void showGrowlMessage(String summary, String detail) {
         String script = GROWL_MESSAGE.replace("SUMMARY", summary).replace("DETAIL", detail)
                 .replace("SEVERITY", "info");

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -2536,7 +2536,11 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     }
 
     /**
-     * Export METS.
+     * Export Mets.
+     *
+     * @param processId Id of which process should be exported
+     * @throws IOException Thrown on IO error
+     * @throws DAOException Thrown on database like error
      */
     public static void exportMets(int processId) throws IOException, DAOException {
         Process process = ServiceManager.getProcessService().getById(processId);
@@ -2544,6 +2548,12 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         export.startExport(process);
     }
 
+    /**
+     * Link a list of given processes to user home directory.
+     *
+     * @param processes List of processes
+     * @throws DAOException Thrown on database like error
+     */
     public static void downloadToHome(List<Process> processes) throws DAOException {
         WebDav webDav = new WebDav();
         for (Process processForDownload : processes) {

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -12,8 +12,8 @@
  *
 -->
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- Checkstyle configuration that checks the Kitodo coding conventions.
      To completely disable a check, just comment it out or delete it from the file.
@@ -216,12 +216,6 @@
             <property name="sortStaticImportsAlphabetically" value="true"/>
         </module>
 
-        <module name="CustomImportOrder">
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
-        </module>
-
         <module name="MethodParamPad"/>
 
         <module name="OperatorWrap">
@@ -260,12 +254,13 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
+        </module>
+
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="minLineCount" value="2"/>
         </module>
 
         <module name="MethodName">

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                             <dependency>
                                 <groupId>com.puppycrawl.tools</groupId>
                                 <artifactId>checkstyle</artifactId>
-                                <version>8.24</version>
+                                <version>8.29</version>
                             </dependency>
                         </dependencies>
                         <executions>


### PR DESCRIPTION
Updating checkstyle to version 8.29. `CustomImportOrder` must be removed as this rules are causing trouble with the `groups` definition in `ImportOrder`.