### PR TITLE
Remove the LDAP group of default users for empty installations

### DIFF
--- a/Kitodo/setup/default.sql
+++ b/Kitodo/setup/default.sql
@@ -25,18 +25,18 @@ INSERT INTO `ldapgruppen` (
 --
 
 /*!40000 ALTER TABLE `benutzer` DISABLE KEYS */;
-INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`ldapgruppenID`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
- (1,'testAdmin','OvEJ00yyYZQ=','test','Admin',1,'Göttingen',0,10,2,'de',0);
-INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`ldapgruppenID`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
- (2,'testScanning','OvEJ00yyYZQ=','test','Scanning',1,'Göttingen',0,10,2,'de',0);
-INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`ldapgruppenID`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
- (3,'testQC','OvEJ00yyYZQ=','test','QC',1,'Göttingen',0,10,2,'de',0);
-INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`ldapgruppenID`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
- (4,'testImaging','OvEJ00yyYZQ=','test','Imaging',1,'Göttingen',0,10,2,'de',0);
-INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`ldapgruppenID`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
- (5,'testMetaData','OvEJ00yyYZQ=','test','MetaData',1,'Göttingen',0,10,2,'de',0);
-INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`ldapgruppenID`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
- (6,'testProjectmanagement','OvEJ00yyYZQ=','test','Projectmanagement',1,'Göttingen',0,10,2,'de',0);
+INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
+ (1,'testAdmin','OvEJ00yyYZQ=','test','Admin',1,'Göttingen',0,10,'de',0);
+INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
+ (2,'testScanning','OvEJ00yyYZQ=','test','Scanning',1,'Göttingen',0,10,'de',0);
+INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
+ (3,'testQC','OvEJ00yyYZQ=','test','QC',1,'Göttingen',0,10,'de',0);
+INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
+ (4,'testImaging','OvEJ00yyYZQ=','test','Imaging',1,'Göttingen',0,10,'de',0);
+INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
+ (5,'testMetaData','OvEJ00yyYZQ=','test','MetaData',1,'Göttingen',0,10,'de',0);
+INSERT INTO `benutzer` (`BenutzerID`,`Login`,`Passwort`,`Vorname`,`Nachname`,`IstAktiv`,`Standort`,`mitMassendownload`,`Tabellengroesse`,`metadatensprache`,`confVorgangsdatumAnzeigen`) VALUES
+ (6,'testProjectmanagement','OvEJ00yyYZQ=','test','Projectmanagement',1,'Göttingen',0,10,'de',0);
 /*!40000 ALTER TABLE `benutzer` ENABLE KEYS */;
 
 /*!40000 ALTER TABLE `benutzergruppen` DISABLE KEYS */;

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
@@ -50,6 +50,7 @@
                 <p:outputLabel for="ldapGroup" value="#{msgs.ldapGroup}"/>
                 <p:selectOneMenu id="ldapGroup" value="#{UserForm.userObject.ldapGroup}"
                                  disabled="#{isViewMode || isConfigMode}" converter="#{ldapGroupConverter}">
+                    <f:selectItem itemValue="#{null}" itemLabel="#{msgs.notSelected}" noSelectionOption="true"/>
                     <f:selectItems value="#{LdapGroupForm.ldapGroups}" var="ldapGroup"
                                    itemValue="#{ldapGroup}" itemLabel="#{ldapGroup.title}"/>
                     <p:ajax event="change" oncomplete="toggleSave()"/>


### PR DESCRIPTION
So far, the default users have been linked to an incompletely configured sample LDAP group in the delivery state. This pull request removes the link as the LDAP group is now optional.

Part of #456

Follow-up pull request to #4091 ([immediate diff](https://github.com/matthias-ronge/kitodo-production/compare/issue-456_1+4014...issue-456_2))