### PR TITLE
Expand correct metadata panel automatically

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1847,31 +1847,31 @@ Column content
 }
 
 #structurePanel > div,
-#structureWrapperPanel {
+#structureAccordion {
     height: 100%;
 }
 
-#structureWrapperPanel {
+#structureAccordion {
     display: flex;
     flex-direction: column;
 }
 
-#structureWrapperPanel .ui-accordion-header {
+#structureAccordion .ui-accordion-header {
     flex: 0 0 var(--input-height);
     box-sizing: border-box;
 }
 
-#structureWrapperPanel .ui-accordion-content {
+#structureAccordion .ui-accordion-content {
     flex: 1 0;
     overflow: hidden;
     padding: 0;
 }
 
-#structureWrapperPanel .ui-tree-container {
+#structureAccordion .ui-tree-container {
     overflow: initial;
 }
 
-#structureWrapperPanel .scroll-wrapper {
+#structureAccordion .scroll-wrapper {
     box-sizing: border-box;
     height: 100%;
     overflow: auto;
@@ -1974,6 +1974,7 @@ Column content
     height: 100%;
 }
 
+#structureAccordion .ui-accordion-header,
 #metadataAccordion .ui-accordion-header {
     display: none;
 }
@@ -1982,6 +1983,7 @@ Column content
     overflow-y: hidden;
 }
 
+#structureAccordion.separateStructure .ui-accordion-header,
 #metadataAccordion.separateStructure .ui-accordion-header {
     display: block;
 }
@@ -2357,10 +2359,11 @@ Column content
 
 .thumbnail.selected + .thumbnail-container img {
     border-color: var(--green);
+    border-style: dashed;
 }
 
 .thumbnail.selected.last-selection + .thumbnail-container img {
-    border-style: dashed;
+    border-style: solid;
 }
 
 .thumbnail-container {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -232,7 +232,7 @@ metadataEditor.shortcuts = {
 };
 
 function expandMetadata(panelClass) {
-    $("." + panelClass + "[aria-expanded='false']").click()
+    $("." + panelClass + "[aria-expanded='false']").click();
 }
 
 $(document).ready(function () {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 /* globals select, setGalleryViewMode, destruct, initialize, scrollToSelectedThumbnail, changeToMapView, PF, scrollToStructureThumbnail,
-    scrollToPreviewThumbnail */
+    scrollToPreviewThumbnail, expandMetadata */
 
 var metadataEditor = {
     dragging: false,
@@ -230,6 +230,10 @@ metadataEditor.shortcuts = {
         }
     }
 };
+
+function expandMetadata(panelClass) {
+    $("." + panelClass + "[aria-expanded='false']").click()
+}
 
 $(document).ready(function () {
     metadataEditor.shortcuts.listen();

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -15,7 +15,6 @@
         xmlns="http://www.w3.org/1999/xhtml"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-        xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:p="http://primefaces.org/ui">
     <div class="scroll-up-area"></div>
     <div class="scroll-wrapper">
@@ -29,7 +28,7 @@
                 dragdropScope="logicalTree">
             <p:ajax event="select"
                     listener="#{DataEditorForm.structurePanel.treeLogicalSelect}"
-                    oncomplete="scrollToSelectedThumbnail();changeToMapView()"
+                    oncomplete="scrollToSelectedThumbnail();changeToMapView();expandMetadata('logical-metadata-tab');"
                     update="@(.stripe)
                             @(.thumbnail)
                             galleryHeadingWrapper

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/paginationControls.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/paginationControls.xhtml
@@ -21,7 +21,7 @@
 
     <ui:fragment id="actionButtons">
         <p:remoteCommand name="showStructure"
-                         update="structureWrapperPanel, metadataAccordion"
+                         update="structureAccordion, metadataAccordion"
                          action="#{DataEditorForm.structurePanel.show()}"/>
         <p:commandButton id="pagingButton"
                          value="#{msgs.pagination}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
@@ -15,7 +15,6 @@
         xmlns="http://www.w3.org/1999/xhtml"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-        xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:p="http://primefaces.org/ui">
     <div class="scroll-up-area"></div>
     <div class="scroll-wrapper">
@@ -30,7 +29,7 @@
                 dragdropScope="physicalTree">
             <p:ajax event="select"
                     listener="#{DataEditorForm.structurePanel.treePhysicalSelect}"
-                    oncomplete="initializeImage()"
+                    oncomplete="initializeImage();expandMetadata('physical-metadata-tab');"
                     update="@(.thumbnail)
                             @(.stripe)
                             galleryHeadingWrapper

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -13,13 +13,15 @@
 
 <ui:composition
         xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:p="http://primefaces.org/ui">
-    <p:accordionPanel id="structureWrapperPanel"
-                      styleClass="wrapperPanel"
+    <!--@elvariable id="separateStructure" type="boolean"-->
+    <ui:param name="separateStructure"
+              value="#{DataEditorForm.structurePanel.separateMedia}"/>
+    <p:accordionPanel id="structureAccordion"
+                      styleClass="wrapperPanel #{separateStructure ? 'separateStructure' : ''}"
                       multiple="true"
-                      activeIndex="0#{DataEditorForm.structurePanel.separateMedia ? ',1' : ''}"
+                      activeIndex="0#{separateStructure ? ',1' : ''}"
                       prependId="false">
         <!--@elvariable id="readOnly" type="boolean"-->
         <ui:param name="readOnly" value="#{SecurityAccessController.hasAuthorityToViewProcessStructureData() and not SecurityAccessController.hasAuthorityToEditProcessStructureData()}"/>
@@ -33,7 +35,7 @@
         <!-- Physical Tree -->
         <p:tab id="physicalStructure"
                title="#{msgs.physical} #{msgs.structure}"
-               rendered="#{DataEditorForm.structurePanel.separateMedia}">
+               rendered="#{separateStructure}">
             <ui:include src="/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml"/>
         </p:tab>
     </p:accordionPanel>

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -105,10 +105,12 @@
                             <div id="metadataPanel" data-min-height="100" class="#{viewMetadata ? '' : 'collapsed'}">
                                 <p:accordionPanel id="metadataAccordion"
                                                   styleClass="#{DataEditorForm.structurePanel.separateMedia ? 'separateStructure' : ''}">
-                                    <p:tab title="#{msgs.logical} #{msgs.metadata}">
+                                    <p:tab title="#{msgs.logical} #{msgs.metadata}"
+                                           titleStyleClass="logical-metadata-tab">
                                         <ui:include src="/WEB-INF/templates/includes/metadataEditor/logicalMetadata.xhtml" />
                                     </p:tab>
                                     <p:tab title="#{msgs.physical} #{msgs.metadata}"
+                                           titleStyleClass="physical-metadata-tab"
                                            rendered="#{DataEditorForm.structurePanel.separateMedia}">
                                         <ui:include src="/WEB-INF/templates/includes/metadataEditor/physicalMetadata.xhtml" />
                                     </p:tab>


### PR DESCRIPTION
- Expand correct metadata panel in separate structure tree mode when selecting node in corresponding tree
- hide accordion tab headers in structure tree in combined tree
- update styling of selected thumbnails (dashed border for selected thumbnails, solid border for last selected thumbnail)