### PR TITLE
Issue 4131

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/exceptions/RulesetNotFoundException.java
+++ b/Kitodo/src/main/java/org/kitodo/exceptions/RulesetNotFoundException.java
@@ -11,11 +11,12 @@
 
 package org.kitodo.exceptions;
 
+import java.io.FileNotFoundException;
 import java.util.Arrays;
 
 import org.kitodo.production.helper.Helper;
 
-public class RulesetNotFoundException extends Exception {
+public class RulesetNotFoundException extends FileNotFoundException {
     /**
      * Creates a new ruleset not found exception.
      *

--- a/Kitodo/src/main/java/org/kitodo/exceptions/RulesetNotFoundException.java
+++ b/Kitodo/src/main/java/org/kitodo/exceptions/RulesetNotFoundException.java
@@ -11,15 +11,18 @@
 
 package org.kitodo.exceptions;
 
+import java.util.Arrays;
+
+import org.kitodo.production.helper.Helper;
+
 public class RulesetNotFoundException extends Exception {
     /**
-     * Constructor with given exception message.
+     * Creates a new ruleset not found exception.
      *
-     * @param exceptionMessage
-     *            as String
+     * @param missingFile
+     *            name of missing ruleset file
      */
-    public RulesetNotFoundException(String exceptionMessage) {
-        super(exceptionMessage);
+    public RulesetNotFoundException(String missingFile) {
+        super(Helper.getTranslation("rulesetNotFound", Arrays.asList(missingFile)));
     }
-
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
@@ -29,7 +29,6 @@ import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.export.ExportDms;
 import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.enums.ChartMode;
@@ -316,7 +315,7 @@ public class ProcessListBaseView extends BaseForm {
     public boolean createProcessesWithCalendar(ProcessDTO processDTO) {
         try {
             return ProcessService.canCreateProcessWithCalendar(processDTO);
-        } catch (IOException | DAOException | RulesetNotFoundException e) {
+        } catch (IOException | DAOException e) {
             Helper.setErrorMessage(ERROR_READING, new Object[] {ObjectType.PROCESS.getTranslationSingular() }, logger,
                     e);
         }
@@ -333,7 +332,7 @@ public class ProcessListBaseView extends BaseForm {
     public boolean createProcessAsChildPossible(ProcessDTO processDTO) {
         try {
             return ProcessService.canCreateChildProcess(processDTO);
-        } catch (IOException | DAOException | RulesetNotFoundException e) {
+        } catch (IOException | DAOException e) {
             Helper.setErrorMessage(ERROR_READING, new Object[] {ObjectType.PROCESS.getTranslationSingular() }, logger,
                     e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -83,10 +83,10 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
     /**
      * Returns the ruleset management to access the ruleset.
      *
-     * @return the ruleset
+     * @return the ruleset management
      */
     @Override
-    public RulesetManagementInterface getRuleset() {
+    public RulesetManagementInterface getRulesetManagement() {
         return rulesetManagement;
     }
 
@@ -96,11 +96,11 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
      * @throws RulesetNotFoundException thrown if ruleset could not be found
      */
     public void updateRulesetAndDocType(Ruleset ruleset) throws RulesetNotFoundException {
-        setRulesetManagementInterface(ruleset);
+        setRulesetManagement(ruleset);
         processDataTab.setAllDocTypes(getAllRulesetDivisions());
     }
 
-    private void setRulesetManagementInterface(Ruleset ruleset) throws RulesetNotFoundException {
+    private void setRulesetManagement(Ruleset ruleset) throws RulesetNotFoundException {
         try {
             this.rulesetManagement = ServiceManager.getRulesetService().openRuleset(ruleset);
         } catch (IOException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -92,20 +92,15 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
 
     /**
      * Update ruleset and docType.
-     * @param ruleset as Ruleset
-     * @throws RulesetNotFoundException thrown if ruleset could not be found
+     * 
+     * @param ruleset
+     *            as Ruleset
+     * @throws IOException
+     *             thrown if ruleset could not be read
      */
-    public void updateRulesetAndDocType(Ruleset ruleset) throws RulesetNotFoundException {
-        setRulesetManagement(ruleset);
+    public void updateRulesetAndDocType(Ruleset ruleset) throws IOException {
+        rulesetManagement = ServiceManager.getRulesetService().openRuleset(ruleset);
         processDataTab.setAllDocTypes(getAllRulesetDivisions());
-    }
-
-    private void setRulesetManagement(Ruleset ruleset) throws RulesetNotFoundException {
-        try {
-            this.rulesetManagement = ServiceManager.getRulesetService().openRuleset(ruleset);
-        } catch (IOException e) {
-            logger.error(e.getLocalizedMessage());
-        }
     }
 
     private List<SelectItem> getAllRulesetDivisions() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -294,14 +294,14 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
         } catch (DataException e) {
             Helper.setErrorMessage("errorSaving", new Object[] {ObjectType.PROCESS.getTranslationSingular() },
                     logger, e);
-        } catch (IOException | ProcessGenerationException e) {
-            logger.error(e.getLocalizedMessage());
         } catch (RulesetNotFoundException e) {
             String rulesetFile = "Process list is empty";
             if (!this.processes.isEmpty() && Objects.nonNull(getMainProcess().getRuleset())) {
                 rulesetFile = getMainProcess().getRuleset().getFile();
             }
             Helper.setErrorMessage("rulesetNotFound", new Object[] {rulesetFile }, logger, e);
+        } catch (IOException | ProcessGenerationException e) {
+            logger.error(e.getLocalizedMessage(), e);
         }
         return this.stayOnCurrentPage;
     }
@@ -370,7 +370,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
 
                 }
             }
-        } catch (ProcessGenerationException | RulesetNotFoundException | DataException | DAOException | IOException e) {
+        } catch (ProcessGenerationException | DataException | DAOException | IOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
     }
@@ -379,7 +379,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
      * Create process hierarchy.
      */
     private void createProcessHierarchy()
-            throws DataException, ProcessGenerationException, IOException, RulesetNotFoundException {
+            throws DataException, ProcessGenerationException, IOException {
         // discard all processes in hierarchy except the first if parent process in
         // title record link tab is selected!
         if (this.processes.size() > 1 && Objects.nonNull(this.titleRecordLinkTab.getTitleRecordProcess())
@@ -462,7 +462,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
             ImportService.processProcessChildren(getMainProcess(), this.childProcesses, template,
                     rulesetManagement, acquisitionStage, priorityList);
         } catch (DataException | InvalidMetadataValueException | NoSuchMetadataFieldException
-                | ProcessGenerationException | IOException | RulesetNotFoundException e) {
+                | ProcessGenerationException | IOException e) {
             Helper.setErrorMessage("Unable to attach child documents to process: " + e.getMessage());
         }
     }
@@ -493,10 +493,11 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
                             acquisitionStage, priorityList);
                 } catch (InvalidMetadataValueException | NoSuchMetadataFieldException e) {
                     throw new ProcessGenerationException("Error creating process hierarchy: invalid metadata found!");
+                } catch (RulesetNotFoundException e) {
+                    throw new ProcessGenerationException(
+                            "Ruleset not found:" + tempProcess.getProcess().getRuleset().getTitle());
                 } catch (IOException e) {
                     throw new ProcessGenerationException("Error reading Ruleset: " + tempProcess.getProcess().getRuleset().getTitle());
-                } catch (RulesetNotFoundException e) {
-                    throw new ProcessGenerationException("Ruleset not found:" + tempProcess.getProcess().getRuleset().getTitle());
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -69,7 +69,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
     private final SearchTab searchTab = new SearchTab(this);
     private final TitleRecordLinkTab titleRecordLinkTab = new TitleRecordLinkTab(this);
 
-    private RulesetManagementInterface rulesetManagementInterface;
+    private RulesetManagementInterface rulesetManagement;
     private List<Locale.LanguageRange> priorityList = ServiceManager.getUserService().getCurrentMetadataLanguage();
     private String acquisitionStage = "create";
     private Project project;
@@ -87,7 +87,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
      */
     @Override
     public RulesetManagementInterface getRuleset() {
-        return rulesetManagementInterface;
+        return rulesetManagement;
     }
 
     /**
@@ -102,14 +102,14 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
 
     private void setRulesetManagementInterface(Ruleset ruleset) throws RulesetNotFoundException {
         try {
-            this.rulesetManagementInterface = ServiceManager.getRulesetService().openRuleset(ruleset);
+            this.rulesetManagement = ServiceManager.getRulesetService().openRuleset(ruleset);
         } catch (IOException e) {
             logger.error(e.getLocalizedMessage());
         }
     }
 
     private List<SelectItem> getAllRulesetDivisions() {
-        List<SelectItem> allDocTypes = rulesetManagementInterface
+        List<SelectItem> allDocTypes = rulesetManagement
                 .getStructuralElements(priorityList).entrySet()
                 .stream().map(entry -> new SelectItem(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
@@ -460,7 +460,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
         // set parent relations between main process and its imported child processes!
         try {
             ImportService.processProcessChildren(getMainProcess(), this.childProcesses, template,
-                    rulesetManagementInterface, acquisitionStage, priorityList);
+                    rulesetManagement, acquisitionStage, priorityList);
         } catch (DataException | InvalidMetadataValueException | NoSuchMetadataFieldException
                 | ProcessGenerationException | IOException | RulesetNotFoundException e) {
             Helper.setErrorMessage("Unable to attach child documents to process: " + e.getMessage());
@@ -489,7 +489,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
                 ImportService.updateTasks(process);
             } else if (Objects.nonNull(tempProcess.getMetadataNodes())) {
                 try {
-                    ImportService.processTempProcess(tempProcess, template, rulesetManagementInterface,
+                    ImportService.processTempProcess(tempProcess, template, rulesetManagement,
                             acquisitionStage, priorityList);
                 } catch (InvalidMetadataValueException | NoSuchMetadataFieldException e) {
                     throw new ProcessGenerationException("Error creating process hierarchy: invalid metadata found!");

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ImportDialog.java
@@ -227,7 +227,7 @@ public class ImportDialog implements Serializable {
                 // import ancestors
                 LinkedList<TempProcess> processes = ServiceManager.getImportService().importProcessHierarchy(
                         this.currentRecordId, opac, projectId, templateId, this.importDepth,
-                        this.createProcessForm.getRuleset().getFunctionalKeys(
+                        this.createProcessForm.getRulesetManagement().getFunctionalKeys(
                                 FunctionalMetadata.HIGHERLEVEL_IDENTIFIER));
                 this.createProcessForm.setProcesses(processes);
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
@@ -191,7 +191,7 @@ public class ProcessDataTab {
         List<ProcessDetail> processDetails = this.createProcessForm.getProcessMetadataTab().getProcessDetailsElements();
         Process process = this.createProcessForm.getMainProcess();
         try {
-            StructuralElementViewInterface docTypeView = createProcessForm.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface docTypeView = createProcessForm.getRulesetManagement().getStructuralElementView(
                 docType, createProcessForm.getAcquisitionStage(), createProcessForm.getPriorityList());
             String processTitle = docTypeView.getProcessTitle().orElse("");
             if (processTitle.isEmpty()) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessMetadataTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessMetadataTab.java
@@ -38,7 +38,7 @@ public class ProcessMetadataTab {
      *          which its Metadata are wanted to be shown
      */
     public ProcessFieldedMetadata initializeProcessDetails(IncludedStructuralElement structure) {
-        return ImportService.initializeProcessDetails(structure, this.createProcessForm.getRuleset(),
+        return ImportService.initializeProcessDetails(structure, this.createProcessForm.getRulesetManagement(),
                 this.createProcessForm.getAcquisitionStage(), this.createProcessForm.getPriorityList());
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -36,7 +36,6 @@ import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.MetadataEditor;
@@ -126,7 +125,7 @@ public class TitleRecordLinkTab {
             try {
                 titleRecordProcess = ServiceManager.getProcessService().getById(Integer.valueOf(chosenParentProcess));
                 createInsertionPositionSelectionTree();
-            } catch (DAOException | DataException | IOException | RulesetNotFoundException e) {
+            } catch (DAOException | DataException | IOException e) {
                 Helper.setErrorMessage("errorLoadingOne",
                         new Object[] {possibleParentProcesses.parallelStream()
                                 .filter(selectItem -> selectItem.getValue().equals(chosenParentProcess)).findAny()
@@ -142,7 +141,7 @@ public class TitleRecordLinkTab {
      * @throws IOException
      *             if the METS file cannot be read
      */
-    public void createInsertionPositionSelectionTree() throws DAOException, DataException, IOException, RulesetNotFoundException {
+    public void createInsertionPositionSelectionTree() throws DAOException, DataException, IOException {
         if (Objects.isNull(titleRecordProcess)) {
             return;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -437,7 +437,7 @@ public class AddDocStrucTypeDialog {
 
     private void prepareDocStructAddTypeSelectionItemsForChildren() {
         docStructAddTypeSelectionItemsForChildren = new ArrayList<>();
-        StructuralElementViewInterface divisionView = dataEditor.getRuleset().getStructuralElementView(
+        StructuralElementViewInterface divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
             dataEditor.getSelectedStructure().orElseThrow(IllegalStateException::new).getType(),
             dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
         for (Entry<String, String> entry : divisionView.getAllowedSubstructuralElements().entrySet()) {
@@ -448,11 +448,11 @@ public class AddDocStrucTypeDialog {
     private void prepareDocStructAddTypeSelectionItemsForParent() {
         docStructAddTypeSelectionItemsForParent = new ArrayList<>();
         if (!parents.isEmpty()) {
-            StructuralElementViewInterface parentDivisionView = dataEditor.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface parentDivisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                 parents.getLast().getType(), dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
             for (Entry<String, String> entry : parentDivisionView.getAllowedSubstructuralElements().entrySet()) {
                 String newParent = entry.getKey();
-                StructuralElementViewInterface newParentDivisionView = dataEditor.getRuleset().getStructuralElementView(
+                StructuralElementViewInterface newParentDivisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                     newParent, dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
                 if (newParentDivisionView.getAllowedSubstructuralElements().containsKey(
                     dataEditor.getSelectedStructure().orElseThrow(IllegalStateException::new).getType())) {
@@ -465,7 +465,7 @@ public class AddDocStrucTypeDialog {
     private void prepareDocStructAddTypeSelectionItemsForSiblings() {
         docStructAddTypeSelectionItemsForSiblings = new ArrayList<>();
         if (!parents.isEmpty()) {
-            StructuralElementViewInterface parentDivisionView = dataEditor.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface parentDivisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                 parents.getLast().getType(), dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
             for (Entry<String, String> entry : parentDivisionView.getAllowedSubstructuralElements().entrySet()) {
                 docStructAddTypeSelectionItemsForSiblings.add(new SelectItem(entry.getKey(), entry.getValue()));
@@ -508,7 +508,7 @@ public class AddDocStrucTypeDialog {
             if (Objects.nonNull(selectedMetadataTreeNode)
                     && Objects.nonNull(selectedMetadataTreeNode.getData())) {
                 existingMetadata = Metadata.mapToKey(((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadata());
-                ComplexMetadataViewInterface metadataView = dataEditor.getRuleset().getMetadataView(
+                ComplexMetadataViewInterface metadataView = dataEditor.getRulesetManagement().getMetadataView(
                         ((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadataID(),
                         dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
                 addableMetadata = metadataView.getAddableMetadata(existingMetadata, Collections.emptyList());
@@ -518,7 +518,7 @@ public class AddDocStrucTypeDialog {
                 addableMetadata = structure.getAddableMetadata(existingMetadata,
                         Collections.emptyList());
             } else {
-                structure = dataEditor.getRuleset()
+                structure = dataEditor.getRulesetManagement()
                         .getStructuralElementView(docStructAddTypeSelectionSelectedItem,
                                 dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
                 addableMetadata = structure.getAddableMetadata(existingMetadata,
@@ -575,7 +575,7 @@ public class AddDocStrucTypeDialog {
     private StructuralElementViewInterface getStructuralElementView() {
         Optional<IncludedStructuralElement> selectedStructure = dataEditor.getSelectedStructure();
         if (selectedStructure.isPresent()) {
-            return dataEditor.getRuleset()
+            return dataEditor.getRulesetManagement()
                     .getStructuralElementView(
                             selectedStructure.get().getType(),
                             dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
@@ -587,7 +587,7 @@ public class AddDocStrucTypeDialog {
                 if (structureTreeNode.getDataObject() instanceof View) {
                     View view = (View) structureTreeNode.getDataObject();
                     if (Objects.nonNull(view.getMediaUnit())) {
-                        return dataEditor.getRuleset().getStructuralElementView(view.getMediaUnit().getType(),
+                        return dataEditor.getRulesetManagement().getStructuralElementView(view.getMediaUnit().getType(),
                                 dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
                     }
                 }
@@ -770,7 +770,7 @@ public class AddDocStrucTypeDialog {
      */
     public String getCurrentStructureLabel() {
         if (dataEditor.getSelectedStructure().isPresent()) {
-            StructuralElementViewInterface divisionView = dataEditor.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                     dataEditor.getSelectedStructure().get().getType(), dataEditor.getAcquisitionStage(),
                     dataEditor.getPriorityList());
             return divisionView.getLabel();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddMediaUnitDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddMediaUnitDialog.java
@@ -104,7 +104,7 @@ public class AddMediaUnitDialog {
 
             if (InsertionPosition.FIRST_CHILD_OF_CURRENT_ELEMENT.equals(selectedPosition)
                     || InsertionPosition.LAST_CHILD_OF_CURRENT_ELEMENT.equals(selectedPosition)) {
-                divisionView = dataEditor.getRuleset().getStructuralElementView(
+                divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                     selectedMediaUnit.orElseThrow(IllegalStateException::new).getType(),
                         dataEditor.getAcquisitionStage(),
                         dataEditor.getPriorityList()
@@ -116,7 +116,7 @@ public class AddMediaUnitDialog {
                     selectedMediaUnit.get(),
                         dataEditor.getWorkpiece().getMediaUnit());
                 if (!parents.isEmpty()) {
-                    divisionView = dataEditor.getRuleset().getStructuralElementView(
+                    divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                             parents.getLast().getType(),
                             dataEditor.getAcquisitionStage(),
                             dataEditor.getPriorityList());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/ChangeDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/ChangeDocStrucTypeDialog.java
@@ -131,7 +131,7 @@ public class ChangeDocStrucTypeDialog {
         IncludedStructuralElement rootElement = dataEditor.getWorkpiece().getRootElement();
         if (rootElement.equals(includedStructuralElement)) {
             if (Objects.isNull(dataEditor.getProcess().getParent())) {
-                return dataEditor.getRuleset().getStructuralElements(dataEditor.getPriorityList());
+                return dataEditor.getRulesetManagement().getStructuralElements(dataEditor.getPriorityList());
             } else {
                 return getAllowedChildTypesFromParentalProcess();
             }
@@ -159,7 +159,7 @@ public class ChangeDocStrucTypeDialog {
     }
 
     private Map<String, String> getAllowedSubstructuralElements(String parentType) {
-        StructuralElementViewInterface parentView = dataEditor.getRuleset().getStructuralElementView(parentType,
+        StructuralElementViewInterface parentView = dataEditor.getRulesetManagement().getStructuralElementView(parentType,
             dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
         return parentView.getAllowedSubstructuralElements();
     }
@@ -176,7 +176,7 @@ public class ChangeDocStrucTypeDialog {
         for (Iterator<Entry<String, String>> possibleTypesIterator = possibleTypes.entrySet()
                 .iterator(); possibleTypesIterator.hasNext();) {
             String typeToCheck = possibleTypesIterator.next().getKey();
-            StructuralElementViewInterface viewOnTypeToCheck = dataEditor.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface viewOnTypeToCheck = dataEditor.getRulesetManagement().getStructuralElementView(
                 typeToCheck, dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
             if (!viewOnTypeToCheck.getAllowedSubstructuralElements().keySet().containsAll(childTypes)) {
                 possibleTypesIterator.remove();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -52,7 +52,6 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.exceptions.InvalidImagesException;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.interfaces.RulesetSetupInterface;
@@ -228,7 +227,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             selectedMedia = new LinkedList<>();
             init();
             MetadataLock.setLocked(process.getId(), user);
-        } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException | RulesetNotFoundException e) {
+        } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
             return referringView;
         }
@@ -252,7 +251,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
         ServiceManager.getFileService().searchForMedia(process, workpiece);
     }
 
-    private RulesetManagementInterface openRuleset(Ruleset ruleset) throws IOException, RulesetNotFoundException {
+    private RulesetManagementInterface openRuleset(Ruleset ruleset) throws IOException {
         final long begin = System.nanoTime();
         String metadataLanguage = user.getMetadataLanguage();
         priorityList = LanguageRange.parse(metadataLanguage.isEmpty() ? "en" : metadataLanguage);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -521,7 +521,7 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     }
 
     @Override
-    public RulesetManagementInterface getRuleset() {
+    public RulesetManagementInterface getRulesetManagement() {
         return ruleset;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -46,7 +46,6 @@ import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.validation.State;
 import org.kitodo.api.validation.ValidationResult;
 import org.kitodo.data.database.beans.Process;
-import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.exceptions.InvalidImagesException;
@@ -218,7 +217,9 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
                 return referringView;
             }
 
-            ruleset = openRuleset(process.getRuleset());
+            String metadataLanguage = user.getMetadataLanguage();
+            priorityList = LanguageRange.parse(metadataLanguage.isEmpty() ? "en" : metadataLanguage);
+            ruleset = ServiceManager.getRulesetService().openRuleset(process.getRuleset());
             openMetsFile();
             if (!workpiece.getId().equals(process.getId().toString())) {
                 Helper.setErrorMessage("metadataConfusion", new Object[] {process.getId(), workpiece.getId() });
@@ -249,17 +250,6 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
             workpiece.setId(process.getId().toString());
         }
         ServiceManager.getFileService().searchForMedia(process, workpiece);
-    }
-
-    private RulesetManagementInterface openRuleset(Ruleset ruleset) throws IOException {
-        final long begin = System.nanoTime();
-        String metadataLanguage = user.getMetadataLanguage();
-        priorityList = LanguageRange.parse(metadataLanguage.isEmpty() ? "en" : metadataLanguage);
-        RulesetManagementInterface openRuleset = ServiceManager.getRulesetService().openRuleset(ruleset);
-        if (logger.isTraceEnabled()) {
-            logger.trace("Reading ruleset took {} ms", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - begin));
-        }
-        return openRuleset;
     }
 
     private void init() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -188,7 +188,7 @@ public class GalleryPanel {
     }
 
     RulesetManagementInterface getRuleset() {
-        return dataEditor.getRuleset();
+        return dataEditor.getRulesetManagement();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
@@ -126,7 +126,7 @@ public class MetadataPanel implements Serializable {
 
     void showLogical(Optional<IncludedStructuralElement> optionalStructure) {
         if (optionalStructure.isPresent()) {
-            StructuralElementViewInterface divisionView = dataEditorForm.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface divisionView = dataEditorForm.getRulesetManagement().getStructuralElementView(
                     optionalStructure.get().getType(), dataEditorForm.getAcquisitionStage(), dataEditorForm.getPriorityList());
             logicalMetadataTable = new ProcessFieldedMetadata(optionalStructure.get(), divisionView);
             dataEditorForm.getAddDocStrucTypeDialog().prepareSelectAddableMetadataTypesItems(true,
@@ -139,7 +139,7 @@ public class MetadataPanel implements Serializable {
 
     void showPageInLogical(MediaUnit mediaUnit) {
         if (Objects.nonNull(mediaUnit)) {
-            StructuralElementViewInterface divisionView = dataEditorForm.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface divisionView = dataEditorForm.getRulesetManagement().getStructuralElementView(
                     mediaUnit.getType(), dataEditorForm.getAcquisitionStage(), dataEditorForm.getPriorityList());
             logicalMetadataTable = new ProcessFieldedMetadata(mediaUnit, divisionView);
             dataEditorForm.getAddDocStrucTypeDialog().prepareSelectAddableMetadataTypesItems(true,
@@ -152,7 +152,7 @@ public class MetadataPanel implements Serializable {
 
     void showPhysical(Optional<MediaUnit> optionalMediaUnit) {
         if (optionalMediaUnit.isPresent() && Objects.nonNull(optionalMediaUnit.get().getType())) {
-            StructuralElementViewInterface divisionView = dataEditorForm.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface divisionView = dataEditorForm.getRulesetManagement().getStructuralElementView(
                     optionalMediaUnit.get().getType(), dataEditorForm.getAcquisitionStage(), dataEditorForm.getPriorityList());
             physicalMetadataTable = new ProcessFieldedMetadata(optionalMediaUnit.get(), divisionView);
             dataEditorForm.getAddDocStrucTypeDialog().prepareSelectAddableMetadataTypesItems(true);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -451,7 +451,7 @@ public class StructurePanel implements Serializable {
     private Collection<View> buildStructureTreeRecursively(IncludedStructuralElement structure, TreeNode result) {
         StructureTreeNode node;
         if (Objects.isNull(structure.getLink())) {
-            StructuralElementViewInterface divisionView = dataEditor.getRuleset().getStructuralElementView(
+            StructuralElementViewInterface divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                 structure.getType(), dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
             node = new StructureTreeNode(divisionView.getLabel(),
                     divisionView.isUndefined() && Objects.nonNull(structure.getType()), false, structure);
@@ -462,7 +462,7 @@ public class StructurePanel implements Serializable {
                     String type = ServiceManager.getProcessService().getBaseType(child.getId());
                     if (child.getId() == ServiceManager.getProcessService()
                             .processIdFromUri(structure.getLink().getUri())) {
-                        StructuralElementViewInterface view = dataEditor.getRuleset().getStructuralElementView(
+                        StructuralElementViewInterface view = dataEditor.getRulesetManagement().getStructuralElementView(
                             type, dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
                         node = new StructureTreeNode(view.getLabel(), view.isUndefined(), true, structure);
                     }
@@ -563,7 +563,7 @@ public class StructurePanel implements Serializable {
      * @return the generated node so that you can add children to it
      */
     private DefaultTreeNode addTreeNode(String type, boolean linked, Object dataObject, DefaultTreeNode parent) {
-        StructuralElementViewInterface structuralElementView = dataEditor.getRuleset().getStructuralElementView(type,
+        StructuralElementViewInterface structuralElementView = dataEditor.getRulesetManagement().getStructuralElementView(type,
             dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
         return addTreeNode(structuralElementView.getLabel(), structuralElementView.isUndefined(), linked, dataObject,
             parent);
@@ -676,7 +676,7 @@ public class StructurePanel implements Serializable {
     }
 
     private void buildMediaTreeRecursively(MediaUnit mediaUnit, DefaultTreeNode parentTreeNode) {
-        StructuralElementViewInterface divisionView = dataEditor.getRuleset().getStructuralElementView(
+        StructuralElementViewInterface divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                 mediaUnit.getType(), dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
         DefaultTreeNode treeNode = addTreeNode(Objects.equals(mediaUnit.getType(), MediaUnit.TYPE_PAGE)
                         ? divisionView.getLabel().concat(" " + mediaUnit.getOrderlabel()) : divisionView.getLabel(),
@@ -1196,7 +1196,7 @@ public class StructurePanel implements Serializable {
         IncludedStructuralElement dragStructure = (IncludedStructuralElement) dragNode.getDataObject();
         IncludedStructuralElement dropStructure = (IncludedStructuralElement) dropNode.getDataObject();
 
-        StructuralElementViewInterface divisionView = dataEditor.getRuleset().getStructuralElementView(
+        StructuralElementViewInterface divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                 dropStructure.getType(), dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
 
         LinkedList<IncludedStructuralElement> dragParents;
@@ -1232,7 +1232,7 @@ public class StructurePanel implements Serializable {
         MediaUnit dragUnit = (MediaUnit) dragNode.getDataObject();
         MediaUnit dropUnit = (MediaUnit) dropNode.getDataObject();
 
-        StructuralElementViewInterface divisionView = dataEditor.getRuleset().getStructuralElementView(
+        StructuralElementViewInterface divisionView = dataEditor.getRulesetManagement().getStructuralElementView(
                 dropUnit.getType(), dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
 
         LinkedList<MediaUnit> dragParents;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
@@ -21,7 +21,6 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.DoctypeMissingException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.process.NewspaperProcessesGenerator;
 
@@ -85,7 +84,7 @@ public class GeneratesNewspaperProcessesThread extends EmptyTask {
             }
             super.setProgress(100);
         } catch (ConfigurationException | DAOException | DataException | DoctypeMissingException | IOException
-                | ProcessGenerationException | RulesetNotFoundException | CommandException e) {
+                | ProcessGenerationException | CommandException e) {
             setException(e);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/NewspaperMigrationTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/NewspaperMigrationTask.java
@@ -19,7 +19,6 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.production.dto.BatchDTO;
 import org.kitodo.production.migration.NewspaperProcessesMigrator;
 
@@ -124,7 +123,7 @@ public class NewspaperMigrationTask extends EmptyTask {
      *             ruleset
      */
     private void next() throws DAOException, IOException, ProcessGenerationException, DataException,
-            ConfigurationException, RulesetNotFoundException, CommandException {
+            ConfigurationException, CommandException {
         switch (part) {
             case CONVERT_PROCESSES: {
                 super.setWorkDetail(migrator.getProcessTitle(step));
@@ -165,7 +164,7 @@ public class NewspaperMigrationTask extends EmptyTask {
             }
             setProgress(100);
         } catch (ConfigurationException | DAOException | IOException | ProcessGenerationException | DataException
-                | RulesetNotFoundException | CommandException e) {
+                | CommandException e) {
             setException(e);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/RulesetSetupInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/RulesetSetupInterface.java
@@ -27,7 +27,7 @@ public interface RulesetSetupInterface {
      *
      * @return the ruleset
      */
-    RulesetManagementInterface getRuleset();
+    RulesetManagementInterface getRulesetManagement();
 
     /**
      * Returns the current acquisition stage to adapt the displaying of fields

--- a/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
@@ -44,7 +44,6 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.production.dto.BatchDTO;
 import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.helper.tasks.NewspaperMigrationTask;
@@ -278,7 +277,7 @@ public class NewspaperProcessesMigrator {
      *            the ID of the newspaper division in the ruleset
      */
     private void initializeMigrator(Process process, String newspaperIncludedStructalElementDivision)
-            throws IOException, ConfigurationException, RulesetNotFoundException {
+            throws IOException, ConfigurationException {
 
         title = process.getTitle().replaceFirst(INDIVIDUAL_PART, "");
         logger.trace("Newspaper is: {}", title);
@@ -312,7 +311,7 @@ public class NewspaperProcessesMigrator {
      *            index of process to convert in the processes transfer object
      *            list passed to the constructor—<b>not</b> the process ID
      */
-    public void convertProcess(int index) throws DAOException, IOException, ConfigurationException, RulesetNotFoundException {
+    public void convertProcess(int index) throws DAOException, IOException, ConfigurationException {
         final long begin = System.nanoTime();
         Integer processId = transferredProcess.get(index).getId();
         Process process = processService.getById(processId);
@@ -548,7 +547,7 @@ public class NewspaperProcessesMigrator {
      *             An error has occurred in the disk drive.
      */
     public void createOverallProcess() throws ProcessGenerationException, IOException, DataException, DAOException,
-            CommandException, RulesetNotFoundException {
+            CommandException {
         final long begin = System.nanoTime();
         logger.info("Creating overall process {}...", title);
 
@@ -583,7 +582,7 @@ public class NewspaperProcessesMigrator {
      *             if a process cannot be load from the database
      */
     public void createNextYearProcess() throws ProcessGenerationException, IOException, DataException, DAOException,
-            CommandException, RulesetNotFoundException {
+            CommandException {
         final long begin = System.nanoTime();
         Entry<String, IncludedStructuralElement> yearToCreate = yearsIterator.next();
         String yearTitle = getYearTitle(yearToCreate.getKey());

--- a/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
@@ -55,7 +55,6 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.DoctypeMissingException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.production.forms.createprocess.ProcessFieldedMetadata;
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.model.bibliography.course.Course;
@@ -289,7 +288,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
      *             but its value cannot be evaluated to an integer
      */
     public void nextStep() throws ConfigurationException, DAOException, DataException, IOException,
-            ProcessGenerationException, DoctypeMissingException, RulesetNotFoundException, CommandException {
+            ProcessGenerationException, DoctypeMissingException, CommandException {
 
         if (currentStep == 0) {
             initialize();
@@ -310,7 +309,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
      *             if something goes wrong when reading or writing one of the
      *             affected files
      */
-    private void initialize() throws ConfigurationException, IOException, DoctypeMissingException, RulesetNotFoundException {
+    private void initialize() throws ConfigurationException, IOException, DoctypeMissingException {
         final long begin = System.nanoTime();
 
         overallMetadataFileUri = processService.getMetadataFileUri(overallProcess);
@@ -345,7 +344,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
      *             if something goes wrong when reading or writing one of the
      *             affected files
      */
-    private void initializeRulesetFields(String newspaperType) throws ConfigurationException, IOException, RulesetNotFoundException {
+    private void initializeRulesetFields(String newspaperType) throws ConfigurationException, IOException {
         RulesetManagementInterface ruleset = rulesetService.openRuleset(overallProcess.getRuleset());
         StructuralElementViewInterface newspaperView = ruleset.getStructuralElementView(newspaperType, acquisitionStage, ENGLISH);
         StructuralElementViewInterface yearDivisionView = nextSubView(ruleset, newspaperView, acquisitionStage);
@@ -498,7 +497,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
     }
 
     private void createProcess(int index) throws DAOException, DataException, IOException, ProcessGenerationException,
-            CommandException, RulesetNotFoundException {
+            CommandException {
         final long begin = System.nanoTime();
 
         List<IndividualIssue> individualIssuesForProcess = processesToCreate.get(index);
@@ -642,8 +641,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
     }
 
     private void prepareTheAppropriateYearProcess(String yearMark, Map<String, String> genericFields)
-            throws DAOException, DataException, ProcessGenerationException, IOException, CommandException,
-            RulesetNotFoundException {
+            throws DAOException, DataException, ProcessGenerationException, IOException, CommandException {
 
         if (yearMark.equals(currentYear)) {
             return;
@@ -655,7 +653,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         }
     }
 
-    private void saveAndCloseCurrentYearProcess() throws DataException, IOException, RulesetNotFoundException {
+    private void saveAndCloseCurrentYearProcess() throws DataException, IOException {
         final long begin = System.nanoTime();
 
         metsService.saveWorkpiece(yearWorkpiece, yearMetadataFileUri);
@@ -718,7 +716,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
     }
 
     private void createNewYearProcess(String yearMark, Map<String, String> genericFields)
-            throws ProcessGenerationException, DataException, IOException, CommandException, RulesetNotFoundException {
+            throws ProcessGenerationException, DataException, IOException, CommandException {
         final long begin = System.nanoTime();
 
         generateProcess(overallProcess.getTemplate().getId(), overallProcess.getProject().getId());
@@ -781,7 +779,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         return createdChild;
     }
 
-    private void finish() throws DataException, IOException, RulesetNotFoundException {
+    private void finish() throws DataException, IOException {
         final long begin = System.nanoTime();
 
         saveAndCloseCurrentYearProcess();

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -78,7 +78,6 @@ import org.kitodo.exceptions.NoRecordFoundException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.exceptions.ParameterNotFoundException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.exceptions.UnsupportedFormatException;
 import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.forms.createprocess.ProcessBooleanMetadata;
@@ -956,7 +955,7 @@ public class ImportService {
                                               Template template, RulesetManagementInterface managementInterface,
                                               String acquisitionStage, List<Locale.LanguageRange> priorityList)
             throws DataException, InvalidMetadataValueException, NoSuchMetadataFieldException,
-            ProcessGenerationException, IOException, RulesetNotFoundException {
+            ProcessGenerationException, IOException {
         for (TempProcess tempProcess : childProcesses) {
             if (Objects.isNull(tempProcess) || Objects.isNull(tempProcess.getProcess())) {
                 logger.error("Child process " + (childProcesses.indexOf(tempProcess) + 1) + " is null => Skip!");
@@ -1057,8 +1056,8 @@ public class ImportService {
     public static void processTempProcess(TempProcess tempProcess, Template template,
                                           RulesetManagementInterface managementInterface, String acquisitionStage,
                                           List<Locale.LanguageRange> priorityList)
-            throws InvalidMetadataValueException, NoSuchMetadataFieldException, ProcessGenerationException, IOException,
-            RulesetNotFoundException {
+            throws InvalidMetadataValueException, NoSuchMetadataFieldException, ProcessGenerationException,
+            IOException {
         List<ProcessDetail> processDetails = transformToProcessDetails(tempProcess, managementInterface,
                 acquisitionStage, priorityList);
         String docType = tempProcess.getWorkpiece().getRootElement().getType();
@@ -1075,7 +1074,7 @@ public class ImportService {
      * @param process the process to check.
      * @param docType the doctype to check in the ruleset.
      */
-    public static void checkTasks(Process process, String docType) throws IOException, RulesetNotFoundException {
+    public static void checkTasks(Process process, String docType) throws IOException {
         // remove tasks from process, if doctype is configured not to use a workflow
         Collection<String> divisionsWithNoWorkflow = ServiceManager.getRulesetService()
                 .openRuleset(process.getRuleset()).getDivisionsWithNoWorkflow();
@@ -1114,7 +1113,7 @@ public class ImportService {
             ServiceManager.getMetsService().save(tempProcess.getWorkpiece(), out);
         } catch (DAOException | IOException | ProcessGenerationException | XPathExpressionException
                 | ParserConfigurationException | NoRecordFoundException | UnsupportedFormatException
-                | URISyntaxException | SAXException | RulesetNotFoundException | InvalidMetadataValueException
+                | URISyntaxException | SAXException | InvalidMetadataValueException
                 | NoSuchMetadataFieldException | DataException | CommandException e) {
             throw new ImportException(
                     Helper.getTranslation("errorImporting", Arrays.asList(Helper.getTranslation("process"), ppn)));

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -120,7 +120,6 @@ import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.InvalidImagesException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.export.ExportMets;
 import org.kitodo.production.dto.BatchDTO;
 import org.kitodo.production.dto.ProcessDTO;
@@ -2515,10 +2514,9 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      * @return whether child processes for the given ProcessDTO can be created via the calendar or not
      * @throws DAOException if process could not be loaded from database
      * @throws IOException if ruleset file could not be read
-     * @throws RulesetNotFoundException if ruleset file could not be read
      */
     public static boolean canCreateProcessWithCalendar(ProcessDTO processDTO)
-            throws DAOException, IOException, RulesetNotFoundException {
+            throws DAOException, IOException {
         Collection<String> functionalDivisions;
         if (Objects.isNull(processDTO.getRuleset())) {
             return false;
@@ -2542,10 +2540,9 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      * @return whether child processes for the given ProcessDTO can be created via the calendar or not
      * @throws DAOException if process could not be loaded from database
      * @throws IOException if ruleset file could not be read
-     * @throws RulesetNotFoundException if ruleset file could not be read
      */
     public static boolean canCreateChildProcess(ProcessDTO processDTO) throws DAOException,
-            IOException, RulesetNotFoundException {
+            IOException {
         Collection<String> functionalDivisions;
         if (Objects.isNull(processDTO.getRuleset())) {
             return false;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -11,7 +11,6 @@
 
 package org.kitodo.production.services.data;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -227,14 +226,12 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, Rul
      * @return a Ruleset Management in which the ruleset has been loaded
      */
     public RulesetManagementInterface openRuleset(Ruleset ruleset) throws IOException {
-        return openRulesetFile(ruleset.getFile());
-    }
-
-    private RulesetManagementInterface openRulesetFile(String fileName) throws IOException {
         final long begin = System.nanoTime();
-        RulesetManagementInterface ruleset = ServiceManager.getRulesetManagementService().getRulesetManagement();
+        RulesetManagementInterface rulesetManagement = ServiceManager.getRulesetManagementService()
+                .getRulesetManagement();
+        String fileName = ruleset.getFile();
         try {
-            ruleset.load(new File(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_RULESETS), fileName).toString()));
+            rulesetManagement.load(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_RULESETS), fileName).toFile());
         } catch (FileNotFoundException e) {
             throw new RulesetNotFoundException(fileName);
         }
@@ -242,6 +239,6 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, Rul
         if (logger.isTraceEnabled()) {
             logger.trace("Reading ruleset took {} ms", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - begin));
         }
-        return ruleset;
+        return rulesetManagement;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -15,7 +15,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,6 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.RulesetNotFoundException;
 import org.kitodo.production.dto.ClientDTO;
 import org.kitodo.production.dto.RulesetDTO;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
@@ -238,9 +236,7 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, Rul
         try {
             ruleset.load(new File(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_RULESETS), fileName).toString()));
         } catch (FileNotFoundException e) {
-            List<String> param = new ArrayList<>();
-            param.add(fileName);
-            throw new RulesetNotFoundException(Helper.getTranslation("rulesetNotFound", param));
+            throw new RulesetNotFoundException(fileName);
         }
 
         if (logger.isTraceEnabled()) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -226,11 +226,11 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, Rul
      *            database object that references the ruleset
      * @return a Ruleset Management in which the ruleset has been loaded
      */
-    public RulesetManagementInterface openRuleset(Ruleset ruleset) throws IOException, RulesetNotFoundException {
+    public RulesetManagementInterface openRuleset(Ruleset ruleset) throws IOException {
         return openRulesetFile(ruleset.getFile());
     }
 
-    private RulesetManagementInterface openRulesetFile(String fileName) throws IOException, RulesetNotFoundException {
+    private RulesetManagementInterface openRulesetFile(String fileName) throws IOException {
         final long begin = System.nanoTime();
         RulesetManagementInterface ruleset = ServiceManager.getRulesetManagementService().getRulesetManagement();
         try {


### PR DESCRIPTION
There is a lot of cleanup going on here. The real problem is fixed in the last commit: Because the exception is no longer caught at this point, the method crashes and the exception is caught further up (which was already implemented) and displayed as an error. The code no longer tries to continue working and to access the object that could not be initialized. So the UI doesn't crash anymore.

Fixes #4131