### PR TITLE
change colours to specification

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -404,7 +404,7 @@ public enum ParameterCore implements ParameterInterface {
      * Colours used to represent the issues in the calendar editor.
      */
     ISSUE_COLOURS(new Parameter<>("issue.colours",
-            "#CC0000;#0000AA;#33FF00;#FF9900;#5555FF;#006600;#AAAAFF;#000055;#0000FF;#FFFF00;#000000")),
+            "#f94a15;#0071bc;#42ba37;#ee7e5b;#1e3946;#ca2f00;#AAAAFF;#000055;#0000FF;#FFFF00;#000000")),
 
     /**
      * Number of pages per process below which the features in the granularity

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -374,7 +374,7 @@ validateProzessTitelRegex=[\\w-]*
 validateIdentifierRegex=[\\w\\|-]
 
 # Colours used to represent the issues in the calendar editor
-issue.colours=#CC0000;#0000AA;#33FF00;#FF9900;#5555FF;#006600;#AAAAFF;#000055;#0000FF;#FFFF00;#000000
+issue.colours=#f94a15;#0071bc;#42ba37;#ee7e5b;#1e3946;#ca2f00;#AAAAFF;#000055;#0000FF;#FFFF00;#000000
 
 # Minimal average number of pages per process in newspaper process creation
 numberOfPages.minimum=1

--- a/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
@@ -300,7 +300,7 @@ validateIdentifierRegex=[\\w\\|-]
 # Mass process generation
 # -----------------------------------
 # Colours used to represent the issues in the calendar editor
-issue.colours=#CC0000;#0000AA;#33FF00;#FF9900;#5555FF;#006600;#AAAAFF;#000055;#0000FF;#FFFF00;#000000
+issue.colours=#f94a15;#0071bc;#42ba37;#ee7e5b;#1e3946;#ca2f00;#AAAAFF;#000055;#0000FF;#FFFF00;#000000
 # Minimal average number of pages per process in newspaper process creation
 numberOfPages.minimum=1
 # -----------------------------------


### PR DESCRIPTION
This is changing the colours in the calendar to the ones of the kitodo specification
![calendarColours](https://user-images.githubusercontent.com/22615787/76066330-b2063480-5f8d-11ea-9e21-6de94bd714af.PNG)
