### PR TITLE
Query for confirmation before docstruct is deleted

### DIFF
--- a/Goobi/pages/incMeta/Strukturdaten.jsp
+++ b/Goobi/pages/incMeta/Strukturdaten.jsp
@@ -261,7 +261,7 @@
                     </h:panelGroup>--%>
 
                     <%-- Knoten löschen --%>
-                    <h:commandLink rendered="#{Metadaten.isNotRootElement}" action="#{Metadaten.KnotenDelete}" title="#{msgs.strukturelementLoeschen}" target="links">
+                    <h:commandLink rendered="#{Metadaten.isNotRootElement}" onclick="if(!confirm('#{msgs.knotenDeleteQuery}'))return false;" action="#{Metadaten.KnotenDelete}" title="#{msgs.strukturelementLoeschen}" target="links">
                         <h:graphicImage value="/newpages/images/buttons/waste1a_20px.gif" style="margin-left:4px;margin-right:7px;vertical-align:middle" />
                         <h:outputText value="#{msgs.strukturelementLoeschen}" />
                     </h:commandLink>

--- a/Goobi/src/messages/messages_de.properties
+++ b/Goobi/src/messages/messages_de.properties
@@ -638,6 +638,7 @@ keineAngabe=Keine Angabe
 keineBerechtigungAngegeben=Keine Berechtigung angegeben
 keineLdapgruppeAngegeben=Keine LDAPgruppe angegeben
 keineNutzung=Keine Nutzung
+knotenDeleteQuery=Wollen Sie das Strukturelement l\u00F6schen?
 korrektur=Korrektur
 korrekturmeldungAnVorherigeStationSenden=Korrekturmeldung an vorherige Station senden
 korrekturmeldungSenden=Korrekturmeldung senden

--- a/Goobi/src/messages/messages_en.properties
+++ b/Goobi/src/messages/messages_en.properties
@@ -640,6 +640,7 @@ keineAngabe=No information entered
 keineBerechtigungAngegeben=No authorisation defined
 keineLdapgruppeAngegeben=No LDAP group defined
 keineNutzung=Not used
+knotenDeleteQuery=Do you want to delete the docstruct?
 korrektur=correction
 korrekturmeldungAnVorherigeStationSenden=Send correction message to previous task
 korrekturmeldungSenden=Send correction message


### PR DESCRIPTION
Before a docstruct is deleted, a query will be asked. This reduces the risk of accidentally creating an invalid process.