### PR TITLE
Improve rendering of metadata panel in read only mode

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2006,13 +2006,53 @@ Column content
 #metadataAccordion\:metadata\:metadataTable_data .ui-spinner,
 #metadataAccordion\:physicalMetadata\:metadataTable_data .ui-spinner,
 #metadataAccordion\:metadata\:metadataTable_data .ui-selectonemenu,
-#metadataAccordion\:physicalMetadata\:metadataTable_data .ui-selectonemenu {
+#metadataAccordion\:physicalMetadata\:metadataTable_data .ui-selectonemenu,
+#metadataAccordion\:metadata\:metadataTable_data .ui-selectoneradio,
+#metadataAccordion\:physicalMetadata\:metadataTable_data .ui-selectoneradio {
     background: inherit;
     box-sizing: border-box;
     margin-right: var(--default-half-size);
     max-width: calc(100% - 93px);
+    overflow: hidden;
     text-overflow: ellipsis;
     width: 100%;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-calendar .ui-inputfield,
+#metadataAccordion\:physicalMetadata\:metadataTable_data .ui-calendar .ui-inputfield {
+    max-width: calc(100% - 139px);
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-calendar .ui-datepicker-trigger {
+    background: var(--pure-white);
+    border: solid var(--default-border-width) var(--light-blue);
+    margin: 0 3px 0 0;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-calendar .ui-datepicker-trigger::before {
+    color: var(--light-blue);
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-calendar.read-only .ui-datepicker-trigger {
+    display: none;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .read-only,
+#metadataAccordion\:metadata\:metadataTable_data .ui-calendar.read-only .ui-inputfield {
+    max-width: 100%;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-inputfield.ui-selectmanymenu.read-only,
+#metadataAccordion\:metadata\:metadataTable_data .ui-selectoneradio.read-only {
+    max-width: unset;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-selectoneradio {
+    display: inline-table;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-selectoneradio td {
+    padding: var(--input-padding-none) var(--input-padding);
 }
 
 #metadataAccordion\:metadata\:metadataTable_data .ui-spinner-input,

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -518,6 +518,7 @@ button.ui-datepicker-trigger.ui-button-icon-only::before {
 .ui-inputfield,
 .ui-selectcheckboxmenu-multiple-container.ui-inputfield,
 .ui-picklist-list-wrapper,
+.ui-selectoneradio,
 .ui-widget-content .ui-inputfield {
     border: solid var(--default-border-width) var(--blue);
     box-shadow: 0 0 0 transparent;
@@ -799,7 +800,8 @@ button.ui-datepicker-trigger.ui-button-icon-only::before {
 .ui-selectonemenu.ui-state-disabled .ui-selectonemenu-label,
 .ui-selectonemenu.ui-state-disabled .ui-selectonemenu-trigger,
 .ui-spinner.ui-state-disabled .ui-spinner-input,
-.ui-spinner.ui-state-disabled .ui-spinner-button::after {
+.ui-spinner.ui-state-disabled .ui-spinner-button::after,
+.ui-selectoneradio.disabled {
     color: var(--medium-gray);
     border-color: var(--medium-gray);
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalMetadata.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalMetadata.xhtml
@@ -29,14 +29,16 @@
                 <ui:param name="readOnly" value="#{readOnly}" />
             </ui:include>
 
-            <p:panelGrid style="margin-top:10px;" styleClass="ui-noborder full-width">
+            <p:panelGrid style="margin-top:10px;"
+                         styleClass="ui-noborder full-width"
+                         rendered="#{not readOnly}">
                 <p:row>
                     <h:panelGroup id="addMetadataButtonWrapper"
                                   title="#{empty DataEditorForm.addDocStrucTypeDialog.selectAddableMetadataTypesItems ? msgs['dataEditor.addMetadata.noMetadataAddable'] : msgs['dataEditor.addMetadata.newMetadata']}">
                         <p:commandButton id="addMetadataButton"
                                          icon="fa fa-plus"
-                                         styleClass="secondary #{readOnly ? 'disabled' : ''}"
-                                         disabled="#{readOnly or empty DataEditorForm.addDocStrucTypeDialog.selectAddableMetadataTypesItems}"
+                                         styleClass="secondary"
+                                         disabled="#{empty DataEditorForm.addDocStrucTypeDialog.selectAddableMetadataTypesItems}"
                                          update="addMetadataForm"
                                          oncomplete="PF('addMetadataDialog').show();"/>
                     </h:panelGroup>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalMetadata.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalMetadata.xhtml
@@ -16,6 +16,7 @@
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:p="http://primefaces.org/ui">
 
+    <!--@elvariable id="readOnly" type="boolean"-->
     <ui:param name="readOnly"
               value="#{SecurityAccessController.hasAuthorityToViewProcessMetaData() and not SecurityAccessController.hasAuthorityToEditProcessMetaData()}"
     />
@@ -28,14 +29,16 @@
                 <ui:param name="buttonUpdate" value="metadataAccordion:metadata:metadataTable" />
             </ui:include>
 
-            <p:panelGrid style="margin-top:10px;" styleClass="ui-noborder full-width">
+            <p:panelGrid style="margin-top:10px;"
+                         styleClass="ui-noborder full-width"
+                         rendered="#{not readOnly}">
                 <p:row>
                     <h:panelGroup id="addMetadataButtonWrapper"
                                   title="#{empty DataEditorForm.addDocStrucTypeDialog.selectAddableMetadataTypesItems ? msgs['dataEditor.addMetadata.noMetadataAddable'] : msgs['dataEditor.addMetadata.newMetadata']}">
                         <p:commandButton id="addMetadataButton"
                                          icon="fa fa-plus"
-                                         styleClass="secondary #{readOnly ? 'disabled' : ''}"
-                                         disabled="#{readOnly or empty DataEditorForm.addDocStrucTypeDialog.selectAddableMetadataTypesItems}"
+                                         styleClass="secondary"
+                                         disabled="#{empty DataEditorForm.addDocStrucTypeDialog.selectAddableMetadataTypesItems}"
                                          oncomplete="PF('addMetadataDialog').show();"
                                          update="addMetadataForm"/>
                     </h:panelGroup>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -25,6 +25,7 @@
 
     <!--@elvariable id="readOnly" type="boolean"-->
     <!--@elvariable id="root" type="org.primefaces.model.TreeNode"-->
+    <!--@elvariable id="buttonUpdate" type="java.lang.String"-->
     <p:treeTable value="#{root}"
                  var="item"
                  styleClass="no-header"
@@ -36,88 +37,105 @@
                            title="#{msgs['dataEditor.undefinedKey']}" rendered="#{item.undefined}" />
 
             <!-- inputText -->
-            <p:inputText id="inputText"
-                         value="#{item.value}"
-                         disabled="#{not item.editable or readOnly}"
-                         required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
-                         styleClass="#{not item.editable or readOnly ? 'disabled' : ''}"
-                         rendered="#{item.input eq 'inputText'}">
-                <p:ajax event="blur"/>
-            </p:inputText>
-
-            <!-- inputTextarea -->
-            <p:inputTextarea id="inputTextarea"
+            <h:panelGroup rendered="#{item.input eq 'inputText'}"
+                          title="#{item.value}">
+                <p:inputText id="inputText"
                              value="#{item.value}"
-                             rows="2"
                              disabled="#{not item.editable or readOnly}"
                              required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
-                             styleClass="#{not item.editable or readOnly ? 'disabled' : ''}"
-                             rendered="#{item.input eq 'inputTextarea'}">
-                <p:ajax event="blur"/>
-            </p:inputTextarea>
+                             styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
+                    <p:ajax event="blur"/>
+                </p:inputText>
+            </h:panelGroup>
+
+            <!-- inputTextarea -->
+            <h:panelGroup rendered="#{item.input eq 'inputTextarea'}"
+                          title="#{item.value}">
+                <p:inputTextarea id="inputTextarea"
+                                 value="#{item.value}"
+                                 rows="2"
+                                 disabled="#{not item.editable or readOnly}"
+                                 required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                                 styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
+                    <p:ajax event="blur"/>
+                </p:inputTextarea>
+            </h:panelGroup>
 
             <!-- spinner -->
-            <p:spinner id="spinner"
-                       value="#{item.value}"
-                       disabled="#{not item.editable or readOnly}"
-                       required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
-                       styleClass="#{not item.editable ? 'disabled' : ''}"
-                       rendered="#{item.input eq 'spinner'}">
-                <p:ajax event="blur"/>
-            </p:spinner>
+            <h:panelGroup rendered="#{item.input eq 'spinner'}"
+                          title="#{item.value}">
+                <p:spinner id="spinner"
+                           value="#{item.value}"
+                           disabled="#{not item.editable or readOnly}"
+                           required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                           styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
+                    <p:ajax event="blur"/>
+                </p:spinner>
+            </h:panelGroup>
 
             <!-- calendar -->
-            <p:calendar id="calendar"
-                        value="#{item.date}"
-                        pattern="yyyy-mm-dd"
-                        styleClass="input-with-button #{not item.editable ? 'disabled' : ''}"
-                        showOn="button"
-                        required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
-                        disabled="#{not item.editable or readOnly}"
-                        rendered="#{item.input eq 'calendar'}">
-                <p:ajax event="dateSelect"/>
-            </p:calendar>
+            <h:panelGroup rendered="#{item.input eq 'calendar'}">
+                <p:calendar id="calendar"
+                            value="#{item.date}"
+                            pattern="yyyy-mm-dd"
+                            styleClass="input-with-button #{not item.editable or readOnly ? 'read-only disabled' : ''}"
+                            showOn="button"
+                            required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                            disabled="#{not item.editable or readOnly}">
+                    <p:ajax event="dateSelect"/>
+                </p:calendar>
+            </h:panelGroup>
 
             <!-- manyMenu -->
-            <p:selectManyMenu id="selectManyMenu"
-                              value="#{item.selectedItems}"
-                              readonly="#{not item.editable}"
-                              styleClass="#{not entry.editable ? 'disabled' : ''}"
-                              showCheckbox="true"
-                              rendered="#{item.input eq 'manyMenu'}">
-                <f:selectItems value="#{item.items}"/>
-                <p:ajax event="change"/>
-            </p:selectManyMenu>
+            <h:panelGroup rendered="#{item.input eq 'manyMenu'}">
+                <p:selectManyMenu id="selectManyMenu"
+                                  value="#{item.selectedItems}"
+                                  readonly="#{not item.editable}"
+                                  styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
+                                  disabled="#{not item.editable or readOnly}"
+                                  showCheckbox="true">
+                    <f:selectItems value="#{item.items}"/>
+                    <p:ajax event="change"/>
+                </p:selectManyMenu>
+            </h:panelGroup>
 
             <!-- oneMenu -->
-            <p:selectOneMenu id="selectOneMenu"
-                             value="#{item.selectedItem}"
-                             readonly="#{not item.editable}"
-                             autoWidth="false"
-                             rendered="#{item.input eq 'oneMenu'}">
-                <f:selectItem itemValue="#{null}" itemLabel="#{msgs.notSelected}" noSelectionOption="true"/>
-                <f:selectItems value="#{item.items}"/>
-                <p:ajax event="change"/>
-            </p:selectOneMenu>
+            <h:panelGroup rendered="#{item.input eq 'oneMenu'}"
+                          title="#{item.selectedItem}">
+                <p:selectOneMenu id="selectOneMenu"
+                                 value="#{item.selectedItem}"
+                                 readonly="#{not item.editable}"
+                                 autoWidth="false"
+                                 disabled="#{not item.editable or readOnly}"
+                                 styleClass="#{readOnly ? 'read-only' : ''}">
+                    <f:selectItem itemValue="#{null}" itemLabel="#{msgs.notSelected}" noSelectionOption="true"/>
+                    <f:selectItems value="#{item.items}"/>
+                    <p:ajax event="change"/>
+                </p:selectOneMenu>
+            </h:panelGroup>
 
             <!-- oneRadio -->
-            <p:selectOneRadio id="selectOneRadio"
-                              value="#{item.selectedItem}"
-                              readonly="#{not item.editable}"
-                              styleClass="#{not entry.editable ? 'disabled' : ''}"
-                              rendered="#{item.input eq 'oneRadio'}"
-                              layout="grid"
-                              columns="1">
-                <f:selectItems value="#{item.items}"/>
-                <p:ajax event="blur"/>
-            </p:selectOneRadio>
+            <h:panelGroup rendered="#{item.input eq 'oneRadio'}">
+                <p:selectOneRadio id="selectOneRadio"
+                                  value="#{item.selectedItem}"
+                                  readonly="#{not item.editable}"
+                                  disabled="#{not item.editable or readOnly}"
+                                  styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
+                                  layout="grid"
+                                  columns="1">
+                    <f:selectItems value="#{item.items}"/>
+                    <p:ajax event="blur"/>
+                </p:selectOneRadio>
+            </h:panelGroup>
 
             <!-- toggleSwitch -->
-            <p:selectBooleanCheckbox id="selectBooleanCheckbox"
-                                     value="#{item.active}"
-                                     rendered="#{item.input eq 'toggleSwitch'}">
-                <p:ajax event="blur"/>
-            </p:selectBooleanCheckbox>
+            <h:panelGroup rendered="#{item.input eq 'toggleSwitch'}"
+                          title="#{item.active}">
+                <p:selectBooleanCheckbox id="selectBooleanCheckbox"
+                                         value="#{item.active}">
+                    <p:ajax event="blur"/>
+                </p:selectBooleanCheckbox>
+            </h:panelGroup>
 
             <!-- button to delete -->
             <p:commandButton id="deleteMetadata"
@@ -127,11 +145,10 @@
                              tabindex="-1"
                              title="#{msgs.metadataDelete}"
                              styleClass="secondary #{readOnly ? 'disabled' : ''}"
-                             disabled="#{readOnly}"
                              onclick="$('#loadingScreen').show()"
                              oncomplete="$('#loadingScreen').hide()"
                              action="#{item.delete}"
-                             rendered="#{not empty buttonUpdate}"
+                             rendered="#{not empty buttonUpdate and not readOnly}"
             />
 
             <!-- button to duplicate -->
@@ -142,11 +159,11 @@
                                  immediate="true"
                                  tabindex="-1"
                                  styleClass="secondary #{readOnly ? 'disabled' : ''}"
-                                 disabled="#{readOnly or not DataEditorForm.canBeAdded(item)}"
+                                 disabled="#{not DataEditorForm.canBeAdded(item)}"
                                  onclick="$('#loadingScreen').show()"
                                  oncomplete="$('#loadingScreen').hide()"
                                  action="#{item.copy}"
-                                 rendered="#{not empty buttonUpdate}"
+                                 rendered="#{not empty buttonUpdate and not readOnly}"
                 />
             </h:panelGroup>
         </p:column>


### PR DESCRIPTION
Update styling of metadata panel in metadata editor for users with authorization to _read_ but not _write_ metadata:
- hide `addMetadata` button instead of just disabling it
- hide `duplicate` and `delete` buttons next to metadata fields instead of just disabling them
- use full available width for - disabled - metadata input fields when buttons are hidden
- use proper `disabled` styling for metadata fields of type calendar, selectOneMenu and selectOneRadio

**old:**
<img width="301" alt="Bildschirmfoto 2020-05-05 um 17 00 05" src="https://user-images.githubusercontent.com/19183925/81081231-f2ccec00-8ef1-11ea-8bea-fc08870cb81e.png">

**new:**
<img width="300" alt="Bildschirmfoto 2020-05-05 um 16 57 25" src="https://user-images.githubusercontent.com/19183925/81081208-ec3e7480-8ef1-11ea-8096-261626b75259.png">