### PR TITLE
Use MIME type which is included in the distribution

### DIFF
--- a/Kitodo/setup/default.sql
+++ b/Kitodo/setup/default.sql
@@ -101,7 +101,7 @@ INSERT INTO `projectfilegroups` (`ProjectFileGroupID`, `name`, `path`, `mimetype
 (1, 'MAX', 'http://www.example.com/content/$(meta.CatalogIDDigital)/jpgs/max/', 'image/jpeg', 'jpg', 1, '', 0),
 (2, 'DEFAULT', 'http://www.example.com/content/$(meta.CatalogIDDigital)/jpgs/default/', 'image/jpeg', 'jpg', 1, '', 0),
 (3, 'THUMBS', 'http://www.example.com/content/$(meta.CatalogIDDigital)/jpgs/thumbs/', 'image/jpeg', 'jpg', 1, '', 0),
-(4, 'FULLTEXT', 'http://www.example.com/content/$(meta.CatalogIDDigital)/ocr/alto/', 'text/xml', 'xml', 1, '', 0),
+(4, 'FULLTEXT', 'http://www.example.com/content/$(meta.CatalogIDDigital)/ocr/alto/', 'application/alto+xml', 'xml', 1, '', 0),
 (5, 'DOWNLOAD', 'http://www.example.com/content/$(meta.CatalogIDDigital)/pdf/', 'application/pdf', 'pdf', 1, '', 0);
 /*!40000 ALTER TABLE `projectfilegroups` ENABLE KEYS */;
 


### PR DESCRIPTION
This is the cause of the error #3297. The file `kitodo_fileFormats.xml` in the `kitodo-production-3.1.0-config.zip` of the release does not contain a definition for `text/xml`. In the project configuration this is not noticeable, instead the first definition from `kitodo_fileFormats.xml` is displayed, which would happen to be the correct one.

Please note that file [master:Kitodo/src/main/resources/kitodo_fileFormats.xml](https://github.com/kitodo/kitodo-production/blob/master/Kitodo/src/main/resources/kitodo_fileFormats.xml) **does contain** this definition, so the error does not occur when using the configuration file from the repository.