### PR TITLE
Fix illegal character in path on Windows'

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -448,8 +448,12 @@ public class ExportDms extends ExportMets {
                 .collect(Collectors.toList());
         VariableReplacer variableReplacer = new VariableReplacer(null, null, process, null);
 
+        String uriToDestination = destination.toString();
+        if (!uriToDestination.endsWith("/")) {
+            uriToDestination = uriToDestination.concat("/");
+        }
         for (Subfolder processDir : processDirs) {
-            URI dstDir = new URI(destination.toString() + File.separator
+            URI dstDir = new URI(uriToDestination
                     + variableReplacer.replace(processDir.getFolder().getRelativePath()));
             fileService.createDirectories(dstDir);
 


### PR DESCRIPTION
URI segments must be concatenated using forward slashes only, so using `File.separator` caused an error on Windows systems.