### PR TITLE
Fix sorting task list by title

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -45,7 +45,7 @@
 
             <p:column id="titleColumn"
                       headerText="#{msgs.task}"
-                      sortBy="#{item.title}"
+                      sortBy="#{item.title.keyword}"
                       rendered="#{CurrentTaskForm.showColumn('task.title')}">
                 <h:outputText title="#{item.title}"
                               value="#{item.title}"/>


### PR DESCRIPTION
Sorting task list by title doesn't work correctly if task name contains empty spaces or special characters, which cause the string to be tokenized during indexing. Using `task.title.keyword` instead of `task.title` for sorting fixes this problem since `keyword` is not tokenized.