### PR TITLE
add id to index to enable sorting by id

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
@@ -33,6 +33,7 @@ public class ProcessType extends BaseType<Process> {
         int processParentId = Objects.nonNull(process.getParent()) ? process.getParent().getId() : 0;
 
         Map<String, Object> jsonObject = new HashMap<>();
+        jsonObject.put(ProcessTypeField.ID.getKey(), preventNull(process.getId()));
         jsonObject.put(ProcessTypeField.TITLE.getKey(), preventNull(process.getTitle()));
         jsonObject.put(ProcessTypeField.CREATION_DATE.getKey(), getFormattedDate(process.getCreationDate()));
         jsonObject.put(ProcessTypeField.WIKI_FIELD.getKey(), preventNull(process.getWikiField()));

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/ProcessTypeTest.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/ProcessTypeTest.java
@@ -309,7 +309,7 @@ public class ProcessTypeTest {
         Process process = prepareData().get(0);
         Map<String, Object> actual = processType.createDocument(process);
 
-        assertEquals("Amount of keys is incorrect!", 27, actual.keySet().size());
+        assertEquals("Amount of keys is incorrect!", 28, actual.keySet().size());
 
         List<Map<String, Object>> batches = ProcessTypeField.BATCHES.getJsonArray(actual);
         Map<String, Object> batch = batches.get(0);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -758,9 +758,12 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     public List<ProcessDTO> findLinkableParentProcesses(String searchInput, int projectId, int rulesetId)
             throws DataException {
 
-        BoolQueryBuilder query = new BoolQueryBuilder()
-                .must(new BoolQueryBuilder().should(new MatchQueryBuilder(ProcessTypeField.ID.getKey(), searchInput))
-                        .should(createSimpleWildcardQuery(ProcessTypeField.TITLE.getKey(), searchInput)))
+        BoolQueryBuilder processQuery = new BoolQueryBuilder()
+                .should(createSimpleWildcardQuery(ProcessTypeField.TITLE.getKey(), searchInput));
+        if (searchInput.matches("\\d*")) {
+            processQuery.should(new MatchQueryBuilder(ProcessTypeField.ID.getKey(), searchInput));
+        }
+        BoolQueryBuilder query = new BoolQueryBuilder().must(processQuery)
                 .must(new MatchQueryBuilder(ProcessTypeField.PROJECT_ID.getKey(), projectId))
                 .must(new MatchQueryBuilder(ProcessTypeField.RULESET.getKey(), rulesetId));
         return findByQuery(query, false);

--- a/Kitodo/src/main/resources/mapping.json
+++ b/Kitodo/src/main/resources/mapping.json
@@ -302,6 +302,9 @@
         "process": {
             "dynamic": "strict",
             "properties": {
+                "id": {
+                    "type": "text"
+                },
                 "batches": {
                     "properties": {
                         "id": {

--- a/Kitodo/src/main/resources/mapping.json
+++ b/Kitodo/src/main/resources/mapping.json
@@ -303,7 +303,7 @@
             "dynamic": "strict",
             "properties": {
                 "id": {
-                    "type": "text"
+                    "type": "long"
                 },
                 "batches": {
                     "properties": {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -28,7 +28,7 @@
                      paginator="true"
                      resizableColumns="true"
                      liveResize="true"
-                     sortBy="#{process.properties.id}"
+                     sortBy="#{process.id}"
                      sortOrder="descending"
                      rows="#{LoginForm.loggedUser.tableSize}"
                      paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {NextPageLink} {LastPageLink}"
@@ -49,8 +49,8 @@
                       styleClass="numeric"
                       resizable="false"
                       headerText="#{msgs.id}"
-                      sortBy="#{process.properties.id}"
-                      filterBy="#{process.properties.id}">
+                      sortBy="#{process.id}"
+                      filterBy="#{process.id}">
                 <h:outputText value="#{process.id}"
                               title="#{process.id}"/>
             </p:column>


### PR DESCRIPTION
To sort by id, it needs to be added to the indexed object. Sorting by object id in index (_id) is not possible.
fixes #3417 