### PR TITLE
Automatically assign media units to the effective root element

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/View.java
@@ -20,6 +20,20 @@ import java.util.Objects;
  * {@code MediaUnit} as a whole.
  */
 public class View {
+
+    /**
+     * Creates a new view with a media unit.
+     * 
+     * @param mediaUnit
+     *            media unit to set in the view
+     * @return a new view with a media unit
+     */
+    public static View of(MediaUnit mediaUnit) {
+        View view = new View();
+        view.setMediaUnit(mediaUnit);
+        return view;
+    }
+
     /**
      * Media unit in view.
      */

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -228,4 +228,16 @@ public class Workpiece {
     public static <T extends Division<T>> Stream<T> treeStream(Division<T> tree) {
         return Stream.concat(Stream.of((T) tree), tree.getChildren().stream().flatMap(Workpiece::treeStream));
     }
+
+    /**
+     * Generates a stream of nodes from structure tree.
+     *
+     * @param tree
+     *            starting node
+     * @return all nodes as stream
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends Division<T>> Stream<T> treeStream(Division<T> tree) {
+        return Stream.concat(Stream.of((T) tree), tree.getChildren().stream().flatMap(child -> treeStream(child)));
+    }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -228,16 +228,4 @@ public class Workpiece {
     public static <T extends Division<T>> Stream<T> treeStream(Division<T> tree) {
         return Stream.concat(Stream.of((T) tree), tree.getChildren().stream().flatMap(Workpiece::treeStream));
     }
-
-    /**
-     * Generates a stream of nodes from structure tree.
-     *
-     * @param tree
-     *            starting node
-     * @return all nodes as stream
-     */
-    @SuppressWarnings("unchecked")
-    public static <T extends Division<T>> Stream<T> treeStream(Division<T> tree) {
-        return Stream.concat(Stream.of((T) tree), tree.getChildren().stream().flatMap(child -> treeStream(child)));
-    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -467,10 +467,9 @@ public class MetadataEditor {
             LinkedList<Division<T>> ancestors = new LinkedList<>();
             ancestors.add(parent);
             return ancestors;
-
         }
-        for (T child : position.getChildren()) {
-            LinkedList<Division<T>> maybeFound = getAncestorsRecursive(searched, (Division<T>)child, position);
+        for (Division<T> child : position.getChildren()) {
+            LinkedList<Division<T>> maybeFound = getAncestorsRecursive(searched, child, position);
             if (!maybeFound.isEmpty()) {
                 if (Objects.nonNull(parent)) {
                     maybeFound.addFirst(parent);


### PR DESCRIPTION
Fixes #3434

Follow-up pull request to #3921 ([immediate diff](https://github.com/matthias-ronge/kitodo-production/compare/refactor-workpiece-get-all-methods...issue-3434))