### PR TITLE
Fix error message when trying to create metadata group panel

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -259,7 +259,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                     MetadataGroup metadataGroup = (MetadataGroup) nextMetadata;
                     value = metadataGroup.getGroup();
                 } else {
-                    throw new IllegalStateException("Got simple metadata entry with key \"" + metadataKey
+                    throw new IllegalStateException("Got simple metadata entry with key \"" + nextMetadata.getKey()
                             + "\" which is declared as substructured key in the rule set.");
                 }
                 break;


### PR DESCRIPTION
When method `createMetadataGroupPanel` encountered an instance of `Metadata` where a `MetadataGroup` was expected, the resulting error message did not include the correct metadata key.