### PR TITLE
Offer all available metadata for newspaper editions

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/calendar/CalendarService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/calendar/CalendarService.java
@@ -25,12 +25,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.faces.model.SelectItem;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
+import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewWithValuesInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.config.ConfigCore;
@@ -106,8 +108,16 @@ public class CalendarService {
         StructuralElementViewInterface issueView = ruleset.getStructuralElementView(issueType, acquisitionStage, priorityList);
 
         // From view to output, get all addable metadata
+        List<MetadataViewWithValuesInterface<Object>> alreadyShowing = issueView
+                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
         Collection<MetadataViewInterface> addable = issueView.getAddableMetadata(Collections.emptyMap(), Collections.emptyList());
-        return addable.stream()
+        return Stream
+                .concat(
+                    alreadyShowing.stream()
+                            .filter(metadataViewWithValues -> metadataViewWithValues.getMetadata().isPresent())
+                            .map(metadataViewWithValues -> metadataViewWithValues.getMetadata().get()),
+                    addable.stream())
+                .filter(new UniqueMetadataView())
                 .map(metadataView -> new SelectItem(metadataView.getId(), metadataView.getLabel()))
                 .collect(Collectors.toList());
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/calendar/UniqueMetadataView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/calendar/UniqueMetadataView.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.calendar;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
+
+public class UniqueMetadataView implements Predicate<MetadataViewInterface> {
+
+    Set<String> idsAlreadyOccurred = ConcurrentHashMap.newKeySet();
+    
+    @Override
+    public boolean test(MetadataViewInterface metadataView) {
+        return idsAlreadyOccurred.add(metadataView.getId());
+    }
+}


### PR DESCRIPTION
The problem was that `getAddableMetadata()` returns the possible metadata for the add button. In particular, this does not include any lists that are required (minOccurs≥1), as they always exist in the displayed table, so they can no longer be added. So both the already displayed metadata and the metadata that can be added must be taken, whereby duplicates must be sorted out. That is what the filter class does.

Fixes #3480