### PR TITLE
Show metadata for orientation

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalMetadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalMetadata.java
@@ -36,6 +36,12 @@ public enum FunctionalMetadata {
     DATA_SOURCE("dataSource"),
 
     /**
+     * Display metadata as summary on Title Record Link tab when creating a new
+     * process.
+     */
+    DISPLAY_SUMMARY("displaySummary"),
+
+    /**
      * The key of a higher-level data record in a hierarchical data structure of
      * 1:n relationships, which are stored from bottom to top.
      */

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/RulesetManagementInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/RulesetManagementInterface.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Interface for a service that provides access to the ruleset.
@@ -87,6 +88,18 @@ public interface RulesetManagementInterface {
      */
     StructuralElementViewInterface getStructuralElementView(String structuralElement, String acquisitionStage,
             List<LanguageRange> priorityList);
+
+    /**
+     * Returns the most appropriate label for a key, if there is one.
+     *
+     * @param key
+     *            key whose label should be returned
+     * @param priorityList
+     *            weighted list of user-preferred display languages. Return
+     *            value of the function {@link LanguageRange#parse(String)}.
+     * @return the best-matching label, if any
+     */
+    Optional<String> getTranslationForKey(String key, List<LanguageRange> priorityList);
 
     /**
      * Loads a ruleset into this management.

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
@@ -149,6 +149,28 @@ public class RulesetManagement implements RulesetManagementInterface {
     }
 
     /**
+     * Returns the most appropriate label for a key, if there is one.
+     *
+     * @param key
+     *            key whose label should be returned
+     * @param priorityList
+     *            weighted list of user-preferred display languages. Return
+     *            value of the function {@link LanguageRange#parse(String)}.
+     * @return the best-matching label, if any
+     */
+    @Override
+    public Optional<String> getTranslationForKey(String key, List<LanguageRange> priorityList) {
+        Optional<Key> optionalKey = ruleset.getKey(key);
+        if (optionalKey.isPresent()) {
+            UniversalKey universalKey = new UniversalKey(ruleset, optionalKey.get());
+            String label = universalKey.getLabel(priorityList);
+            return Optional.of(label);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * Loads a ruleset from a file.
      *
      * @param rulesetFile

--- a/Kitodo-DataEditor/src/test/resources/ruleset.xsd
+++ b/Kitodo-DataEditor/src/test/resources/ruleset.xsd
@@ -49,7 +49,7 @@
         <xs:attribute type="xs:string" name="processTitle"/>
         <xs:attribute type="xs:NMTOKEN" name="dates"/>
         <xs:attribute type="xs:string" name="scheme"/>
-        <xs:attribute type="ruleset:UseDivision" name="use"/>
+        <xs:attribute type="ruleset:DivisionUseAttribute" name="use"/>
     </xs:complexType>
 
     <xs:simpleType name="DomainAttribute">
@@ -81,7 +81,7 @@
         </xs:sequence>
         <xs:attribute use="required" type="xs:NMTOKEN" name="id"/>
         <xs:attribute type="ruleset:DomainAttribute" name="domain" default="description"/>
-        <xs:attribute type="ruleset:UseAttribute" name="use"/>
+        <xs:attribute type="ruleset:KeyUseAttribute" name="use"/>
     </xs:complexType>
 
     <xs:complexType name="Label">
@@ -178,7 +178,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="UseAttribute">
+    <xs:simpleType name="KeyUseAttribute">
         <xs:restriction>
             <xs:simpleType>
                 <xs:list>
@@ -186,6 +186,7 @@
                         <xs:restriction base="xs:token">
                             <xs:enumeration value="authorLastName"/>
                             <xs:enumeration value="dataSource"/>
+                            <xs:enumeration value="displaySummary"/>
                             <xs:enumeration value="higherlevelIdentifier"/>
                             <xs:enumeration value="recordIdentifier"/>
                             <xs:enumeration value="title"/>
@@ -197,7 +198,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="UseDivision">
+    <xs:simpleType name="DivisionUseAttribute">
         <xs:restriction>
             <xs:simpleType>
                 <xs:list>

--- a/Kitodo/rulesets/ruleset.xsd
+++ b/Kitodo/rulesets/ruleset.xsd
@@ -49,6 +49,7 @@
         <xs:attribute type="xs:string" name="processTitle"/>
         <xs:attribute type="xs:NMTOKEN" name="dates"/>
         <xs:attribute type="xs:string" name="scheme"/>
+        <xs:attribute type="ruleset:DivisionUseAttribute" name="use"/>
     </xs:complexType>
 
     <xs:simpleType name="DomainAttribute">
@@ -80,6 +81,7 @@
         </xs:sequence>
         <xs:attribute use="required" type="xs:NMTOKEN" name="id"/>
         <xs:attribute type="ruleset:DomainAttribute" name="domain" default="description"/>
+        <xs:attribute type="ruleset:KeyUseAttribute" name="use"/>
     </xs:complexType>
 
     <xs:complexType name="Label">
@@ -176,4 +178,39 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="KeyUseAttribute">
+        <xs:restriction>
+            <xs:simpleType>
+                <xs:list>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                            <xs:enumeration value="authorLastName"/>
+                            <xs:enumeration value="dataSource"/>
+                            <xs:enumeration value="displaySummary"/>
+                            <xs:enumeration value="higherlevelIdentifier"/>
+                            <xs:enumeration value="recordIdentifier"/>
+                            <xs:enumeration value="title"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:list>
+            </xs:simpleType>
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="DivisionUseAttribute">
+        <xs:restriction>
+            <xs:simpleType>
+                <xs:list>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                            <xs:enumeration value="createChildrenFromParent"/>
+                            <xs:enumeration value="createChildrenWithCalendar"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:list>
+            </xs:simpleType>
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/InsertionPositionSelectionTreeNode.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/InsertionPositionSelectionTreeNode.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.production.forms.createprocess;
 
+import java.util.List;
+
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
 
@@ -22,7 +24,7 @@ public class InsertionPositionSelectionTreeNode extends DefaultTreeNode {
     private int itemIndex;
     private String label;
     private boolean possibleInsertionPosition;
-    private String tooltip;
+    private List<String> tooltip;
 
     /**
      * Creates a new node for a radio button.
@@ -47,7 +49,7 @@ public class InsertionPositionSelectionTreeNode extends DefaultTreeNode {
      * @param label
      *            label for the included structural element
      */
-    InsertionPositionSelectionTreeNode(TreeNode parent, String label, String tooltip) {
+    InsertionPositionSelectionTreeNode(TreeNode parent, String label, List<String> tooltip) {
         super(null, parent);
         this.label = label;
         this.possibleInsertionPosition = false;
@@ -79,7 +81,7 @@ public class InsertionPositionSelectionTreeNode extends DefaultTreeNode {
      *
      * @return the tooltip
      */
-    public String getTooltip() {
+    public List<String> getTooltip() {
         return tooltip;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -260,8 +260,8 @@ public class TitleRecordLinkTab {
                 String value = MetadataEditor.getMetadataValue(rootElement, key);
 
                 if (Objects.nonNull(value)) {
-                    Optional<String> label = ruleset.getTranslationForKey(rootElement.getType(), priorityList);
-                    toolTip.add(label.orElse(rootElement.getType()) + ": " + value);
+                    Optional<String> label = ruleset.getTranslationForKey(key, priorityList);
+                    toolTip.add(label.orElse(key) + ": " + value);
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -14,18 +14,21 @@ package org.kitodo.production.forms.createprocess;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Locale.LanguageRange;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.faces.model.SelectItem;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.IncludedStructuralElement;
@@ -39,6 +42,7 @@ import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ProcessService;
+import org.kitodo.production.services.dataformat.MetsService;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
 
@@ -47,6 +51,10 @@ import org.primefaces.model.TreeNode;
  */
 public class TitleRecordLinkTab {
     private static final Logger logger = LogManager.getLogger(TitleRecordLinkTab.class);
+
+    private static final String ACQUISITION_STAGE = "create";
+    private static final MetsService metsService = ServiceManager.getMetsService();
+    private static final ProcessService processService = ServiceManager.getProcessService();
 
     /**
      * Maximum number of search hits to show.
@@ -139,7 +147,7 @@ public class TitleRecordLinkTab {
             return;
         }
         URI uri = ServiceManager.getProcessService().getMetadataFileUri(titleRecordProcess);
-        Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(uri);
+        Workpiece workpiece = metsService.loadWorkpiece(uri);
 
         RulesetManagementInterface ruleset = ServiceManager.getRulesetService()
                 .openRuleset(titleRecordProcess.getRuleset());
@@ -184,7 +192,7 @@ public class TitleRecordLinkTab {
             RulesetManagementInterface ruleset, List<LanguageRange> priorityList) throws IOException, DAOException {
 
         String type;
-        String tooltip = "";
+        List<String> tooltip = Collections.emptyList();
         if (Objects.isNull(currentIncludedStructuralElement.getLink())) {
             type = currentIncludedStructuralElement.getType();
         } else {
@@ -192,7 +200,7 @@ public class TitleRecordLinkTab {
             int linkedProcessUri = processService.processIdFromUri(currentIncludedStructuralElement.getLink().getUri());
             Process linkedProcess = processService.getById(linkedProcessUri);
             type = processService.getBaseType(linkedProcess);
-            tooltip = Helper.getTranslation("tooltip", Arrays.asList(Integer.toString(linkedProcessUri)));
+            tooltip = getToolTip(ruleset, linkedProcess);
         }
 
         StructuralElementViewInterface currentIncludedStructuralElementView = ruleset.getStructuralElementView(type,
@@ -224,6 +232,47 @@ public class TitleRecordLinkTab {
             }
         }
     }
+
+    /**
+     * Determines the overlay text for a node of the tree.
+     *
+     * @param ruleset
+     *            Ruleset of the process
+     * @param linkedProcess
+     *            Linked child process
+     * @return text to be displayed
+     * @throws IOException
+     *             if the METS file cannot be read
+     */
+    private List<String> getToolTip(RulesetManagementInterface ruleset, Process linkedProcess) throws IOException {
+
+        Collection<String> summaryKeys = ruleset.getFunctionalKeys(FunctionalMetadata.DISPLAY_SUMMARY);
+        List<String> toolTip = new ArrayList<>();
+        if (!summaryKeys.isEmpty()) {
+
+            Workpiece workpiece = metsService.loadWorkpiece(processService.getMetadataFileUri(linkedProcess));
+            IncludedStructuralElement rootElement = workpiece.getRootElement();
+
+            final String metadataLanguage = ServiceManager.getUserService().getCurrentUser().getMetadataLanguage();
+            List<LanguageRange> priorityList = Locale.LanguageRange.parse(metadataLanguage);
+
+            for (String key : summaryKeys) {
+                String value = MetadataEditor.getMetadataValue(rootElement, key);
+
+                if (Objects.nonNull(value)) {
+                    Optional<String> label = ruleset.getTranslationForKey(rootElement.getType(), priorityList);
+                    toolTip.add(label.orElse(rootElement.getType()) + ": " + value);
+                }
+            }
+        }
+
+        if (toolTip.isEmpty()) {
+            toolTip.add(linkedProcess.toString());
+        }
+
+        return toolTip;
+    }
+
 
     /**
      * Returns the HTML identifier of the selected parent process.

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/titleRecordLink.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/titleRecordLink.xhtml
@@ -85,9 +85,14 @@
                                        rendered="#{node.possibleInsertionPosition}"/>
                         <h:outputText value="#{node.label}" id="treeNodeText"
                                        rendered="#{not node.possibleInsertionPosition}"/>
-                        <p:tooltip id="treeNodeTooltip" for="treeNodeText" value="#{node.tooltip}"
+                        <p:tooltip id="treeNodeTooltip" for="treeNodeText"
                                        position="right" showEffect="clip" hideEffect="explode"
-                                       rendered="#{not node.possibleInsertionPosition and not empty node.tooltip}"/>
+                                       rendered="#{not node.possibleInsertionPosition and not empty node.tooltip}"
+                        >
+                            <p:repeat var="line" value="#{node.tooltip}">
+                                <div><h:outputText value="#{line}"/></div>
+                            </p:repeat>
+                        </p:tooltip>
                     </p:treeNode>
                 </p:tree>
             </h:panelGroup>

--- a/Kitodo/src/test/java/org/kitodo/DummyRulesetManagement.java
+++ b/Kitodo/src/test/java/org/kitodo/DummyRulesetManagement.java
@@ -17,10 +17,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
+import java.util.Optional;
 
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalDivision;
-import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
+import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 
 public class DummyRulesetManagement implements RulesetManagementInterface {
@@ -49,6 +50,11 @@ public class DummyRulesetManagement implements RulesetManagementInterface {
     public StructuralElementViewInterface getStructuralElementView(String division, String acquisitionStage,
             List<LanguageRange> priorityList) {
         return new DummyStructuralElementView(division);
+    }
+
+    @Override
+    public Optional<String> getTranslationForKey(String key, List<LanguageRange> priorityList) {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
This displays metadata for "select insertion position". The metadata can be selected in the ruleset with `use="displaySummary"`.

Fixes #3406