### PR TITLE
remove unneccessary assignment of processes

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/migration/MigrationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/migration/MigrationService.java
@@ -194,7 +194,6 @@ public class MigrationService {
             ServiceManager.getProcessService().save(process);
         }
         template.getProjects().addAll(projects.keySet());
-        template.getProcesses().addAll(processesToAddToTemplate);
         ServiceManager.getTemplateService().save(template);
     }
 


### PR DESCRIPTION
the double assignment of processes leads to a hibernate exception when saving the template.