### PR TITLE
Fix a possible integer overflow

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
@@ -120,12 +120,12 @@ public class IndexingForm {
      * Return the number of all objects processed during the current indexing
      * progress.
      *
-     * @return int number of all currently indexed objects
+     * @return long number of all currently indexed objects
      */
-    public int getAllIndexed() {
+    public long getAllIndexed() {
         try {
             return ServiceManager.getIndexingService().getAllIndexed();
-        } catch (DataException e) {
+        } catch (DataException | ArithmeticException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
             return 0;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -191,11 +191,13 @@ public class IndexingService {
      * progress.
      *
      * @return int number of all currently indexed objects
+     * @throws ArithmeticException
+     *             if the value will not fit in a {@code long}
      */
-    public int getAllIndexed() throws DataException {
-        int allIndexed = 0;
+    public long getAllIndexed() throws DataException {
+        long allIndexed = 0;
         for (ObjectType objectType : objectTypes) {
-            allIndexed += getNumberOfIndexedObjects(objectType);
+            allIndexed = Math.addExact(allIndexed, getNumberOfIndexedObjects(objectType));
         }
         return allIndexed;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -190,7 +190,7 @@ public class IndexingService {
      * Return the number of all objects processed during the current indexing
      * progress.
      *
-     * @return int number of all currently indexed objects
+     * @return long number of all currently indexed objects
      * @throws ArithmeticException
      *             if the value will not fit in a {@code long}
      */


### PR DESCRIPTION
An [integer overflow](https://en.wikipedia.org/wiki/Integer_overflow) can occur when a number becomes larger than the maximum allowed, in which case the rest is added to the minimum. This typically only happens with large numbers and is therefore usually inconspicuous in development.

[The weakness](https://lgtm.com/projects/g/kitodo/kitodo-production/snapshot/05c6a0fab4e82861d27f146b8ec4f992c5c55e35/files/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java#x9b6a8b81dfc6fa67:1) was discovered by the LGTM scanner (see issue #320)