### PR TITLE
Remove a cast from an abstract collection to a concrete implementation

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/MetadataGroup.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/MetadataGroup.java
@@ -11,24 +11,26 @@
 
 package org.kitodo.api;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+/**
+ * Metadata grouped together to describe something more complex using subfields.
+ */
 public class MetadataGroup extends Metadata {
-
     /**
-     * The value of the metadata is a list of metadata objects.
+     * The contents of the metadata group.
      */
-    private List<Metadata> group = new ArrayList<>();
+    private Collection<Metadata> group = new HashSet<>();
 
     /**
      * Get the grouped metadata.
      *
-     * @return The grouped metadata.
+     * @return The grouped metadata
      */
-    public List<Metadata> getGroup() {
+    public Collection<Metadata> getGroup() {
         return group;
     }
 
@@ -36,9 +38,9 @@ public class MetadataGroup extends Metadata {
      * Set the grouped metadata.
      *
      * @param group
-     *            the grouped metadata.
+     *            the grouped metadata
      */
-    public void setGroup(List<Metadata> group) {
+    public void setGroup(Collection<Metadata> group) {
         this.group = group;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -532,7 +532,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
             if (optionalDomain.isPresent()) {
                 metadataGroup.setDomain(DOMAIN_TO_MDSEC.get(optionalDomain.get()));
             }
-            metadataGroup.setGroup((ArrayList<Metadata>) metadata);
+            metadataGroup.setGroup(metadata);
             container.metadata.add(metadataGroup);
             copy = false;
         }


### PR DESCRIPTION
[The weakness](https://lgtm.com/projects/g/kitodo/kitodo-production/snapshot/3d43d1d54a249fcbcb6b17a337dd77c3fd9d7af3/files/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java#x1a05841abfe9f4ba:1) was discovered by the LGTM scanner (see issue #320)