### PR TITLE
Fix updating process status after closing a task

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -436,6 +436,8 @@ public class WorkflowControllerService {
             activateConcurrentTasks(concurrentTasksForOpen);
         }
 
+        process = ServiceManager.getProcessService().getById(process.getId());
+
         URI imagesOrigDirectory = ServiceManager.getProcessService().getImagesOriginDirectory(true, process);
         Integer numberOfFiles = ServiceManager.getFileService().getNumberOfFiles(imagesOrigDirectory);
         if (!process.getSortHelperImages().equals(numberOfFiles)) {


### PR DESCRIPTION
Fixes a bug where the status of a closed tasks following tasks in the workflow were not properly saved but overwritten by the old previous state of the process.

This happens when the task (T2 in the example below) immediately following the closed task (T1) is skipped due to an unfulfilled workflow condition and the then following task (T3) should be opened instead.

T1 (closed task) -> T2 (skipped task) -> T3 