### PR TITLE
Display whether manually executing a task script is succuessful or not

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -435,7 +435,13 @@ public class CurrentTaskForm extends BaseForm {
      */
     public void executeScript() throws DAOException, DataException {
         Task task = ServiceManager.getTaskService().getById(this.currentTask.getId());
-        ServiceManager.getTaskService().executeScript(task, this.scriptPath, false);
+        if (ServiceManager.getTaskService().executeScript(task, this.scriptPath, false)) {
+            Helper.setMessageWithoutDescription(MessageFormat.format(
+                    Helper.getTranslation("scriptExecutionSuccessful"), this.currentTask.getScriptName()));
+        } else {
+            Helper.setErrorMessagesWithoutDescription(MessageFormat.format(
+                    Helper.getTranslation("scriptExecutionError"), this.currentTask.getScriptName()));
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -168,17 +168,6 @@ public class Helper implements Observer, Serializable {
         }
     }
 
-    private static String getRootCause(Throwable problem) {
-        Throwable cause = problem.getCause();
-        String className = problem.getClass().getSimpleName();
-        if (Objects.nonNull(cause)) {
-            return className + " / " + getRootCause(cause);
-        } else {
-            String message = problem.getLocalizedMessage();
-            return StringUtils.isEmpty(message) ? className : className + ": " + message;
-        }
-    }
-
     /**
      * Set error message to message tag with given name 'title'. Substitute all
      * placeholders in message tag with elements of given array 'parameters'.
@@ -234,6 +223,17 @@ public class Helper implements Observer, Serializable {
         setMessage(null, message, "", MessageLevel.ERROR, false);
     }
 
+    private static String getRootCause(Throwable problem) {
+        Throwable cause = problem.getCause();
+        String className = problem.getClass().getSimpleName();
+        if (Objects.nonNull(cause)) {
+            return className + " / " + getRootCause(cause);
+        } else {
+            String message = problem.getLocalizedMessage();
+            return StringUtils.isEmpty(message) ? className : className + ": " + message;
+        }
+    }
+
     private static String getExceptionMessage(Throwable e) {
         String message = e.getMessage();
         if (Objects.isNull(message)) {
@@ -262,17 +262,6 @@ public class Helper implements Observer, Serializable {
      */
     public static void setMessage(String message) {
         setMessage(null, message, "", MessageLevel.INFO);
-    }
-
-    /**
-     * Set message with empty description, e.g. only with title. That means no compound message is created.
-     * This is a convenience function for calling "setMessage" with parameters "level" = "MessageLevel.INFO" and
-     * "createCompoundMessage" = "false".
-     *
-     * @param message message String to be displayed.
-     */
-    public static void setMessageWithoutDescription(String message) {
-        setMessage(null, message, "", MessageLevel.INFO, false);
     }
 
     /**
@@ -337,6 +326,17 @@ public class Helper implements Observer, Serializable {
             logger.log(MessageLevel.ERROR.equals(level) ? Level.ERROR : MessageLevel.WARN.equals(level) ? Level.WARN : Level.INFO,
                     compoundMessage);
         }
+    }
+
+    /**
+     * Set message with empty description, e.g. only with title. That means no compound message is created.
+     * This is a convenience function for calling "setMessage" with parameters "level" = "MessageLevel.INFO" and
+     * "createCompoundMessage" = "false".
+     *
+     * @param message message String to be displayed.
+     */
+    public static void setMessageWithoutDescription(String message) {
+        setMessage(null, message, "", MessageLevel.INFO, false);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -79,17 +79,6 @@ public class Helper implements Observer, Serializable {
     }
 
     /**
-     * Set error message with empty description, e.g. only with title. That means no compound message is created.
-     * This is a convenience function for calling "setMessage" with parameters "level" = "MessageLevel.ERROR" and
-     * "createCompoundMessage" = "false".
-     *
-     * @param message message String to be displayed.
-     */
-    public static void setErrorMessagesWithoutDescription(String message) {
-        setMessage(null, message, "", MessageLevel.ERROR, false);
-    }
-
-    /**
      * Set error message and description for user.
      *
      * @param message
@@ -232,6 +221,17 @@ public class Helper implements Observer, Serializable {
     public static void setErrorMessage(String title, String description, Logger logger, Exception exception) {
         logger.error(title, exception);
         setErrorMessage(title, description);
+    }
+
+    /**
+     * Set error message with empty description, e.g. only with title. That means no compound message is created.
+     * This is a convenience function for calling "setMessage" with parameters "level" = "MessageLevel.ERROR" and
+     * "createCompoundMessage" = "false".
+     *
+     * @param message message String to be displayed.
+     */
+    public static void setErrorMessagesWithoutDescription(String message) {
+        setMessage(null, message, "", MessageLevel.ERROR, false);
     }
 
     private static String getExceptionMessage(Throwable e) {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -79,6 +79,17 @@ public class Helper implements Observer, Serializable {
     }
 
     /**
+     * Set error message with empty description, e.g. only with title. That means no compound message is created.
+     * This is a convenience function for calling "setMessage" with parameters "level" = "MessageLevel.ERROR" and
+     * "createCompoundMessage" = "false".
+     *
+     * @param message message String to be displayed.
+     */
+    public static void setErrorMessagesWithoutDescription(String message) {
+        setMessage(null, message, "", MessageLevel.ERROR, false);
+    }
+
+    /**
      * Set error message and description for user.
      *
      * @param message
@@ -254,6 +265,17 @@ public class Helper implements Observer, Serializable {
     }
 
     /**
+     * Set message with empty description, e.g. only with title. That means no compound message is created.
+     * This is a convenience function for calling "setMessage" with parameters "level" = "MessageLevel.INFO" and
+     * "createCompoundMessage" = "false".
+     *
+     * @param message message String to be displayed.
+     */
+    public static void setMessageWithoutDescription(String message) {
+        setMessage(null, message, "", MessageLevel.INFO, false);
+    }
+
+    /**
      * Set message and description for user.
      *
      * @param message
@@ -279,16 +301,25 @@ public class Helper implements Observer, Serializable {
         setMessage(control, message, description, MessageLevel.INFO);
     }
 
+    private static void setMessage(String control, String message, String description, MessageLevel level) {
+        setMessage(control, message, description, level, true);
+    }
+
     /**
      * Transfer an error message for a specific control to the current form.
      */
-    private static void setMessage(String control, String message, String description, MessageLevel level) {
+    private static void setMessage(String control, String message, String description, MessageLevel level,
+                                   boolean createCompoundMessage) {
         String msg = getTranslation(Objects.toString(message));
         String descript = getTranslation(Objects.toString(description));
+        String detail = descript;
 
         String compoundMessage = msg.replaceFirst(":\\s*$", "");
-        if (StringUtils.isNotEmpty(descript)) {
-            compoundMessage += ": " + descript;
+        if (createCompoundMessage) {
+            if (StringUtils.isNotEmpty(descript)) {
+                compoundMessage += ": " + descript;
+            }
+            detail = null;
         }
         if (Objects.nonNull(activeMQReporting)) {
             new WebServiceResult(activeMQReporting.get("queueName"), activeMQReporting.get("id"),
@@ -300,7 +331,7 @@ public class Helper implements Observer, Serializable {
         if (Objects.nonNull(context)) {
             context.addMessage(control,
                 new FacesMessage(MessageLevel.ERROR.equals(level) ? FacesMessage.SEVERITY_ERROR : MessageLevel.WARN.equals(level)
-                        ? FacesMessage.SEVERITY_WARN : FacesMessage.SEVERITY_INFO, compoundMessage, null));
+                        ? FacesMessage.SEVERITY_WARN : FacesMessage.SEVERITY_INFO, compoundMessage, detail));
         } else {
             // wenn kein Kontext da ist, dann die Meldungen in Log
             logger.log(MessageLevel.ERROR.equals(level) ? Level.ERROR : MessageLevel.WARN.equals(level) ? Level.WARN : Level.INFO,

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -153,6 +153,7 @@ errorSAXException=Die XML-Daten konnten nicht geparst werden. \u00DCberpr\u00FCf
 stepInWorkError=Der Schritt ist nicht mehr f\u00FCr die Bearbeitung offen, wahrscheinlich hat in der Zwischenzeit jemand diesen Schritt angenommen
 stepSaveError=Es ist ein Fehler beim Speichern des Schrittes aufgetreten.
 errorOnSearch=Fehler bei der Suche nach ''{0}''
+scriptExecutionError=Fehler bei der Ausf\u00FChrung von Skript ''{0}''.
 
 # T
 errorTransformerException=Bei der Umwandlung in XML trat ein Fehler auf.

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -152,6 +152,7 @@ errorSAXException=Basic error while parsing the XML data. You may want to check 
 stepInWorkError=Someone is already editing this step.
 stepSaveError=Step save did not work. Error has been logged.
 errorOnSearch=Error on searching for ''{0}''
+scriptExecutionError=Error: Execution of script ''{0}'' was not successful!.
 
 # T
 errorTransformerException=An exceptional condition occurred during the transformation process to XML.

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -815,6 +815,7 @@ rulesets=Regels\u00E4tze
 saveTifHeaderFile=Datei mit Tiff-Header speichern
 script=Skript
 scriptExecute=Skript ausf\u00FChren
+scriptExecutionSuccessful=Skript ''{0}'' erfolgreich ausgef\u00FChrt.
 scriptName=Skriptname
 scriptPath=Skriptpfad
 scriptTask=Skript-Schritt

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -830,6 +830,7 @@ rulesets=Rulesets
 saveTifHeaderFile=Save file with tiff header
 script=Script
 scriptExecute=Execute script
+scriptExecutionSuccessful=Script ''{0}'' successfully executed.
 scriptName=Script name
 scriptPath=Script path
 scriptTask=Script task


### PR DESCRIPTION
When clicking the `Execute script` button on the details page of a task the user now receives feedback whether the script call was successful or not.

Success:
<img width="1401" alt="Bildschirmfoto 2021-01-19 um 11 06 50" src="https://user-images.githubusercontent.com/19183925/105019523-7873d600-5a46-11eb-8e38-055c033719ba.png">

Error:
<img width="1401" alt="Bildschirmfoto 2021-01-19 um 11 06 20" src="https://user-images.githubusercontent.com/19183925/105019544-7f9ae400-5a46-11eb-8c89-c54cb9163e7c.png">
