### PR TITLE
Fix equals method of MetadataEntry and MetadataGroup

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/MetadataEntry.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/MetadataEntry.java
@@ -18,39 +18,28 @@ public class MetadataEntry extends Metadata {
     /**
      * The value of the metadata.
      */
-    private String value;
+    private String value = "";
 
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
+        if (Objects.isNull(obj)) {
             return false;
         }
         if (getClass() != obj.getClass()) {
             return false;
         }
         MetadataEntry other = (MetadataEntry) obj;
-        if (key == null) {
-            if (other.key != null) {
-                return false;
-            }
-        } else if (!key.equals(other.key)) {
+        if (!Objects.equals(key, other.key)) {
             return false;
         }
         if ((Objects.nonNull(domain) ? domain : MdSec.DMD_SEC) != (Objects.nonNull(other.domain) ? other.domain
                 : MdSec.DMD_SEC)) {
             return false;
         }
-        if (value == null) {
-            if (other.value != null) {
-                return false;
-            }
-        } else if (!value.equals(other.value)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(value, other.value);
     }
 
     @Override

--- a/Kitodo-API/src/main/java/org/kitodo/api/MetadataGroup.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/MetadataGroup.java
@@ -49,32 +49,21 @@ public class MetadataGroup extends Metadata {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
+        if (Objects.isNull(obj)) {
             return false;
         }
         if (getClass() != obj.getClass()) {
             return false;
         }
         MetadataGroup other = (MetadataGroup) obj;
-        if (key == null) {
-            if (other.key != null) {
-                return false;
-            }
-        } else if (!key.equals(other.key)) {
+        if (!Objects.equals(key, other.key)) {
             return false;
         }
         if ((Objects.nonNull(domain) ? domain : MdSec.DMD_SEC) != (Objects.nonNull(other.domain) ? other.domain
                 : MdSec.DMD_SEC)) {
             return false;
         }
-        if (group == null) {
-            if (other.group != null) {
-                return false;
-            }
-        } else if (!group.equals(other.group)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(group, other.group);
     }
 
     @Override


### PR DESCRIPTION
~~Fix `equals` method to return `true` when comparing two metadata entries where one has `null` as the metadata value and the second has an empty String ("").~~ 

Initialize `MetadataEntry.value` with empty String as @matthias-ronge suggested.

This prevents the method `DataEditorForm.checkForChanges` to falsely claim there are unsaved changes when the user clicks on a `MediaUnit` or `IncludedStructuralElement` for which some metadata is configured as `alwaysShowing` but without a default value. At the moment this would trigger the corresponding metadata to be shown in the metadata panel with an empty string as value and cause the `equals` method to incorrectly return `false`.