### PR TITLE
Ignore duplicate keys

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -169,7 +169,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     private void createMetadataTable() {
         // the existing metadata is passed to the rule set, which sorts it
         Map<Metadata, String> metadataWithKeys = addLabels(metadata).parallelStream()
-                .collect(Collectors.toMap(Function.identity(), Metadata::getKey, (duplicate1, duplicate2) -> duplicate1));
+                .collect(Collectors.toMap(Function.identity(), Metadata::getKey, (duplicateOne, duplicateTwo) -> duplicateOne));
         List<MetadataViewWithValuesInterface<Metadata>> tableData = metadataView
                 .getSortedVisibleMetadata(metadataWithKeys, additionallySelectedFields);
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -169,7 +169,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     private void createMetadataTable() {
         // the existing metadata is passed to the rule set, which sorts it
         Map<Metadata, String> metadataWithKeys = addLabels(metadata).parallelStream()
-                .collect(Collectors.toMap(Function.identity(), Metadata::getKey));
+                .collect(Collectors.toMap(Function.identity(), Metadata::getKey, (duplicate1, duplicate2) -> duplicate1));
         List<MetadataViewWithValuesInterface<Metadata>> tableData = metadataView
                 .getSortedVisibleMetadata(metadataWithKeys, additionallySelectedFields);
 


### PR DESCRIPTION
The "ORDERLABEL" attribute produces an exception because of duplicate keys when collecting the stream.