### PR TITLE
Invoke div.getCONTENTIDS() only if there is data

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -240,7 +240,9 @@ public class DivXmlElementAccess extends IncludedStructuralElement {
     DivType toDiv(Map<MediaUnit, String> mediaUnitIDs, LinkedList<Pair<String, String>> smLinkData, Mets mets) {
         DivType div = new DivType();
         div.setID(metsReferrerId);
-        super.getContentIds().parallelStream().map(URI::toString).forEachOrdered(div.getCONTENTIDS()::add);
+        if (!super.getContentIds().isEmpty()) {
+            super.getContentIds().parallelStream().map(URI::toString).forEachOrdered(div.getCONTENTIDS()::add);
+        }
         div.setLABEL(super.getLabel());
         if (getOrder() > 0) {
             div.setORDER(BigInteger.valueOf(getOrder()));


### PR DESCRIPTION
Obviously, the invocation of `div.getCONTENTIDS()` causes the `CONTENTIDS` attribute to be written. This produces empty `CONTENTIDS=""` attributes all through the struct maps. This change should remove them.

Fixes #3959