### PR TITLE
Bring back KitodoScript button for copyData

### DIFF
--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -25,6 +25,7 @@ calendar.upload.missingMandatoryElement=Ein erforderliches XML-Element konnte ni
 calendar.upload.missingMandatoryValue=Ein erforderlicher Wert konnte nicht gefunden werden.
 calendar.upload.overlappingDateRanges=Der Erscheinungsverlauf konnte nicht importiert werden, da sich Datumsbereiche von Bl\u00F6cken \u00FCberlappen\:
 catalogError=Fehler bei Abfrage von Katalog \u201E{0}\u201C
+copyDataError=Fehler beim Kopieren der Daten
 createProcessForm.createNewProcess.noInsertionPositionSelected=Es wurde keine Position f\u00FCr die Titelsatzverkn\u00FCpfung ausgew\u00E4hlt.
 createProcessForm.createNewProcess.titleRecordOpen=Der Vorgang kann nicht erstellt werden, weil der Titelsatz gerade von {0} bearbeitet wird.
 errorChangeTaskStatus=Fehler beim \u00E4ndern des Aufgabenstatus ''{0}'' f\u00FCr den Prozess mit der ID {1}.

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -25,6 +25,7 @@ calendar.upload.missingMandatoryElement=A mandatory XML element could not be fou
 calendar.upload.missingMandatoryValue=A mandatory value could not be found.
 calendar.upload.overlappingDateRanges=Due to overlapping date ranges of blocks, the course of appearance could not be imported\:
 catalogError=Error querying OPAC \u201E{0}\u201C
+copyDataError=Error while copying the data
 createProcessForm.createNewProcess.noInsertionPositionSelected=No title record linking position was selected.
 createProcessForm.createNewProcess.titleRecordOpen=The process cannot be created because the title record is being edited by {0}.
 errorChangeTaskStatus=Error change task status ''{0}'' for process with ID {1}.

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/executeScriptSelectedPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/executeScriptSelectedPopup.xhtml
@@ -65,6 +65,9 @@
                                 <p:commandButton value="exportDms"
                                                  update="executeScriptSelectedForm:selectionScriptFieldTextArea"
                                                  onclick="document.getElementById('executeScriptSelectedForm:selectionScriptFieldTextArea').value='action:exportDms exportImages:false'"/>
+                                <p:commandButton value="copyData"
+                                                 update="executeScriptSelectedForm:selectionScriptFieldTextArea"
+                                                 onclick="document.getElementById('executeScriptSelectedForm:selectionScriptFieldTextArea').value='action:copyData &lt;rule(s)&gt;'"/>
                                 <p:commandButton value="generateImages"
                                                  update="executeScriptSelectedForm:selectionScriptFieldTextArea"
                                                  onclick="document.getElementById('executeScriptSelectedForm:selectionScriptFieldTextArea').value='action:generateImages folders:all|jpgs/max,jpgs/thumbs,... images:missingOrDamaged|missing|all'"/>


### PR DESCRIPTION
This was introduced in version 2 after the fork. Therefore the code was adopted. It needed minor adjustments.