### PR TITLE
Prevent ViewExpiredException by saving ViewState in client

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -24,7 +24,7 @@
 
     <context-param>
         <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>server</param-value>
+        <param-value>client</param-value>
     </context-param>
 
     <context-param>


### PR DESCRIPTION
Fixes #3444 by saving the `ViewState` of a page in the client instead of the server. (see last sentence in https://stackoverflow.com/a/8474609/5467214) 

Since this is quite a fundamental configuration change it should be scrutinized and discussed by as many developers as possible.