### PR TITLE
Prevent unparsable date exception caused by empty strings

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
@@ -16,6 +16,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MetadataEntry;
@@ -51,7 +52,7 @@ public class ProcessDateMetadata extends ProcessTextMetadata {
      * @return value of date
      */
     public Date getDate() {
-        if (Objects.isNull(date) && Objects.nonNull(getValue())) {
+        if (Objects.isNull(date) && StringUtils.isNotBlank(getValue())) {
             try {
                 date = new SimpleDateFormat("yyyy-MM-dd").parse(getValue());
             } catch (ParseException e) {


### PR DESCRIPTION
Fix check for empty values when parsing date strings to prevent `java.text.ParseException: Unparseable date: ""`