### PR TITLE
Print an error message if something wasn’t found

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -204,7 +205,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             selectedMedia = new LinkedList<>();
             init();
             openProcesses.put(process.getId(), user);
-        } catch (IOException | DAOException | InvalidImagesException e) {
+        } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
             return referringView;
         }


### PR DESCRIPTION
The display of a white page for the metadata editor was caused by a missing entry in `kitodo_fileFormats.xml` because the exception was not caught. This will fix this.

Fixes #3297