### PR TITLE
Check for unsaved changes when leaving metadata editor

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.api;
 
+import java.util.Objects;
+
 public class Metadata {
     /**
      * In which conceptual area in the METS file this metadata entry is stored.
@@ -58,5 +60,18 @@ public class Metadata {
      */
     public void setKey(String key) {
         this.key = key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Metadata metadata = (Metadata) o;
+        return domain == metadata.domain
+                && Objects.equals(key, metadata.key);
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/IncludedStructuralElement.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/IncludedStructuralElement.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.kitodo.api.Metadata;
 import org.kitodo.api.dataformat.mets.LinkedMetsResource;
@@ -233,5 +234,24 @@ public class IncludedStructuralElement implements Parent<IncludedStructuralEleme
     @Override
     public String toString() {
         return type + " \"" + label + "\"";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IncludedStructuralElement that = (IncludedStructuralElement) o;
+        return order == that.order
+                && Objects.equals(label, that.label)
+                && Objects.equals(link, that.link)
+                && Objects.equals(metadata, that.metadata)
+                && Objects.equals(orderlabel, that.orderlabel)
+                && Objects.equals(subincludedStructuralElements, that.subincludedStructuralElements)
+                && Objects.equals(type, that.type)
+                && Objects.equals(views, that.views);
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/MediaUnit.java
@@ -216,6 +216,23 @@ public class MediaUnit implements Parent<MediaUnit> {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MediaUnit)) {
+            return false;
+        }
+        MediaUnit mediaUnit = (MediaUnit) o;
+        return order == mediaUnit.order
+                && Objects.equals(children, mediaUnit.children)
+                && Objects.equals(mediaFiles, mediaUnit.mediaFiles)
+                && Objects.equals(metadata, mediaUnit.metadata)
+                && Objects.equals(orderlabel, mediaUnit.orderlabel)
+                && Objects.equals(type, mediaUnit.type);
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
@@ -226,36 +243,4 @@ public class MediaUnit implements Parent<MediaUnit> {
         return hashCode;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof MediaUnit)) {
-            return false;
-        }
-        MediaUnit other = (MediaUnit) obj;
-        if (mediaFiles == null) {
-            if (other.mediaFiles != null) {
-                return false;
-            }
-        } else if (!mediaFiles.equals(other.mediaFiles)) {
-            return false;
-        }
-        if (order != other.order) {
-            return false;
-        }
-        if (orderlabel == null) {
-            if (other.orderlabel != null) {
-                return false;
-            }
-        } else if (!orderlabel.equals(other.orderlabel)) {
-            return false;
-        }
-        if (Objects.isNull(type)) {
-            return !Objects.nonNull(other.type);
-        } else {
-            return type.equals(other.type);
-        }
-    }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.api.dataformat;
 
+import java.util.Objects;
+
 /**
  * A view on a media unit. The individual levels of the
  * {@link IncludedStructuralElement} refer to {@code View}s on
@@ -40,6 +42,18 @@ public class View {
      */
     public void setMediaUnit(MediaUnit mediaUnit) {
         this.mediaUnit = mediaUnit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        View view = (View) o;
+        return Objects.equals(mediaUnit, view.mediaUnit);
     }
 
     @Override

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -164,21 +164,19 @@ public class Workpiece {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-
-        if (obj instanceof Workpiece) {
-            Workpiece other = (Workpiece) obj;
-
-            if (Objects.isNull(id)) {
-                return Objects.isNull(other.id);
-            } else {
-                return id.equals(other.id);
-            }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
         }
-        return false;
+        Workpiece workpiece = (Workpiece) o;
+        return Objects.equals(creationDate, workpiece.creationDate)
+                && Objects.equals(editHistory, workpiece.editHistory)
+                && Objects.equals(id, workpiece.id)
+                && Objects.equals(mediaUnit, workpiece.mediaUnit)
+                && Objects.equals(rootElement, workpiece.rootElement);
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/LinkedMetsResource.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/mets/LinkedMetsResource.java
@@ -12,6 +12,7 @@
 package org.kitodo.api.dataformat.mets;
 
 import java.net.URI;
+import java.util.Objects;
 
 /**
  * Data about a linked METS resource.
@@ -63,5 +64,18 @@ public class LinkedMetsResource {
      */
     public void setUri(URI uri) {
         this.uri = uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LinkedMetsResource that = (LinkedMetsResource) o;
+        return Objects.equals(loctype, that.loctype)
+                && Objects.equals(uri, that.uri);
     }
 }

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -208,7 +208,9 @@ public class DivXmlElementAccess extends IncludedStructuralElement {
                     if (value instanceof KitodoType) {
                         KitodoType kitodoType = (KitodoType) value;
                         for (MetadataType metadataEntry : kitodoType.getMetadata()) {
-                            metadata.add(new MetadataXmlElementAccess(mdSec, metadataEntry).getMetadataEntry());
+                            if (!metadataEntry.getValue().isEmpty()) {
+                                metadata.add(new MetadataXmlElementAccess(mdSec, metadataEntry).getMetadataEntry());
+                            }
                         }
                         for (MetadataGroupType metadataGroup : kitodoType.getMetadataGroup()) {
                             metadata.add(new MetadataGroupXmlElementAccess(mdSec, metadataGroup).getMetadataGroup());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -154,6 +154,11 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     private Workpiece workpiece;
 
     /**
+     * Original state of workpiece. Used to check whether any unsaved changes exist when leaving the editor.
+     */
+    private Workpiece workpieceOriginalState;
+
+    /**
      * This List of Pairs stores all selected physical elements and the logical elements in which the physical element was selected.
      * It is necessary to store the logical elements as well, because a physical element can be assigned to multiple logical elements.
      */
@@ -239,6 +244,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     private void openMetsFile() throws IOException, InvalidImagesException {
         mainFileUri = ServiceManager.getProcessService().getMetadataFileUri(process);
         workpiece = ServiceManager.getMetsService().loadWorkpiece(mainFileUri);
+        workpieceOriginalState = ServiceManager.getMetsService().loadWorkpiece(mainFileUri);
         if (Objects.isNull(workpiece.getId())) {
             logger.warn("Workpiece has no ID. Cannot verify workpiece ID. Setting workpiece ID.");
             workpiece.setId(process.getId().toString());
@@ -289,6 +295,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         metadataPanel.clear();
         structurePanel.clear();
         workpiece = null;
+        workpieceOriginalState = null;
         mainFileUri = null;
         ruleset = null;
         currentChildren.clear();
@@ -739,6 +746,16 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         }
         else {
             return true;
+        }
+    }
+
+    /**
+     * Check for changes in workpiece.
+     */
+    public void checkForChanges() {
+        if (Objects.nonNull(PrimeFaces.current())) {
+            boolean unsavedChanges = !this.workpiece.equals(workpieceOriginalState);
+            PrimeFaces.current().executeScript("setConfirmUnload(" + unsavedChanges + ");");
         }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
@@ -139,7 +139,10 @@ public class MetadataPanel implements Serializable {
 
     }
 
-    void preserve() {
+    /**
+     * Preserve metadata.
+     */
+    public void preserve() {
         try {
             this.preserveLogical();
             this.preservePhysical();
@@ -150,9 +153,11 @@ public class MetadataPanel implements Serializable {
 
     void preserveLogical() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         logicalMetadataTable.preserve();
+        this.dataEditorForm.checkForChanges();
     }
 
     void preservePhysical() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         physicalMetadataTable.preserve();
+        this.dataEditorForm.checkForChanges();
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
@@ -36,7 +36,7 @@ import org.kitodo.production.services.ServiceManager;
  */
 public class PaginationPanel {
 
-    private DataEditorForm dataEditor;
+    private final DataEditorForm dataEditor;
     private boolean fictitiousCheckboxChecked = false;
     private int newPagesCountValue = 0;
     private List<SelectItem> paginationSelectionItems;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -53,7 +53,7 @@ import org.primefaces.model.TreeNode;
 public class StructurePanel implements Serializable {
     private static final Logger logger = LogManager.getLogger(StructurePanel.class);
 
-    private DataEditorForm dataEditor;
+    private final DataEditorForm dataEditor;
 
     /**
      * If changing the tree node fails, we need this value to undo the user’s
@@ -313,6 +313,7 @@ public class StructurePanel implements Serializable {
     private void preserveLogical() {
         if (!this.logicalTree.getChildren().isEmpty()) {
             preserveLogicalRecursive(this.logicalTree.getChildren().get(logicalTree.getChildCount() - 1));
+            this.dataEditor.checkForChanges();
         }
     }
 
@@ -343,6 +344,7 @@ public class StructurePanel implements Serializable {
     private void preservePhysical() {
         if (!physicalTree.getChildren().isEmpty()) {
             preservePhysicalRecursive(physicalTree.getChildren().get(0));
+            this.dataEditor.checkForChanges();
         }
     }
 
@@ -416,6 +418,7 @@ public class StructurePanel implements Serializable {
         this.selectedPhysicalNode = physicalTree.getChildren().get(0);
         this.previouslySelectedLogicalNode = selectedLogicalNode;
         this.previouslySelectedPhysicalNode = selectedPhysicalNode;
+        this.dataEditor.checkForChanges();
     }
 
     private void restoreSelection(String rowKey, TreeNode parentNode) {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 /* globals select, setGalleryViewMode, destruct, initialize, scrollToSelectedThumbnail, changeToMapView, PF, scrollToStructureThumbnail,
-    scrollToPreviewThumbnail, expandMetadata */
+    scrollToPreviewThumbnail, expandMetadata, preserveMetadata, setConfirmUnload */
 
 var metadataEditor = {
     dragging: false,
@@ -238,4 +238,11 @@ function expandMetadata(panelClass) {
 $(document).ready(function () {
     metadataEditor.shortcuts.listen();
     metadataEditor.contextMenu.listen();
+    $("#metadataAccordion input").blur("input", function () {
+        preserveMetadata();
+    });
 });
+
+function setConfirmUnload(on) {
+    window.onbeforeunload = (on) ? function() { return true; } : void 0;
+}

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -238,7 +238,7 @@ function expandMetadata(panelClass) {
 $(document).ready(function () {
     metadataEditor.shortcuts.listen();
     metadataEditor.contextMenu.listen();
-    $("#metadataAccordion input").blur("input", function () {
+    $("#metadataAccordion input").blur(function () {
         preserveMetadata();
     });
 });

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
@@ -35,7 +35,7 @@
                          styleClass="#{mayWrite ? '' : 'disabled'}"
                          disabled="#{not mayWrite}"
                          style="margin-left: 16px;"
-                         onclick="PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','detail':'#{msgs.youWillBeRedirected}','severity':'info'});"
+                         onclick="setConfirmUnload(false);PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','detail':'#{msgs.youWillBeRedirected}','severity':'info'});"
                          update="notifications"/>
         <p:commandButton id="save"
                          widgetVar="save"
@@ -46,7 +46,8 @@
                          styleClass="#{mayWrite ? '' : 'disabled'} secondary"
                          disabled="#{not mayWrite}"
                          style="margin-left: 16px;"
-                         onclick="PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','severity':'info'});$('loadingScreen').show()"
+                         onclick="setConfirmUnload(false);PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','severity':'info'});$('loadingScreen').show()"
+                         oncomplete="$('#structureTreeForm\\:physicalTree li[aria-selected=\'true\']').click();"
                          update="notifications"/>
         <p:commandButton value="#{msgs.validate}"
                          actionListener="#{DataEditorForm.validate}"
@@ -57,6 +58,7 @@
                          style="margin-left: 16px;"
                          styleClass="secondary"/>
         <p:commandButton value="#{msgs.exit}"
+                         onclick="setConfirmUnload(false);"
                          action="#{DataEditorForm.close}"
                          icon="fa fa-times fa-lg"
                          iconPos="right"

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -25,6 +25,9 @@
     </f:metadata>
     <ui:define name="content">
 
+        <p:remoteCommand name="preserveMetadata"
+                         actionListener="#{DataEditorForm.metadataPanel.preserve}"/>
+
         <!--@elvariable id="viewStructure" type="boolean"-->
         <ui:param name="viewStructure" value="#{SecurityAccessController.hasAuthorityToViewProcessStructureData()}"/>
         <!--@elvariable id="viewMetadata" type="boolean"-->


### PR DESCRIPTION
- check for unsaved changes in workpiece when leaving the metadata editor without saving or explicitly closing.
- skip metadata with empty values when loading workpiece from XML
- preserve metadata on input fields `blur` events in metadata panel