### PR TITLE
Don’t return empty non-select element from ruleset management

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
@@ -143,8 +143,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
      */
     @Override
     public Map<String, String> getSelectItems() {
-        Map<String, String> selectItems = universal.getSelectItems(priorityList);
-        return universalRule.getSelectItems(selectItems);
+        return universalRule.getSelectItems(universal.getSelectItems(priorityList));
     }
 
     @Override
@@ -233,7 +232,8 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
         }
 
         // If the key has options, then the value must be in it.
-        if (universal.isHavingOptions() && !universalRule.getSelectItems(universal.getSelectItems()).contains(value)) {
+        if (universal.isHavingOptions()
+                && !universalRule.getSelectItems(universal.getSelectItems(priorityList)).containsKey(value)) {
             return false;
         }
 

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/UniversalRule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/UniversalRule.java
@@ -18,9 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Triple;
 import org.kitodo.dataeditor.ruleset.xml.Rule;
@@ -183,18 +181,6 @@ public class UniversalRule {
             universalPermitRuleForKey.merge(ruleset.getUniversalRestrictionRuleForKey(keyId));
         }
         return universalPermitRuleForKey;
-    }
-
-    /**
-     * Returns the selection items.
-     *
-     * @param selectItems
-     *            the selection items
-     * @return the selection items
-     */
-    Set<String> getSelectItems(Set<String> selectItems) {
-        return getSelectItems(selectItems.stream().collect(Collectors.toMap(Function.identity(), Function.identity())))
-                .keySet();
     }
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/UniversalRule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/UniversalRule.java
@@ -184,10 +184,7 @@ public class UniversalRule {
     }
 
     /**
-     * Returns the selection items. This is with filter, and besides, if it is
-     * not multiple choice but optional then the first field is empty with empty
-     * to select nothing as option. The question is if this must be here but I
-     * have now made it for convenience, otherwise goes elsewhere.
+     * Returns the selection items allowed by the rule.
      *
      * @param selectItems
      *            the selection items

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/UniversalRule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/UniversalRule.java
@@ -208,17 +208,7 @@ public class UniversalRule {
      * @return the selection items
      */
     Map<String, String> getSelectItems(Map<String, String> selectItems) {
-        Map<String, String> filteredOptions = filterPossibilitiesBasedOnRule(selectItems, Rule::getValue);
-        if (!isRepeatable() && (!optionalRule.isPresent() || optionalRule.get().getMinOccurs() == null
-                || optionalRule.get().getMinOccurs() < 1)) {
-            Map<String, String> mapWithANonselectedElement = new LinkedHashMap<>(
-                    (int) Math.ceil((filteredOptions.size() + 1) / 0.75));
-            mapWithANonselectedElement.put("", "");
-            mapWithANonselectedElement.putAll(filteredOptions);
-            return mapWithANonselectedElement;
-        } else {
-            return filteredOptions;
-        }
+        return filterPossibilitiesBasedOnRule(selectItems, Rule::getValue);
     }
 
     /**

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -247,20 +247,6 @@ public class RulesetManagementIT {
             contains(InputType.MULTI_LINE_SINGLE_SELECTION, InputType.ONE_LINE_SINGLE_SELECTION,
                 InputType.ONE_LINE_TEXT, InputType.ONE_LINE_TEXT, InputType.ONE_LINE_TEXT,
                 InputType.MULTIPLE_SELECTION));
-
-        // 4. In the optional single selections, one empty element is in it, not
-        // in the others.
-
-        assertThat(((SimpleMetadataViewInterface) mvwviList.get(0).getMetadata().get()).getSelectItems(),
-            not(hasEntry("", "")));
-        assertThat(((SimpleMetadataViewInterface) mvwviList.get(1).getMetadata().get()).getSelectItems(),
-            not(hasEntry("", "")));
-        assertThat(((SimpleMetadataViewInterface) mvwviList.get(2).getMetadata().get()).getSelectItems(),
-            not(hasEntry("", "")));
-        List<MetadataViewInterface> mviList = (List<MetadataViewInterface>) mviColl;
-        assertThat(((SimpleMetadataViewInterface) mviList.get(0)).getSelectItems(), hasEntry("", ""));
-        assertThat(((SimpleMetadataViewInterface) mviList.get(1)).getSelectItems(), hasEntry("", ""));
-        assertThat(((SimpleMetadataViewInterface) mviList.get(2)).getSelectItems(), not(hasEntry("", "")));
     }
 
     /**


### PR DESCRIPTION
Non-select element is inserted from GUI. It is not necessary to insert it from ruleset management, too.

Fixes #4050, fixes #4070