### PR TITLE
Log Hibernate exceptions during indexing

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.HibernateException;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.exceptions.DAOException;
@@ -76,7 +77,7 @@ public class IndexWorker implements Runnable {
                     indexChunks(batchSize);
                 }
             }
-        } catch (CustomResponseException | DAOException e) {
+        } catch (CustomResponseException | DAOException | HibernateException e) {
             logger.error(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
It is easily possible to have a Hibernate exception when indexing a database for the first time after the migration from Production 2.x, because the database often still contains legacy errors. To improve troubleshooting, the exception should be logged.