### PR TITLE
Fix pagination button

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/paginationControls.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/paginationControls.xhtml
@@ -28,6 +28,7 @@
                          title="#{msgs.pagination}"
                          actionListener="#{DataEditorForm.paginationPanel.show()}"
                          oncomplete="PF('paginationDialog').show();"
+                         process="@this"
                          update="paginationForm"
                          styleClass="secondary #{readOnly ? 'disabled' : ''}"
                          disabled="#{readOnly}"


### PR DESCRIPTION
Fixes #3708 

**Note**: adding `process=@this` to the pagination button prevents the `PropertyNotWritableException` and re-enables the pagination, because it causes the rest of the enclosing `structureTreeForm` to be ignored when being submitted via the pagination button - including potentially faulty parts/fields of the form. 

This means the broken functionality will be restored, but the underlying bug must still be fixed.

I would still suggest to merge this pull request because the change is an improvement nonetheless - for opening the pagination dialog, the rest of the form is irrelevant and _should_ be ignored.