### PR TITLE
Reset datatable page to index 0 after filtering

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -20,6 +20,7 @@
     <h:form id="processesForm">
         <!--@elvariable id="process" type="org.kitodo.production.dto.ProcessDTO"-->
         <p:dataTable id="processesTable"
+                     widgetVar="processesTable"
                      styleClass="default-layout"
                      var="process"
                      value="#{ProcessForm.lazyDTOModel}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -20,6 +20,7 @@
     <p:importEnum type="org.kitodo.data.database.enums.TaskStatus" allSuffix="ALL_ENUM_VALUES"/>
     <h:form id="tasksForm">
         <p:dataTable id="taskTable"
+                     widgetVar="taskTable"
                      var="item"
                      value="#{CurrentTaskForm.lazyDTOModel}"
                      first="#{CurrentTaskForm.firstRow}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/userList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/userList.xhtml
@@ -18,6 +18,7 @@
         xmlns:p="http://primefaces.org/ui">
     <p:dataTable var="item"
                  id="usersTable"
+                 widgetVar="usersTable"
                  styleClass="default-layout"
                  value="#{UserForm.lazyDTOModel}"
                  first="#{UserForm.firstRow}"

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -40,6 +40,7 @@
                              value="#{ProcessForm.filter}"
                              placeholder="#{msgs.filter}">
                     <p:ajax event="change"
+                            onstart="PF('processesTable').getPaginator().setPage(0);"
                             update="processesTabView:processesForm:processesTable"/>
                 </p:inputText>
                 <p:commandButton id="filterMenuTrigger" icon="fa fa-chevron-down"/>

--- a/Kitodo/src/main/webapp/pages/tasks.xhtml
+++ b/Kitodo/src/main/webapp/pages/tasks.xhtml
@@ -37,6 +37,7 @@
                              value="#{CurrentTaskForm.filter}"
                              placeholder="#{msgs.filter}">
                     <p:ajax event="change"
+                            onstart="PF('taskTable').getPaginator().setPage(0);"
                             update="tasksTabView:tasksForm:taskTable"/>
                 </p:inputText>
                 <p:commandButton id="filterMenuTrigger" icon="fa fa-chevron-down"/>

--- a/Kitodo/src/main/webapp/pages/users.xhtml
+++ b/Kitodo/src/main/webapp/pages/users.xhtml
@@ -81,7 +81,8 @@
                                  value="#{UserForm.filter}"
                                  placeholder="#{msgs.filter}">
                         <p:ajax event="change"
-                                update="@all"/>
+                                onstart="PF('usersTable').getPaginator().setPage(0);"
+                                update="usersTabView:usersTable sticky-notifications"/>
                     </p:inputText>
                     <p:commandButton id="filterMenuTrigger" icon="fa fa-chevron-down"/>
                     <p:overlayPanel for="filterMenuTrigger" my="right top" at="right bottom">


### PR DESCRIPTION
Fixes #4132

(since our filter field is not part of the lists we cannot use the corresponding `filter` event to reset the list to the first page)