### PR TITLE
Do not save empty metadata entries

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -79,6 +79,10 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
 
     @Override
     public Collection<Metadata> getMetadata() throws InvalidMetadataValueException {
+        value = value.trim();
+        if (value.isEmpty()) {
+            return Collections.emptyList();
+        }
         /* if (!settings.isValid(value)) {
             throw new InvalidMetadataValueException(label, value);
         }*/


### PR DESCRIPTION
This is only a small fix, but currently empty metadata is stored internally for fields that are shown empty:

``` xml
<ns3:metadata name="slub_linktext">Katalognachweis</ns3:metadata> <!-- ok -->
<ns3:metadata name="CatalogIDSourceKXP"></ns3:metadata> <!-- should not be -->
<ns3:metadata name="shelfmarksource"></ns3:metadata> <!-- should not be -->
<ns3:metadata name="PublicationYearSorting"></ns3:metadata> <!-- should not be -->
<ns3:metadata name="TSL_ATS">Aben</ns3:metadata> <!-- ok -->
<ns3:metadata name="PublicationStart">1312</ns3:metadata> <!-- ok -->
```
This will fix this.