### PR TITLE
Check for existing parent process during import even with import depth 1

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -244,7 +244,8 @@
                                          value="#{ProcessForm.getAllParentProcesses(process.id)}"
                                          rendered="#{process.getParentID() ne 0}">
                                 <p:column>
-                                    <h:outputText value="#{parent.getTitle()}"/>
+                                    <h:outputText value="#{parent.getTitle()}"
+                                                  title="#{parent.getTitle()}"/>
                                 </p:column>
                                 <p:column styleClass="actionsColumn">
                                     <h:link outcome="processEdit"


### PR DESCRIPTION
Always try to find a parent process in the database for the last process in the process hierarchy to link to during OPAC import, even if `importDepth=1`.

Fixes #3257