### PR TITLE
Add 'Apply' button to pagination that keeps dialog open

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1287,9 +1287,14 @@ Popup dialogs
     display: none;
 }
 
-.ui-dialog.legal-dialog div.dialogFieldWrapper {
-    overflow-y: scroll;
+#paginationForm {
+    position: relative;
+    height: 95%;
+}
+
+.ui-dialog div.dialogFieldWrapper {
     max-height: calc(100% - 100px);
+    overflow-y: scroll;
 }
 
 .ui-dialog.legal-dialog button.secondary.right {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/pagination.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/pagination.xhtml
@@ -22,18 +22,18 @@
               widgetVar="paginationDialog"
               modal="true"
               resizable="false"
+              draggable="true"
               dynamic="true"
               appendTo="@(body)"
-              width="480px">
+              width="640"
+              height="480">
         <h3>#{msgs.paginationEdit}</h3>
         <h:form id="paginationForm">
-            <p:panel id="paginationWrapperPanel" styleClass="wrapperPanel">
-                <p:panelGrid columns="1" layout="grid">
-                    <p:row>
-
-                        <h:panelGroup layout="block"
-                                      styleClass="dialogFieldWrapper">
-
+            <h:panelGroup layout="block"
+                          styleClass="dialogFieldWrapper">
+                <p:panel id="paginationWrapperPanel" styleClass="wrapperPanel">
+                    <p:panelGrid columns="1" layout="grid">
+                        <p:row>
                             <div>
                                 <p:commandButton id="createPaginationButton"
                                                  action="#{DataEditorForm.paginationPanel.createPagination()}"
@@ -49,7 +49,7 @@
                             <div>
                                 <p:selectManyMenu id="paginationSelection" styleClass="pagination-select-items"
                                                   value="#{DataEditorForm.paginationPanel.paginationSelectionSelectedItems}"
-                                                  style="height: 100%;"
+                                                  style="width: 100%;"
                                                   required="true"
                                                   requiredMessage="#{msgs.paginationNoPagesSelected}"
                                                   filter="true"
@@ -125,7 +125,7 @@
                                 <p:inputText id="newPagesCount"
                                              value="#{DataEditorForm.paginationPanel.newPagesCountValue}"
                                              class="input"
-                                             style="width: 70%;"
+                                             style="width: 80%;"
                                              label="#{msgs.paginationStartValue}">
                                     <p:ajax event="blur"/>
                                     <f:convertNumber integerOnly="true"/>
@@ -134,6 +134,7 @@
                                 <p:commandButton id="generateDummyImagesButton"
                                                  value="#{msgs.insert}"
                                                  styleClass="secondary"
+                                                 style="margin: 0;"
                                                  action="#{DataEditorForm.paginationPanel.generateDummyImagesButtonClick()}"
                                                  update="structureTreeForm,galleryWrapperPanel"
                                                  immediate="true"/>
@@ -143,24 +144,34 @@
                                 <p:outputLabel for="fictitiousCheckbox"
                                                value="#{msgs.paginationFictitious}"/>
                                 <p:selectBooleanCheckbox id="fictitiousCheckbox"
-                                                         styleClass="input"
+                                                         styleClass="input switch"
                                                          style="margin-bottom: 0;"
                                                          value="#{DataEditorForm.paginationPanel.fictitiousCheckboxChecked}"/>
                             </div>
-
-                        </h:panelGroup>
-
-                        <h:panelGroup layout="block"
+                        </p:row>
+                    </p:panelGrid>
+                </p:panel>
+            </h:panelGroup>
+            <h:panelGroup layout="block"
                                       styleClass="dialogButtonWrapper">
 
-                            <p:commandButton id="startPagination"
+                            <p:commandButton id="applyAndExit"
                                              action="#{DataEditorForm.paginationPanel.startPaginationClick()}"
                                              oncomplete="PF('paginationDialog').hide();"
                                              styleClass="primary right"
                                              icon="fa fa-check fa-lg"
                                              iconPos="right"
                                              update="paginationForm:paginationSelection,structureTreeForm,galleryWrapperPanel"
-                                             value="#{msgs.save}">
+                                             value="#{msgs.apply} &amp; #{msgs.exit}">
+                            </p:commandButton>
+
+                            <p:commandButton id="apply"
+                                             action="#{DataEditorForm.paginationPanel.startPaginationClick()}"
+                                             styleClass="secondary right"
+                                             icon="fa fa-check fa-lg"
+                                             iconPos="right"
+                                             update="paginationForm:paginationSelection,structureTreeForm,galleryWrapperPanel"
+                                             value="#{msgs.apply}">
                             </p:commandButton>
 
                             <p:button id="cancel"
@@ -171,9 +182,6 @@
                                       iconPos="right"
                                       update="structureTreeForm"/>
                         </h:panelGroup>
-                    </p:row>
-                </p:panelGrid>
-            </p:panel>
         </h:form>
     </p:dialog>
 </ui:composition>


### PR DESCRIPTION
- add 'Apply' button to pagination dialog that applies the pagination but keeps the dialog open
- rename 'Save' button to 'Apply & Exit'

<img width="632" alt="Bildschirmfoto 2020-05-04 um 13 26 31" src="https://user-images.githubusercontent.com/19183925/80961389-28e37080-8e0b-11ea-8a32-4b6738f886ac.png">

Fixes #3537 
Fixes #3570 