### PR TITLE
Prevent NumberFormatException in task filter

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -837,8 +837,10 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
         Set<Integer> ids = new HashSet<>();
         List<String> stringIds = getFilterValuesFromFilterString(filter, filterString);
         for (String tempId : stringIds) {
-            Integer id = Integer.parseInt(tempId);
-            ids.add(id);
+            if (!tempId.isEmpty()) {
+                Integer id = Integer.parseInt(tempId);
+                ids.add(id);
+            }
         }
         return ids;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -837,7 +838,7 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
         Set<Integer> ids = new HashSet<>();
         List<String> stringIds = getFilterValuesFromFilterString(filter, filterString);
         for (String tempId : stringIds) {
-            if (!tempId.isEmpty()) {
+            if (!tempId.isEmpty() && StringUtils.isNumeric(tempId)) {
                 Integer id = Integer.parseInt(tempId);
                 ids.add(id);
             }


### PR DESCRIPTION
Prevent NumberFormatException when entering filter values with leading or trailing whitespaces in task filter (e.g. "id: 3")