### PR TITLE
Extend keyboard navigation in metadata editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -159,6 +159,11 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     private Workpiece workpieceOriginalState;
 
     /**
+     * String indicating which UI area is currently focused receiving navigation shortcuts.
+     */
+    private String focusedArea = "";
+
+    /**
      * This List of Pairs stores all selected physical elements and the logical elements in which the physical element was selected.
      * It is necessary to store the logical elements as well, because a physical element can be assigned to multiple logical elements.
      */
@@ -755,6 +760,24 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             boolean unsavedChanges = !this.workpiece.equals(workpieceOriginalState);
             PrimeFaces.current().executeScript("setConfirmUnload(" + unsavedChanges + ");");
         }
+    }
+
+    /**
+     * Get focusedArea.
+     *
+     * @return value of focusedArea
+     */
+    public String getFocusedArea() {
+        return focusedArea;
+    }
+
+    /**
+     * Set focusedArea.
+     *
+     * @param focusedArea as java.lang.String
+     */
+    public void setFocusedArea(String focusedArea) {
+        this.focusedArea = focusedArea;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -159,11 +159,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     private Workpiece workpieceOriginalState;
 
     /**
-     * String indicating which UI area is currently focused receiving navigation shortcuts.
-     */
-    private String focusedArea = "";
-
-    /**
      * This List of Pairs stores all selected physical elements and the logical elements in which the physical element was selected.
      * It is necessary to store the logical elements as well, because a physical element can be assigned to multiple logical elements.
      */
@@ -760,24 +755,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             boolean unsavedChanges = !this.workpiece.equals(workpieceOriginalState);
             PrimeFaces.current().executeScript("setConfirmUnload(" + unsavedChanges + ");");
         }
-    }
-
-    /**
-     * Get focusedArea.
-     *
-     * @return value of focusedArea
-     */
-    public String getFocusedArea() {
-        return focusedArea;
-    }
-
-    /**
-     * Set focusedArea.
-     *
-     * @param focusedArea as java.lang.String
-     */
-    public void setFocusedArea(String focusedArea) {
-        this.focusedArea = focusedArea;
     }
 
     /**

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1569,6 +1569,11 @@ Metadata Editor
     border-top: solid var(--contrast-border-width) var(--medium-gray);
 }
 
+.focusable.focused {
+    border: dashed var(--contrast-border-width) var(--blue);
+    box-sizing: border-box;
+}
+
 form#metadata,
 form#metadata textarea,
 form#metadata div label,
@@ -1918,6 +1923,7 @@ Column content
     overflow: initial;
 }
 
+#containerStructure.ui-accordion-content,
 #structureAccordion .scroll-wrapper {
     box-sizing: border-box;
     height: 100%;

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -189,7 +189,7 @@ metadataEditor.shortcuts = {
     jumpToSelectedTreeNode(tree, delta, vertical) {
         let lastSelection = tree.find("li.ui-treenode[aria-selected='true']");
         if (!vertical && lastSelection.length === 1) {
-            lastSelection.children(".ui-treenode-children").is(":visible")
+            lastSelection.children(".ui-treenode-children").is(":visible");
             if (delta <= -1 && lastSelection.children(".ui-treenode-children").is(":visible")) {
                 lastSelection.children(".ui-treenode-content").children(".ui-tree-toggler").click();
             } else if (delta >= 1 && lastSelection.children(".ui-treenode-children").is(":hidden")) {
@@ -214,7 +214,7 @@ metadataEditor.shortcuts = {
     },
     navigateByShortcut(delta, vertical) {
         let focusedArea = $(".focused");
-        if (focusedArea.length !== 1 || focusedArea[0] == null) {
+        if (focusedArea.length !== 1 || focusedArea[0] === null) {
             return;
         }
         switch (focusedArea[0].id) {
@@ -282,7 +282,7 @@ metadataEditor.shortcuts = {
             }
         });
     },
-    listen: function (shortcuts) {
+    listen (shortcuts) {
         metadataEditor.shortcuts.KEYS = shortcuts;
         $(document).on("keydown.shortcuts", function (event) {
             metadataEditor.shortcuts.evaluateKeys(event.originalEvent);

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -21,6 +21,9 @@ var metadataEditor = {
         } else if (target.closest(".thumbnail-container").length === 1) {
             this.pages.handleMouseDown(event, target.closest(".thumbnail-container"));
         }
+        // set focus for gallery (used for keyboard shortcuts)
+        $(".focusable").removeClass("focused");
+        $("#imagePreviewForm").addClass("focused");
     },
     handleMouseUp(event) {
         let target = $(event.target);
@@ -174,6 +177,56 @@ metadataEditor.shortcuts = {
             }
         }
     },
+    jumpToTreeNode(treeNodes, selectedTreeNode, delta) {
+        let currentIndex = treeNodes.index(selectedTreeNode);
+        let newIndex = currentIndex + delta;
+        if (currentIndex >= 0 && newIndex >= 0 && newIndex < treeNodes.length) {
+            treeNodes.eq(newIndex).children(".ui-treenode-content").children(".ui-treenode-label").click();
+            return true;
+        }
+        return false;
+    },
+    jumpToSelectedTreeNode(tree, delta, vertical) {
+        let lastSelection = tree.find("li.ui-treenode[aria-selected='true']");
+        if (!vertical && lastSelection.length === 1) {
+            lastSelection.children(".ui-treenode-children").is(":visible")
+            if (delta <= -1 && lastSelection.children(".ui-treenode-children").is(":visible")) {
+                lastSelection.children(".ui-treenode-content").children(".ui-tree-toggler").click();
+            } else if (delta >= 1 && lastSelection.children(".ui-treenode-children").is(":hidden")) {
+                lastSelection.children(".ui-treenode-content").children(".ui-tree-toggler").click();
+            }
+        } else if (vertical && lastSelection.length === 1) {
+            let treeNodes = tree.find("li.ui-treenode:visible");
+            if (delta > 0) {
+                for (; delta > 0; delta--) {
+                    if (this.jumpToTreeNode(treeNodes, lastSelection, delta)) {
+                        break;
+                    }
+                }
+            } else if (delta < 0) {
+                for (; delta < 0; delta++) {
+                    if (this.jumpToTreeNode(treeNodes, lastSelection, delta)) {
+                        break;
+                    }
+                }
+            }
+        }
+    },
+    navigateByShortcut(delta, vertical) {
+        let focusedArea = $(".focused");
+        if (focusedArea.length !== 1 || focusedArea[0] == null) {
+            return;
+        }
+        switch (focusedArea[0].id) {
+            case "logicalTree":
+            case "physicalTree":
+                metadataEditor.shortcuts.jumpToSelectedTreeNode(focusedArea.eq(0), delta, vertical);
+                break;
+            case "imagePreviewForm":
+            default:
+                metadataEditor.shortcuts.jumpToSelectedImage(delta, vertical); // gallery
+        }
+    },
     handleShortcut(shortcut) {
         switch (shortcut) {
             case "help":
@@ -188,28 +241,28 @@ metadataEditor.shortcuts = {
                 metadataEditor.shortcuts.changeView("PREVIEW");
                 break;
             case "nextItem":
-                metadataEditor.shortcuts.jumpToSelectedImage(1, false);
+                metadataEditor.shortcuts.navigateByShortcut(1, false);
                 break;
             case "previousItem":
-                metadataEditor.shortcuts.jumpToSelectedImage(-1, false);
+                metadataEditor.shortcuts.navigateByShortcut(-1, false);
                 break;
             case "nextItemMulti":
-                metadataEditor.shortcuts.jumpToSelectedImage(20, false);
+                metadataEditor.shortcuts.navigateByShortcut(20, false);
                 break;
             case "previousItemMulti":
-                metadataEditor.shortcuts.jumpToSelectedImage(-20, false);
+                metadataEditor.shortcuts.navigateByShortcut(-20, false);
                 break;
             case "downItem":
-                metadataEditor.shortcuts.jumpToSelectedImage(1, true);
+                metadataEditor.shortcuts.navigateByShortcut(1, true);
                 break;
             case "upItem":
-                metadataEditor.shortcuts.jumpToSelectedImage(-1, true);
+                metadataEditor.shortcuts.navigateByShortcut(-1, true);
                 break;
             case "downItemMulti":
-                metadataEditor.shortcuts.jumpToSelectedImage(10, true);
+                metadataEditor.shortcuts.navigateByShortcut(20, true);
                 break;
             case "upItemMulti":
-                metadataEditor.shortcuts.jumpToSelectedImage(-10, true);
+                metadataEditor.shortcuts.navigateByShortcut(-20, true);
                 break;
             default:
                 // This default case is only reached when shortcuts exist which are not implemented.
@@ -229,10 +282,14 @@ metadataEditor.shortcuts = {
             }
         });
     },
-    listen(shortcuts) {
+    listen: function (shortcuts) {
         metadataEditor.shortcuts.KEYS = shortcuts;
         $(document).on("keydown.shortcuts", function (event) {
             metadataEditor.shortcuts.evaluateKeys(event.originalEvent);
+        });
+        $(document).on("click.shortcuts", ".focusable", function (event) {
+            $(".focused").removeClass("focused");
+            event.currentTarget.classList.add("focused");
         });
     },
     ignore() {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -24,7 +24,7 @@
         <!--@elvariable id="editImages" type="boolean"-->
         <ui:param name="editImages" value="#{SecurityAccessController.hasAuthorityToEditProcessImages()}"/>
 
-        <h:form id="imagePreviewForm" style="height: 100%;">
+        <h:form id="imagePreviewForm" style="height: 100%;" styleClass="focusable">
             <p:graphicImage id="mediaViewData" value="#{DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).mediaViewData}" style="display: none;"/>
 
             <p:remoteCommand name="select"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -21,6 +21,7 @@
         <p:tree id="logicalTree"
                 value="#{DataEditorForm.structurePanel.logicalTree}"
                 var="logicalNode"
+                styleClass="focusable"
                 selectionMode="single"
                 selection="#{DataEditorForm.structurePanel.selectedLogicalNode}"
                 draggable="#{not readOnly}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
@@ -22,6 +22,7 @@
                 rendered="#{DataEditorForm.structurePanel.separateMedia}"
                 value="#{DataEditorForm.structurePanel.physicalTree}"
                 var="physicalNode"
+                styleClass="focusable"
                 selectionMode="single"
                 selection="#{DataEditorForm.structurePanel.selectedPhysicalNode}"
                 draggable="#{not readOnly}"

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -212,6 +212,9 @@
         <h:outputScript name="js/metadata_editor.js" target="body"/>
         <h:outputScript name="js/pf_contextMenu_custom.js" target="body"/>
         <h:outputScript>
+            PrimeFaces.widget.VerticalTree.prototype.bindKeyEvents = function () {
+                // Prevent PrimeFaces' default keyboard event handling for VerticalTrees.
+            };
             $(document).ready(function () {
                 metadataEditor.shortcuts.listen(#{DataEditorForm.shortcuts});
                 metadataEditor.contextMenu.listen();


### PR DESCRIPTION
Enable keyboard navigation for trees and use focus area for keyboard navigation.