### PR TITLE
Prevent Zip Slip attack

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
+++ b/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
@@ -275,6 +275,9 @@ public class KitodoServiceLoader<T> {
                 if (currentJarEntry.getName().contains(RESOURCES_FOLDER)
                         || currentJarEntry.getName().contains(POM_PROPERTIES_FILE)) {
                     File resourceFile = new File(destinationFolder + File.separator + currentJarEntry.getName());
+                    if (!resourceFile.toPath().normalize().startsWith(destinationFolder.toPath())) {
+                        throw new IOException("ZIP file damaged! Invalid entry: " + currentJarEntry.getName());
+                    }
                     if (currentJarEntry.isDirectory()) {
                         resourceFile.mkdirs();
                         continue;


### PR DESCRIPTION
A Zip Slip attack is a security vulnerability, caused by a corrupted ZIP file to overwrite files outside of the directory. A check prevents this now.

[The weakness](https://lgtm.com/projects/g/kitodo/kitodo-production/snapshot/3d43d1d54a249fcbcb6b17a337dd77c3fd9d7af3/files/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java#x9e09eb37c96ff2ce:1) was discovered by the LGTM scanner (see issue #320)