### PR TITLE
Update hibernate

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -105,17 +105,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
             <version>1.1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <org.apache.xmlgraphics.version>2.3</org.apache.xmlgraphics.version>
         <hamcrest.version>2.2-rc1</hamcrest.version>
-        <hibernate.version>5.4.12.Final</hibernate.version>
+        <hibernate.version>5.4.18.Final</hibernate.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.2.0</jaxen.version>
         <jersey.version>1.19.4</jersey.version>


### PR DESCRIPTION
Update hibernate to version 5.4.18 for at least fixing security issues in hibernate itself and / or hibernate dependencies like dom4j (see #3853).