### PR TITLE
Fix issue with saving workflows

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
@@ -500,4 +500,16 @@ public class WorkflowForm extends BaseForm {
     public String getLanguage() {
         return ServiceManager.getUserService().getCurrentUser().getLanguage();
     }
+
+    /**
+     * Set language.
+     *
+     * @param language as String
+     */
+    public void setLanguage(String language) {
+        // We don't need to do anything. The language value is written into a hidden input field for the localization
+        // of the editor. On saving the workflow form it gets submitted again. Therfore, a setter is expected and we
+        // only need it for completeness sake. If we find a better way to get the language value into the editor's JS
+        // we should do so. :)
+    }
 }


### PR DESCRIPTION
PR #3460 added a new `language` property to the `WorkflowForm` that gets rendered into a hidden input field (https://github.com/kitodo/kitodo-production/pull/3460/commits/5eab6818b47f72566c55bd7174b82c51a326b5b3). If you now save a workflow you'll get an error because the new field gets submitted by the request. The form doesn't know how to handle this property though.

I added a setter for the `language` field for completeness sake. It doesn't do anything and just enables saving again. The same logic applies to the `roleID`-property in the `WorkflowForm`. It only exists because it gets submitted via a hidden `select`-element although it is not necessary for saving a workflow at all.

If we had a better way of getting information into the editor's JS we should do so. But I have no idea so this has to be the way.

