### PR TITLE
remove index references on migration

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
@@ -517,7 +517,7 @@ public class MigrationForm extends BaseForm {
             }
             newspaperMigrationRendered = false;
             newspaperBatchesSelectedItems = new ArrayList<>();
-        } catch (DataException e) {
+        } catch (DAOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/NewspaperMigrationTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/NewspaperMigrationTask.java
@@ -69,14 +69,14 @@ public class NewspaperMigrationTask extends EmptyTask {
     /**
      * Creates a new newspaper migration task.
      *
-     * @param transferredBatch
-     *            an object that transfers a newspaper batch from index
+     * @param batch
+     *            the batch object which holds together the newspaper processes
      */
-    public NewspaperMigrationTask(Batch transferredBatch) {
-        super(transferredBatch.getTitle());
-        this.numberOfProcesses = transferredBatch.getProcesses().size();
+    public NewspaperMigrationTask(Batch batch) {
+        super(batch.getTitle());
+        this.numberOfProcesses = batch.getProcesses().size();
         this.part = Part.CONVERT_PROCESSES;
-        this.migrator = new NewspaperProcessesMigrator(transferredBatch);
+        this.migrator = new NewspaperProcessesMigrator(batch);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/NewspaperMigrationTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/NewspaperMigrationTask.java
@@ -15,11 +15,11 @@ import java.io.IOException;
 
 import javax.naming.ConfigurationException;
 
+import org.kitodo.data.database.beans.Batch;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.production.dto.BatchDTO;
 import org.kitodo.production.migration.NewspaperProcessesMigrator;
 
 /**
@@ -72,7 +72,7 @@ public class NewspaperMigrationTask extends EmptyTask {
      * @param transferredBatch
      *            an object that transfers a newspaper batch from index
      */
-    public NewspaperMigrationTask(BatchDTO transferredBatch) {
+    public NewspaperMigrationTask(Batch transferredBatch) {
         super(transferredBatch.getTitle());
         this.numberOfProcesses = transferredBatch.getProcesses().size();
         this.part = Part.CONVERT_PROCESSES;

--- a/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
@@ -137,9 +137,9 @@ public class NewspaperProcessesMigrator {
     private static final ProcessService processService = ServiceManager.getProcessService();
 
     /**
-     * List of transferred processes.
+     * List of processes.
      */
-    private final List<Process> transferredProcess;
+    private final List<Process> processes;
 
     /**
      * Record ID of the process template.
@@ -196,12 +196,12 @@ public class NewspaperProcessesMigrator {
     /**
      * Creates a new process migrator.
      *
-     * @param batchTransfer
+     * @param batch
      *            transfers Production v. 2 newspaper batch
      */
-    public NewspaperProcessesMigrator(Batch batchTransfer) {
-        this.batchNumber = batchTransfer.getId();
-        this.transferredProcess = batchTransfer.getProcesses();
+    public NewspaperProcessesMigrator(Batch batch) {
+        this.batchNumber = batch.getId();
+        this.processes = batch.getProcesses();
     }
 
     /**
@@ -313,7 +313,7 @@ public class NewspaperProcessesMigrator {
      */
     public void convertProcess(int index) throws DAOException, IOException, ConfigurationException {
         final long begin = System.nanoTime();
-        Integer processId = transferredProcess.get(index).getId();
+        Integer processId = processes.get(index).getId();
         Process process = processService.getById(processId);
         String processTitle = process.getTitle();
         logger.info("Starting to convert process {} (ID {})...", processTitle, processId);
@@ -667,7 +667,7 @@ public class NewspaperProcessesMigrator {
      * @return the process title
      */
     public String getProcessTitle(int transferIndex) {
-        return transferredProcess.get(transferIndex).getTitle();
+        return processes.get(transferIndex).getTitle();
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/production/helper/tasks/NewspaperMigrationTaskIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/tasks/NewspaperMigrationTaskIT.java
@@ -102,7 +102,7 @@ public class NewspaperMigrationTaskIT {
         Assert.assertEquals("should not yet have created overall process", 0,
             processService.findByTitle("NewsMiTe").size());
 
-        NewspaperMigrationTask underTest = new NewspaperMigrationTask(batchService.findById(5));
+        NewspaperMigrationTask underTest = new NewspaperMigrationTask(batchService.getById(5));
         underTest.start();
         Assert.assertTrue("should be running", underTest.isAlive());
         underTest.join();
@@ -117,10 +117,12 @@ public class NewspaperMigrationTaskIT {
         Assert.assertEquals("should have added date for day", "1850-03-12",
             rootElement.getChildren().get(0).getOrderlabel());
 
+        Process newspaperProcess = processService.getById(4);
+        processService.save(newspaperProcess);
+        Process yearProcess = processService.getById(5);
+        processService.save(yearProcess);
         Assert.assertEquals("should have created year process", 1, processService.findByTitle("NewsMiTe_1850").size());
         Assert.assertEquals("should have created overall process", 1, processService.findByTitle("NewsMiTe").size());
-        Process newspaperProcess = processService.getById(4);
-        Process yearProcess = processService.getById(5);
         Assert.assertTrue("should have added link from newspaper process to year process",
             newspaperProcess.getChildren().contains(yearProcess));
         List<Process> linksInYear = yearProcess.getChildren();


### PR DESCRIPTION
Migration should be index-independent, as the index may be empty. This leads to triggering the whole index while migrating and therefore a huge lack in migration.
If index is filled first, the metadata of processes will not be indexed, so migrating first is recommended.