### PR TITLE
Disable no-selection-option in selectOneMenus for mandatory metadata

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -110,7 +110,10 @@
                                      autoWidth="false"
                                      disabled="#{not item.editable or readOnly}"
                                      styleClass="#{readOnly ? 'read-only' : ''}">
-                        <f:selectItem itemValue="#{null}" itemLabel="#{msgs.notSelected}" noSelectionOption="true"/>
+                        <f:selectItem itemValue="#{null}"
+                                      itemDisabled="#{item.required}"
+                                      itemLabel="#{msgs.notSelected}"
+                                      noSelectionOption="true"/>
                         <f:selectItems value="#{item.items}"/>
                         <p:ajax event="change" oncomplete="#{request.requestURI.contains('metadataEditor') ? 'preserveMetadata()' : ''}"/>
                     </p:selectOneMenu>


### PR DESCRIPTION
Required metadata (`minOccurs > 0` in ruleset) with options resulting in a pulldown menu should not allow the user to select the `noSelectionOption`, hence it is deactivated with this pull request.