### PR TITLE
Prevent possible NPE

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
@@ -339,7 +339,11 @@ public class User extends BaseBean {
     }
 
     public String getMetadataLanguage() {
-        return this.metadataLanguage;
+        if (Objects.isNull(this.metadataLanguage)) {
+            return "";
+        } else {
+            return this.metadataLanguage;
+        }
     }
 
     public void setMetadataLanguage(String metadataLanguage) {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -85,7 +85,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
             User user = ServiceManager.getUserService().getAuthenticatedUser();
             String metadataLanguage = user != null ? user.getMetadataLanguage()
                     : Helper.getRequestParameter("Accept-Language");
-            this.priorityList = LanguageRange.parse(metadataLanguage != null ? metadataLanguage : "en");
+            this.priorityList = LanguageRange.parse(! metadataLanguage.isEmpty() ? metadataLanguage : "en");
         } catch (NullPointerException e) {
             /*
              * new Metadaten() throws a NullPointerException in asynchronous

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
@@ -85,7 +85,7 @@ public class LegacyPrefsHelper {
                     User user = ServiceManager.getUserService().getAuthenticatedUser();
                     String metadataLanguage = user != null ? user.getMetadataLanguage()
                             : Helper.getRequestParameter("Accept-Language");
-                    priorityList = LanguageRange.parse(metadataLanguage != null ? metadataLanguage : "en");
+                    priorityList = LanguageRange.parse(! metadataLanguage.isEmpty() ? metadataLanguage : "en");
                 } catch (NullPointerException e) {
                     /*
                      * new Metadaten() throws a NullPointerException in

--- a/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
@@ -227,7 +227,7 @@ public class MetadataValidationService {
         User user = ServiceManager.getUserService().getAuthenticatedUser();
         String metadataLanguage = user != null ? user.getMetadataLanguage()
                 : Helper.getRequestParameter("Accept-Language");
-        return LanguageRange.parse(metadataLanguage != null ? metadataLanguage : "en");
+        return LanguageRange.parse(! metadataLanguage.isEmpty() ? metadataLanguage : "en");
     }
 
     private Map<String, String> getTranslations() {


### PR DESCRIPTION
Fix integration test
```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 5.087 s <<< FAILURE! - in org.kitodo.production.forms.copyprocess.CreateProcessFormIT
[ERROR] shouldCreateNewProcess  Time elapsed: 0.012 s  <<< ERROR!
java.lang.NullPointerException
	at org.kitodo.production.forms.copyprocess.CreateProcessFormIT.shouldCreateNewProcess(CreateProcessFormIT.java:79)
```

Stacktrace of null pointer exception is
```
java.lang.NullPointerException
    at org.kitodo.production.services.data.UserService.getCurrentMetadataLanguage(UserService.java:491)
    at org.kitodo.production.forms.createprocess.CreateProcessForm.<init>(CreateProcessForm.java:71)
    at org.kitodo.production.forms.copyprocess.CreateProcessFormIT.shouldCreateNewProcess(CreateProcessFormIT.java:83)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
...
```

Reason for null pointer is, that field `metadataLanguage` is defined as nullable in database but accessed as string class object without any null check.