### PR TITLE
remove unused userHome URI

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
@@ -61,9 +61,7 @@ public class ExportMets {
      *            Process object
      */
     public void startExport(Process process) throws IOException, DAOException {
-        User user = ServiceManager.getUserService().getAuthenticatedUser();
-        URI userHome = ServiceManager.getUserService().getHomeDirectory(user);
-        boolean exportSucessfull = startExport(process, userHome);
+        boolean exportSucessfull = startExport(process, null);
         if (exportSucessfull) {
             process.setExported(true);
         }


### PR DESCRIPTION
If the export is started from an automatic task, no user is found because everything happens in a Thread. an NPE occured
As the URI is not used in the method, null is enough.