### PR TITLE
Ignore current number if it doesn't contain a numerical value

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/HierarchyMigrationTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/HierarchyMigrationTask.java
@@ -311,8 +311,8 @@ public class HierarchyMigrationTask extends EmptyTask {
     private static Integer getCurrentNo(IncludedStructuralElement includedStructualElement) {
         Integer currentNo = includedStructualElement.getMetadata().parallelStream()
                 .filter(metadata -> metadata.getKey().equals("CurrentNo")).filter(MetadataEntry.class::isInstance)
-                .map(MetadataEntry.class::cast).map(MetadataEntry::getValue).map(Integer::valueOf).findFirst()
-                .orElse(null);
+                .map(MetadataEntry.class::cast).map(MetadataEntry::getValue).filter(value -> value.matches("\\d+"))
+                .map(Integer::valueOf).findFirst().orElse(null);
         return currentNo;
     }
 


### PR DESCRIPTION
In some cases, the current number can have values that are not numerical. These are to be treated as if the number were not there (which, strictly speaking, is not).