### PR TITLE
Remove deprecated and error-prone Workpiece.getMediaUnits()

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -108,17 +108,6 @@ public class Workpiece {
     }
 
     /**
-     * Returns the media units of this workpiece.
-     *
-     * @return the media units
-     * @deprecated Use {@code getMediaUnit().getChildren()}.
-     */
-    @Deprecated
-    public List<MediaUnit> getMediaUnits() {
-        return mediaUnit.getChildren();
-    }
-
-    /**
      * Returns the root element of the included structural element.
      *
      * @return root element of the included structural element

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -54,7 +54,7 @@ public class MetsXmlElementAccessIT {
                 .read(new FileInputStream(new File("src/test/resources/meta.xml")));
 
         // METS file has 183 associated images
-        assertEquals(183, workpiece.getMediaUnits().size());
+        assertEquals(183, workpiece.getMediaUnit().getChildren().size());
 
         // METS file has 17 unstructured images
         assertEquals(17, workpiece.getRootElement().getViews().size());
@@ -67,7 +67,7 @@ public class MetsXmlElementAccessIT {
 
         // file URIs can be read
         assertEquals(new URI("images/ThomPhar_644901748_media/00000001.tif"),
-            workpiece.getMediaUnits().get(0).getMediaFiles().entrySet().iterator().next().getValue());
+            workpiece.getMediaUnit().getChildren().get(0).getMediaFiles().entrySet().iterator().next().getValue());
 
         // pagination can be read
         assertEquals(
@@ -86,7 +86,7 @@ public class MetsXmlElementAccessIT {
                 "uncounted", "uncounted", "113", "114", "115", "116", "117", "118", "uncounted", "uncounted", "119",
                 "120", "uncounted", "uncounted", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130",
                 "131", "132", "133", "134", "uncounted", "uncounted", "uncounted"),
-            workpiece.getMediaUnits().stream().map(MediaUnit::getOrderlabel)
+            workpiece.getMediaUnit().getChildren().stream().map(MediaUnit::getOrderlabel)
                     .collect(Collectors.toList()));
     }
 
@@ -105,7 +105,7 @@ public class MetsXmlElementAccessIT {
             numImages.setDomain(MdSec.TECH_MD);
             numImages.setValue("100");
             partialOrder.getMetadata().add(numImages);
-            workpiece.getMediaUnits().add(partialOrder);
+            workpiece.getMediaUnit().getChildren().add(partialOrder);
         }
 
         // add files
@@ -118,7 +118,7 @@ public class MetsXmlElementAccessIT {
             mediaUnit.setOrder(i);
             mediaUnit.getMediaFiles().put(local, path);
             pages.add(mediaUnit);
-            workpiece.getMediaUnits().add(mediaUnit);
+            workpiece.getMediaUnit().getChildren().add(mediaUnit);
         }
 
         // create document structure
@@ -200,7 +200,7 @@ public class MetsXmlElementAccessIT {
         MediaVariant max = new MediaVariant();
         max.setUse("MAX");
         max.setMimeType("image/jpeg");
-        for (MediaUnit mediaUnit : workpiece.getMediaUnits()) {
+        for (MediaUnit mediaUnit : workpiece.getMediaUnit().getChildren()) {
             URI tiffFile = mediaUnit.getMediaFiles().get(local);
             if (tiffFile != null) {
                 String jpgFile = tiffFile.toString().replaceFirst("^.*?(\\d+)\\.tif$", "images/max/$1.jpg");
@@ -226,7 +226,7 @@ public class MetsXmlElementAccessIT {
         Workpiece reread = new MetsXmlElementAccess().read(new FileInputStream(new File("src/test/resources/out.xml")));
 
         assertEquals(1, reread.getEditHistory().size());
-        List<MediaUnit> mediaUnits = reread.getMediaUnits();
+        List<MediaUnit> mediaUnits = reread.getMediaUnit().getChildren();
         assertEquals(8, mediaUnits.size());
         for (int i = 0; i <= 3; i++) {
             MediaUnit mediaUnit = mediaUnits.get(i);

--- a/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
+++ b/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
@@ -205,7 +205,7 @@ public class MetadataValidation implements MetadataValidationInterface {
 
         if (!Workpiece.treeStream(workpiece.getRootElement())
                 .flatMap(structure -> structure.getViews().stream()).map(View::getMediaUnit)
-                .allMatch(workpiece.getMediaUnits()::contains)) {
+                .allMatch(workpiece.getAllMediaUnits()::contains)) {
             messages.add(translations.get(MESSAGE_MEDIA_MISSING));
             error = true;
         }
@@ -227,7 +227,8 @@ public class MetadataValidation implements MetadataValidationInterface {
         Collection<String> messages = new HashSet<>();
 
         KeySetView<MediaUnit, ?> unassignedMediaUnits = ConcurrentHashMap.newKeySet();
-        unassignedMediaUnits.addAll(workpiece.getMediaUnits());
+        unassignedMediaUnits.addAll(Workpiece.treeStream(workpiece.getMediaUnit())
+                .filter(mediaUnit -> !mediaUnit.getMediaFiles().isEmpty()).collect(Collectors.toList()));
         Workpiece.treeStream(workpiece.getRootElement()).flatMap(structure -> structure.getViews().stream())
                 .map(View::getMediaUnit)
                 .forEach(unassignedMediaUnits::remove);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -129,7 +129,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
 
     @Deprecated
     public LegacyFileSetDocStructHelper getFileSet() {
-        return new LegacyFileSetDocStructHelper(workpiece.getMediaUnits());
+        return new LegacyFileSetDocStructHelper(workpiece.getMediaUnit().getChildren());
     }
 
     @Deprecated
@@ -139,7 +139,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
 
     @Deprecated
     public LegacyDocStructHelperInterface getPhysicalDocStruct() {
-        return new LegacyFileSetDocStructHelper(workpiece.getMediaUnits());
+        return new LegacyFileSetDocStructHelper(workpiece.getMediaUnit().getChildren());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -144,7 +144,7 @@ public class SchemaService {
     private void replaceFLocatForExport(Workpiece workpiece, Process process) throws URISyntaxException {
         List<Folder> folders = process.getProject().getFolders();
         VariableReplacer variableReplacer = new VariableReplacer(null, null, process, null);
-        for (MediaUnit mediaUnit : workpiece.getMediaUnits()) {
+        for (MediaUnit mediaUnit : workpiece.getAllMediaUnits()) {
             for (Entry<MediaVariant, URI> mediaFileForMediaVariant : mediaUnit.getMediaFiles().entrySet()) {
                 for (Folder folder : folders) {
                     if (folder.getFileGroup().equals(mediaFileForMediaVariant.getKey().getUse())) {

--- a/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/dataformat/MetsServiceIT.java
@@ -34,7 +34,7 @@ public class MetsServiceIT {
                 .loadWorkpiece(new File("../Kitodo-DataFormat/src/test/resources/meta.xml").toURI());
 
         // METS file has 183 associated images
-        assertEquals(183, workpiece.getMediaUnits().size());
+        assertEquals(183, workpiece.getMediaUnit().getChildren().size());
 
         // METS file has 17 unstructured images
         assertEquals(17, workpiece.getRootElement().getViews().size());
@@ -47,7 +47,7 @@ public class MetsServiceIT {
 
         // file URIs can be read
         assertEquals(new URI("images/ThomPhar_644901748_media/00000001.tif"),
-            workpiece.getMediaUnits().get(0).getMediaFiles().entrySet().iterator().next().getValue());
+            workpiece.getMediaUnit().getChildren().get(0).getMediaFiles().entrySet().iterator().next().getValue());
 
         // pagination can be read
         assertEquals(
@@ -66,6 +66,6 @@ public class MetsServiceIT {
                 "uncounted", "uncounted", "113", "114", "115", "116", "117", "118", "uncounted", "uncounted", "119",
                 "120", "uncounted", "uncounted", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130",
                 "131", "132", "133", "134", "uncounted", "uncounted", "uncounted"),
-            workpiece.getMediaUnits().stream().map(MediaUnit::getOrderlabel).collect(Collectors.toList()));
+            workpiece.getMediaUnit().getChildren().stream().map(MediaUnit::getOrderlabel).collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
Before the introduction of editability of the physical structure tree, the physical structure tree was flat. `List<MediaUnit> getMediaUnits()` offered access to the first child level of the physical structure tree, which contains the pages of digitized books. The method has been deprecated for a long time and its use is prone to errors because the other parts of the physical structure tree are not evaluated. The method is removed and the now correct `List<MediaUnit> getAllMediaUnits()` is used where it was still used.

Follow-up pull request to #3921 ([immediate diff](https://github.com/matthias-ronge/kitodo-production/compare/refactor-workpiece-get-all-methods...remove-use-of-get-mediaunits))

