### PR TITLE
Restore saving of folder uses

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
@@ -498,7 +498,7 @@ public class ProjectForm extends BaseForm {
 
     private Map<String, Folder> getFolderMap() {
         return getFolderList().parallelStream()
-                .collect(Collectors.toMap(Folder::toString, Function.identity()));
+                .collect(Collectors.toMap(Folder::getFileGroup, Function.identity()));
     }
 
     /**


### PR DESCRIPTION
When you save a project, the folder usage look-up did not work. Usage was set to `null`. Now it works again.