### PR TITLE
Invoke setter on corresponding object type

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
@@ -87,12 +87,14 @@ public class ProcessBooleanMetadata extends ProcessSimpleMetadata implements Ser
     }
 
     @Override
-    Pair<Method, Object> getStructureFieldValue() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
+    Pair<Collection<Method>, String> getStructureFieldValue()
+            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
+
         if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
             if (!isValid()) {
                 throw new InvalidMetadataValueException(label, settings.convertBoolean(active).orElse(""));
             }
-            return Pair.of(super.getStructureFieldSetter(settings), settings.convertBoolean(active).orElse(null));
+            return Pair.of(super.getStructureFieldSetters(settings), settings.convertBoolean(active).orElse(null));
         } else {
             return null;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDetail.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDetail.java
@@ -134,7 +134,7 @@ public abstract class ProcessDetail implements Serializable {
      * @throws NoSuchMetadataFieldException
      *             if the field configured in the rule set does not exist
      */
-    abstract Pair<Method, Object> getStructureFieldValue()
+    abstract Pair<Collection<Method>, String> getStructureFieldValue()
             throws InvalidMetadataValueException, NoSuchMetadataFieldException;
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -462,7 +462,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     }
 
     @Override
-    Pair<Method, Object> getStructureFieldValue() {
+    Pair<Collection<Method>, String> getStructureFieldValue() {
         return null;
     }
 
@@ -509,10 +509,10 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
             metadata.clear();
             for (TreeNode child : treeNode.getChildren()) {
                 ProcessDetail row = (ProcessDetail) child.getData();
-                Pair<Method, Object> metsFieldValue = row.getStructureFieldValue();
+                Pair<Collection<Method>, String> metsFieldValue = row.getStructureFieldValue();
                 if (Objects.nonNull(metsFieldValue)) {
                     try {
-                        metsFieldValue.getKey().invoke(division, metsFieldValue.getValue());
+                        setMetsFieldValue(metsFieldValue);
                     } catch (IllegalAccessException | InvocationTargetException e) {
                         throw new IllegalStateException(e);
                     }
@@ -534,6 +534,25 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
             metadataGroup.setGroup(metadata);
             container.metadata.add(metadataGroup);
             copy = false;
+        }
+    }
+
+    private void setMetsFieldValue(Pair<Collection<Method>, String> metsFieldValue)
+            throws IllegalAccessException, InvocationTargetException {
+
+        ClassCastException notAnInstace = null;
+        for (Method setter : metsFieldValue.getKey()) {
+            try {
+                setter.invoke(division, metsFieldValue.getValue());
+                notAnInstace = null;
+                break;
+            } catch (ClassCastException e) {
+                notAnInstace = e;
+                continue;
+            }
+        }
+        if (Objects.nonNull(notAnInstace)) {
+            throw notAnInstace;
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -148,13 +148,14 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     }
 
     @Override
-    Pair<Method, Object> getStructureFieldValue() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
+    Pair<Collection<Method>, String> getStructureFieldValue()
+            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
             String value = String.join(" ", selectedItems);
             if (!settings.isValid(value)) {
                 throw new InvalidMetadataValueException(label, value);
             }
-            return Pair.of(super.getStructureFieldSetter(settings), value);
+            return Pair.of(super.getStructureFieldSetters(settings), value);
         } else {
             return null;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -92,12 +92,13 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
     }
 
     @Override
-    Pair<Method, Object> getStructureFieldValue() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
+    Pair<Collection<Method>, String> getStructureFieldValue()
+            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
             if (!settings.isValid(value)) {
                 throw new InvalidMetadataValueException(label, value);
             }
-            return Pair.of(super.getStructureFieldSetter(settings), value);
+            return Pair.of(super.getStructureFieldSetters(settings), value);
         } else {
             return null;
         }

--- a/Kitodo/src/test/java/org/kitodo/ExecutionPermission.java
+++ b/Kitodo/src/test/java/org/kitodo/ExecutionPermission.java
@@ -18,20 +18,26 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.lang.SystemUtils;
+
 public class ExecutionPermission {
 
     public static void setExecutePermission(File file) throws IOException {
-        Set<PosixFilePermission> permissions = setNoExecutePermission();
+        if (SystemUtils.IS_OS_UNIX) {
+            Set<PosixFilePermission> permissions = setNoExecutePermission();
 
-        permissions.add(PosixFilePermission.OWNER_EXECUTE);
-        permissions.add(PosixFilePermission.OTHERS_EXECUTE);
-        permissions.add(PosixFilePermission.GROUP_EXECUTE);
+            permissions.add(PosixFilePermission.OWNER_EXECUTE);
+            permissions.add(PosixFilePermission.OTHERS_EXECUTE);
+            permissions.add(PosixFilePermission.GROUP_EXECUTE);
 
-        Files.setPosixFilePermissions(file.toPath(), permissions);
+            Files.setPosixFilePermissions(file.toPath(), permissions);
+        }
     }
 
     public static void setNoExecutePermission(File file) throws IOException {
-        Files.setPosixFilePermissions(file.toPath(), setNoExecutePermission());
+        if (SystemUtils.IS_OS_UNIX) {
+            Files.setPosixFilePermissions(file.toPath(), setNoExecutePermission());
+        }
     }
 
     private static Set<PosixFilePermission> setNoExecutePermission() {


### PR DESCRIPTION
The problem is that the setter for `mets:div` metadata is located by introspection on `IncludedStructuralElement`, so Java refuses invoking the setter on `MediaUnit`, even though the method signature is the same. Therefore class cast exception. The solution is to locate the setter on both classes and try them both.

Fixes #3819, fixes #3820