### PR TITLE
Update icons on mass import buttons

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1150,6 +1150,28 @@ Import form
     margin-bottom: var(--default-double-size);
 }
 
+#fileMassImportForm .ui-panelgrid-cell,
+#textMassImportForm .ui-panelgrid-cell {
+    padding-left: var(--default-full-size);
+}
+
+#fileMassImportForm .ui-fileupload-buttonbar {
+    padding: 0;
+}
+
+#fileMassImportForm .ui-fileupload-buttonbar .ui-button {
+    margin-right: var(--default-full-size);
+}
+
+#fileMassImportForm .ui-fileupload-choose .ui-button-text {
+    padding-top: 10px;
+}
+
+#textMassImportForm\:importFromText {
+    margin-left: var(--default-full-size);
+    vertical-align: top;
+}
+
 /*----------------------------------------------------------------------
 Calendar
 ----------------------------------------------------------------------*/

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/fileMassImport.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/fileMassImport.xhtml
@@ -31,7 +31,15 @@
         </p:selectOneMenu>
     </div>
         <div>
-            <p:fileUpload value="#{MassImportForm.file}" rendered="#{MassImportForm.selectedCatalog ne null}" fileUploadListener="#{MassImportForm.handleFileUpload}" allowTypes="/(\.|\/)(csv)$/" skinSimple="true"/>
+            <p:fileUpload value="#{MassImportForm.file}"
+                          rendered="#{MassImportForm.selectedCatalog ne null}"
+                          fileUploadListener="#{MassImportForm.handleFileUpload}"
+                          allowTypes="/(\.|\/)(csv)$/"
+                          skinSimple="true"
+                          uploadLabel="#{msgs.massImport}"
+                          chooseIcon="fa fa-plus fa-lg"
+                          uploadIcon="fa fa-download fa-lg"
+                          cancelIcon="fa fa-times fa-lg"/>
         </div>
     </p:row>
     </p:panelGrid>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/textMassImport.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/textMassImport.xhtml
@@ -36,7 +36,7 @@
                     </p:inputTextarea>
                     <p:commandButton id="importFromText" disabled="#{MassImportForm.ppnString eq null}"
                                      value="#{msgs.massImport}"
-                                     icon="fa fa-align-center"
+                                     icon="fa fa-download fa-lg"
                                      iconPos="right"
                                      action="#{MassImportForm.importFromText}"/>
                 </div>


### PR DESCRIPTION
### old:
<img width="334" alt="Bildschirmfoto 2020-04-07 um 21 07 07" src="https://user-images.githubusercontent.com/19183925/78709411-e87bfa00-7913-11ea-927d-02dbb798d963.png">

### new:
<img width="409" alt="Bildschirmfoto 2020-04-07 um 21 06 54" src="https://user-images.githubusercontent.com/19183925/78709434-f03b9e80-7913-11ea-82a9-552b3a30e057.png">
