### PR TITLE
Fix thumbnails not being displayed

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -159,13 +159,13 @@ public class GalleryPanel {
     public StreamedContent getPreviewData() {
         FacesContext context = FacesContext.getCurrentInstance();
         if (context.getCurrentPhaseId() != PhaseId.RENDER_RESPONSE) {
-            String id = context.getExternalContext().getRequestParameterMap().get("id");
+            String id = context.getExternalContext().getRequestParameterMap().get("mediaId");
             GalleryMediaContent mediaContent = previewImageResolver.get(id);
             if (Objects.nonNull(mediaContent)) {
                 logger.trace("Serving image request {}", id);
                 return mediaContent.getPreviewData();
             }
-            logger.debug("Cannot serve image request, id = {}", id);
+            logger.debug("Cannot serve image request, mediaId = {}", id);
         }
         return new DefaultStreamedContent();
     }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -120,7 +120,7 @@
                                                        a:data-stripe="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe)}">
                                             <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
                                                             rendered="#{media.showingInPreview}">
-                                                <f:param name="id"
+                                                <f:param name="mediaId"
                                                          value="#{media.id}" />
                                                 <f:param name="process"
                                                          value="#{DataEditorForm.process.id}"/>
@@ -205,7 +205,7 @@
                                                     <!-- only render those pages that are not assigned to a stripe (structure) here! -->
                                                     <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
                                                                     rendered="#{media.showingInPreview}">
-                                                        <f:param name="id"
+                                                        <f:param name="mediaId"
                                                                  value="#{media.id}"/>
                                                         <f:param name="process"
                                                                  value="#{DataEditorForm.process.id}"/>
@@ -314,7 +314,7 @@
                                                            a:data-order="#{media.order}">
                                                 <h:outputText><p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
                                                                               rendered="#{media.showingInPreview}">
-                                                    <f:param name="id"
+                                                    <f:param name="mediaId"
                                                              value="#{media.id}" />
                                                     <f:param name="process"
                                                              value="#{DataEditorForm.process.id}"/>


### PR DESCRIPTION
HTTP requests return a 403 "forbidden" if the request URL contains an `id` parameter whose value is not purely numerical:
https://github.com/kitodo/kitodo-production/blob/63413321fa7767e0e077466a2f656e9d0ab0aba0/Kitodo/src/main/java/org/kitodo/production/security/SecurityObjectAccessFilter.java#L58

Therefore, the thumbnails in the metadata editor gallery now use a different query parameter (`mediaId`) for which this restriction does not apply.

Fixes #3437  