### PR TITLE
Fix pagination crashing metadata editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/IllustratedSelectItem.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/IllustratedSelectItem.java
@@ -23,6 +23,12 @@ public class IllustratedSelectItem {
     private String image;
 
     /**
+     * Constructor required by some JSF-internal processing.
+     */
+    public IllustratedSelectItem() {
+    }
+
+    /**
      * Creates a new illustrated select item.
      *
      * @param value


### PR DESCRIPTION
Fixed by providing the missing method:
```
Caused by: java.lang.NoSuchMethodException:
    org.kitodo.production.forms.dataeditor.IllustratedSelectItem.<init>()
```

Fixes #3378