### PR TITLE
Hotfix: Prevent `PropertyNotWritableException` in Metadata Editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -104,6 +104,11 @@ public class StructurePanel implements Serializable {
     private int order = 1;
 
     /**
+     * Active tabs in StructurePanel's accordion.
+     */
+    private String activeTabs;
+
+    /**
      * Creates a new structure panel.
      *
      * @param dataEditor
@@ -1435,6 +1440,23 @@ public class StructurePanel implements Serializable {
         return severalAssignments;
     }
 
+    /**
+     * Get activeTabs.
+     *
+     * @return value of activeTabs
+     */
+    public String getActiveTabs() {
+        return activeTabs;
+    }
+
+    /**
+     * Set activeTabs.
+     *
+     * @param activeTabs as java.lang.String
+     */
+    public void setActiveTabs(String activeTabs) {
+        this.activeTabs = activeTabs;
+    }
 
     /**
      * Get the index of this StructureTreeNode's MediaUnit out of all MediaUnits

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/structure.xhtml
@@ -21,7 +21,7 @@
     <p:accordionPanel id="structureAccordion"
                       styleClass="wrapperPanel #{separateStructure ? 'separateStructure' : ''}"
                       multiple="true"
-                      activeIndex="0#{separateStructure ? ',1' : ''}"
+                      activeIndex="#{DataEditorForm.structurePanel.activeTabs}"
                       prependId="false">
         <!--@elvariable id="readOnly" type="boolean"-->
         <ui:param name="readOnly" value="#{SecurityAccessController.hasAuthorityToViewProcessStructureData() and not SecurityAccessController.hasAuthorityToEditProcessStructureData()}"/>

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -21,6 +21,7 @@
 
     <f:metadata>
         <f:viewAction action="#{DataEditorForm.initMetadataEditor()}"/>
+        <f:viewAction action="#{DataEditorForm.structurePanel.setActiveTabs(DataEditorForm.structurePanel.separateMedia ? '0,1' : '0')}"/>
     </f:metadata>
     <ui:define name="content">
 


### PR DESCRIPTION
Saves the value of the `activeIndex` attribute for the accordionPanel properly. Providing no setter for `activeIndex` caused a `PropertyNotWritableException`.
Resolves #3708. 