### PR TITLE
Remove MediaUnit assignments from previously assigned structure element

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
@@ -205,8 +205,10 @@ public class EditPagesDialog {
     }
 
     private List<View> getViewsToAdd(List<Integer> pages) {
-        return pages.parallelStream().map(dataEditor.getWorkpiece().getAllMediaUnitsSorted()::get)
-                .map(MetadataEditor::createUnrestrictedViewOn).collect(Collectors.toList());
+        return pages.parallelStream()
+                .map(dataEditor.getWorkpiece().getAllMediaUnitsSorted()::get)
+                .map(MetadataEditor::getFirstViewForMediaUnit)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -499,6 +499,23 @@ public class MetadataEditor {
     }
 
     /**
+     * Get the first view the given MediaUnit is assigned to.
+     * @param mediaUnit MediaUnit to get the view for
+     * @return View or null if no View was found
+     */
+    public static View getFirstViewForMediaUnit(MediaUnit mediaUnit) {
+        List<IncludedStructuralElement> includedStructuralElements = mediaUnit.getIncludedStructuralElements();
+        if (!includedStructuralElements.isEmpty() && Objects.nonNull(includedStructuralElements.get(0))) {
+            for (View view : includedStructuralElements.get(0).getViews()) {
+                if (Objects.nonNull(view) && Objects.equals(view.getMediaUnit(), mediaUnit)) {
+                    return view;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Reads the simple metadata from an included structural element defined by
      * the simple metadata view interface, including {@code mets:div} metadata.
      *


### PR DESCRIPTION
Removing the old assignments prevents the new assignments from being displayed as links.
Resolves #3494.