### PR TITLE
Execute tests in random order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,14 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <runOrder>random</runOrder>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -140,6 +148,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${maven-failsafe-plugin.version}</version>
+                        <configuration>
+                            <runOrder>random</runOrder>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
This pull request change the order of test execution from default "filesystem" to "random". This can improve the quality of tests as they are not executed in a system specific ordering and bad written tests will be visible.