### PR TITLE
Remove old and obsolete dom4j 1.x dependency

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -105,17 +105,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
             <version>1.1.1</version>


### PR DESCRIPTION
This dependency is not needed any more and removing this dependecy will "fix" the following CVEs:
- [CVE-2020-10683](https://github.com/advisories/GHSA-hwj3-m3p6-hj38) (rating: high)
- [CVE-2018-1000632](https://github.com/advisories/GHSA-6pcc-3rfx-4gpm) (rating: moderate)

dom4j is only needed by Hibernate and Hibernate will be updated in a separate pull request.