### PR TITLE
Fix wrong conditional in IllustratedSelectItemConverter

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
@@ -29,7 +29,7 @@ public class IllustratedSelectItemConverter implements Converter, Serializable {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (Objects.nonNull(value) || !value.isEmpty()) {
+        if (Objects.nonNull(value) && !value.isEmpty()) {
             List<IllustratedSelectItem> illustratedSelectItems = (List<IllustratedSelectItem>) component.getAttributes()
                     .get("illustratedSelectItems");
             for (IllustratedSelectItem illustratedSelectItem : illustratedSelectItems) {


### PR DESCRIPTION
LGTM report:
    Variable value is always null here.

Signed-off-by: Stefan Weil <sw@weilnetz.de>