### PR TITLE
Move statistic results to separate popup dialog

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
@@ -49,7 +49,7 @@ public class ProcessListBaseView extends BaseForm {
     private HorizontalBarChartModel stackedBarModel;
     private PieChartModel pieModel;
     private Map<String,Integer> statisticResult;
-    private final List<ProcessMetadataStatistic> processMetadataStatistics = new ArrayList<>();
+    private List<ProcessMetadataStatistic> processMetadataStatistics = new ArrayList<>();
     private int numberOfGlobalImages;
     private int numberOfGlobalStructuralElements;
     private int numberOfGlobalMetadata;
@@ -82,6 +82,8 @@ public class ProcessListBaseView extends BaseForm {
     public void showDurationOfTasks() {
         chartMode = ChartMode.BAR;
         stackedBarModel = ServiceManager.getProcessService().getBarChartModel(selectedProcesses);
+        PrimeFaces.current().executeScript("PF('statisticsDialog').show();");
+        PrimeFaces.current().ajax().update("statisticsDialog");
     }
 
     /**
@@ -91,6 +93,8 @@ public class ProcessListBaseView extends BaseForm {
         chartMode = ChartMode.PIE;
         statisticResult = ServiceManager.getProcessService().getProcessTaskStates(selectedProcesses);
         pieModel = ServiceManager.getProcessService().getPieChardModel(statisticResult);
+        PrimeFaces.current().executeScript("PF('statisticsDialog').show();");
+        PrimeFaces.current().ajax().update("statisticsDialog");
     }
 
     /**
@@ -98,6 +102,7 @@ public class ProcessListBaseView extends BaseForm {
      */
     public void showProcessMetadataStatistic() {
         chartMode = ChartMode.METADATA_STATISTIC;
+        processMetadataStatistics = new ArrayList<>();
         resetGlobalStatisticValues();
         Workpiece workpiece;
         for (Process selectedProcess : selectedProcesses) {
@@ -120,6 +125,8 @@ public class ProcessListBaseView extends BaseForm {
             processMetadataStatistics.add(new ProcessMetadataStatistic(selectedProcess.getTitle(),
                     numberOfProcessImages, numberOfProcessStructuralElements, numberOfProcessMetadata));
         }
+        PrimeFaces.current().executeScript("PF('statisticsDialog').show();");
+        PrimeFaces.current().ajax().update("statisticsDialog");
     }
 
     /**

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1140,6 +1140,37 @@ h3#headerText {
 }
 
 /*----------------------------------------------------------------------
+Statistics
+----------------------------------------------------------------------*/
+
+#statisticsDialog {
+    overflow-y: hidden;
+}
+
+#statisticsDialog h3#headerText {
+    margin-bottom: 0;
+    overflow: unset;
+}
+
+#statisticPanel {
+    overflow-x: hidden;
+}
+
+#statisticResult {
+    display: inline-block;
+    vertical-align: top;
+    width: 50%;
+}
+
+#pieChartWrapper {
+    display: inline-block;
+    width: 45%;
+    height: 45%;
+    overflow-x: hidden;
+    padding: var(--default-full-size);
+}
+
+/*----------------------------------------------------------------------
 Import form
 ----------------------------------------------------------------------*/
 

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1170,6 +1170,11 @@ Statistics
     padding: var(--default-full-size);
 }
 
+#statisticsDialog #closeButtonForm\:close {
+    float: right;
+    margin-right: var(--default-full-size);
+}
+
 /*----------------------------------------------------------------------
 Import form
 ----------------------------------------------------------------------*/

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -255,24 +255,17 @@
                 <p:menuitem id="stateOfVolume"
                             value="#{msgs.stateOfVolume}"
                             action="#{ProcessForm.showStateOfVolume}"
-                            update="processesTabView:processesForm:statisticPanel"
                             icon="fa fa-arrow-circle-o-up"/>
                 <p:menuitem id="durationOfTasks"
                             value="#{msgs.durationOfTasks}"
                             action="#{ProcessForm.showDurationOfTasks}"
-                            update="processesTabView:processesForm:statisticPanel"
                             icon="fa fa-arrow-circle-o-up"/>
                 <p:menuitem id="processMetadataStatistic"
                             value="#{msgs.numberOfMetadata}"
                             action="#{ProcessForm.showProcessMetadataStatistic}"
-                            update="processesTabView:processesForm:statisticPanel"
                             icon="fa fa-arrow-circle-o-up"/>
             </p:menu>
         </div>
-
-        <ui:include src="/WEB-INF/templates/includes/processes/statistics.xhtml">
-            <ui:param name="StatisticView" value="#{ProcessForm}"/>
-        </ui:include>
 
     </h:form>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/statistics.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/statistics.xhtml
@@ -16,72 +16,100 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:p="http://primefaces.org/ui">
 
-    <!--@elvariable id="StatisticView" type="org.kitodo.production.forms.ProcessListBaseView"-->
-    <h:panelGroup id="statisticPanel">
-        <p:pieChart rendered="#{StatisticView.showPieModel()}"
-                    model="#{StatisticView.pieModel}"/>
-        <p:dataTable  id="statisticResult"
-                      style="width: 50%;"
-                      rendered="#{StatisticView.showPieModel()}"
-                      value="#{StatisticView.statisticResult}"
-                      var="result">
-            <p:column headerText="#{msgs.task}"
-                      width="50">
-                <h:outputText title="#{result.key}"
-                              value="#{result.key}"/>
-            </p:column>
-            <p:column headerText="#{msgs.amount}"
-                      width="50">
-                <h:outputText title="#{result.value}"
-                              value="#{result.value}"/>
-            </p:column>
-        </p:dataTable>
+    <p:dialog id="statisticsDialog"
+              widgetVar="statisticsDialog"
+              height="80%"
+              width="80%"
+              resizable="false">
 
-        <p:barChart rendered="#{StatisticView.showBarModel()}"
-                    model="#{StatisticView.stackedBarModel}"
-                    style="width: 100%;"/>
+        <!--@elvariable id="StatisticView" type="org.kitodo.production.forms.ProcessListBaseView"-->
+        <h3 id="headerText">
+            <h:outputText value="#{msgs.stateOfVolume}" rendered="#{StatisticView.showPieModel()}"/>
+            <h:outputText value="#{msgs.durationOfTasks}" rendered="#{StatisticView.showBarModel()}"/>
+            <h:outputText value="#{msgs.numberOfMetadata}" rendered="#{StatisticView.showProcessMetadataStatisticTable()}"/>
+        </h3>
 
-        <p:dataTable id="processMetadataTable"
-                     style="width: 50%;"
-                     rendered="#{StatisticView.showProcessMetadataStatisticTable()}"
-                     value="#{StatisticView.processMetadataStatistics}"
-                     var="processStatistic">
-            <p:column headerText="#{msgs.title}"
-                      width="25">
-                <h:outputText title="#{processStatistic.processTitle}"
-                              value="#{processStatistic.processTitle}"/>
-            </p:column>
-            <p:column headerText="#{msgs.images}"
-                      width="10">
-                <h:outputText title="#{processStatistic.numberOfImages}"
-                              value="#{processStatistic.numberOfImages}"/>
-            </p:column>
-            <p:column headerText="#{msgs.relativeAmount}"
-                      width="10">
-                <p:progressBar value="#{StatisticView.getRelativeImageAmount(processStatistic.numberOfImages)}"
-                               displayOnly="true"/>
-            </p:column>
-            <p:column headerText="#{msgs.structuralElement}"
-                      width="10">
-                <h:outputText title="#{processStatistic.numberOfStructuralElements}"
-                              value="#{processStatistic.numberOfStructuralElements}"/>
-            </p:column>
-            <p:column headerText="#{msgs.relativeAmount}"
-                      width="10">
-                <p:progressBar value="#{StatisticView.getRelativeStructuralElementAmount(processStatistic.numberOfStructuralElements)}"
-                               displayOnly="true"/>
-            </p:column>
-            <p:column headerText="#{msgs.metadata}"
-                      width="10">
-                <h:outputText title="#{processStatistic.numberOfMetadata}"
-                              value="#{processStatistic.numberOfMetadata}"/>
-            </p:column>
-            <p:column headerText="#{msgs.relativeAmount}"
-                      width="10">
-                <p:progressBar value="#{StatisticView.getRelativeMetadataAmount(processStatistic.numberOfMetadata)}"
-                               displayOnly="true"/>
-            </p:column>
-        </p:dataTable>
-    </h:panelGroup>
+        <h:panelGroup id="statisticPanel"
+                      layout="block">
+            <h:panelGroup id="pieChartWrapper">
+                <p:pieChart rendered="#{StatisticView.showPieModel()}"
+                            model="#{StatisticView.pieModel}"/>
+            </h:panelGroup>
+            <p:dataTable  id="statisticResult"
+                          rendered="#{StatisticView.showPieModel()}"
+                          value="#{StatisticView.statisticResult}"
+                          scrollable="true"
+                          var="result">
+                <p:column headerText="#{msgs.task}"
+                          width="50">
+                    <h:outputText title="#{result.key}"
+                                  value="#{result.key}"/>
+                </p:column>
+                <p:column headerText="#{msgs.amount}"
+                          width="50">
+                    <h:outputText title="#{result.value}"
+                                  value="#{result.value}"/>
+                </p:column>
+            </p:dataTable>
+
+            <p:barChart rendered="#{StatisticView.showBarModel()}"
+                        model="#{StatisticView.stackedBarModel}"
+                        style="width: 100%;"/>
+
+            <p:dataTable id="processMetadataTable"
+                         scrollable="true"
+                         scrollHeight="350"
+                         styleClass="default-layout"
+                         rendered="#{StatisticView.showProcessMetadataStatisticTable()}"
+                         value="#{StatisticView.processMetadataStatistics}"
+                         var="processStatistic">
+                <p:column headerText="#{msgs.processTitle}"
+                          width="25">
+                    <h:outputText title="#{processStatistic.processTitle}"
+                                  value="#{processStatistic.processTitle}"/>
+                </p:column>
+                <p:column headerText="#{msgs.images}"
+                          width="10">
+                    <h:outputText title="#{processStatistic.numberOfImages}"
+                                  value="#{processStatistic.numberOfImages}"/>
+                </p:column>
+                <p:column headerText="#{msgs.relativeAmount}"
+                          width="10">
+                    <p:progressBar value="#{StatisticView.getRelativeImageAmount(processStatistic.numberOfImages)}"
+                                   displayOnly="true"/>
+                </p:column>
+                <p:column headerText="#{msgs.structuralElement}"
+                          width="10">
+                    <h:outputText title="#{processStatistic.numberOfStructuralElements}"
+                                  value="#{processStatistic.numberOfStructuralElements}"/>
+                </p:column>
+                <p:column headerText="#{msgs.relativeAmount}"
+                          width="10">
+                    <p:progressBar value="#{StatisticView.getRelativeStructuralElementAmount(processStatistic.numberOfStructuralElements)}"
+                                   displayOnly="true"/>
+                </p:column>
+                <p:column headerText="#{msgs.metadata}"
+                          width="10">
+                    <h:outputText title="#{processStatistic.numberOfMetadata}"
+                                  value="#{processStatistic.numberOfMetadata}"/>
+                </p:column>
+                <p:column headerText="#{msgs.relativeAmount}"
+                          width="10">
+                    <p:progressBar value="#{StatisticView.getRelativeMetadataAmount(processStatistic.numberOfMetadata)}"
+                                   displayOnly="true"/>
+                </p:column>
+            </p:dataTable>
+        </h:panelGroup>
+
+        <h:form id="closeButtonForm">
+            <p:commandButton id="close"
+                             value="#{msgs.close}"
+                             icon="fa fa-times fa-lg"
+                             iconPos="right"
+                             styleClass="secondary"
+                             onclick="PF('statisticsDialog').hide();"/>
+        </h:form>
+
+    </p:dialog>
 
 </ui:composition>

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -108,5 +108,8 @@
         <ui:include src="/WEB-INF/templates/includes/processes/deleteChildrenDialog.xhtml">
             <ui:param name="ProcessListView" value="#{ProcessForm}"/>
         </ui:include>
+        <ui:include src="/WEB-INF/templates/includes/processes/statistics.xhtml">
+            <ui:param name="StatisticView" value="#{ProcessForm}"/>
+        </ui:include>
     </ui:define>
 </ui:composition>

--- a/Kitodo/src/main/webapp/pages/searchResult.xhtml
+++ b/Kitodo/src/main/webapp/pages/searchResult.xhtml
@@ -234,17 +234,14 @@
                             <p:menuitem id="stateOfVolume"
                                         value="#{msgs.stateOfVolume}"
                                         action="#{SearchResultForm.showStateOfVolume}"
-                                        update="searchResultTabView:configureFilters:statisticPanel"
                                         icon="fa fa-arrow-circle-o-up"/>
                             <p:menuitem id="durationOfTasks"
                                         value="#{msgs.durationOfTasks}"
                                         action="#{SearchResultForm.showDurationOfTasks}"
-                                        update="searchResultTabView:configureFilters:statisticPanel"
                                         icon="fa fa-arrow-circle-o-up"/>
                             <p:menuitem id="processMetadataStatistic"
                                         value="#{msgs.numberOfMetadata}"
                                         action="#{SearchResultForm.showProcessMetadataStatistic}"
-                                        update="searchResultTabView:configureFilters:statisticPanel"
                                         icon="fa fa-arrow-circle-o-up"/>
                         </p:menu>
                     </div>
@@ -301,10 +298,6 @@
                         </h:panelGroup>
                     </div>
 
-                    <ui:include src="/WEB-INF/templates/includes/processes/statistics.xhtml">
-                        <ui:param name="StatisticView" value="#{SearchResultForm}"/>
-                    </ui:include>
-
                 </h:form>
             </p:tab>
         </p:tabView>
@@ -318,6 +311,9 @@
     <ui:define name="dialog">
         <ui:include src="/WEB-INF/templates/includes/processes/deleteChildrenDialog.xhtml">
             <ui:param name="ProcessListView" value="#{SearchResultForm}"/>
+        </ui:include>
+        <ui:include src="/WEB-INF/templates/includes/processes/statistics.xhtml">
+            <ui:param name="StatisticView" value="#{SearchResultForm}"/>
         </ui:include>
     </ui:define>
 


### PR DESCRIPTION
Moves statistic results - diagrams, datatables etc. - to separate popup dialog.

Fixes #3430 