### PR TITLE
Automatic MediaUnit selection

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -517,8 +517,7 @@ public class AddDocStrucTypeDialog {
                                         : "dataTable"));
             }
             if (!dataEditor.getProcess().getRuleset().isOrderMetadataByRuleset()) {
-                Collections.sort(selectAddableMetadataTypesItems,
-                    (one, another) -> one.getLabel().compareTo(another.getLabel()));
+                selectAddableMetadataTypesItems.sort(Comparator.comparing(SelectItem::getLabel));
             }
         } catch (InvalidMetadataValueException e) {
             Helper.setErrorMessage(e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -245,6 +245,8 @@ public class StructurePanel implements Serializable {
         if (Objects.nonNull(matchingTreeNode)) {
             updatePhysicalNodeSelection(matchingTreeNode);
             matchingTreeNode.setSelected(true);
+            previouslySelectedPhysicalNode.setSelected(false);
+            show(true);
         }
     }
 

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1299,6 +1299,10 @@ Popup dialogs
     overflow-y: scroll;
 }
 
+#dialogAddDocStrucTypeForm\:dialogAddDocStrucTypeFormContent {
+    overflow-y: hidden;
+}
+
 .ui-dialog.legal-dialog button.secondary.right {
     position: absolute;
     bottom: var(--default-double-size);

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addMediaUnit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addMediaUnit.xhtml
@@ -61,7 +61,7 @@
                                          icon="fa fa-check fa-lg"
                                          iconPos="right"
                                          styleClass="primary right"
-                                         update="structureTreeForm:physicalTree,metadataAccordion:physicalMetadataWrapperPanel"
+                                         update="structureTreeForm:physicalTree,structureTreeForm:paginationPanel,metadataAccordion:physicalMetadataWrapperPanel"
                                          oncomplete="PF('dialogAddMediaUnit').hide();"/>
                         <p:commandButton value="#{msgs.cancel}"
                                          icon="fa fa-times fa-lg"


### PR DESCRIPTION
Directly select new MediaUnit after adding them in the physical structure tree and update MetadataEditor panels accordingly.