### PR TITLE
Fix media paths for virtual file groups and on export on Windows

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
@@ -265,27 +265,27 @@ public class Subfolder {
     }
 
     private List<String> getUriComponents(String canonical) {
-        List<String> x = new ArrayList<>(3);
         int lastSeparator = folder.getPath().lastIndexOf(File.separator);
         String lastSegment = folder.getPath().substring(lastSeparator + 1);
-        x.add(process.getId().toString());
+        List<String> components = new ArrayList<>(3);
+        components.add(process.getId().toString());
 
         if (lastSegment.indexOf('*') == -1) {
             String localName = canonical + getFileFormat().getExtension(true);
-            x.add(variableReplacer.replace(folder.getPath()));
-            x.add(localName);
+            components.add(variableReplacer.replace(folder.getPath()));
+            components.add(localName);
         } else {
             String realPath = folder.getPath().substring(0, lastSeparator);
             String localName = lastSegment.replaceFirst("\\*", canonical).replaceFirst("\\*$",
                 getFileFormat().getExtension(false));
             if (realPath.isEmpty()) {
-                x.add(localName);
+                components.add(localName);
             } else {
-                x.add(variableReplacer.replace(realPath));
-                x.add(localName);
+                components.add(variableReplacer.replace(realPath));
+                components.add(localName);
             }
         }
-        return x;
+        return components;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -11,7 +11,6 @@
 
 package org.kitodo.production.services.schema;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -148,7 +147,7 @@ public class SchemaService {
             for (Entry<MediaVariant, URI> mediaFileForMediaVariant : mediaUnit.getMediaFiles().entrySet()) {
                 for (Folder folder : folders) {
                     if (folder.getFileGroup().equals(mediaFileForMediaVariant.getKey().getUse())) {
-                        int lastSeparator = mediaFileForMediaVariant.getValue().toString().lastIndexOf(File.separator);
+                        int lastSeparator = mediaFileForMediaVariant.getValue().toString().lastIndexOf('/');
                         String lastSegment = mediaFileForMediaVariant.getValue().toString()
                                 .substring(lastSeparator + 1);
                         mediaFileForMediaVariant

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -202,18 +202,18 @@ public class SchemaService {
     /**
      * Adds a use to a media unit.
      *
-     * @param useFolder
-     *            use folder for the use
+     * @param subfolder
+     *            subfolder for the use
      * @param canonical
      *            the canonical part of the file name of the media file
      * @param mediaUnit
      *            media unit to add to
      */
-    private void addUse(Subfolder useFolder, String canonical, MediaUnit mediaUnit) {
+    private void addUse(Subfolder subfolder, String canonical, MediaUnit mediaUnit) {
         MediaVariant mediaVariant = new MediaVariant();
-        mediaVariant.setUse(useFolder.getFolder().getFileGroup());
-        mediaVariant.setMimeType(useFolder.getFolder().getMimeType());
-        URI mediaFile = useFolder.getUri(canonical);
+        mediaVariant.setUse(subfolder.getFolder().getFileGroup());
+        mediaVariant.setMimeType(subfolder.getFolder().getMimeType());
+        URI mediaFile = subfolder.getRelativeFilePath(canonical);
         mediaUnit.getMediaFiles().put(mediaVariant, mediaFile);
     }
 


### PR DESCRIPTION
Media file paths were wrong if file groups did not exist (due to non-existent files) and are only added during export (for example if images or OCR is generated in an after-step), and media paths were not correctly truncated on Windows because of wrong separator (URI always uses slashes, even on Windows). Fixes both.