### PR TITLE
Add option to apply multiple XSLT files during import

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/SchemaConverterInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/SchemaConverterInterface.java
@@ -14,6 +14,7 @@ package org.kitodo.api.schemaconverter;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.List;
 
 /** Enables the conversion of a DataRecord from one format to another. */
 public interface SchemaConverterInterface {
@@ -24,11 +25,11 @@ public interface SchemaConverterInterface {
      * @param record DataRecord to be converted
      * @param targetMetadataFormat MetadataFormat to which the given DataRecord is converted
      * @param targetFileFormat FileFormat to which the given DataRecord is converted
-     * @param mappingFile mapping file; if null, the schema converter module uses a default mapping
+     * @param mappingFiles list of mapping files; if empty, the schema converter module uses a default mapping
      * @return The result of the conversion as a DataRecord.
      */
     DataRecord convert(DataRecord record, MetadataFormat targetMetadataFormat, FileFormat targetFileFormat,
-                       File mappingFile) throws IOException, URISyntaxException;
+                       List<File> mappingFiles) throws IOException, URISyntaxException;
 
     /**
      * Check and return whether the current SchemaConverter supports the given MetadataFormat as a target format or not.

--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -107,7 +107,7 @@ public class OPACConfig {
      * @param catalogName String identifying the catalog by its title
      * @return HierarchicalConfiguration for catalog's "mappingFile"
      */
-    public static String getXsltMappingFile(String catalogName) {
+    public static String getXsltMappingFiles(String catalogName) {
         return getCatalog(catalogName).getString("mappingFile");
     }
 

--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -15,6 +15,7 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
@@ -103,12 +104,13 @@ public class OPACConfig {
     }
 
     /**
-     * Retrieve the "mappingFile" of the catalog identified by its title.
+     * Retrieve list of "mappingFiles" of the catalog identified by its title.
      * @param catalogName String identifying the catalog by its title
-     * @return HierarchicalConfiguration for catalog's "mappingFile"
+     * @return List of Strings containing mapping files names for catalog
      */
-    public static String getXsltMappingFiles(String catalogName) {
-        return getCatalog(catalogName).getString("mappingFile");
+    public static List<String> getXsltMappingFiles(String catalogName) {
+        return getCatalog(catalogName).configurationAt("mappingFiles").configurationsAt("file").stream()
+                .map(c -> c.getRoot().getValue().toString()).collect(Collectors.toList());
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/exceptions/ConfigException.java
+++ b/Kitodo-API/src/main/java/org/kitodo/exceptions/ConfigException.java
@@ -14,13 +14,13 @@ package org.kitodo.exceptions;
 public class ConfigException extends RuntimeException {
 
     /**
-     * Constructor with given parameter name for exception message.
+     * Constructor with given parameter catalogName for exception message.
      *
-     * @param name
+     * @param catalogName
      *            as String
      */
-    public ConfigException(String name) {
-        super("The catalog '" + name + "' is not found!");
+    public ConfigException(String catalogName) {
+        super("The catalog '" + catalogName + "' is not found!");
     }
 
     /**

--- a/Kitodo-Query-URL-Import/src/test/resources/kitodo_opac.xml
+++ b/Kitodo-Query-URL-Import/src/test/resources/kitodo_opac.xml
@@ -50,7 +50,9 @@
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>MODS</metadataFormat>
-        <mappingFile>mods2kitodo.xsl</mappingFile>
+        <mappingFiles>
+            <file>mods2kitodo.xsl</file>
+        </mappingFiles>
         <config>
             <param name="host" value="sru.gbv.de" />
             <param name="scheme" value="http" />
@@ -77,7 +79,9 @@
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>MODS</metadataFormat>
-        <mappingFile>mods2kitodo.xsl</mappingFile>
+        <mappingFiles>
+            <file>mods2kitodo.xsl</file>
+        </mappingFiles>
         <config>
             <param name="host" value="localhost" />
             <param name="scheme" value="http" />

--- a/Kitodo-XML-SchemaConverter/src/test/java/org/kitodo/xmlschemaconverter/XmlSchemaConverterTest.java
+++ b/Kitodo-XML-SchemaConverter/src/test/java/org/kitodo/xmlschemaconverter/XmlSchemaConverterTest.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -28,7 +29,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kitodo.api.schemaconverter.DataRecord;
 import org.kitodo.api.schemaconverter.FileFormat;
@@ -63,7 +63,7 @@ public class XmlSchemaConverterTest {
 
         try (InputStream inputStream = Files.newInputStream(Paths.get(MODS_TEST_FILE_PATH))) {
             testRecord.setOriginalData(IOUtils.toString(inputStream, Charset.defaultCharset()));
-            internalFormatRecord = converter.convert(testRecord, MetadataFormat.KITODO, FileFormat.XML, null);
+            internalFormatRecord = converter.convert(testRecord, MetadataFormat.KITODO, FileFormat.XML, Collections.emptyList());
         }
 
         Assert.assertNotNull("Conversion result is empty!", internalFormatRecord);
@@ -110,7 +110,7 @@ public class XmlSchemaConverterTest {
 
         try (InputStream inputStream = Files.newInputStream(Paths.get(MARC_TEST_FILE_PATH))) {
             testRecord.setOriginalData(IOUtils.toString(inputStream, Charset.defaultCharset()));
-            internalFormatRecord = converter.convert(testRecord, MetadataFormat.KITODO, FileFormat.XML, null);
+            internalFormatRecord = converter.convert(testRecord, MetadataFormat.KITODO, FileFormat.XML, Collections.emptyList());
         }
 
         Assert.assertNotNull("Conversion result is empty!", internalFormatRecord);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -518,9 +518,9 @@ public class ImportService {
         LinkedList<TempProcess> childProcesses = new LinkedList<>();
         if (!childRecords.isEmpty()) {
             SchemaConverterInterface converter = getSchemaConverter(childRecords.get(0));
-            File mappingFile = getMappingFile(opac);
+            List<File> mappingFiles = getMappingFiles(opac);
             for (DataRecord childRecord : childRecords) {
-                DataRecord internalRecord = converter.convert(childRecord, MetadataFormat.KITODO, FileFormat.XML, mappingFile);
+                DataRecord internalRecord = converter.convert(childRecord, MetadataFormat.KITODO, FileFormat.XML, mappingFiles);
                 Document childDocument = XMLUtils.parseXMLString((String)internalRecord.getOriginalData());
                 childProcesses.add(createTempProcessFromDocument(childDocument, templateId, projectId));
             }
@@ -547,7 +547,7 @@ public class ImportService {
         // depending on metadata and return form, call corresponding schema converter module!
         SchemaConverterInterface converter = getSchemaConverter(dataRecord);
 
-        File mappingFile = getMappingFile(opac);
+        List<File> mappingFiles = getMappingFiles(opac);
 
         // transform dataRecord to Kitodo internal format using appropriate SchemaConverter!
         File debugFolder = ConfigCore.getKitodoDebugDirectory();
@@ -555,7 +555,7 @@ public class ImportService {
             FileUtils.writeStringToFile(new File(debugFolder, "catalogRecord.xml"),
                 (String) dataRecord.getOriginalData(), StandardCharsets.UTF_8);
         }
-        DataRecord internalRecord = converter.convert(dataRecord, MetadataFormat.KITODO, FileFormat.XML, mappingFile);
+        DataRecord internalRecord = converter.convert(dataRecord, MetadataFormat.KITODO, FileFormat.XML, mappingFiles);
         if (Objects.nonNull(debugFolder)) {
             FileUtils.writeStringToFile(new File(debugFolder, "internalRecord.xml"),
                 (String) internalRecord.getOriginalData(), StandardCharsets.UTF_8);
@@ -578,16 +578,18 @@ public class ImportService {
         return kitodoNode.getChildNodes();
     }
 
-    private File getMappingFile(String opac) throws URISyntaxException {
-        File mappingFile = null;
+    private List<File> getMappingFiles(String opac) throws URISyntaxException {
+        List<File> mappingFiles = new ArrayList<>();
 
-        String mappingFileName = OPACConfig.getXsltMappingFile(opac);
-        if (!StringUtils.isBlank(mappingFileName)) {
-            URI xsltFile = Paths.get(ConfigCore.getParameter(ParameterCore.DIR_XSLT)).toUri()
-                    .resolve(new URI(mappingFileName));
-            mappingFile = ServiceManager.getFileService().getFile(xsltFile);
+        String mappingFileNames = OPACConfig.getXsltMappingFiles(opac);
+        if (!StringUtils.isBlank(mappingFileNames)) {
+            for (String mappingFileName : mappingFileNames.split(",")) {
+                URI xsltFile = Paths.get(ConfigCore.getParameter(ParameterCore.DIR_XSLT)).toUri()
+                        .resolve(new URI(mappingFileName.trim()));
+                mappingFiles.add(ServiceManager.getFileService().getFile(xsltFile));
+            }
         }
-        return mappingFile;
+        return mappingFiles;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -364,7 +364,7 @@ public class ImportService {
     private String importProcessAndReturnParentID(String recordId, LinkedList<TempProcess> allProcesses, String opac,
                                                  int projectID, int templateID)
             throws IOException, ProcessGenerationException, XPathExpressionException, ParserConfigurationException,
-            NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException, ConfigException {
+            NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException {
 
         Document internalDocument = importDocument(opac, recordId, allProcesses.isEmpty());
         TempProcess tempProcess = createTempProcessFromDocument(internalDocument, templateID, projectID);
@@ -403,8 +403,7 @@ public class ImportService {
     public LinkedList<TempProcess> importProcessHierarchy(String recordId, String opac, int projectId, int templateId,
                                                           int importDepth, Collection<String> parentIdMetadata)
             throws IOException, ProcessGenerationException, XPathExpressionException, ParserConfigurationException,
-            NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException, DAOException,
-            ConfigException {
+            NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException, DAOException {
         importModule = initializeImportModule();
         processGenerator = new ProcessGenerator();
         LinkedList<TempProcess> processes = new LinkedList<>();
@@ -512,7 +511,7 @@ public class ImportService {
     public LinkedList<TempProcess> getChildProcesses(String opac, String elementID, int projectId, int templateId,
                                                      int rows)
             throws SAXException, UnsupportedFormatException, URISyntaxException, ParserConfigurationException,
-            NoRecordFoundException, IOException, ProcessGenerationException, ConfigException {
+            NoRecordFoundException, IOException, ProcessGenerationException {
         loadOpacConfiguration(opac);
         importModule = initializeImportModule();
         List<DataRecord> childRecords = searchChildRecords(opac, elementID, rows);
@@ -535,7 +534,7 @@ public class ImportService {
 
     private Document importDocument(String opac, String identifier, boolean extractExemplars) throws NoRecordFoundException,
             UnsupportedFormatException, URISyntaxException, IOException, XPathExpressionException,
-            ParserConfigurationException, SAXException, ConfigException {
+            ParserConfigurationException, SAXException {
         // ################ IMPORT #################
         importModule = initializeImportModule();
         DataRecord dataRecord = importModule.getFullRecordById(opac, identifier);
@@ -579,7 +578,7 @@ public class ImportService {
         return kitodoNode.getChildNodes();
     }
 
-    private List<File> getMappingFiles(String opac) throws URISyntaxException, ConfigException {
+    private List<File> getMappingFiles(String opac) throws URISyntaxException {
         List<File> mappingFiles = new ArrayList<>();
         try {
             for (String mappingFileName : OPACConfig.getXsltMappingFiles(opac)) {
@@ -588,7 +587,7 @@ public class ImportService {
                 mappingFiles.add(ServiceManager.getFileService().getFile(xsltFile));
             }
         } catch (IllegalArgumentException e) {
-            throw new ConfigException(e.getMessage(), e);
+            logger.error(e.getMessage());
         }
         return mappingFiles;
     }

--- a/Kitodo/src/main/resources/kitodo_opac.xml
+++ b/Kitodo/src/main/resources/kitodo_opac.xml
@@ -81,7 +81,9 @@
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>PICA</metadataFormat>
-        <mappingFile>pica2kitodo.xsl</mappingFile>
+        <mappingFiles>
+            <file>pica2kitodo.xsl</file>
+        </mappingFiles>
         <config>
             <param name="host" value="sru.k10plus.de" />
             <param name="scheme" value="https" />
@@ -109,7 +111,9 @@
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>MODS</metadataFormat>
-        <mappingFile>mods2kitodo.xsl</mappingFile>
+        <mappingFiles>
+            <file>mods2kitodo.xsl</file>
+        </mappingFiles>
         <config>
             <param name="host" value="kalliope-verbund.info" />
             <param name="scheme" value="http" />

--- a/Kitodo/src/test/resources/kitodo_opac.xml
+++ b/Kitodo/src/test/resources/kitodo_opac.xml
@@ -50,7 +50,9 @@
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>MODS</metadataFormat>
-        <mappingFile>mods2kitodo.xsl</mappingFile>
+        <mappingFiles>
+            <file>mods2kitodo.xsl</file>
+        </mappingFiles>
         <config>
             <param name="host" value="sru.gbv.de" />
             <param name="scheme" value="http" />
@@ -77,7 +79,9 @@
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>MODS</metadataFormat>
-        <mappingFile>mods2kitodo.xsl</mappingFile>
+        <mappingFiles>
+            <file>mods2kitodo.xsl</file>
+        </mappingFiles>
         <config>
             <param name="host" value="localhost" />
             <param name="scheme" value="http" />


### PR DESCRIPTION
These changes add the option to apply multiple XSL transformations sequentially to an imported XML document, similar to how the current import of MARCXML documents works (first map MARC to MODS, then MODS to Kitodo). 

The XSLT files need to be ~~separated by a comma in the `<mappingFile>` element of~~ added to the corresponding OPAC configuration in `kitodo_opac.xml`  as individual `<file>` elements, contained in a new `mappingFiles` grouping element in the order in which they should be applied like this:
```
<mappingFiles>
    <file>marc21slim2mods.xsl</file>
    <file>mods2kitodo.xsl</file>
</mappingFile>
```
Note that existing configurations with a single mapping file ~~are not affected and do not need to be changed!~~ need to be updated to this new syntax to continue to work (with just a single `<file>` element in the `<mappingFiles>` container)