### PR TITLE
Revert "Replace 'Goobi Identifier' with 'Kitodo Identifier' in dockets"

### DIFF
--- a/Kitodo-Docket/src/test/resources/docket.xsl
+++ b/Kitodo-Docket/src/test/resources/docket.xsl
@@ -59,7 +59,7 @@
                                 </fo:table-row>
                                 <fo:table-row>
                                     <fo:table-cell>
-                                        <fo:block>Kitodo Identifier:</fo:block>
+                                        <fo:block>Goobi Identifier:</fo:block>
                                     </fo:table-cell>
                                     <fo:table-cell>
                                         <fo:block>

--- a/Kitodo-Docket/src/test/resources/docket_multipage.xsl
+++ b/Kitodo-Docket/src/test/resources/docket_multipage.xsl
@@ -62,7 +62,7 @@
                             </fo:table-row>
                             <fo:table-row>
                                 <fo:table-cell>
-                                    <fo:block>Kitodo Identifier:</fo:block>
+                                    <fo:block>Goobi Identifier:</fo:block>
                                 </fo:table-cell>
                                 <fo:table-cell>
                                     <fo:block>

--- a/Kitodo/src/main/resources/docket.xsl
+++ b/Kitodo/src/main/resources/docket.xsl
@@ -59,7 +59,7 @@
                                 </fo:table-row>
                                 <fo:table-row>
                                     <fo:table-cell>
-                                        <fo:block>Kitodo Identifier:</fo:block>
+                                        <fo:block>Goobi Identifier:</fo:block>
                                     </fo:table-cell>
                                     <fo:table-cell>
                                         <fo:block>

--- a/Kitodo/src/main/resources/docket_multipage.xsl
+++ b/Kitodo/src/main/resources/docket_multipage.xsl
@@ -62,7 +62,7 @@
                             </fo:table-row>
                             <fo:table-row>
                                 <fo:table-cell>
-                                    <fo:block>Kitodo Identifier:</fo:block>
+                                    <fo:block>Goobi Identifier:</fo:block>
                                 </fo:table-cell>
                                 <fo:table-cell>
                                     <fo:block>

--- a/Kitodo/src/test/resources/xslt/docket.xsl
+++ b/Kitodo/src/test/resources/xslt/docket.xsl
@@ -59,7 +59,7 @@
                                 </fo:table-row>
                                 <fo:table-row>
                                     <fo:table-cell>
-                                        <fo:block>Kitodo Identifier:</fo:block>
+                                        <fo:block>Goobi Identifier:</fo:block>
                                     </fo:table-cell>
                                     <fo:table-cell>
                                         <fo:block>


### PR DESCRIPTION
Breaking tests in Travis. It is not clear to me why Travis Test worked without problems here. Requires an update of binary files `Kitodo-Docket/src/test/resources/docket.pdf` and `Kitodo-Docket/src/test/resources/docket-multipage.pdf` to work. Hence, revert to fix bugs.

Reverts kitodo/kitodo-production#3510