### PR TITLE
Fix workflow exception thrown when unknown roles are assigned to tasks

### DIFF
--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -164,11 +164,11 @@ errorUploading=Fehler beim Hochladen von ''{0}''.
 errorVolume=Bandnummer ist keine g\u00DCltige Zahl.
 
 # W
-workflowExceptionParallelBranch=Eine Aufgabe in paralleler Verzweigung kann keine zweite Aufgabe haben. Bitte entfernen Sie die Aufgabe nach der Aufgabe mit dem Namen ''{0}''.
-workflowExceptionLoop=Die Workflowaufgabe mit dem Namen ''{0}'' hat mehr als ein eingehendes Element - wahrscheinlich enth\u00E4lt der Workflow eine nicht zul\u00E4ssige Schleife.
-workflowExceptionMissingGateway=Eine Aufgabe mit dem Namen ''{0}'' hat mehrere aufeinander folgende Aufgaben ohne Gateway dazwischen!
-workflowExceptionMissingRole=Der Workflowaufgabe mit dem Namen ''{0}'' wurden keine Rollen zugewiesen.
-workflowExceptionNotFoundRole=Der Workflowaufgabe mit dem Namen ''{0}'' wurden nicht vorhandene Rollen zugewiesen.
+workflowExceptionParallelBranch=Eine Aufgabe in paralleler Verzweigung kann keine zweite Aufgabe haben. Bitte entfernen Sie die Aufgabe nach der Aufgabe ''{0}''.
+workflowExceptionLoop=Die Workflowaufgabe ''{0}'' hat mehr als ein eingehendes Element - wahrscheinlich enth\u00E4lt der Workflow eine nicht zul\u00E4ssige Schleife.
+workflowExceptionMissingGateway=Eine Aufgabe ''{0}'' hat mehrere aufeinander folgende Aufgaben ohne Gateway dazwischen!
+workflowExceptionMissingRoleAssignment=Der Workflowaufgabe ''{0}'' wurden keine Rollen zugewiesen.
+workflowExceptionRoleNotFound=Der Workflowaufgabe ''{0}'' wurden nicht vorhandene Rollen zugewiesen.
 workflowExceptionParallelGatewayOneTask=Auf die Parallel-Verzweigung folgt nur eine Aufgabe!
 workflowExceptionParallelGatewayNoTask=Auf die Parallel-Verzweigung folgen keine Aufgaben!
 

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -163,11 +163,11 @@ errorUploading=Error uploading ''{0}''.
 errorVolume=Volume number is not a valid number.
 
 # W
-workflowExceptionParallelBranch=Task in parallel branch cannot have second task. Please remove task after task with name ''{0}''.
-workflowExceptionLoop=Task with name ''{0}'' has more than one incoming elements - probably workflow contains not allowed loop.
-workflowExceptionMissingGateway=Task with name ''{0}'' has more than one following tasks without any gateway in between!
-workflowExceptionMissingRole=No roles assigned to the workflow task with name ''{0}''.
-workflowExceptionNotFoundRole=Roles assigned to the workflow task with name ''{0}'' don't exists.
+workflowExceptionParallelBranch=Task in parallel branch cannot have second task. Please remove task after task ''{0}''.
+workflowExceptionLoop=Task ''{0}'' has more than one incoming elements - probably workflow contains not allowed loop.
+workflowExceptionMissingGateway=Task ''{0}'' has more than one following tasks without any gateway in between!
+workflowExceptionMissingRoleAssignment=No roles assigned to the workflow task ''{0}''.
+workflowExceptionRoleNotFound=Roles assigned to workflow task ''{0}'' do not exists.
 workflowExceptionParallelGatewayOneTask=Parallel gateway is followed by one task!
 workflowExceptionParallelGatewayNoTask=Parallel gateway is not followed by any tasks!
 


### PR DESCRIPTION
- Fix usage of workflow exception thrown when unknown roles are assigned to a task (didn't show task name).
- update corresponding error messages to clarify meaning