### PR TITLE
Remove unneeded access to DataEditorService

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/production/helper/tasks/MigrationTaskIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/tasks/MigrationTaskIT.java
@@ -55,13 +55,9 @@ public class MigrationTaskIT {
     @Test
     public void testMigrationTask() throws Exception {
         MigrationTask migrationTask = new MigrationTask(project);
-        Field dataEditorServiceField = ServiceManager.class.getDeclaredField("dataEditorService");
-        dataEditorServiceField.setAccessible(true);
-        Assert.assertTrue(Objects.isNull(dataEditorServiceField.get(null)));
         migrationTask.start();
         Assert.assertTrue(migrationTask.isAlive());
         migrationTask.join();
-        Assert.assertTrue(Objects.nonNull(dataEditorServiceField.get(null)));
         Assert.assertFalse(migrationTask.isAlive());
         Assert.assertEquals(100, migrationTask.getProgress());
         Assert.assertNotNull("Process migration failed",


### PR DESCRIPTION
Fix integration test
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.527 s <<< FAILURE! - in org.kitodo.production.helper.tasks.MigrationTaskIT
[ERROR] testMigrationTask  Time elapsed: 0.021 s  <<< FAILURE!
java.lang.AssertionError
	at org.kitodo.production.helper.tasks.MigrationTaskIT.testMigrationTask(MigrationTaskIT.java:60)
```

Test is written with assumption that DataEditorService is not used at all before running the test. As this service - as all other too - is written as a singleton and test execution is executed in randomly there is no guaranty that this service is used before. Removing the assertions for this service did not change in any way the test execution.