### PR TITLE
Rewrite the URIs correctly so that images are displayed again

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -47,6 +47,8 @@ import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.model.Subfolder;
+import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.file.FileService;
 import org.primefaces.PrimeFaces;
 import org.primefaces.event.DragDropEvent;
 import org.primefaces.model.DefaultStreamedContent;
@@ -57,6 +59,8 @@ import org.primefaces.model.StreamedContent;
  */
 public class GalleryPanel {
     private static final Logger logger = LogManager.getLogger(GalleryPanel.class);
+
+    private static final FileService fileService = ServiceManager.getFileService();
 
     // Structured media
     private static final Pattern DRAG_STRIPE_IMAGE = Pattern
@@ -460,9 +464,13 @@ public class GalleryPanel {
     private GalleryMediaContent createGalleryMediaContent(View view) {
         MediaUnit mediaUnit = view.getMediaUnit();
         URI previewUri = mediaUnit.getMediaFiles().get(previewVariant);
+        URI resourcePreviewUri = previewUri.isAbsolute() ? previewUri
+                : fileService.getResourceUriForProcessRelativeUri(dataEditor.getProcess(), previewUri);
         URI mediaViewUri = mediaUnit.getMediaFiles().get(mediaViewVariant);
-        String canonical = Objects.nonNull(previewUri) ? previewFolder.getCanonical(previewUri) : null;
-        return new GalleryMediaContent(this, view, canonical, previewUri, mediaViewUri);
+        URI resourceMediaViewUri = mediaViewUri.isAbsolute() ? mediaViewUri
+                : fileService.getResourceUriForProcessRelativeUri(dataEditor.getProcess(), mediaViewUri);
+        String canonical = Objects.nonNull(resourcePreviewUri) ? previewFolder.getCanonical(resourcePreviewUri) : null;
+        return new GalleryMediaContent(this, view, canonical, resourcePreviewUri, resourceMediaViewUri);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -811,6 +811,21 @@ public class FileService {
     }
 
     /**
+     * Returns the URI of the resource in the file management module for a URI
+     * relative to the process directory.
+     *
+     * @param process
+     *            Process in whose possession the URI should be resolved
+     * @param processRelativeUri
+     *            URI relative to the specified process
+     * @return URI of the resource
+     */
+    public URI getResourceUriForProcessRelativeUri(Process process, URI processRelativeUri) {
+        URI processBaseUri = getProcessBaseUriForExistingProcess(process);
+        return asDirectory(processBaseUri).resolve(processRelativeUri);
+    }
+
+    /**
      * This method is needed for migration purposes. It maps existing filePaths
      * to the correct URI. File.separator doesn't work because on Windows it
      * appends backslash to URI.


### PR DESCRIPTION
There was no distinction between URIs relative to the process directory and URIs for resources of the file management (whose appearance is determined by the file management). This is now resolved via the file service.