### PR TITLE
Prevent potential XML External Entity attack

### DIFF
--- a/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/XmlResponseHandler.java
+++ b/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/XmlResponseHandler.java
@@ -13,6 +13,7 @@ package org.kitodo.sruimport;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.LinkedList;
 import java.util.Objects;
 
@@ -48,6 +49,11 @@ abstract class XmlResponseHandler {
 
     static {
         documentBuilderFactory.setNamespaceAware(true);
+        try {
+            documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (ParserConfigurationException parserConfigurationException) {
+            throw new UndeclaredThrowableException(parserConfigurationException);
+        }
         xmlOutputter.setFormat(Format.getPrettyFormat());
     }
 


### PR DESCRIPTION
An XML External Entity attack may occur if the received XML contains references to external files, which the parser will download by its own. This may cause various security holes.

[The weakness](https://lgtm.com/projects/g/kitodo/kitodo-production/snapshot/3d43d1d54a249fcbcb6b17a337dd77c3fd9d7af3/files/Kitodo-SRU-Import/src/main/java/org/kitodo/sruimport/XmlResponseHandler.java#x5230156a3adcc412:1) was discovered by the LGTM scanner (see issue #320)