### PR TITLE
Prevent ClassCastException in MetadataEditor

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -130,7 +130,7 @@
 
             <!-- toggleSwitch -->
             <h:panelGroup rendered="#{item.input eq 'toggleSwitch'}"
-                          title="#{item.active}">
+                          title="#{item.active.toString()}">
                 <p:selectBooleanCheckbox id="selectBooleanCheckbox"
                                          value="#{item.active}">
                     <p:ajax event="blur"/>


### PR DESCRIPTION
Prevent potential ClassCastException in MetadataPanel of MetadataEditor when rendering title of boolean metadata.