### PR TITLE
Fix required attribute of catalog selection

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/fileMassImport.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/fileMassImport.xhtml
@@ -22,9 +22,10 @@
     <div>
         <p:outputLabel for="catalogueSelect"
                        value="#{msgs['newProcess.catalogueSearch.catalogue']}"/>
-        <p:selectOneMenu id="catalogueSelect"
+        <p:selectOneMenu id="catalogueSelect" required="true"
                          value="#{MassImportForm.selectedCatalog}">
-            <f:selectItem itemValue="#{null}" itemLabel="-- #{msgs.selectCatalog} --" noSelectionOption="true"/>
+            <f:selectItem itemValue="#{null}" itemLabel="-- #{msgs.selectCatalog} --" noSelectionOption="true"
+                          itemDisabled="true"/>
             <f:selectItems value="#{CreateProcessForm.importDialog.catalogs}" var="catalog" itemLabel="#{catalog}"
                            itemValue="#{catalog}"/>
             <p:ajax update="fileMassImportForm"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/textMassImport.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/textMassImport.xhtml
@@ -24,7 +24,8 @@
                                    value="#{msgs['newProcess.catalogueSearch.catalogue']}"/>
                     <p:selectOneMenu id="catalogueSelect" required="true"
                                      value="#{MassImportForm.selectedCatalog}">
-                        <f:selectItem itemValue="#{null}" itemLabel="-- #{msgs.selectCatalog} --" noSelectionOption="true"/>
+                        <f:selectItem itemValue="#{null}" itemLabel="-- #{msgs.selectCatalog} --"
+                                      noSelectionOption="true" itemDisabled="true"/>
                         <f:selectItems value="#{CreateProcessForm.importDialog.catalogs}" var="step" itemLabel="#{step}"
                                        itemValue="#{step}"/>
                         <p:ajax update="textMassImportForm"/>


### PR DESCRIPTION
Deactivate `noSelectionOption` in MassImport catalog selection lists after a catalog has been selected. This prevents incorrect validation errors currently being triggered when switching back to the `noSelectionOption` after selecting a valid OPAC (see screenshot)

<img width="780" alt="Bildschirmfoto 2020-04-22 um 10 41 45" src="https://user-images.githubusercontent.com/19183925/79961502-1cfcc380-8487-11ea-87be-6378cca412c7.png">
