### PR TITLE
Show updated ORDER attribute after drag'n'drop of structural element in tree

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1256,7 +1256,6 @@ public class StructurePanel implements Serializable {
                         preserveLogicalAndPhysical();
                     }
                     this.dataEditor.getGalleryPanel().updateStripes();
-                    return;
                 } else {
                     Helper.setErrorMessage(Helper.getTranslation("dataEditor.childNotContainedError",
                             Collections.singletonList(dragNode.getLabel())));
@@ -1290,7 +1289,6 @@ public class StructurePanel implements Serializable {
                 MediaUnit parentUnit = dragParents.get(dragParents.size() - 1);
                 if (parentUnit.getChildren().contains(dragUnit)) {
                     preservePhysical();
-                    return;
                 } else {
                     Helper.setErrorMessage(Helper.getTranslation("dataEditor.childNotContainedError",
                             Collections.singletonList(dragUnit.getType())));


### PR DESCRIPTION
ORDER attribute of pages in structural elements that were moved via drag'n'drop in the combined structure tree in the metadata editor where not updated. This PR fixes that.