### PR TITLE
restore blockedUser

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -120,6 +120,9 @@ public class Process extends BaseTemplateBean {
     private boolean exported;
 
     @Transient
+    private User blockedUser;
+
+    @Transient
     private List<Map<String, Object>> metadata;
 
     /**
@@ -500,6 +503,25 @@ public class Process extends BaseTemplateBean {
      */
     public void setMetadata(List<Map<String, Object>> metadata) {
         this.metadata = metadata;
+    }
+
+    /**
+     * Get blocked user.
+     *
+     * @return User object if this user is blocked
+     */
+    public User getBlockedUser() {
+        return blockedUser;
+    }
+
+    /**
+     * Set blocked user.
+     *
+     * @param blockedUser
+     *            User object
+     */
+    public void setBlockedUser(User blockedUser) {
+        this.blockedUser = blockedUser;
     }
 
     /**


### PR DESCRIPTION
The blocked user was removed in #3592 but is used in the currentTaskPage.
as it is not set anymore, a more detailed change is necessary here, this PR just restores the currentTaskPage.
fixes #3615 