### PR TITLE
Consistently use relative file paths internally

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -997,7 +997,7 @@ public class FileService {
         }
         Map<String, Map<Subfolder, URI>> mediaToAdd = new TreeMap<>(new MetadataImageComparator());
         for (Subfolder subfolder : subfolders.values()) {
-            for (Entry<String, URI> element : subfolder.listContents().entrySet()) {
+            for (Entry<String, URI> element : subfolder.listContents(false).entrySet()) {
                 mediaToAdd.computeIfAbsent(element.getKey(), any -> new HashMap<>(mapCapacity));
                 mediaToAdd.get(element.getKey()).put(subfolder, element.getValue());
             }


### PR DESCRIPTION
The wrong behavior was as follows: If files were found when searching for new media, they were written to the METS file with an absolute path. The next time the file was opened, the absolute paths were then corrected to relative (a function that is available for dealing with 2.x files that contain full paths). Now the paths are written relatively to the file from the very beginning.

Fixes #3385