### PR TITLE
resetting parentTempProcess for processes without a parent

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -383,10 +383,10 @@ public class ImportService {
             throw new ProcessGenerationException("Ruleset of template " + template.getId() + " is null!");
         }
         int level = 1;
+        this.parentTempProcess = null;
         while (Objects.nonNull(parentID) && level < importDepth) {
             HashMap<String, String> parentIDMetadata = new HashMap<>();
             parentIDMetadata.put(identifierMetadata, parentID);
-            this.parentTempProcess = null;
             try {
                 Process parentProcess = loadParentProcess(parentIDMetadata, template.getRuleset().getId(), projectId);
                 if (Objects.isNull(parentProcess)) {


### PR DESCRIPTION
the ImportService is holding the parentTempProcess, which can lead to the behaviour of "filling the titelsatzverknüpfungstab" without importing a parent, because the parentTempProcess was set from an earlier import but not reset because setting it to null only happend when a parent was found.

The parentTemptProcess is now reset in any case.