### PR TITLE
Add MetadataGroup to index

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -158,6 +158,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     private static final String OPEN = "open";
     private static final String PROCESS_TITLE = "(processtitle)";
     private static final String METADATA_SEARCH_KEY = ProcessTypeField.METADATA + ".mdWrap.xmlData.kitodo.metadata";
+    private static final String METADATA_GROUP_SEARCH_KEY = ProcessTypeField.METADATA + ".mdWrap.xmlData.kitodo.metadataGroup.metadata";
     private static final String METADATA_FILE_NAME = "meta.xml";
     private static final String NEW_LINE_ENTITY = "\n";
     private static final boolean USE_ORIG_FOLDER = ConfigCore
@@ -555,6 +556,8 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     public List<ProcessDTO> findByAnything(String searchQuery) throws DataException {
         NestedQueryBuilder nestedQueryForMetadataContent = nestedQuery(METADATA_SEARCH_KEY,
             matchQuery(METADATA_SEARCH_KEY + ".content", searchQuery).operator(Operator.AND), ScoreMode.Total);
+        NestedQueryBuilder nestedQueryForMetadataGroupContent = nestedQuery(METADATA_GROUP_SEARCH_KEY,
+            matchQuery(METADATA_GROUP_SEARCH_KEY + ".content", searchQuery).operator(Operator.AND), ScoreMode.Total);
         MultiMatchQueryBuilder multiMatchQueryForProcessFields = multiMatchQuery(searchQuery,
                 ProcessTypeField.TITLE.getKey(),
                 ProcessTypeField.PROJECT_TITLE.getKey(),
@@ -564,6 +567,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
 
         BoolQueryBuilder boolQuery = new BoolQueryBuilder();
         boolQuery.should(nestedQueryForMetadataContent);
+        boolQuery.should(nestedQueryForMetadataGroupContent);
         boolQuery.should(multiMatchQueryForProcessFields);
 
         if (!searchQuery.contains(" ")) {

--- a/Kitodo/src/main/resources/mapping.json
+++ b/Kitodo/src/main/resources/mapping.json
@@ -421,6 +421,33 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                "metadataGroup": {
+                                                    "properties": {
+                                                        "metadata": {
+                                                            "type": "nested",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "text",
+                                                                    "fields": {
+                                                                        "keyword": {
+                                                                            "type": "keyword",
+                                                                            "ignore_above": 256
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "content": {
+                                                                    "type": "text",
+                                                                    "fields": {
+                                                                        "keyword": {
+                                                                            "type": "keyword",
+                                                                            "ignore_above": 256
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -226,6 +226,12 @@ public class ProcessServiceIT {
     }
 
     @Test
+    public void shouldFindByMetadataGroupContent() throws DataException {
+        processService.findByTitle("Second Process");
+        assertEquals(processNotFound, 1, processService.findByAnything("August").size());
+    }
+
+    @Test
     public void shouldFindLinkableParentProcesses() throws DataException {
         assertEquals("Processes were not found in index!", 1,
             processService.findLinkableParentProcesses("HierarchyParent", 1, 1).size());

--- a/Kitodo/src/test/resources/mapping.json
+++ b/Kitodo/src/test/resources/mapping.json
@@ -421,6 +421,33 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                "metadataGroup": {
+                                                    "properties": {
+                                                        "metadata": {
+                                                            "type": "nested",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "text",
+                                                                    "fields": {
+                                                                        "keyword": {
+                                                                            "type": "keyword",
+                                                                            "ignore_above": 256
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "content": {
+                                                                    "type": "text",
+                                                                    "fields": {
+                                                                        "keyword": {
+                                                                            "type": "keyword",
+                                                                            "ignore_above": 256
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/Kitodo/src/test/resources/metadata/2/meta.xml
+++ b/Kitodo/src/test/resources/metadata/2/meta.xml
@@ -27,6 +27,10 @@
                     <kitodo:metadata name="TitleDocMain">Second process</kitodo:metadata>
                     <kitodo:metadata name="TitleDocMainShort">SecondMetaShort</kitodo:metadata>
                     <kitodo:metadata name="TSL_ATS">Proc</kitodo:metadata>
+                    <kitodo:metadataGroup name="Person">
+                        <kitodo:metadata name="IdentifierPPN">079309542</kitodo:metadata>
+                        <kitodo:metadata name="PersonalName">August</kitodo:metadata>
+                    </kitodo:metadataGroup>
                 </kitodo:kitodo>
             </mets:xmlData>
         </mets:mdWrap>


### PR DESCRIPTION
Makes Metadatagroups searchable by searchbar
fixes #3565  (the part "retrivable by filter" is not fixed, because filters don't respect metadata at all)