### PR TITLE
Migrate more variants of databases

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_18__Change_process_id_to_not_null_for_template.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_18__Change_process_id_to_not_null_for_template.sql
@@ -13,4 +13,6 @@
 -- Migration: Changing the columns for process id in template table to not null
 --
 
+SET FOREIGN_KEY_CHECKS = 0;
 ALTER TABLE template MODIFY process_id INT(11) NOT NULL;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_29__Split_processes_and_templates.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_29__Split_processes_and_templates.sql
@@ -100,10 +100,10 @@ DELETE batch_x_process FROM batch_x_process
 --
 
 SET FOREIGN_KEY_CHECKS = 0;
-DELETE FROM property WHERE id IN (SELECT property_id FROM `template_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1));
-DELETE FROM `template_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1);
-DELETE FROM property WHERE id IN (SELECT property_id FROM `workpiece_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1));
-DELETE FROM `workpiece_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1);
+DELETE FROM property WHERE id IN (SELECT property_id FROM template_x_property WHERE process_id IN (SELECT id FROM process WHERE template = 1));
+DELETE FROM template_x_property WHERE process_id IN (SELECT id FROM process WHERE template = 1);
+DELETE FROM property WHERE id IN (SELECT property_id FROM workpiece_x_property WHERE process_id IN (SELECT id FROM process WHERE template = 1));
+DELETE FROM workpiece_x_property WHERE process_id IN (SELECT id FROM process WHERE template = 1);
 SET FOREIGN_KEY_CHECKS = 1; 
 DELETE FROM process
 WHERE template = 1;

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_29__Split_processes_and_templates.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_29__Split_processes_and_templates.sql
@@ -99,6 +99,12 @@ DELETE batch_x_process FROM batch_x_process
 -- 11. Remove templates from process table
 --
 
+SET FOREIGN_KEY_CHECKS = 0;
+DELETE FROM property WHERE id IN (SELECT property_id FROM `template_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1));
+DELETE FROM `template_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1);
+DELETE FROM property WHERE id IN (SELECT property_id FROM `workpiece_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1));
+DELETE FROM `workpiece_x_property` WHERE process_id IN (SELECT id FROM process WHERE template = 1);
+SET FOREIGN_KEY_CHECKS = 1; 
 DELETE FROM process
 WHERE template = 1;
 

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_43__Add_dummy_client.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_43__Add_dummy_client.sql
@@ -23,4 +23,6 @@ SET projectTable.client_id = dummyClient.id WHERE projectTable.client_id IS NULL
 SET SQL_SAFE_UPDATES = 1;
 
 -- 5. Set the client_id column of project table to NOT NULL
+SET FOREIGN_KEY_CHECKS = 0;
 ALTER TABLE project CHANGE COLUMN `client_id` `client_id` INT(11) NOT NULL;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_44__Change_authority_concept.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_44__Change_authority_concept.sql
@@ -41,7 +41,9 @@ UPDATE client_x_user client_x_userTable, (SELECT * FROM client WHERE name = 'Cli
 SET client_x_userTable.client_id = dummyClient.id WHERE client_x_userTable.client_id IS NULL;
 
 -- 6. Set client_id column to not null
+SET FOREIGN_KEY_CHECKS = 0;
 ALTER TABLE client_x_user MODIFY COLUMN client_id INT(11) NOT NULL;
+SET FOREIGN_KEY_CHECKS = 1;
 
 -- 7. Add '_globalAssignable' to every existing authority entry
 UPDATE authority set title=concat(title,'_globalAssignable');


### PR DESCRIPTION
We had to make these adjustments as part of the migration workshop so that the database in the example could be migrated.