### PR TITLE
Fix casting of URI for user home dir

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/WebDav.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/WebDav.java
@@ -168,10 +168,10 @@ public class WebDav implements Serializable {
 
             // for mass download, the project and directory must exist
             if (currentUser.isWithMassDownload()) {
-                URI project = Paths.get(userHome + process.getProject().getTitle()).toUri();
+                URI project = Paths.get(userHome.getPath() + process.getProject().getTitle()).toUri();
                 fileService.createDirectoryForUser(project, currentUser.getLogin());
 
-                project = Paths.get(userHome + doneDirectoryName).toUri();
+                project = Paths.get(userHome.getPath() + doneDirectoryName).toUri();
                 fileService.createDirectoryForUser(project, currentUser.getLogin());
             }
 


### PR DESCRIPTION
This fixes the behaviour described in issue  #3084. 