### PR TITLE
trigger index on save in metadata editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -338,6 +338,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             structurePanel.preserve();
             try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
                 ServiceManager.getMetsService().save(workpiece, out);
+                ServiceManager.getProcessService().saveToIndex(process,false);
                 PrimeFaces.current().executeScript("PF('notifications').renderMessage({'summary':'"
                         + Helper.getTranslation("metadataSaved") + "','severity':'info'})");
             } catch (IOException e) {
@@ -361,6 +362,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             structurePanel.preserve();
             try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
                 ServiceManager.getMetsService().save(workpiece, out);
+                ServiceManager.getProcessService().saveToIndex(process,false);
                 return close();
             } catch (IOException e) {
                 Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);


### PR DESCRIPTION
Fixes the problem on missing indexed metadata after editing it in the metadataeditor