### PR TITLE
Fix metadata synchronization with separate structure

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -632,13 +632,21 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
                 if (structureTreeNode.getDataObject() instanceof IncludedStructuralElement
                         && selectedStructure.isPresent()) {
                     // Logical structure element selected
-                    IncludedStructuralElement structuralElement = selectedStructure.get();
-                    getSelectedMedia().clear();
-                    if (!structuralElement.getViews().isEmpty()) {
-                        ArrayList<View> views = new ArrayList<>(structuralElement.getViews());
-                        if (Objects.nonNull(views.get(0))) {
-                            updatePhysicalStructureTree(views.get(0));
+                    if (structurePanel.isSeparateMedia()) {
+                        IncludedStructuralElement structuralElement = selectedStructure.get();
+                        if (!structuralElement.getViews().isEmpty()) {
+                            ArrayList<View> views = new ArrayList<>(structuralElement.getViews());
+                            if (Objects.nonNull(views.get(0))) {
+                                updatePhysicalStructureTree(views.get(0));
+                                if (updateGallery) {
+                                    updateGallery(views.get(0));
+                                }
+                            }
+                        } else {
+                            updatePhysicalStructureTree(null);
                         }
+                    } else {
+                        getSelectedMedia().clear();
                     }
                 } else if (structureTreeNode.getDataObject() instanceof View) {
                     // Page selected in logical tree
@@ -679,9 +687,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
 
     private void updatePhysicalStructureTree(View view) {
         GalleryMediaContent galleryMediaContent = this.galleryPanel.getGalleryMediaContent(view);
-        if (Objects.nonNull(galleryMediaContent)) {
-            structurePanel.updatePhysicalNodeSelection(galleryMediaContent);
-        }
+        structurePanel.updatePhysicalNodeSelection(galleryMediaContent);
     }
 
     private void updateGallery(View view) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -480,9 +480,11 @@ public class GalleryPanel {
     }
 
     GalleryMediaContent getGalleryMediaContent(View view) {
-        for (GalleryMediaContent galleryMediaContent : this.medias) {
-            if (galleryMediaContent.getView().getMediaUnit().equals(view.getMediaUnit())) {
-                return galleryMediaContent;
+        if (Objects.nonNull(view)) {
+            for (GalleryMediaContent galleryMediaContent : this.medias) {
+                if (galleryMediaContent.getView().getMediaUnit().equals(view.getMediaUnit())) {
+                    return galleryMediaContent;
+                }
             }
         }
         return null;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -780,16 +780,12 @@ public class StructurePanel implements Serializable {
             if (Objects.nonNull(previouslySelectedPhysicalNode)) {
                 previouslySelectedPhysicalNode.setSelected(false);
             }
-            if (Objects.nonNull(selectedPhysicalNode)) {
+            if (Objects.nonNull(selectedPhysicalNode) && !selectedPhysicalNode.equals(treeNode)) {
                 selectedPhysicalNode.setSelected(false);
             }
-            if (Objects.nonNull(physicalTree)) {
-                if (Objects.nonNull(treeNode)) {
-                    setSelectedPhysicalNode(treeNode);
-                    this.dataEditor.getMetadataPanel().showPhysical(this.dataEditor.getSelectedMediaUnit());
-                } else {
-                    Helper.setErrorMessage("Unable to update Node selection in physical structure!");
-                }
+            if (Objects.nonNull(physicalTree) && Objects.nonNull(treeNode)) {
+                setSelectedPhysicalNode(treeNode);
+                this.dataEditor.getMetadataPanel().showPhysical(this.dataEditor.getSelectedMediaUnit());
             }
         }
     }
@@ -877,6 +873,9 @@ public class StructurePanel implements Serializable {
     }
 
     private TreeNode updatePhysicalNodeSelectionRecursive(GalleryMediaContent galleryMediaContent, TreeNode treeNode) {
+        if (Objects.isNull(galleryMediaContent)) {
+            return null;
+        }
         TreeNode matchingTreeNode = null;
         for (TreeNode currentTreeNode : treeNode.getChildren()) {
             if (currentTreeNode.getChildCount() < 1 && treeNodeMatchesGalleryMediaContent(galleryMediaContent, currentTreeNode)) {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -35,10 +35,11 @@
                 dragdropScope="logicalTree">
             <p:ajax event="select"
                     listener="#{DataEditorForm.structurePanel.treeLogicalSelect}"
-                    oncomplete="scrollToSelectedThumbnail();initializeImage()"
+                    oncomplete="scrollToSelectedThumbnail();changeToMapView()"
                     update="@(.stripe)
                             @(.thumbnail)
                             galleryHeadingWrapper
+                            imagePreviewForm:mediaViewData
                             structureTreeForm:contextMenuLogicalTree
                             structureTreeForm:physicalTree
                             metadataAccordion:logicalMetadataWrapperPanel"/>


### PR DESCRIPTION
- Fixes an error where the gallery would not be updated when the user selected the media unit in the physical structure tree
- Fixes an error where the media unit was deselected in the physical structure tree when the users selected the same logical structure twice
- Fixes an error where the previous selection in the physical tree was not deselected when the user selected a logical structure without any physical structures assigned