### PR TITLE
Fix initial doctype selection in 'addDocStrucTypeDialog'

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -216,7 +216,7 @@ public class AddDocStrucTypeDialog {
      * @return selected doc struct type
      */
     public String getDocStructAddTypeSelectionSelectedItem() {
-        return docStructAddTypeSelectionSelectedItem;
+        return StringUtils.isBlank(docStructAddTypeSelectionSelectedItem) ? null : docStructAddTypeSelectionSelectedItem;
     }
 
     /**


### PR DESCRIPTION
Fixes bug where "Type: Validation Error: Value is required" would be displayed when adding a new structural elements from selected pages even if the type was already selected.