### PR TITLE
Prevent NPE when comment or message is null

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
@@ -67,7 +67,9 @@ public class ProcessType extends BaseType<Process> {
         String commentsMessages = "";
         List<Comment> processComments = process.getComments();
         for (Comment comment : processComments) {
-            commentsMessages = commentsMessages.concat(comment.getMessage());
+            if (Objects.nonNull(comment) && Objects.nonNull(comment.getMessage())) {
+                commentsMessages = commentsMessages.concat(comment.getMessage());
+            }
         }
         return commentsMessages;
     }


### PR DESCRIPTION
This bug occurs when indexing processes with comments with `null` values.