### PR TITLE
Correct a warning message

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalDivision.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalDivision.java
@@ -83,7 +83,7 @@ public enum FunctionalDivision {
                 }
             }
             logger.warn("Ruleset declares undefined field use '{}', must be one of: {}", mark,
-                    Arrays.stream(values()).map(FunctionalDivision::toString).collect(Collectors.joining(", ")));
+                    Arrays.stream(values()).map(FunctionalDivision::getMark).collect(Collectors.joining(", ")));
         }
         return values;
     }


### PR DESCRIPTION
Current warning message prints constant names instead of constat values:
`Ruleset declares undefined field use 'createChildrenWithCalendar', must be one of: CREATE_CHILDREN_WITH_CALENDAR, CREATE_CHILDREN_FROM_PARENT`

**Should be:**
`Ruleset declares undefined field use 'createChildrenWithCalendar', must be one of: createChildrenWithCalendar, createChildrenFromParent`