### PR TITLE
Replace findbugs with spotbugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ services:
   - mysql
 
 script:
-  - mvn clean install -B '-Pall-tests,flyway,checkstyle,findbugs,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
+  - mvn clean install -B '-Pall-tests,flyway,checkstyle,spotbugs,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
 
 # install: true is deactivating the separate install-step, which runs before the script
 install: true

--- a/pom.xml
+++ b/pom.xml
@@ -189,16 +189,16 @@
             </build>
         </profile>
         <profile>
-            <id>findbugs</id>
+            <id>spotbugs</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>3.0.5</version>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>3.1.12.2</version>
                         <configuration>
                             <xmlOutput>true</xmlOutput>
-                            <xmlOutputDirectory>target/findbugsreports</xmlOutputDirectory>
+                            <xmlOutputDirectory>target/spotbugsreports</xmlOutputDirectory>
                             <effort>Max</effort>
                             <failOnError>false</failOnError>
                             <threshold>medium</threshold>


### PR DESCRIPTION
As the development of [findbugs](https://github.com/findbugsproject/findbugs) has stopped and future development is in project [spotbugs](https://github.com/spotbugs/spotbugs), we should replace findbugs with spotbugs.

Alternative is to remove the findbugs profile.