### PR TITLE
Update number of processes to be generated in calender confirm dialog

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.enterprise.context.SessionScoped;
+import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 import javax.xml.transform.TransformerException;
 
@@ -64,7 +64,7 @@ import org.xml.sax.SAXException;
  * enter the course of appearance of a newspaper.
  */
 @Named("CalendarForm")
-@SessionScoped
+@ViewScoped
 public class CalendarForm implements Serializable {
     private static final Logger logger = LogManager.getLogger(CalendarForm.class);
 
@@ -184,6 +184,9 @@ public class CalendarForm implements Serializable {
     public void setGranularity(Granularity granularity) {
         this.granularity = granularity;
         course.splitInto(granularity);
+        if (Objects.nonNull(PrimeFaces.current())) {
+            PrimeFaces.current().ajax().update("createProcessesConfirmDialog");
+        }
     }
 
     /**

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1278,7 +1278,8 @@ Popup dialogs
     text-align: left;
 }
 
-#deleteConfirmDialog .ui-confirm-dialog-severity.ui-icon-alert {
+.ui-dialog.confirm-delete .ui-confirm-dialog-severity.ui-icon,
+.ui-dialog.confirm-delete .ui-confirm-dialog-severity.ui-icon-alert {
     display: none;
 }
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/createProcessesConfirmDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/createProcessesConfirmDialog.xhtml
@@ -1,0 +1,51 @@
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+    <p:confirmDialog header="#{msgs['granularity.create']}"
+                     global="true"
+                     showEffect="fade"
+                     hideEffect="fade"
+                     styleClass="confirm-delete"
+                     id="createProcessesConfirmDialog"
+                     style="padding-left: var(--default-double-size); padding-right: var(--default-double-size);"
+                     message="#{CalendarForm.formatString('granularity.info.noNumberOfPages', CalendarForm.course.getNumberOfProcesses())}"
+                     widgetVar="createProcessesConfirmDialog">
+        <h:form>
+            <h:panelGroup styleClass="ui-confirm-dialog-message"
+                          style="display: block; margin-left: -6px; margin-top: -16px;">
+                <h:outputText value="#{msgs.confirm}"/>
+            </h:panelGroup>
+            <p:commandButton
+                    id="yesButton"
+                    value="#{msgs.yes}"
+                    styleClass="ui-confirmdialog-yes primary right"
+                    action="#{CalendarForm.createProcesses}"
+                    icon="fa fa-check fa-lg"
+                    iconPos="right"
+                    immediate="true"/>
+            <p:commandButton
+                    id="noButton"
+                    value="#{msgs.no}"
+                    type="button"
+                    styleClass="ui-confirmdialog-no secondary right"
+                    onclick="PF('createProcessesConfirmDialog').hide();"
+                    iconPos="right"
+                    icon="fa fa-times fa-lg" />
+        </h:form>
+    </p:confirmDialog>
+</ui:composition>

--- a/Kitodo/src/main/webapp/pages/calendarEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/calendarEdit.xhtml
@@ -27,16 +27,13 @@
             <h:outputText value="#{msgs.calendar}"/>
         </h3>
         <p:commandButton id="save"
-                         action="#{CalendarForm.createProcesses}"
                          value="#{msgs['granularity.create']}"
                          icon="fa fa-floppy-o fa-lg"
                          iconPos="right"
-                         onclick="setConfirmUnload(false)"
-                         update="notifications">
-            <p:confirm id="calendarCreateProcessesConfirm"
-                       header="#{msgs['granularity.create']}"
-                       message="#{CalendarForm.formatString('granularity.info.noNumberOfPages', CalendarForm.course.getNumberOfProcesses())} #{msgs.confirm}"/>
-        </p:commandButton>
+                         actionListener="#{CalendarForm.setGranularity(CalendarForm.granularity)}"
+                         onclick="setConfirmUnload(false);"
+                         oncomplete="PF('createProcessesConfirmDialog').show();"
+                         update="notifications"/>
         <p:commandButton value="#{msgs.fileDownload}"
                          icon="fa fa-download fa-lg"
                          iconPos="right"
@@ -88,6 +85,7 @@
 
     <ui:define name="dialog">
         <ui:include src="/WEB-INF/templates/includes/calendarEdit/uploadFileDialog.xhtml"/>
+        <ui:include src="/WEB-INF/templates/includes/calendarEdit/createProcessesConfirmDialog.xhtml"/>
         <ui:include src="/WEB-INF/templates/includes/calendarEdit/calendarSettingsDialog.xhtml"/>
     </ui:define>
 


### PR DESCRIPTION
- Replace `p:confirm` with `p:confirmDialog` in calendar to be able to update number of processes to be generated
- change `CalendarForm.java` from `SessionScoped` to `ViewScoped`. **Note**: this resets the calendar on page reload but also prevents the calendar from keeping values from previous visits to the calendar page.

Fixes #3230 