### PR TITLE
add use to division

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalDivision.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalDivision.java
@@ -1,0 +1,90 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.api.dataeditor.rulesetmanagement;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/*
+ Divisions that have a function.
+ */
+public enum FunctionalDivision {
+
+    /**
+     * Childrens are created by calendar form.
+     */
+    CREATE_CHILDREN_WITH_CALENDAR("createChildrenWithCalendar"),
+    /**
+     * A division which childs are created from this division directly.
+     */
+    CREATE_CHILDREN_FROM_PARENT("createChildrenFromParent");
+    /**
+     * With the logger, text can be written to a log file or to the console.
+     */
+    private static final Logger logger = LogManager.getLogger(FunctionalDivision.class);
+
+    /**
+     * This character string defines how the special field is to be marked in
+     * the ruleset.
+     */
+    private final String mark;
+
+    /**
+     * Since this is an enum, the constructor cannot be called, except from Java
+     * when building the class.
+     *
+     * @param mark
+     *            how the special field is to be marked
+     */
+    private FunctionalDivision(String mark) {
+        this.mark = mark;
+    }
+
+    /**
+     * Returns a string which defines how the special field is to be marked in
+     * the ruleset.
+     *
+     * @return how the special field is to be marked
+     */
+    public String getMark() {
+        return mark;
+    }
+
+    /**
+     * This function is like {@code valueOf(String)}, except that it allows
+     * multiple values in the input string and can return multiple values in the
+     * return value. Unknown strings (misspellings) are reported in logging.
+     *
+     * @param marks
+     *            string to be processed
+     * @return fields
+     */
+    public static Set<FunctionalDivision> valuesOf(String marks) {
+        Set<FunctionalDivision> values = new HashSet<>();
+        for (String mark : marks.split("\\s+", 0)) {
+            for (FunctionalDivision candidate : FunctionalDivision.values()) {
+                if (mark.equals(candidate.mark)) {
+                    values.add(candidate);
+                    break;
+                }
+            }
+            logger.warn("Ruleset declares undefined field use '{}', must be one of: {}", mark,
+                    Arrays.stream(values()).map(FunctionalDivision::toString).collect(Collectors.joining(", ")));
+        }
+        return values;
+    }
+}

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/RulesetManagementInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/RulesetManagementInterface.java
@@ -48,6 +48,16 @@ public interface RulesetManagementInterface {
     Collection<String> getFunctionalKeys(FunctionalMetadata functionalMetadata);
 
     /**
+     * Returns all metadata divisions that are used as the specified functional
+     * divisions.
+     *
+     * @param functionalDivision
+     *            functional division to search for
+     * @return all divisions used as the functional division
+     */
+    Collection<String> getFunctionalDivisions(FunctionalDivision functionalDivision);
+
+    /**
      * Returns all outline elements. The result is a map whose keys are the ID
      * strings of the outline elements. The mapped values are the labels in the
      * language best suited to the given language priority list. This function

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
@@ -28,6 +28,7 @@ import javax.xml.bind.Unmarshaller;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalDivision;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
@@ -71,6 +72,26 @@ public class RulesetManagement implements RulesetManagementInterface {
     @Override
     public List<String> getFunctionalKeys(FunctionalMetadata functionalMetadata) {
         return getIdsOfKeysForSpecialField(ruleset.getKeys(), functionalMetadata);
+    }
+
+    @Override
+    public List<String> getFunctionalDivisions(FunctionalDivision functionalDivision) {
+        return getIdsOfDivisionsForSpecialField(ruleset.getDivisions(), functionalDivision);
+    }
+
+    private List<String> getIdsOfDivisionsForSpecialField(List<Division> divisions,
+            FunctionalDivision functionalDivision) {
+        ArrayList<String> idsOfDivisionsForSpecialField = new ArrayList<>();
+        for (Division division : divisions) {
+            if (Objects.isNull(division.getUse())) {
+                continue;
+            }
+            Set<FunctionalDivision> uses = FunctionalDivision.valuesOf(division.getUse());
+            if (uses.contains(functionalDivision)) {
+                idsOfDivisionsForSpecialField.add(division.getId());
+            }
+        }
+        return idsOfDivisionsForSpecialField;
     }
 
     private List<String> getIdsOfKeysForSpecialField(List<Key> keys, FunctionalMetadata functionalMetadata) {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Division.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Division.java
@@ -44,6 +44,12 @@ public class Division {
     private String dates;
 
     /**
+     * The use of the division.
+     */
+    @XmlAttribute
+    private String use;
+
+    /**
      * The schema in which the part of the date relevant to this division is
      * stored. Apart from the dates built into Java and interpreted by the
      * runtime, there is still the special string “{@code yyyy/yyyy}”, which
@@ -138,5 +144,15 @@ public class Division {
         } else {
             return subdivisionByDate.getYearBegin();
         }
+    }
+
+
+    /**
+     * Returns the use.
+     *
+     * @return the use
+     */
+    public String getUse() {
+        return use;
     }
 }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.DatesSimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
+import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalDivision;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.InputType;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -715,6 +716,9 @@ public class RulesetManagementIT {
         assertThat("Person@LastName was not found!",
             rulesetManagement.getFunctionalKeys(FunctionalMetadata.AUTHOR_LAST_NAME),
             contains("Person@LastName"));
+        assertThat("Periodical was not found!",
+                rulesetManagement.getFunctionalDivisions(FunctionalDivision.CREATE_CHILDREN_FROM_PARENT),
+                contains("Periodical"));
 
         // not existing uses
         assertThat("Something was found!",

--- a/Kitodo-DataEditor/src/test/resources/ruleset.xsd
+++ b/Kitodo-DataEditor/src/test/resources/ruleset.xsd
@@ -49,6 +49,7 @@
         <xs:attribute type="xs:string" name="processTitle"/>
         <xs:attribute type="xs:NMTOKEN" name="dates"/>
         <xs:attribute type="xs:string" name="scheme"/>
+        <xs:attribute type="ruleset:UseDivision" name="use"/>
     </xs:complexType>
 
     <xs:simpleType name="DomainAttribute">
@@ -188,6 +189,22 @@
                             <xs:enumeration value="higherlevelIdentifier"/>
                             <xs:enumeration value="recordIdentifier"/>
                             <xs:enumeration value="title"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:list>
+            </xs:simpleType>
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="UseDivision">
+        <xs:restriction>
+            <xs:simpleType>
+                <xs:list>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                            <xs:enumeration value="createChildrenFromParent"/>
+                            <xs:enumeration value="createChildrenWithCalendar"/>
                         </xs:restriction>
                     </xs:simpleType>
                 </xs:list>

--- a/Kitodo-DataEditor/src/test/resources/testAnExtensiveRulesetCanBeLoaded.xml
+++ b/Kitodo-DataEditor/src/test/resources/testAnExtensiveRulesetCanBeLoaded.xml
@@ -107,7 +107,7 @@
             <label>Article</label>
             <label lang="de">Zeitschriften-Artikel</label>
         </division>
-        <division id="Periodical">
+        <division id="Periodical" use="createChildrenFromParent">
             <label>periodical</label>
             <label lang="de">Zeitschrift</label>
         </division>

--- a/Kitodo/src/test/java/org/kitodo/DummyRulesetManagement.java
+++ b/Kitodo/src/test/java/org/kitodo/DummyRulesetManagement.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
 
+import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalDivision;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
@@ -31,6 +32,11 @@ public class DummyRulesetManagement implements RulesetManagementInterface {
 
     @Override
     public Collection<String> getFunctionalKeys(FunctionalMetadata functionalMetadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getFunctionalDivisions(FunctionalDivision functionalDivision) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Adding a use to division to mark a divsion for special functions.

This is for example needed to show process-create buttons on periodicals or newspapers.