### PR TITLE
Remove child link from parent workpiece when deleting process

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
@@ -133,7 +133,7 @@ public class DesktopForm extends BaseForm {
         try {
             ProcessService.deleteProcess(processID);
             emptyCache();
-        } catch (DataException | DAOException e) {
+        } catch (DataException | DAOException | IOException e) {
             Helper.setErrorMessage(ERROR_DELETING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },
                     logger, e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -196,7 +196,7 @@ public class ProcessForm extends TemplateBaseForm {
 
     /**
      * Delete Process.
-     * 
+     *
      * @param processDTO
      *            process to delete.
      */
@@ -217,7 +217,7 @@ public class ProcessForm extends TemplateBaseForm {
         if (this.process.getChildren().isEmpty()) {
             try {
                 ProcessService.deleteProcess(this.process);
-            } catch (DataException e) {
+            } catch (DataException | IOException e) {
                 Helper.setErrorMessage(ERROR_DELETING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },
                         logger, e);
             }
@@ -236,7 +236,7 @@ public class ProcessForm extends TemplateBaseForm {
                 ProcessService.deleteProcess(child);
             }
             ProcessService.deleteProcess(this.process);
-        } catch (DataException e) {
+        } catch (DataException | IOException e) {
             Helper.setErrorMessage(ERROR_DELETING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },
                     logger, e);
         }
@@ -254,7 +254,7 @@ public class ProcessForm extends TemplateBaseForm {
             try {
                 ServiceManager.getProcessService().save(child);
                 ProcessService.deleteProcess(this.process);
-            } catch (DataException e) {
+            } catch (DataException | IOException e) {
                 Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.PROCESS.getTranslationSingular() }, logger,
                         e);
             }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
@@ -172,7 +172,7 @@ public class SearchResultForm extends BaseForm {
         try {
             ProcessService.deleteProcess(processDTO.getId());
             filteredList.remove(processDTO);
-        } catch (DataException | DAOException e) {
+        } catch (DataException | DAOException | IOException e) {
             Helper.setErrorMessage(ERROR_DELETING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },
                     logger, e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -51,7 +51,6 @@ import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.enums.TaskEditType;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.exceptions.DoctypeMissingException;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.exceptions.ProcessGenerationException;

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -88,45 +88,6 @@ public class MetadataEditor {
     }
 
     /**
-     * Remove link to process with ID 'childProcessId' from workpiece of Process 'parentProcess'.
-     *
-     * @param parentProcess Process from which link is removed
-     * @param childProcessId ID of process whose link will be remove from workpiece of parent process
-     * @throws IOException thrown if meta.xml could not be loaded
-     */
-    public static void removeLink(Process parentProcess, int childProcessId) throws IOException {
-        URI metadataFileUri = ServiceManager.getProcessService().getMetadataFileUri(parentProcess);
-        Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metadataFileUri);
-        if (removeLinkRecursive(workpiece.getRootElement(), childProcessId)) {
-            ServiceManager.getFileService().createBackupFile(parentProcess);
-            ServiceManager.getMetsService().saveWorkpiece(workpiece, metadataFileUri);
-        } else {
-            Helper.setErrorMessage("errorDeleting", new Object[] {Helper.getTranslation("link") });
-        }
-    }
-
-    private static boolean removeLinkRecursive(IncludedStructuralElement element, int childId) {
-        IncludedStructuralElement parentElement = null;
-        IncludedStructuralElement linkElement = null;
-        for (IncludedStructuralElement structuralElement : element.getChildren()) {
-            if (Objects.nonNull(structuralElement.getLink()) && Objects.nonNull(structuralElement.getLink().getUri())
-                && structuralElement.getLink().getUri().toString().endsWith("process.id=" + childId)) {
-                parentElement = element;
-                linkElement = structuralElement;
-                break;
-            } else {
-                return removeLinkRecursive(structuralElement, childId);
-            }
-        }
-        // no need to check if 'linkElement' is Null since it is set in the same place as 'parentElement'!
-        if (Objects.nonNull(parentElement)) {
-            parentElement.getChildren().remove(linkElement);
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * Connects two processes by means of a link. The link is sorted as a linked
      * included structural element in a included structural element of the
      * parent process. The order is based on the order number specified by the
@@ -158,6 +119,45 @@ public class MetadataEditor {
         } else {
             children.add(index, includedStructuralElement);
         }
+    }
+
+    /**
+     * Remove link to process with ID 'childProcessId' from workpiece of Process 'parentProcess'.
+     *
+     * @param parentProcess Process from which link is removed
+     * @param childProcessId ID of process whose link will be remove from workpiece of parent process
+     * @throws IOException thrown if meta.xml could not be loaded
+     */
+    public static void removeLink(Process parentProcess, int childProcessId) throws IOException {
+        URI metadataFileUri = ServiceManager.getProcessService().getMetadataFileUri(parentProcess);
+        Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metadataFileUri);
+        if (removeLinkRecursive(workpiece.getRootElement(), childProcessId)) {
+            ServiceManager.getFileService().createBackupFile(parentProcess);
+            ServiceManager.getMetsService().saveWorkpiece(workpiece, metadataFileUri);
+        } else {
+            Helper.setErrorMessage("errorDeleting", new Object[] {Helper.getTranslation("link") });
+        }
+    }
+
+    private static boolean removeLinkRecursive(IncludedStructuralElement element, int childId) {
+        IncludedStructuralElement parentElement = null;
+        IncludedStructuralElement linkElement = null;
+        for (IncludedStructuralElement structuralElement : element.getChildren()) {
+            if (Objects.nonNull(structuralElement.getLink()) && Objects.nonNull(structuralElement.getLink().getUri())
+                    && structuralElement.getLink().getUri().toString().endsWith("process.id=" + childId)) {
+                parentElement = element;
+                linkElement = structuralElement;
+                break;
+            } else {
+                return removeLinkRecursive(structuralElement, childId);
+            }
+        }
+        // no need to check if 'linkElement' is Null since it is set in the same place as 'parentElement'!
+        if (Objects.nonNull(parentElement)) {
+            parentElement.getChildren().remove(linkElement);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -130,6 +130,7 @@ import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMet
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataTypeHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
+import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.metadata.MetadataLock;
 import org.kitodo.production.metadata.copier.CopierData;
 import org.kitodo.production.metadata.copier.DataCopier;
@@ -2466,7 +2467,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         return Math.toIntExact(countDatabaseRows("SELECT COUNT(*) FROM Process WHERE parent_id = " + processId));
     }
 
-    public static void deleteProcess(int processID) throws DAOException, DataException {
+    public static void deleteProcess(int processID) throws DAOException, DataException, IOException {
         Process process = ServiceManager.getProcessService().getById(processID);
         deleteProcess(process);
     }
@@ -2476,7 +2477,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      *
      * @param processToDelete process to delete
      */
-    public static void deleteProcess(Process processToDelete) throws DataException {
+    public static void deleteProcess(Process processToDelete) throws DataException, IOException {
         deleteMetadataDirectory(processToDelete);
 
         processToDelete.getProject().getProcesses().remove(processToDelete);
@@ -2487,6 +2488,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         if (Objects.nonNull(parent)) {
             parent.getChildren().remove(processToDelete);
             processToDelete.setParent(null);
+            MetadataEditor.removeLink(parent, processToDelete.getId());
             ServiceManager.getProcessService().save(processToDelete);
             ServiceManager.getProcessService().save(parent);
         }


### PR DESCRIPTION
When deleting a process that is linked to a parent process (for example deleting a Volume that is child of a MultiVolumeWork), the link to the child process was not removed from the parents processes meta.xml, which led to various other errors later on. The changes in this pull request fix this problem.