### PR TITLE
correct date setting

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Block.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Block.java
@@ -489,6 +489,7 @@ public class Block {
      */
     public void setFirstAppearanceDate(Date firstAppearance) {
         if (Objects.nonNull(firstAppearance)) {
+            firstAppearance.setHours(5);
             setFirstAppearance(firstAppearance.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
         }
     }
@@ -531,6 +532,7 @@ public class Block {
      */
     public void setLastAppearanceDate(Date lastAppearance) {
         if (Objects.nonNull(lastAppearance)) {
+            lastAppearance.setHours(5);
             setLastAppearance(lastAppearance.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
         }
     }


### PR DESCRIPTION
All dates before 01.01.1970 are calculated with negativ millisecond values. Du to convertion from java.Date to java.time a mistake happens, because our dates ar always set to midnight. With negative values it skips to the previous date.
This PR sets the time to 5 o'clock so it won't skip to the previous day.