### PR TITLE
Cache images only until editor is closed

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -92,6 +93,8 @@ public class GalleryPanel {
     private List<GalleryStripe> stripes;
 
     private Subfolder previewFolder;
+
+    private String cachingUUID = "";
 
     GalleryPanel(DataEditorForm dataEditor) {
         this.dataEditor = dataEditor;
@@ -391,6 +394,7 @@ public class GalleryPanel {
         medias = new ArrayList<>(mediaUnits.size());
         stripes = new ArrayList<>();
         previewImageResolver = new HashMap<>();
+        cachingUUID = UUID.randomUUID().toString();
 
         previewFolder = new Subfolder(process, project.getPreview());
         for (MediaUnit mediaUnit : mediaUnits) {
@@ -834,5 +838,14 @@ public class GalleryPanel {
             return dataEditor.getStructurePanel().getSeveralAssignments().indexOf(galleryMediaContent.getView().getMediaUnit());
         }
         return -1;
+    }
+
+    /**
+     * Get cachingUUID.
+     *
+     * @return value of cachingUUID
+     */
+    public String getCachingUUID() {
+        return cachingUUID;
     }
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -124,6 +124,8 @@
                                                          value="#{media.id}" />
                                                 <f:param name="process"
                                                          value="#{DataEditorForm.process.id}"/>
+                                                <f:param name="sessionId"
+                                                         value="#{DataEditorForm.galleryPanel.cachingUUID}"/>
                                             </p:graphicImage>
                                             <h:outputText value="#{DataEditorForm.galleryPanel.getSeveralAssignmentsIndex(media) + 1}"
                                                           rendered="#{media.assignedSeveralTimes}"
@@ -209,6 +211,8 @@
                                                                  value="#{media.id}"/>
                                                         <f:param name="process"
                                                                  value="#{DataEditorForm.process.id}"/>
+                                                        <f:param name="sessionId"
+                                                                 value="#{DataEditorForm.galleryPanel.cachingUUID}"/>
                                                     </p:graphicImage>
                                                     <h:panelGroup class="thumbnail-overlay">
                                                         #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
@@ -279,6 +283,8 @@
                                                      value="#{media.id}"/>
                                             <f:param name="process"
                                                      value="#{DataEditorForm.process.id}"/>
+                                            <f:param name="sessionId"
+                                                     value="#{DataEditorForm.galleryPanel.cachingUUID}"/>
                                         </p:graphicImage>
                                     <h:panelGroup styleClass="thumbnail-overlay">
                                         #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
@@ -318,6 +324,8 @@
                                                              value="#{media.id}" />
                                                     <f:param name="process"
                                                              value="#{DataEditorForm.process.id}"/>
+                                                    <f:param name="sessionId"
+                                                             value="#{DataEditorForm.galleryPanel.cachingUUID}"/>
                                                 </p:graphicImage></h:outputText>
                                                 <h:panelGroup layout="block" styleClass="thumbnail-overlay">
                                                     #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}


### PR DESCRIPTION
Images are cached in the metadata editor for all Ajax requests and page reloads.
With these changes the images are only cached for the time the editor is open. When the user closes and reopens the editor all cached images are reloaded.
This prevents too extensive caching e.g. when the images have been changed and must be reloaded in the editor.