### PR TITLE
Fix code documentation (LGTM)

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetadataGroupXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetadataGroupXmlElementAccess.java
@@ -42,7 +42,7 @@ public class MetadataGroupXmlElementAccess extends MetadataXmlElementsAccess {
      * 
      * @param domain
      *            domain of the METS document where the metadata was read
-     * @param oup
+     * @param xmlMetadataGroup
      *            {@code <kitodo:metadataGroup>} XML element
      */
     MetadataGroupXmlElementAccess(MdSec domain, MetadataGroupType xmlMetadataGroup) {


### PR DESCRIPTION
LGTM report:
    @param tag "oup" does not match any actual parameter of constructor "MetadataGroupXmlElementAccess()".

Signed-off-by: Stefan Weil <sw@weilnetz.de>