### PR TITLE
Disable physical structure trees context menu during AJAX requests

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -158,11 +158,13 @@
                                 metadataAccordion:physicalMetadataWrapperPanel"/>
                 <p:ajax event="contextMenu"
                         listener="#{DataEditorForm.structurePanel.treePhysicalSelect}"
+                        onstart="$('#structureTreeForm\\:contextMenuPhysicalTree .ui-menuitem').addClass('ui-state-disabled')"
                         oncomplete="initializeImage();PF('contextMenuPhysicalTree').show(currentEvent)"
                         update="@(.stripe)
                                 @(.thumbnail)
                                 galleryHeadingWrapper
                                 imagePreviewForm:mediaViewData
+                                structureTreeForm:contextMenuPhysicalTree
                                 structureTreeForm:logicalTree
                                 metadataAccordion:physicalMetadataWrapperPanel"/>
                 <p:ajax event="dragdrop"


### PR DESCRIPTION
Brings context menu of physical structure tree in line with logical tree after changes in #3620 