### PR TITLE
Delete on index

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
@@ -20,6 +20,7 @@ import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
+import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.services.data.base.SearchService;
 
 public class IndexWorker implements Runnable {
@@ -61,6 +62,7 @@ public class IndexWorker implements Runnable {
         int batchSize = ConfigCore.getIntParameterOrDefaultValue(ParameterCore.ELASTICSEARCH_BATCH);
         int indexLimit = ConfigCore.getIntParameterOrDefaultValue(ParameterCore.ELASTICSEARCH_INDEXLIMIT);
         try {
+            this.searchService.removeLooseIndexData(searchService.findAll());
             int amountToIndex = getAmountToIndex();
 
             if (amountToIndex < batchSize) {
@@ -77,7 +79,7 @@ public class IndexWorker implements Runnable {
                     indexChunks(batchSize);
                 }
             }
-        } catch (CustomResponseException | DAOException | HibernateException e) {
+        } catch (CustomResponseException | DAOException | DataException | HibernateException e) {
             logger.error(e.getMessage(), e);
         }
     }
@@ -91,7 +93,7 @@ public class IndexWorker implements Runnable {
     }
 
     @SuppressWarnings("unchecked")
-    private void indexChunks(int batchSize) throws CustomResponseException, DAOException {
+    private void indexChunks(int batchSize) throws CustomResponseException, DAOException, DataException {
         List<Object> objectsToIndex;
         int indexLimit = ConfigCore.getIntParameterOrDefaultValue(ParameterCore.ELASTICSEARCH_INDEXLIMIT);
         while (this.indexedObjects < indexLimit) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -358,7 +358,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     public List<Map<String, Object>> findAllDocuments() throws DataException {
         QueryBuilder queryBuilder = matchAllQuery();
         try {
-            return searcher.findDocuments(queryBuilder);
+            return searcher.findDocuments(queryBuilder, null, null, Math.toIntExact(count()));
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }
@@ -853,6 +853,22 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
             return SortBuilders.fieldSort(sortField).order(org.elasticsearch.search.sort.SortOrder.DESC);
         } else {
             return null;
+        }
+    }
+
+    /**
+     * Removes all objects from index, which are no longer in Database.
+     * @param baseIndexedBeans the list of beans to check for missing db eintries.
+     * 
+     */
+    public void removeLooseIndexData(List<S> baseIndexedBeans) throws DataException, CustomResponseException {
+        for (S baseIndexedBean : baseIndexedBeans) {
+            Integer baseIndexedBeanId = baseIndexedBean.getId();
+            try {
+                getById(baseIndexedBeanId);
+            } catch (DAOException e) {
+                removeFromIndex(baseIndexedBeanId,true);
+            }
         }
     }
 }


### PR DESCRIPTION
If an Object is removed from Database (by hand from admin or by accident) then the only way to get a clean index was to delete the whole index and reindex everything. Now a check is added, which removes loose index data in indexing.