### PR TITLE
Process property search

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/PropertyDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/PropertyDAO.java
@@ -11,8 +11,13 @@
 
 package org.kitodo.data.database.persistence;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import javax.persistence.PersistenceException;
+
+import org.hibernate.Session;
 import org.kitodo.data.database.beans.Property;
 import org.kitodo.data.database.exceptions.DAOException;
 
@@ -46,5 +51,19 @@ public class PropertyDAO extends BaseDAO<Property> {
     @Override
     public void remove(Integer propertyId) throws DAOException {
         removeObject(Property.class, propertyId);
+    }
+
+    /**
+     * Retrieve and return distinct Property titles from database.
+     *
+     * @return list of distinct Property titles sorted alphabetically.
+     */
+    public List<String> retrieveDistinctTitles() {
+        try (Session session = HibernateUtil.getSession()) {
+            List<?> titles = session.createQuery("SELECT DISTINCT title FROM Property").list();
+            return titles.stream().map(Object::toString).sorted().collect(Collectors.toList());
+        } catch (PersistenceException e) {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
@@ -26,14 +26,14 @@ public enum FilterString {
     PROCESS("process:", "prozess:"),
     BATCH("batch:", "gruppe:"),
     TASKAUTOMATIC("stepautomatic:", "schrittautomatisch:"),
-    PROPERTY("property:","eigenschaft" );
+    PROPERTY("property:","eigenschaft:");
 
     private String filterEnglish;
     private String filterGerman;
 
     /**
      * Constructor.
-     * 
+     *
      * @param filterEnglish
      *            English version of filter string
      * @param filterGerman
@@ -46,7 +46,7 @@ public enum FilterString {
 
     /**
      * Get English version of filter string.
-     * 
+     *
      * @return English version of filter string
      */
     public String getFilterEnglish() {
@@ -55,7 +55,7 @@ public enum FilterString {
 
     /**
      * Get German version of filter string.
-     * 
+     *
      * @return German version of filter string
      */
     public String getFilterGerman() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
@@ -312,7 +312,8 @@ public class SearchForm {
         }
         if (StringUtils.isNotBlank(this.processPropertyValue)) {
             if (StringUtils.isNotBlank(this.processPropertyTitle)) {
-                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + this.processPropertyTitle + ":" + this.processPropertyValue + "\" ";
+                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + this.processPropertyTitle + ":"
+                        + this.processPropertyValue + "\" ";
             } else {
                 search += "\"" + FilterString.PROPERTY.getFilterEnglish() + "*:" + this.processPropertyValue + "\" ";
             }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
@@ -96,7 +96,7 @@ public class SearchForm {
      * Initialise drop down list of process property titles.
      */
     private void initProcessPropertyTitles() {
-        this.processPropertyTitles = ServiceManager.getPropertyService().findProcessPropertiesTitlesDistinct();
+        this.processPropertyTitles = ServiceManager.getPropertyService().findDistinctTitles();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
@@ -310,8 +310,16 @@ public class SearchForm {
             search += "\"" + FilterString.TASKDONEUSER.getFilterEnglish() + this.stepdoneuser + "\" \""
                     + FilterString.TASKDONETITLE.getFilterEnglish() + this.stepdonetitle + "\" ";
         }
-        if (StringUtils.isNotBlank(this.processPropertyTitle) && StringUtils.isNotBlank(this.processPropertyValue)) {
-            search += "\"" + FilterString.PROPERTY.getFilterEnglish() + this.processPropertyTitle + ":" + this.processPropertyValue + "\" ";
+        if (StringUtils.isNotBlank(this.processPropertyValue)) {
+            if (StringUtils.isNotBlank(this.processPropertyTitle)) {
+                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + this.processPropertyTitle + ":" + this.processPropertyValue + "\" ";
+            } else {
+                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + "*:" + this.processPropertyValue + "\" ";
+            }
+        } else {
+            if (StringUtils.isNotBlank(this.processPropertyTitle)) {
+                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + this.processPropertyTitle + ":*\" ";
+            }
         }
         return search;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
@@ -86,11 +86,18 @@ public class SearchForm {
         initStepStatus();
         initProjects();
         initStepTitles();
+        initProcessPropertyTitles();
         initUserList();
         this.processForm = processForm;
         this.taskForm = taskForm;
     }
 
+    /**
+     * Initialise drop down list of process property titles.
+     */
+    private void initProcessPropertyTitles() {
+        this.processPropertyTitles = ServiceManager.getPropertyService().findProcessPropertiesTitlesDistinct();
+    }
 
     /**
      * Initialise drop down list of projects.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -490,15 +490,17 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
         return new BoolQueryBuilder();
     }
 
-    private QueryBuilder createProcessPropertyFilter(String filter, ObjectType objectType) {
+    private QueryBuilder createProcessPropertyFilter(String filter, ObjectType objectType) throws DataException {
+        BoolQueryBuilder propertyQuery = new BoolQueryBuilder();
+        Set<String> strings = filterValuesAsStrings(filter, FilterString.PROPERTY);
+        for (String string : strings) {
+            String[] split = string.split(":");
+            propertyQuery.should(ServiceManager.getProcessService().createPropertyQuery(split[0], split[1]));
+        }
         if (objectType == ObjectType.PROCESS) {
-            BoolQueryBuilder propertyQuery = new BoolQueryBuilder();
-            Set<String> strings = filterValuesAsStrings(filter, FilterString.PROPERTY);
-            for (String string : strings) {
-                String[] split = string.split(":");
-                propertyQuery.should(ServiceManager.getProcessService().createPropertyQuery(split[0], split[1]));
-            }
             return propertyQuery;
+        } else if (objectType == ObjectType.TASK) {
+            return getQueryAccordingToObjectTypeAndSearchInObject(ObjectType.TASK, ObjectType.PROCESS, propertyQuery);
         }
         return new BoolQueryBuilder();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -721,8 +721,12 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         String valueSearchKey = ProcessTypeField.PROPERTIES + ".value.keyword";
 
         BoolQueryBuilder pairQuery = new BoolQueryBuilder();
-        pairQuery.must(matchQuery(titleSearchKey, title));
-        pairQuery.must(matchQuery(valueSearchKey, value));
+        if (!WILDCARD.equals(title)) {
+            pairQuery.must(matchQuery(titleSearchKey, title));
+        }
+        if (!WILDCARD.equals(value)) {
+            pairQuery.must(matchQuery(valueSearchKey, value));
+        }
         return nestedQuery(ProcessTypeField.PROPERTIES.toString(), pairQuery, ScoreMode.Total);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -13,7 +13,6 @@ package org.kitodo.production.services.data;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,39 +71,14 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
     }
 
     /**
-     * Find all distinct titles from workpiece properties.
+     * Find all distinct property titles.
      *
      * @return a list of titles.
      */
-    public List<String> findWorkpiecePropertiesTitlesDistinct() {
-        return findDistinctTitles("workpiece");
-    }
-
-    /**
-     * Find all distinct titles from template properties.
-     *
-     * @return a list of titles.
-     */
-    public List<String> findTemplatePropertiesTitlesDistinct() {
-        return findDistinctTitles("template");
-    }
-
-    /**
-     * Find all distinct titles from process properties.
-     *
-     * @return a list of titles.
-     */
-    public List<String> findProcessPropertiesTitlesDistinct() {
-        return findDistinctTitles("process");
-    }
-
-    private List<String> findDistinctTitles(String type) {
-        List<Property> byQuery = getByQuery("SELECT DISTINCT property FROM Property AS property GROUP BY property.title");
-        HashSet<String> titles = new HashSet<>();
-        for (Property property : byQuery) {
-            titles.add(property.getTitle());
-        }
-        return titles.stream().sorted().collect(Collectors.toList());
+    public List<String> findDistinctTitles() {
+        List<Property> properties =
+                getByQuery("SELECT DISTINCT property FROM Property AS property GROUP BY property.title");
+        return properties.stream().map(Property::getTitle).sorted().collect(Collectors.toList());
     }
 
     /**
@@ -112,13 +86,9 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
      *
      * @param title
      *            of the searched property
-     * @param type
-     *            "process", "workpiece" or "template" as String
-     * @param contains
-     *            of the searched property
      * @return list of JSON objects with properties
      */
-    public List<Property> findByTitle(String title, String type, boolean contains) {
+    public List<Property> findByTitle(String title) {
         HashMap<String, Object> parameters = new HashMap<>();
         parameters.put("title", title);
         return getByQuery("from Property as property where property.title=:title", parameters);
@@ -129,14 +99,10 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
      *
      * @param value
      *            of the searched property
-     * @param type
-     *            "process", "workpiece" or "template" as String
-     * @param contains
-     *            of the searched property
      * @return list of JSON objects with properties
      */
-    List<Property> findByValue(String value, String type, boolean contains) {
-        HashMap parameters = new HashMap<String, String>();
+    List<Property> findByValue(String value) {
+        HashMap<String, Object> parameters = new HashMap<>();
         parameters.put("value", value);
         return getByQuery("from Property as property where property.value=:value", parameters);
     }
@@ -149,14 +115,10 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
      *            of the searched property
      * @param value
      *            of the searched property
-     * @param type
-     *            "process", "workpiece" or "template" as String
-     * @param contains
-     *            true or false
      * @return list of JSON objects with batches of exact type
      */
-    List<Property> findByTitleAndValue(String title, String value, String type, boolean contains) {
-        HashMap parameters = new HashMap<String, String>();
+    List<Property> findByTitleAndValue(String title, String value) {
+        HashMap<String, Object> parameters = new HashMap<>();
         parameters.put("title", title);
         parameters.put("value", value);
         return getByQuery("from Property as property where property.title=:title and property.value=:value", parameters);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -99,7 +99,7 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
     }
 
     private List<String> findDistinctTitles(String type) {
-        List<Property> byQuery = getByQuery("SELECT DISTINCT property FROM Property AS property GROUP BY property.id");
+        List<Property> byQuery = getByQuery("SELECT DISTINCT property FROM Property AS property GROUP BY property.title");
         HashSet<String> titles = new HashSet<>();
         for (Property property : byQuery) {
             titles.add(property.getTitle());

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -13,9 +13,11 @@ package org.kitodo.production.services.data;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.kitodo.data.database.beans.Property;
 import org.kitodo.data.database.exceptions.DAOException;
@@ -97,12 +99,12 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
     }
 
     private List<String> findDistinctTitles(String type) {
-        List<Property> byQuery = getByQuery("FROM Property AS property GROUP BY title");
-        List<String> titles = new ArrayList<>();
+        List<Property> byQuery = getByQuery("SELECT DISTINCT property FROM Property AS property GROUP BY property.id");
+        HashSet<String> titles = new HashSet<>();
         for (Property property : byQuery) {
             titles.add(property.getTitle());
         }
-        return titles;
+        return titles.stream().sorted().collect(Collectors.toList());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -97,7 +97,7 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
     }
 
     private List<String> findDistinctTitles(String type) {
-        List<Property> byQuery = getByQuery("SELECT DISTINCT property.title from Property as property");
+        List<Property> byQuery = getByQuery("FROM Property AS property GROUP BY title");
         List<String> titles = new ArrayList<>();
         for (Property property : byQuery) {
             titles.add(property.getTitle());
@@ -117,7 +117,7 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
      * @return list of JSON objects with properties
      */
     public List<Property> findByTitle(String title, String type, boolean contains) {
-        HashMap parameters = new HashMap<String, String>();
+        HashMap<String, Object> parameters = new HashMap<>();
         parameters.put("title", title);
         return getByQuery("from Property as property where property.title=:title", parameters);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/PropertyService.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.kitodo.data.database.beans.Property;
 import org.kitodo.data.database.exceptions.DAOException;
@@ -76,9 +75,7 @@ public class PropertyService extends SearchDatabaseService<Property, PropertyDAO
      * @return a list of titles.
      */
     public List<String> findDistinctTitles() {
-        List<Property> properties =
-                getByQuery("SELECT DISTINCT property FROM Property AS property GROUP BY property.title");
-        return properties.stream().map(Property::getTitle).sorted().collect(Collectors.toList());
+        return dao.retrieveDistinctTitles();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -68,6 +68,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     protected Searcher searcher;
     protected Indexer indexer;
     protected BaseType type;
+    protected static final String WILDCARD = "*";
 
     /**
      * Constructor necessary to use searcher in child classes.
@@ -399,7 +400,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
             throw new DataException(e);
         }
     }
-    
+
     /**
      * Display all documents for exact type in a given range.
      *
@@ -909,7 +910,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     /**
      * Removes all objects from index, which are no longer in Database.
      * @param baseIndexedBeansId the list of beans to check for missing db eintries.
-     * 
+     *
      */
     public void removeLooseIndexData(List<Integer> baseIndexedBeansId) throws DataException, CustomResponseException {
         for (Integer baseIndexedBeanId : baseIndexedBeansId) {

--- a/Kitodo/src/main/webapp/pages/extendedSearch.xhtml
+++ b/Kitodo/src/main/webapp/pages/extendedSearch.xhtml
@@ -76,7 +76,7 @@
                     <!--properties -->
                     <p:row>
                         <p:column>
-                            <p:outputLabel for="processproperty" value="#{msgs.processProperties}"/>
+                            <p:outputLabel for="processProperty" value="#{msgs.processProperties}"/>
                         </p:column>
                         <p:column>
                             <p:selectOneMenu value="#{SearchForm.processPropertyOperand}">
@@ -92,7 +92,7 @@
                             </p:selectOneMenu>
                         </p:column>
                         <p:column>
-                            <p:inputText id="processproperty"
+                            <p:inputText id="processProperty"
                                          value="#{SearchForm.processPropertyValue}"
                                          styleClass="extended-search-input-field"/>
                         </p:column>

--- a/Kitodo/src/main/webapp/pages/extendedSearch.xhtml
+++ b/Kitodo/src/main/webapp/pages/extendedSearch.xhtml
@@ -76,14 +76,24 @@
                     <!--properties -->
                     <p:row>
                         <p:column>
-                            <p:outputLabel for="propertyTitle" value="#{msgs.properties}"/>
+                            <p:outputLabel for="processproperty" value="#{msgs.processProperties}"/>
                         </p:column>
                         <p:column>
-                            <p:inputText id="propertyTitle" placeholder="#{msgs.title}" value="#{SearchForm.processPropertyTitle}"
-                                         styleClass="extended-search-input-field"/>
+                            <p:selectOneMenu value="#{SearchForm.processPropertyOperand}">
+                                <f:selectItems value="#{SearchForm.operands}"/>
+                            </p:selectOneMenu>
                         </p:column>
                         <p:column>
-                            <p:inputText id="propertyValue" placeholder="#{msgs.value}" value="#{SearchForm.processPropertyValue}"
+                            <p:selectOneMenu value="#{SearchForm.processPropertyTitle}">
+                                <f:selectItem itemValue="#{null}" itemLabel="#{msgs.notSelected}" noSelectionOption="true"/>
+                                <f:selectItems value="#{SearchForm.processPropertyTitles}"
+                                               var="proc" itemLabel="#{proc}"
+                                               itemValue="#{proc}"/>
+                            </p:selectOneMenu>
+                        </p:column>
+                        <p:column>
+                            <p:inputText id="processproperty"
+                                         value="#{SearchForm.processPropertyValue}"
                                          styleClass="extended-search-input-field"/>
                         </p:column>
                     </p:row>

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/PropertyServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/PropertyServiceIT.java
@@ -12,16 +12,12 @@
 package org.kitodo.production.services.data;
 
 import static org.awaitility.Awaitility.await;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
-import org.elasticsearch.index.query.Operator;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -102,21 +98,20 @@ public class PropertyServiceIT {
     }
 
     /**
-     * test distinc titles.
+     * test distinct titles.
      */
-    @Ignore
     @Test
-    public void shouldFindDistinctTitles() throws Exception {
-        assertEquals("Incorrect size of distinct titles for process properties!", 2,
+    public void shouldFindDistinctTitles() {
+        assertEquals("Incorrect size of distinct titles for process properties!", 6,
             propertyService.findDistinctTitles().size());
 
         List<String> processPropertiesTitlesDistinct = propertyService.findDistinctTitles();
 
         String title = processPropertiesTitlesDistinct.get(0);
-        assertEquals("Incorrect sorting of distinct titles for process properties!", "Korrektur notwendig", title);
+        assertEquals("Incorrect sorting of distinct titles for process properties!", "FirstWorkpiece Property", title);
 
         title = processPropertiesTitlesDistinct.get(1);
-        assertEquals("Incorrect sorting of distinct titles for process properties!", "Process Property", title);
+        assertEquals("Incorrect sorting of distinct titles for process properties!", "Korrektur notwendig", title);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/PropertyServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/PropertyServiceIT.java
@@ -108,9 +108,9 @@ public class PropertyServiceIT {
     @Test
     public void shouldFindDistinctTitles() throws Exception {
         assertEquals("Incorrect size of distinct titles for process properties!", 2,
-            propertyService.findProcessPropertiesTitlesDistinct().size());
+            propertyService.findDistinctTitles().size());
 
-        List<String> processPropertiesTitlesDistinct = propertyService.findProcessPropertiesTitlesDistinct();
+        List<String> processPropertiesTitlesDistinct = propertyService.findDistinctTitles();
 
         String title = processPropertiesTitlesDistinct.get(0);
         assertEquals("Incorrect sorting of distinct titles for process properties!", "Korrektur notwendig", title);
@@ -163,22 +163,22 @@ public class PropertyServiceIT {
     @Test
     public void shouldFindByValue() {
         assertEquals("Properties were not found in database!", 2,
-            propertyService.findByValue("second", null, true).size());
+            propertyService.findByValue("second").size());
 
         assertEquals("Property was not found in database!", 1,
-            propertyService.findByValue("second value", null, true).size());
+            propertyService.findByValue("second value").size());
     }
 
     @Test
     public void shouldFindByTitleAndValue() {
         assertEquals("Property was not found in database!", 1,
-            propertyService.findByTitleAndValue("Korrektur notwendig", "second value", null, true).size());
+            propertyService.findByTitleAndValue("Korrektur notwendig", "second value").size());
     }
 
     @Test
     public void shouldNotFindByTitleAndValue() {
         assertEquals("Property was found in database!", 0,
-            propertyService.findByTitleAndValue("Korrektur notwendig", "third", null, true).size());
+            propertyService.findByTitleAndValue("Korrektur notwendig", "third").size());
     }
 
 }


### PR DESCRIPTION
This PR restores the option to search for tasks by process property via the extended search and filters. It also restores the pulldown menu for process properties in the extended search and allows wildcard searches for process property names or values, resultung in filter strings 
- `"property:[Property-Name]:*"` for wildcard searches of all processes with any value of process property with name `Property-Name` and  
- `"property:*:[Property-Value]"` for wildcard searches of all processes with any properties that have the value `Property-Value`.