### PR TITLE
Add option to add a preset for the current date in rulesets

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.forms.createprocess;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kitodo.api.MetadataEntry;
+import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
+
+public class ProcessDateMetadata extends ProcessTextMetadata {
+    private static final Logger logger = LogManager.getLogger(ProcessDateMetadata.class);
+    private static final String NOW = "now";
+
+    private Date date;
+
+    ProcessDateMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings, MetadataEntry value) {
+        super(container, settings, value);
+        if (Objects.isNull(value)) {
+            this.setValue(NOW.equals(settings.getDefaultValue()) ? new SimpleDateFormat("yyyy-MM-dd").format(new Date()) : "");
+        }
+    }
+
+    private ProcessDateMetadata(ProcessDateMetadata template) {
+        super(template);
+        this.date = Objects.isNull(template.date) ? null : new Date(template.date.getTime());
+    }
+
+    @Override
+    ProcessTextMetadata getClone() {
+        return new ProcessDateMetadata(this);
+    }
+
+
+    /**
+     * Get date.
+     *
+     * @return value of date
+     */
+    public Date getDate() {
+        if (Objects.isNull(date) && Objects.nonNull(getValue())) {
+            try {
+                date = new SimpleDateFormat("yyyy-MM-dd").parse(getValue());
+            } catch (ParseException e) {
+                logger.error(e.getLocalizedMessage(), e);
+            }
+        }
+        return date;
+    }
+
+    /**
+     * Set date.
+     *
+     * @param date as java.util.Date
+     */
+    public void setDate(Date date) {
+        this.date = date;
+        if (Objects.nonNull(date)) {
+            this.setValue(new SimpleDateFormat("yyyy-MM-dd").format(date));
+        }
+    }
+
+}

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -300,6 +300,8 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                     data = new ProcessBooleanMetadata(this, simpleMetadataView, oneValue(values, MetadataEntry.class));
                     break;
                 case DATE:
+                    data = new ProcessDateMetadata(this, simpleMetadataView, oneValue(values, MetadataEntry.class));
+                    break;
                 case INTEGER:
                 case MULTI_LINE_TEXT:
                 case ONE_LINE_TEXT:

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -12,11 +12,8 @@
 package org.kitodo.production.forms.createprocess;
 
 import java.io.Serializable;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
@@ -36,17 +33,15 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
     private static final Logger logger = LogManager.getLogger(ProcessTextMetadata.class);
 
     private String value;
-    private Date date;
 
     ProcessTextMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings, MetadataEntry value) {
         super(container, settings, Objects.isNull(settings) ? value.getKey() : settings.getLabel());
         this.value = Objects.isNull(value) ? settings.getDefaultValue() : value.getValue();
     }
 
-    private ProcessTextMetadata(ProcessTextMetadata template) {
+    ProcessTextMetadata(ProcessTextMetadata template) {
         super(template.container, template.settings, template.label);
         this.value = template.value;
-        this.date = Objects.isNull(template.date) ? null : new Date(template.date.getTime());
     }
 
     @Override
@@ -132,33 +127,4 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
     public void setValue(String value) {
         this.value = value;
     }
-
-    /**
-     * Get date.
-     *
-     * @return value of date
-     */
-    public Date getDate() {
-        if (Objects.isNull(date) && Objects.nonNull(getValue())) {
-            try {
-                date = new SimpleDateFormat("yyyy-MM-dd").parse(getValue());
-            } catch (ParseException e) {
-                logger.error(e.getLocalizedMessage(), e);
-            }
-        }
-        return date;
-    }
-
-    /**
-     * Set date.
-     *
-     * @param date as java.util.Date
-     */
-    public void setDate(Date date) {
-        this.date = date;
-        if (Objects.nonNull(date)) {
-            this.value = new SimpleDateFormat("yyyy-MM-dd").format(date);
-        }
-    }
-
 }


### PR DESCRIPTION
A preset for a date can be defined by the keyword "now":
```
<key id="…">
    …
    <codomain type="date" />
    <preset value="now" />
 </key>
```
The current date will be inserted in the metadata editor upon metadata creation.
