### PR TITLE
Not print bogus and wrong warnings

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalDivision.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalDivision.java
@@ -12,26 +12,27 @@
 package org.kitodo.api.dataeditor.rulesetmanagement;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/*
- Divisions that have a function.
+/**
+ * Divisions that have a function.
  */
 public enum FunctionalDivision {
-
     /**
-     * Childrens are created by calendar form.
+     * Children are created by calendar form.
      */
     CREATE_CHILDREN_WITH_CALENDAR("createChildrenWithCalendar"),
+
     /**
-     * A division which childs are created from this division directly.
+     * A division whose children are created from this division directly.
      */
     CREATE_CHILDREN_FROM_PARENT("createChildrenFromParent");
+
     /**
      * With the logger, text can be written to a log file or to the console.
      */
@@ -95,12 +96,12 @@ public enum FunctionalDivision {
      * @return fields
      */
     public static Set<FunctionalDivision> valuesOf(String marks) {
-        Set<FunctionalDivision> values = new HashSet<>();
+        Set<FunctionalDivision> values = new TreeSet<>();
         for (String mark : marks.split("\\s+", 0)) {
             if (addEnumByMark(mark, values)) {
                 continue;
             }
-            logger.warn("Ruleset declares undefined field use '{}', must be one of: {}", mark,
+            logger.warn("Ruleset declares undefined division use '{}', must be one of: {}", mark,
                     Arrays.stream(values()).map(FunctionalDivision::getMark).collect(Collectors.joining(", ")));
         }
         return values;

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalMetadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/FunctionalMetadata.java
@@ -12,8 +12,8 @@
 package org.kitodo.api.dataeditor.rulesetmanagement;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -86,6 +86,27 @@ public enum FunctionalMetadata {
     }
 
     /**
+     * Iterates over the {@code enum} constants, and if the candidate value has
+     * the searched mark, it is added to the list.
+     *
+     * @param mark
+     *            a character string defining how the special field is to be
+     *            marked in the ruleset
+     * @param to
+     *            object to add value, return value of {@link #valuesOf(String)}
+     * @return whether the loop has to continue
+     */
+    private static boolean addEnumByMark(String mark, Set<FunctionalMetadata> to) {
+        for (FunctionalMetadata candidate : FunctionalMetadata.values()) {
+            if (mark.equals(candidate.mark)) {
+                to.add(candidate);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns a string which defines how the special field is to be marked in
      * the ruleset.
      *
@@ -105,16 +126,13 @@ public enum FunctionalMetadata {
      * @return fields
      */
     public static Set<FunctionalMetadata> valuesOf(String marks) {
-        Set<FunctionalMetadata> values = new HashSet<>(7);
+        Set<FunctionalMetadata> values = new TreeSet<>();
         for (String mark : marks.split("\\s+", 0)) {
-            for (FunctionalMetadata candidate : FunctionalMetadata.values()) {
-                if (mark.equals(candidate.mark)) {
-                    values.add(candidate);
-                    break;
-                }
+            if (addEnumByMark(mark, values)) {
+                continue;
             }
-            logger.warn("Ruleset declares undefined field use '{}', must be one of: {}", mark,
-                Arrays.stream(values()).map(FunctionalMetadata::toString).collect(Collectors.joining(", ")));
+            logger.warn("Ruleset declares undefined division use '{}', must be one of: {}", mark,
+                    Arrays.stream(values()).map(FunctionalMetadata::getMark).collect(Collectors.joining(", ")));
         }
         return values;
     }


### PR DESCRIPTION
There are a lot of false-positive and wrong warning messages in the log file, like
```
[WARN ] 2020-10-29 11:07:28.637 [main] FunctionalMetadata - Ruleset declares undefined field use
    'recordIdentifier', must be one of: AUTHOR_LAST_NAME, DATA_SOURCE, DISPLAY_SUMMARY, HIGHERLEVEL_IDENTIFIER,
    PROCESS_TITLE, RECORD_IDENTIFIER, TITLE
[WARN ] 2020-10-29 11:07:28.637 [main] FunctionalMetadata - Ruleset declares undefined field use 
    'higherlevelIdentifier', must be one of: AUTHOR_LAST_NAME, DATA_SOURCE, DISPLAY_SUMMARY, 
    HIGHERLEVEL_IDENTIFIER, PROCESS_TITLE, RECORD_IDENTIFIER, TITLE
[WARN ] 2020-10-29 11:07:28.637 [main] FunctionalMetadata - Ruleset declares undefined field use
    'authorLastName', must be one of: AUTHOR_LAST_NAME, DATA_SOURCE, DISPLAY_SUMMARY, HIGHERLEVEL_IDENTIFIER, 
    PROCESS_TITLE, RECORD_IDENTIFIER, TITLE
[WARN ] 2020-10-29 11:07:28.643 [main] FunctionalMetadata - Ruleset declares undefined field use 'title', must
    be one of: AUTHOR_LAST_NAME, DATA_SOURCE, DISPLAY_SUMMARY, HIGHERLEVEL_IDENTIFIER, PROCESS_TITLE, 
    RECORD_IDENTIFIER, TITLE
```
They are both false-positive (the strings mentioned as undefined are correct) and wrong (“must be one of” doesn’t list the suitable values, but their internal constant names). Both fixed, and some typos.