### PR TITLE
enable parentExtraction from record

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -13,8 +13,6 @@ package org.kitodo.config;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -118,7 +116,7 @@ public class OPACConfig {
     /**
      * Retrieve the "parentMappingFile" of the catalog identified by its title.
      * @param catalogName String identifying the catalog by its title
-     * @return HierarchicalConfiguration for catalog's "parentMappingFile"
+     * @return String containing given catalogs "parentMappingFile"
      */
     public static String getXsltMappingFileForParentInRecord(String catalogName) {
         return getCatalog(catalogName).getString("parentMappingFile");

--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -114,6 +114,7 @@ public class OPACConfig {
         return getCatalog(catalogName).configurationAt("mappingFiles").configurationsAt("file").stream()
                 .map(c -> c.getRoot().getValue().toString()).collect(Collectors.toList());
     }
+
     /**
      * Retrieve the "parentMappingFile" of the catalog identified by its title.
      * @param catalogName String identifying the catalog by its title
@@ -258,7 +259,7 @@ public class OPACConfig {
     }
 
     /**
-     * If a mappingFile for parentInRecord is configured
+     * If a mappingFile for parentInRecord is configured.
      * @param catalogName OPAC for witch to get the config
      * @return true, if mapping file is configured
      */

--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -120,8 +120,8 @@ public class OPACConfig {
      * @param catalogName String identifying the catalog by its title
      * @return HierarchicalConfiguration for catalog's "parentMappingFile"
      */
-    public static List<String> getXsltMappingFileForParentInRecord(String catalogName) {
-        return Arrays.asList(getCatalog(catalogName).getString("parentMappingFile"));
+    public static String getXsltMappingFileForParentInRecord(String catalogName) {
+        return getCatalog(catalogName).getString("parentMappingFile");
     }
 
     /**
@@ -264,7 +264,7 @@ public class OPACConfig {
      * @return true, if mapping file is configured
      */
     public static boolean isParentInRecord(String catalogName) {
-        return !getXsltMappingFileForParentInRecord(catalogName).isEmpty();
+        return StringUtils.isNotBlank(getXsltMappingFileForParentInRecord(catalogName));
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -13,6 +13,8 @@ package org.kitodo.config;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -111,6 +113,14 @@ public class OPACConfig {
     public static List<String> getXsltMappingFiles(String catalogName) {
         return getCatalog(catalogName).configurationAt("mappingFiles").configurationsAt("file").stream()
                 .map(c -> c.getRoot().getValue().toString()).collect(Collectors.toList());
+    }
+    /**
+     * Retrieve the "parentMappingFile" of the catalog identified by its title.
+     * @param catalogName String identifying the catalog by its title
+     * @return HierarchicalConfiguration for catalog's "parentMappingFile"
+     */
+    public static List<String> getXsltMappingFileForParentInRecord(String catalogName) {
+        return Arrays.asList(getCatalog(catalogName).getString("parentMappingFile"));
     }
 
     /**
@@ -245,6 +255,15 @@ public class OPACConfig {
      */
     public static String getFtpPassword(String catalogName) {
         return getCatalog(catalogName).configurationAt("credentials").getString("password");
+    }
+
+    /**
+     * If a mappingFile for parentInRecord is configured
+     * @param catalogName OPAC for witch to get the config
+     * @return true, if mapping file is configured
+     */
+    public static boolean isParentInRecord(String catalogName) {
+        return !getXsltMappingFileForParentInRecord(catalogName).isEmpty();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -446,9 +446,11 @@ public class ImportService {
                 Process parentProcess = loadParentProcess(parentIDMetadata, template.getRuleset().getId(), projectId);
                 if (Objects.isNull(parentProcess)) {
                     if (OPACConfig.isParentInRecord(opac)) {
-                        parentID = importProcessAndReturnParentID(recordId, processes, opac, projectId, templateId, true);
-                    } else{
-                        parentID = importProcessAndReturnParentID(parentID, processes, opac, projectId, templateId, false);
+                        parentID = importProcessAndReturnParentID(recordId, processes, opac, projectId, templateId,
+                            true);
+                    } else {
+                        parentID = importProcessAndReturnParentID(parentID, processes, opac, projectId, templateId,
+                            false);
                     }
                     level++;
                 } else {
@@ -552,9 +554,9 @@ public class ImportService {
         }
     }
 
-    private Document importDocument(String opac, String identifier, boolean extractExemplars, boolean isParentInRecord) throws NoRecordFoundException,
-            UnsupportedFormatException, URISyntaxException, IOException, XPathExpressionException,
-            ParserConfigurationException, SAXException {
+    private Document importDocument(String opac, String identifier, boolean extractExemplars, boolean isParentInRecord)
+            throws NoRecordFoundException, UnsupportedFormatException, URISyntaxException, IOException,
+            XPathExpressionException, ParserConfigurationException, SAXException {
         // ################ IMPORT #################
         importModule = initializeImportModule();
         DataRecord dataRecord = importModule.getFullRecordById(opac, identifier);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -437,6 +437,14 @@ public class ImportService {
         if (Objects.isNull(template.getRuleset())) {
             throw new ProcessGenerationException("Ruleset of template " + template.getId() + " is null!");
         }
+        importParents(recordId, opac, projectId, templateId, importDepth, processes, parentID, template);
+        return processes;
+    }
+
+    private void importParents(String recordId, String opac, int projectId, int templateId, int importDepth,
+            LinkedList<TempProcess> processes, String parentID, Template template)
+            throws ProcessGenerationException, IOException, XPathExpressionException, ParserConfigurationException,
+            NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException, DAOException {
         int level = 1;
         this.parentTempProcess = null;
         while (Objects.nonNull(parentID) && level < importDepth) {
@@ -461,17 +469,18 @@ public class ImportService {
                     break;
                 }
             } catch (SAXParseException | DAOException e) {
-                // this happens for example if a document is part of a "Virtueller Bestand" in Kalliope for which a
+                // this happens for example if a document is part of a "Virtueller Bestand" in
+                // Kalliope for which a
                 // proper "record" is not returned from its SRU interface
                 logger.error(e.getLocalizedMessage());
                 break;
             }
         }
-        // always try to find a parent for last imported process (e.g. level == importDepth) in the database!
+        // always try to find a parent for last imported process (e.g. level ==
+        // importDepth) in the database!
         if (Objects.nonNull(parentID) && level == importDepth) {
             this.parentTempProcess = checkForParent(parentID, template.getRuleset().getId(), projectId);
         }
-        return processes;
     }
 
     private TempProcess checkForParent(String parentID, int rulesetID, int projectID) throws DAOException, IOException,

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -363,11 +363,11 @@ public class ImportService {
     }
 
     private String importProcessAndReturnParentID(String recordId, LinkedList<TempProcess> allProcesses, String opac,
-                                                 int projectID, int templateID)
+                                                 int projectID, int templateID, boolean isParentInRecord)
             throws IOException, ProcessGenerationException, XPathExpressionException, ParserConfigurationException,
             NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException {
 
-        Document internalDocument = importDocument(opac, recordId, allProcesses.isEmpty());
+        Document internalDocument = importDocument(opac, recordId, allProcesses.isEmpty(), isParentInRecord);
         TempProcess tempProcess = createTempProcessFromDocument(internalDocument, templateID, projectID);
 
         // Workaround for classifying MultiVolumeWorks with insufficient information
@@ -384,7 +384,7 @@ public class ImportService {
         }
 
         allProcesses.add(tempProcess);
-        return getParentID(internalDocument);
+        return isParentInRecord ? null : getParentID(internalDocument);
     }
 
     /**
@@ -432,7 +432,7 @@ public class ImportService {
             parentXpath = parentXpath.replace(REPLACE_ME, parentIdMetadata.toArray()[0].toString());
         }
 
-        String parentID = importProcessAndReturnParentID(recordId, processes, opac, projectId, templateId);
+        String parentID = importProcessAndReturnParentID(recordId, processes, opac, projectId, templateId, false);
         Template template = ServiceManager.getTemplateService().getById(templateId);
         if (Objects.isNull(template.getRuleset())) {
             throw new ProcessGenerationException("Ruleset of template " + template.getId() + " is null!");
@@ -445,7 +445,11 @@ public class ImportService {
             try {
                 Process parentProcess = loadParentProcess(parentIDMetadata, template.getRuleset().getId(), projectId);
                 if (Objects.isNull(parentProcess)) {
-                    parentID = importProcessAndReturnParentID(parentID, processes, opac, projectId, templateId);
+                    if (OPACConfig.isParentInRecord(opac)) {
+                        parentID = importProcessAndReturnParentID(recordId, processes, opac, projectId, templateId, true);
+                    } else{
+                        parentID = importProcessAndReturnParentID(parentID, processes, opac, projectId, templateId, false);
+                    }
                     level++;
                 } else {
                     logger.info("Process with ID '" + parentID + "' already in database. Stop hierarchical import.");
@@ -548,7 +552,7 @@ public class ImportService {
         }
     }
 
-    private Document importDocument(String opac, String identifier, boolean extractExemplars) throws NoRecordFoundException,
+    private Document importDocument(String opac, String identifier, boolean extractExemplars, boolean isParentInRecord) throws NoRecordFoundException,
             UnsupportedFormatException, URISyntaxException, IOException, XPathExpressionException,
             ParserConfigurationException, SAXException {
         // ################ IMPORT #################
@@ -563,7 +567,7 @@ public class ImportService {
         // depending on metadata and return form, call corresponding schema converter module!
         SchemaConverterInterface converter = getSchemaConverter(dataRecord);
 
-        List<File> mappingFiles = getMappingFiles(opac);
+        List<File> mappingFiles = getMappingFiles(opac, isParentInRecord);
 
         // transform dataRecord to Kitodo internal format using appropriate SchemaConverter!
         File debugFolder = ConfigCore.getKitodoDebugDirectory();
@@ -594,10 +598,17 @@ public class ImportService {
         return kitodoNode.getChildNodes();
     }
 
-    private List<File> getMappingFiles(String opac) throws URISyntaxException {
+    private List<File> getMappingFiles(String opac, boolean forParentInRecord) throws URISyntaxException {
         List<File> mappingFiles = new ArrayList<>();
+
+        List<String> mappingFileNames;
         try {
-            for (String mappingFileName : OPACConfig.getXsltMappingFiles(opac)) {
+            if (forParentInRecord) {
+                mappingFileNames = OPACConfig.getXsltMappingFileForParentInRecord(opac);
+            } else {
+                mappingFileNames = OPACConfig.getXsltMappingFiles(opac);
+            }
+            for (String mappingFileName : mappingFileNames) {
                 URI xsltFile = Paths.get(ConfigCore.getParameter(ParameterCore.DIR_XSLT)).toUri()
                         .resolve(new URI(mappingFileName.trim()));
                 mappingFiles.add(ServiceManager.getFileService().getFile(xsltFile));
@@ -606,6 +617,10 @@ public class ImportService {
             logger.error(e.getMessage());
         }
         return mappingFiles;
+    }
+
+    private List<File> getMappingFiles(String opac) throws URISyntaxException {
+        return getMappingFiles(opac, false);
     }
 
     /**
@@ -1101,7 +1116,7 @@ public class ImportService {
             String metadataLanguage = ServiceManager.getUserService().getCurrentUser().getMetadataLanguage();
             List<Locale.LanguageRange> priorityList = Locale.LanguageRange
                     .parse(metadataLanguage.isEmpty() ? "en" : metadataLanguage);
-            importProcessAndReturnParentID(ppn, processList, selectedCatalog, projectId, templateId);
+            importProcessAndReturnParentID(ppn, processList, selectedCatalog, projectId, templateId, false);
             tempProcess = processList.get(0);
             processTempProcess(tempProcess, template,
                 ServiceManager.getRulesetService().openRuleset(template.getRuleset()), "create", priorityList);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -615,7 +615,7 @@ public class ImportService {
         List<String> mappingFileNames;
         try {
             if (forParentInRecord) {
-                mappingFileNames = Arrays.asList(OPACConfig.getXsltMappingFileForParentInRecord(opac));
+                mappingFileNames = Collections.singletonList(OPACConfig.getXsltMappingFileForParentInRecord(opac));
             } else {
                 mappingFileNames = OPACConfig.getXsltMappingFiles(opac);
             }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -615,7 +615,7 @@ public class ImportService {
         List<String> mappingFileNames;
         try {
             if (forParentInRecord) {
-                mappingFileNames = OPACConfig.getXsltMappingFileForParentInRecord(opac);
+                mappingFileNames = Arrays.asList(OPACConfig.getXsltMappingFileForParentInRecord(opac));
             } else {
                 mappingFileNames = OPACConfig.getXsltMappingFiles(opac);
             }

--- a/Kitodo/src/main/resources/kitodo_opac.xml
+++ b/Kitodo/src/main/resources/kitodo_opac.xml
@@ -115,6 +115,7 @@
         <mappingFiles>
             <file>mods2kitodo.xsl</file>
         </mappingFiles>
+        <parentMappingFile>parentMapping.xsl</parentMappingFile>
         <config>
             <param name="host" value="kalliope-verbund.info" />
             <param name="scheme" value="http" />


### PR DESCRIPTION
If parent records are delivered in the child record xml, it is possible to use a parentMapping.xsl to extract the parent record from the childs xml.

This is one part of #3990 