### PR TITLE
Set sort helper status on administrative task status manipulation

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -205,7 +205,7 @@ public class ProcessForm extends TemplateBaseForm {
             }
 
             try {
-                ServiceManager.getProcessService().save(this.process);
+                workflowControllerService.updateProcessSortHelperStatus(this.process);
                 return processListPath;
             } catch (DataException e) {
                 Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },
@@ -268,7 +268,7 @@ public class ProcessForm extends TemplateBaseForm {
 
     /**
      * If processes are generated with calendar.
-     * 
+     *
      * @param processDTO
      *            the process dto to check.
      * @return true if processes are created with calendar, false otherwise
@@ -709,6 +709,7 @@ public class ProcessForm extends TemplateBaseForm {
             try {
                 workflowControllerService.setTasksStatusUp(processForStatus);
                 ServiceManager.getProcessService().save(processForStatus);
+                workflowControllerService.updateProcessSortHelperStatus(processForStatus);
             } catch (DataException | IOException e) {
                 Helper.setErrorMessage("errorChangeTaskStatus",
                     new Object[] {Helper.getTranslation("up"), processForStatus.getId() }, logger, e);
@@ -735,6 +736,7 @@ public class ProcessForm extends TemplateBaseForm {
             try {
                 workflowControllerService.setTasksStatusDown(processForStatus);
                 ServiceManager.getProcessService().save(processForStatus);
+                workflowControllerService.updateProcessSortHelperStatus(processForStatus);
             } catch (DataException e) {
                 Helper.setErrorMessage("errorChangeTaskStatus",
                     new Object[] {Helper.getTranslation("down"), processForStatus.getId() }, logger, e);
@@ -747,16 +749,14 @@ public class ProcessForm extends TemplateBaseForm {
      */
     public void setTaskStatusUp() throws DataException, IOException {
         workflowControllerService.setTaskStatusUp(this.task);
-        save();
         ProcessService.deleteSymlinksFromUserHomes(this.task);
     }
 
     /**
      * Task status down.
      */
-    public void setTaskStatusDown() {
+    public void setTaskStatusDown() throws DataException {
         workflowControllerService.setTaskStatusDown(this.task);
-        save();
         ProcessService.deleteSymlinksFromUserHomes(this.task);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -81,7 +81,7 @@ public class WorkflowControllerService {
      *            to change status up
      */
     public void setTaskStatusUp(Task task) throws DataException, IOException {
-        setTaskStatusUp(Arrays.asList(task));
+        setTaskStatusUp(Collections.singletonList(task));
     }
 
     /**
@@ -111,8 +111,8 @@ public class WorkflowControllerService {
      * @param task
      *            to change status down
      */
-    public void setTaskStatusDown(Task task) {
-        setTaskStatusDown(Arrays.asList(task));
+    public void setTaskStatusDown(Task task) throws DataException {
+        setTaskStatusDown(Collections.singletonList(task));
     }
 
     /**
@@ -672,7 +672,7 @@ public class WorkflowControllerService {
      * @param process
      *            object
      */
-    private void updateProcessSortHelperStatus(Process process) throws DataException {
+    public void updateProcessSortHelperStatus(Process process) throws DataException {
         try {
             process = ServiceManager.getProcessService().getById(process.getId());
         } catch (DAOException e) {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -298,7 +298,8 @@
 
         </p:dataTable>
         <div id="dropDownMenus">
-            <p:commandButton id="actionsButton" value="#{msgs.possibleActions}" styleClass="secondary" icon="fa fa-sort" iconPos="right"/>
+            <p:commandButton id="actionsButton" value="#{msgs.possibleActions}" styleClass="secondary"
+                             icon="fa fa-sort" iconPos="right" process="@this"/>
             <p:menu overlay="true" trigger="processesTabView:processesForm:actionsButton" my="left bottom" at="left top">
                     <p:menuitem id="processingStatusUpSelection"
                                 value="#{msgs.processingStatusUp}"


### PR DESCRIPTION
Fixes finished processes not being hidden from process list if their task status and progress have been set via `taskStatusUp` action instead of accepting and closing tasks via the workflow.