### PR TITLE
Update ElasticSearch to last 5.6.x release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <saxon.version>9.9.1-5</saxon.version>
         <log4j.version>2.12.1</log4j.version>
         <junit.version>5.5.2</junit.version>
-        <elasticsearch.version>5.6.5</elasticsearch.version>
+        <elasticsearch.version>5.6.16</elasticsearch.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>


### PR DESCRIPTION
Installation guide point to last ElasticSearch release which is version `5.6.16` but the Kitodo.Production site is only using version `5.6.5`.

Updating to last 5.6.x release even close some (not all) security issues in ElasticSearch itself or its dependencies.