### PR TITLE
Remove KitodoScript button "add user"

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/executeScriptSelectedPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/executeScriptSelectedPopup.xhtml
@@ -32,9 +32,6 @@
                                   styleClass="dialogFieldWrapper kitodoScript">
                         <div>
                             <div>
-                                <p:commandButton value="addUser"
-                                                 update="executeScriptSelectedForm:selectionScriptFieldTextArea"
-                                                 onclick="document.getElementById('executeScriptSelectedForm:selectionScriptFieldTextArea').value='action:addUser &quot;steptitle:TITLE_STEP&quot; username:USER_NAME'"/>
                                 <p:commandButton value="addRole"
                                                  update="executeScriptSelectedForm:selectionScriptFieldTextArea"
                                                  onclick="document.getElementById('executeScriptSelectedForm:selectionScriptFieldTextArea').value='action:addRole &quot;steptitle:TITLE_STEP&quot; group:GROUP_NAME'"/>


### PR DESCRIPTION
Function "add user" doesn’t make sense in 3.x any more, because users cannot be directly assigned to tasks (only roles can). There is no backing function in KitodoScriptService, so remove button is only logical consequence.