### PR TITLE
Add option to save and load the current layout of the metadata editor

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/DataEditorSetting.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/DataEditorSetting.java
@@ -1,0 +1,132 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.database.beans;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity(name = "DataEditorSetting")
+@Table(name = "dataeditor_setting")
+public class DataEditorSetting extends BaseBean {
+
+    @Column(name = "user_id")
+    private int userId;
+
+    @Column(name = "task_id")
+    private int taskId;
+
+    @Column(name = "structure_width")
+    private float structureWidth;
+
+    @Column(name = "metadata_width")
+    private float metadataWidth;
+
+    @Column(name = "gallery_width")
+    private float galleryWidth;
+
+    /**
+     * Constructor.
+     */
+    public DataEditorSetting() {
+    }
+
+    /**
+     * Get userId.
+     *
+     * @return value of userId
+     */
+    public int getUserId() {
+        return userId;
+    }
+
+    /**
+     * Set userId.
+     *
+     * @param userId as int
+     */
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    /**
+     * Get taskId.
+     *
+     * @return value of taskId
+     */
+    public int getTaskId() {
+        return taskId;
+    }
+
+    /**
+     * Set taskId.
+     *
+     * @param taskId as int
+     */
+    public void setTaskId(int taskId) {
+        this.taskId = taskId;
+    }
+
+    /**
+     * Get structureWidth.
+     *
+     * @return value of structureWidth
+     */
+    public float getStructureWidth() {
+        return structureWidth;
+    }
+
+    /**
+     * Set structureWidth.
+     *
+     * @param structureWidth as float
+     */
+    public void setStructureWidth(float structureWidth) {
+        this.structureWidth = structureWidth;
+    }
+
+    /**
+     * Get metadataWidth.
+     *
+     * @return value of metadataWidth
+     */
+    public float getMetadataWidth() {
+        return metadataWidth;
+    }
+
+    /**
+     * Set metadataWidth.
+     *
+     * @param metadataWidth as float
+     */
+    public void setMetadataWidth(float metadataWidth) {
+        this.metadataWidth = metadataWidth;
+    }
+
+    /**
+     * Get galleryWidth.
+     *
+     * @return value of galleryWidth
+     */
+    public float getGalleryWidth() {
+        return galleryWidth;
+    }
+
+    /**
+     * Set galleryWidth.
+     *
+     * @param galleryWidth as float
+     */
+    public void setGalleryWidth(float galleryWidth) {
+        this.galleryWidth = galleryWidth;
+    }
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DataEditorSettingDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DataEditorSettingDAO.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.database.persistence;
+
+import java.util.List;
+
+import org.kitodo.data.database.beans.DataEditorSetting;
+import org.kitodo.data.database.exceptions.DAOException;
+
+public class DataEditorSettingDAO extends BaseDAO<DataEditorSetting> {
+
+    @Override
+    public DataEditorSetting getById(Integer dataEditorSettingId) throws DAOException {
+        DataEditorSetting dataEditorSetting = retrieveObject(DataEditorSetting.class, dataEditorSettingId);
+        if (dataEditorSetting == null) {
+            throw new DAOException("Object cannot be found in database");
+        }
+        return dataEditorSetting;
+    }
+
+    @Override
+    public List<DataEditorSetting> getAll() throws DAOException {
+        return retrieveAllObjects(DataEditorSetting.class);
+    }
+
+    @Override
+    public List<DataEditorSetting> getAll(int offset, int size) throws DAOException {
+        return retrieveObjects("FROM DataEditorSetting ORDER BY id ASC", offset, size);
+    }
+
+    @Override
+    public List<DataEditorSetting> getAllNotIndexed(int offset, int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void remove(Integer dataEditorSettingId) throws DAOException {
+        removeObject(DataEditorSetting.class, dataEditorSettingId);
+    }
+}

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_101__Add_table_for_metadataeditor_settings.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_101__Add_table_for_metadataeditor_settings.sql
@@ -1,0 +1,33 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+--
+-- Migration: Create table for metadata editor settings.
+--
+-- 1. Add table
+--
+
+CREATE TABLE IF NOT EXISTS dataeditor_setting(
+    id INT(11) NOT NULL AUTO_INCREMENT,
+    user_id INT(11) NOT NULL,
+    task_id INT(11) NOT NULL,
+    structure_width FLOAT(3) DEFAULT NULL,
+    metadata_width FLOAT(3) DEFAULT NULL,
+    gallery_width FLOAT(3) DEFAULT NULL,
+    PRIMARY KEY (id),
+    KEY FK_dataeditorsetting_user_id (user_id),
+    KEY FK_dataeditorsetting_task_id (task_id),
+    CONSTRAINT FK_dataeditorsetting_user_id
+        FOREIGN KEY (user_id) REFERENCES user (id),
+    CONSTRAINT  FK_dataeditorsetting_task_id
+        FOREIGN KEY (task_id) REFERENCES  task (id)
+) DEFAULT CHARACTER SET = utf8mb4
+  COLLATE utf8mb4_unicode_ci;

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/database/persistence/DataEditorSettingDaoIT.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/database/persistence/DataEditorSettingDaoIT.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.database.persistence;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.kitodo.data.database.beans.DataEditorSetting;
+import org.kitodo.data.database.exceptions.DAOException;
+
+
+public class DataEditorSettingDaoIT {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    /**
+     * Test saving and loading DataEditorSettings.
+     * @throws DAOException when loading or saving fails
+     */
+    @Test
+    public void runPersistenceSuitTest() throws DAOException {
+        List<DataEditorSetting> dataEditorSettings = getDataEditorSettings();
+
+        DataEditorSettingDAO dataEditorSettingDAO = new DataEditorSettingDAO();
+        dataEditorSettingDAO.save(dataEditorSettings.get(0));
+        dataEditorSettingDAO.save(dataEditorSettings.get(1));
+        dataEditorSettingDAO.save(dataEditorSettings.get(2));
+
+        assertEquals("Objects were not saved or not found!", 3, dataEditorSettingDAO.getAll().size());
+        assertEquals(0.5f, dataEditorSettingDAO.getById(2).getGalleryWidth(), 0);
+    }
+
+    private List<DataEditorSetting> getDataEditorSettings() {
+        DataEditorSetting firstSetting = new DataEditorSetting();
+        firstSetting.setTaskId(1);
+        firstSetting.setUserId(1);
+        firstSetting.setStructureWidth(0.2f);
+        firstSetting.setMetadataWidth(0.4f);
+        firstSetting.setGalleryWidth(0.4f);
+
+        DataEditorSetting secondSetting = new DataEditorSetting();
+        secondSetting.setTaskId(2);
+        secondSetting.setUserId(1);
+        secondSetting.setStructureWidth(0.5f);
+        secondSetting.setMetadataWidth(0f);
+        secondSetting.setGalleryWidth(0.5f);
+
+        DataEditorSetting thirdSetting = new DataEditorSetting();
+        thirdSetting.setTaskId(3);
+        thirdSetting.setUserId(1);
+        thirdSetting.setStructureWidth(0f);
+        thirdSetting.setMetadataWidth(0f);
+        thirdSetting.setGalleryWidth(1f);
+
+        List<DataEditorSetting> settings = new ArrayList<>();
+        settings.add(firstSetting);
+        settings.add(secondSetting);
+        settings.add(thirdSetting);
+        return settings;
+    }
+}

--- a/Kitodo-DataManagement/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo-DataManagement/src/test/resources/hibernate.cfg.xml
@@ -58,6 +58,7 @@
         <mapping class="org.kitodo.data.database.beans.Batch"/>
         <mapping class="org.kitodo.data.database.beans.Client"/>
         <mapping class="org.kitodo.data.database.beans.Comment"/>
+        <mapping class="org.kitodo.data.database.beans.DataEditorSetting"/>
         <mapping class="org.kitodo.data.database.beans.Docket"/>
         <mapping class="org.kitodo.data.database.beans.Filter"/>
         <mapping class="org.kitodo.data.database.beans.Folder"/>

--- a/Kitodo/src/main/java/org/kitodo/production/enums/ObjectType.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/ObjectType.java
@@ -20,6 +20,7 @@ public enum ObjectType {
     AUTHORITY("authority", "authorities", false),
     CLIENT("client", "clients", false),
     BATCH("batch", "batches", true),
+    DATAEDITORSETTING("dataEditorSetting", "dataEditorSettings", false),
     DOCKET("docket", "dockets", true),
     FOLDER("folder", "folders", false),
     LDAP_GROUP("ldapGroup", "ldapGroups", false),

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -756,6 +756,16 @@ public class CurrentTaskForm extends BaseForm {
     }
 
     /**
+     * Get the id of the template task corresponding to the given task.
+     * The corresponding template task was the blueprint when creating the given task.
+     * @param task task to find the corresponding template task for
+     * @return id of the template task or -1 if no matching task could be found
+     */
+    public static int getCorrespondingTemplateTaskId(Task task) {
+        return TaskService.getCorrespondingTemplateTaskId(task);
+    }
+
+    /**
      * Calculate and return age of given tasks process as a String.
      *
      * @param task TaskDTO object whose process is used

--- a/Kitodo/src/main/java/org/kitodo/production/services/ServiceManager.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/ServiceManager.java
@@ -18,6 +18,7 @@ import org.kitodo.production.services.data.AuthorityService;
 import org.kitodo.production.services.data.BatchService;
 import org.kitodo.production.services.data.ClientService;
 import org.kitodo.production.services.data.CommentService;
+import org.kitodo.production.services.data.DataEditorSettingService;
 import org.kitodo.production.services.data.DocketService;
 import org.kitodo.production.services.data.FilterService;
 import org.kitodo.production.services.data.FolderService;
@@ -58,6 +59,7 @@ public class ServiceManager {
     private static CommandService commandService;
     private static CommentService commentService;
     private static DataEditorService dataEditorService;
+    private static DataEditorSettingService dataEditorSettingService;
     private static DocketService docketService;
     private static FileService fileService;
     private static FileStructureValidationService fileStructureValidationService;
@@ -308,6 +310,12 @@ public class ServiceManager {
     private static void initializeIndexingService() {
         if (Objects.isNull(indexingService)) {
             indexingService = IndexingService.getInstance();
+        }
+    }
+
+    private static void initializeDataEditorSettingService() {
+        if (Objects.isNull(dataEditorSettingService)) {
+            dataEditorSettingService = DataEditorSettingService.getInstance();
         }
     }
 
@@ -688,5 +696,15 @@ public class ServiceManager {
     public static IndexingService getIndexingService() {
         initializeIndexingService();
         return indexingService;
+    }
+
+    /**
+     * Get dataEditorSettingService.
+     *
+     * @return value of dataEditorSettingService
+     */
+    public static DataEditorSettingService getDataEditorSettingService() {
+        initializeDataEditorSettingService();
+        return dataEditorSettingService;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DataEditorSettingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DataEditorSettingService.java
@@ -1,0 +1,93 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.kitodo.data.database.beans.DataEditorSetting;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.database.persistence.DataEditorSettingDAO;
+import org.kitodo.production.services.data.base.SearchDatabaseService;
+import org.primefaces.model.SortOrder;
+
+public class DataEditorSettingService extends SearchDatabaseService<DataEditorSetting, DataEditorSettingDAO> {
+
+    private static volatile DataEditorSettingService instance = null;
+
+    /**
+     * Constructor.
+     */
+    private DataEditorSettingService() {
+        super(new DataEditorSettingDAO());
+    }
+
+    /**
+     * Return signleton variable of type DataEditorSettingService.
+     *
+     * @return unique instance of DataEditorSettingService
+     */
+    public static DataEditorSettingService getInstance() {
+        DataEditorSettingService localReference = instance;
+        if (Objects.isNull(localReference)) {
+            synchronized (DataEditorSettingService.class) {
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new DataEditorSettingService();
+                    instance = localReference;
+                }
+            }
+        }
+        return localReference;
+
+    }
+
+    @Override
+    public List loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long countDatabaseRows() throws DAOException {
+        return countDatabaseRows("SELECT COUNT(*) FROM DataEditorSetting");
+    }
+
+    @Override
+    public Long countResults(Map filters) throws DAOException {
+        return countDatabaseRows();
+    }
+
+    private List<DataEditorSetting> getByUserAndTask(int userId, int taskId) {
+        Map<String, Object> parameterMap = new HashMap<>();
+        parameterMap.put("userId", userId);
+        parameterMap.put("taskId", taskId);
+        return getByQuery("FROM DataEditorSetting WHERE user_id = :userId AND task_id = :taskId ORDER BY id ASC", parameterMap);
+    }
+
+    /**
+     * Load DataEditorSetting from database or return null if no entry matches the specified ids.
+     * @param userId id of the user
+     * @param taskId id of the corresponding template task for the task that is currently edited
+     * @return settings for the data editor
+     */
+    public DataEditorSetting loadDataEditorSetting(int userId, int taskId) {
+        List<DataEditorSetting> results = getByUserAndTask(userId, taskId);
+        if (Objects.nonNull(results) && !results.isEmpty()) {
+            return results.get(0);
+        }
+        return null;
+    }
+
+
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -915,4 +915,21 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
             }
         }
     }
+
+    /**
+     * Get the id of the template task corresponding to the given task.
+     * The corresponding template task was the blueprint when creating the given task.
+     * @param task task to find the corresponding template task for
+     * @return id of the template task or -1 if no matching task could be found
+     */
+    public static int getCorrespondingTemplateTaskId(Task task) {
+        List<Task> templateTasks = task.getProcess().getTemplate().getTasks().stream()
+                .filter(t -> t.getOrdering().equals(task.getOrdering()))
+                .filter(t -> t.getTitle().equals(task.getTitle()))
+                .collect(Collectors.toList());
+        if (templateTasks.size() == 1) {
+            return templateTasks.get(0).getId();
+        }
+        return -1;
+    }
 }

--- a/Kitodo/src/main/resources/hibernate.cfg.xml
+++ b/Kitodo/src/main/resources/hibernate.cfg.xml
@@ -69,6 +69,7 @@
         <mapping class="org.kitodo.data.database.beans.Batch"/>
         <mapping class="org.kitodo.data.database.beans.Client"/>
         <mapping class="org.kitodo.data.database.beans.Comment"/>
+        <mapping class="org.kitodo.data.database.beans.DataEditorSetting"/>
         <mapping class="org.kitodo.data.database.beans.Docket"/>
         <mapping class="org.kitodo.data.database.beans.Filter"/>
         <mapping class="org.kitodo.data.database.beans.Folder"/>

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -277,6 +277,7 @@ dataEditor.galleryUnstructuredView=Unstrukturierte Ansicht
 dataEditor.galleryDetailView=Detailansicht
 dataEditor.invalidMetadataValue=\u201E{0}\u201C kann nicht gespeichert werden: Der Wert ist ung\u00FCltig. Wert: {1}
 dataEditor.invalidStructureField=\u201E{0}\u201C kann nicht gepeichert werden: Es gibt kein solches Feld ({1}).
+dataEditor.saveLayout=Aktuelle Spaltenaufteilung als Standard f\u00FCr diese Aufgabe speichern
 dataEditor.mediaTree=Medien
 dataEditor.multipleMetadataTasksText=Sie haben mehrere Aufgaben zum Editieren von Metadaten in Bearbeitung. Bitte w\u00E4hlen Sie eine dieser Aufgaben aus!
 dataEditor.noParentsError=Elternelement von {0} konnte nicht gefunden werden!

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -281,6 +281,7 @@ dataEditor.galleryUnstructuredView=Unstructured view
 dataEditor.galleryDetailView=Detail view
 dataEditor.invalidMetadataValue=Cannot store "{0}": The value is invalid. Value: {1}
 dataEditor.invalidStructureField=Cannot save "{0}": There is no such field ({1}).
+dataEditor.saveLayout=Save current layout as preset for this task
 dataEditor.mediaTree=Media
 dataEditor.multipleMetadataTasksText=There are multiple metadata editing tasks assigned to you for the current process. Please select the task you want to work on!
 dataEditor.noParentsError=No parents of structure {0} found!

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1586,7 +1586,11 @@ Metadata Editor
 }
 
 #metadataEditorHeader h3 {
-    width: calc(100% - 700px);
+    width: calc(100% - 715px);
+}
+
+#metadataEditorLayoutForm {
+    margin: 0;
 }
 
 #metadataEditorHeader .ui-panel,

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/resize.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/resize.js
@@ -12,6 +12,7 @@
 // jshint unused:false
 
 var SEPARATOR_WIDTH = 3;
+var COLLAPSED = 'collapsed';
 var COLLAPSED_COL_WIDTH = 42;
 var HEADING_HEIGHT = 40;
 var SEPARATOR_HEIGHT = 5;
@@ -60,6 +61,18 @@ $(document).mouseup(function(e) {
     }
 });
 
+function getStructureWidthInput() {
+    return $('#metadataEditorLayoutForm\\:structureWidth');
+}
+
+function getMetadataWidthInput() {
+    return $('#metadataEditorLayoutForm\\:metadataWidth');
+}
+
+function getGalleryWidthInput() {
+    return $('#metadataEditorLayoutForm\\:galleryWidth');
+}
+
 function handleMouseDown(e) {
     e.preventDefault();
     dragging = true;
@@ -68,13 +81,13 @@ function handleMouseDown(e) {
 
     $(document).mousemove(function(e) {
         if (target.id === 'firstResizer') {
-            if (secondColumn.hasClass('collapsed')) {
+            if (secondColumn.hasClass(COLLAPSED)) {
                 resizeFirstAndThird(e);
             } else {
                 resizeFirstAndSecond(e);
             }
         } else if (target.id === 'secondResizer') {
-            if (secondColumn.hasClass('collapsed')) {
+            if (secondColumn.hasClass(COLLAPSED)) {
                 resizeFirstAndThird(e);
             } else {
                 resizeSecondAndThird(e);
@@ -129,7 +142,7 @@ function resizeVertical(e) {
 function getElements() {
     wrapper = $('#metadataEditorWrapper');
     wrapperPositionX = wrapper.offset().left;
-    collapsedColumns = $('#metadataEditorWrapper > .collapsed').length;
+    collapsedColumns = $('#metadataEditorWrapper > COLLAPSED').length;
     var resizers = $('.resizer');
     firstResizer = resizers.first();
     secondResizer = resizers.last();
@@ -144,28 +157,49 @@ function setSizes() {
 
     wrapper.height(window.innerHeight - wrapper.offset().top - $('footer').height());
 
-    if (firstColumn.hasClass('collapsed')) {
+    let savedStructureWidth = parseFloat(getStructureWidthInput().val()) * wrapper.width();
+    let savedMetadataWidth = parseFloat(getMetadataWidthInput().val()) * wrapper.width();
+    let savedGalleryWidth = parseFloat(getGalleryWidthInput().val()) * wrapper.width();
+
+    if (!(savedStructureWidth === 0 && savedMetadataWidth === 0 && savedGalleryWidth === 0)) {
+        // TODO set widths
+        if (savedStructureWidth === 0) {
+            firstColumn.addClass(COLLAPSED);
+        }
+        if (savedMetadataWidth === 0) {
+            secondColumn.addClass(COLLAPSED);
+        }
+        if (savedGalleryWidth === 0) {
+            thirdColumn.addClass(COLLAPSED);
+        }
+    }
+
+    if (firstColumn.hasClass(COLLAPSED)) {
         firstColumn.width(COLLAPSED_COL_WIDTH);
         firstColumnWidth = firstColumn.data('min-width');
-    } else if (secondColumn.hasClass('collapsed') && thirdColumn.hasClass('collapsed')) {
+    } else if (secondColumn.hasClass(COLLAPSED) && thirdColumn.hasClass(COLLAPSED)) {
         firstColumn.width(wrapper.width() - 2 * COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH);
     } else {
-        firstColumn.width(firstColumn.data('min-width'));
+        let minWidth = firstColumn.data('min-width');
+        firstColumn.width(savedStructureWidth > minWidth ? savedStructureWidth : minWidth);
     }
 
-    if (secondColumn.hasClass('collapsed')) {
+    if (secondColumn.hasClass(COLLAPSED)) {
         secondColumn.width(COLLAPSED_COL_WIDTH);
         secondColumnWidth = secondColumn.data('min-width');
-    } else if(firstColumn.hasClass('collapsed') && thirdColumn.hasClass('collapsed')) {
+    } else if(firstColumn.hasClass(COLLAPSED) && thirdColumn.hasClass(COLLAPSED)) {
         secondColumn.width(wrapper.width() - 2 * COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH);
     } else {
-        secondColumn.width(secondColumn.data('min-width'));
+        let minWidth = secondColumn.data('min-width');
+        secondColumn.width(savedMetadataWidth > minWidth ? savedMetadataWidth : minWidth);
     }
 
-    if (thirdColumn.hasClass('collapsed')) {
+    if (thirdColumn.hasClass(COLLAPSED)) {
         thirdColumn.width(COLLAPSED_COL_WIDTH);
         thirdColumnWidth = thirdColumn.data('min-width');
-        secondColumn.width(wrapper.width() - firstColumn.width() - thirdColumn.width() - 2 * SEPARATOR_WIDTH);
+        if (!secondColumn.hasClass(COLLAPSED)) {
+            secondColumn.width(wrapper.width() - firstColumn.width() - thirdColumn.width() - 2 * SEPARATOR_WIDTH);
+        }
     } else {
         thirdColumn.width(wrapper.width() - firstColumn.width() - secondColumn.width() - 2 * SEPARATOR_WIDTH);
     }
@@ -183,10 +217,10 @@ function setHeight() {
 }
 
 function setSectionHeight() {
-    if (firstSection.hasClass('collapsed')) {
+    if (firstSection.hasClass(COLLAPSED)) {
         firstSectionHeight = wrapper.height() / 2 - HEADING_HEIGHT - (parseInt(secondColumn.css('padding-top')) / 2);
         secondSection.height(secondSection.height() + firstSectionHeight);
-    } else if (secondSection.hasClass('collapsed')) {
+    } else if (secondSection.hasClass(COLLAPSED)) {
         firstSection.height(wrapper.height() - 2 * HEADING_HEIGHT - (parseInt(secondColumn.css('padding-top'))) - SEPARATOR_HEIGHT);
     } else {
         firstSection.height(wrapper.height() / 2 - HEADING_HEIGHT - (parseInt(secondColumn.css('padding-top')) / 2));
@@ -198,10 +232,10 @@ function toggleResizers() {
     if (collapsedColumns >= 2) {
         firstResizer.addClass('disabled');
         secondResizer.addClass('disabled');
-    } else if (firstColumn.hasClass('collapsed')) {
+    } else if (firstColumn.hasClass(COLLAPSED)) {
         firstResizer.addClass('disabled');
         secondResizer.removeClass('disabled');
-    } else if (thirdColumn.hasClass('collapsed')) {
+    } else if (thirdColumn.hasClass(COLLAPSED)) {
         firstResizer.removeClass('disabled');
         secondResizer.addClass('disabled');
     } else {
@@ -216,9 +250,9 @@ function toggleCollapseButtons() {
     var thirdButton = $('#thirdColumnWrapper .columnExpandButton');
 
     if (collapsedColumns >= 2) {
-        if (!firstColumn.hasClass('collapsed')) {
+        if (!firstColumn.hasClass(COLLAPSED)) {
             firstButton.prop('disabled', true);
-        } else if (!secondColumn.hasClass('collapsed')) {
+        } else if (!secondColumn.hasClass(COLLAPSED)) {
             secondButton.prop('disabled', true);
         } else {
             thirdButton.prop('disabled', true);
@@ -231,24 +265,24 @@ function toggleCollapseButtons() {
 }
 
 function toggleFirstColumn() {
-    if (!firstColumn.hasClass('collapsed')) {
+    if (!firstColumn.hasClass(COLLAPSED)) {
         firstColumnWidth = firstColumn.width();
     }
-    firstColumn.toggleClass('collapsed');
+    firstColumn.toggleClass(COLLAPSED);
     getElements();
     toggleResizers();
     toggleCollapseButtons();
 
-    if (firstColumn.hasClass('collapsed')) {
+    if (firstColumn.hasClass(COLLAPSED)) {
         firstColumn.animate({width: COLLAPSED_COL_WIDTH});
-        if (secondColumn.hasClass('collapsed')) {
+        if (secondColumn.hasClass(COLLAPSED)) {
             thirdColumn.animate({width: wrapper.width() - 2 * COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH}, function() {resizeMap()});
         } else {
             secondColumn.animate({width:  wrapper.width() - COLLAPSED_COL_WIDTH - thirdColumn.width() - 2 * SEPARATOR_WIDTH});
         }
     } else {
         var neededWidth = firstColumnWidth - COLLAPSED_COL_WIDTH - (secondColumn.width() - secondColumn.data('min-width'));
-        if (secondColumn.hasClass('collapsed')) {
+        if (secondColumn.hasClass(COLLAPSED)) {
             thirdColumn.animate({width: wrapper.width() - firstColumnWidth - COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH}, function() {resizeMap()});
             firstColumn.animate({width: firstColumnWidth});
         } else if (neededWidth > 0) {
@@ -270,24 +304,24 @@ function toggleFirstColumn() {
 }
 
 function toggleSecondColumn() {
-    if (!secondColumn.hasClass('collapsed')) {
+    if (!secondColumn.hasClass(COLLAPSED)) {
         secondColumnWidth = secondColumn.width();
     }
-    secondColumn.toggleClass('collapsed');
+    secondColumn.toggleClass(COLLAPSED);
     getElements();
     toggleResizers();
     toggleCollapseButtons();
 
-    if (secondColumn.hasClass('collapsed')) {
+    if (secondColumn.hasClass(COLLAPSED)) {
         secondColumn.animate({width: COLLAPSED_COL_WIDTH});
-        if (thirdColumn.hasClass('collapsed')) {
+        if (thirdColumn.hasClass(COLLAPSED)) {
             firstColumn.animate({width: wrapper.width() - 2 * COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH});
         } else {
             thirdColumn.animate({width: wrapper.width() - COLLAPSED_COL_WIDTH - firstColumn.width() - 2 * SEPARATOR_WIDTH},function() {resizeMap()});
         }
     } else {
         var neededWidth = secondColumnWidth - COLLAPSED_COL_WIDTH - (thirdColumn.width() - thirdColumn.data('min-width'));
-        if (thirdColumn.hasClass('collapsed')) {
+        if (thirdColumn.hasClass(COLLAPSED)) {
             firstColumn.animate({width: wrapper.width() - secondColumnWidth - COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH});
             secondColumn.animate({width: secondColumnWidth});
         } else if (neededWidth > 0) {
@@ -309,25 +343,25 @@ function toggleSecondColumn() {
 }
 
 function toggleThirdColumn() {
-    if (!thirdColumn.hasClass('collapsed')) {
+    if (!thirdColumn.hasClass(COLLAPSED)) {
         thirdColumnWidth = thirdColumn.width();
     }
-    thirdColumn.toggleClass('collapsed');
+    thirdColumn.toggleClass(COLLAPSED);
     getElements();
     toggleResizers();
     toggleCollapseButtons();
 
 
-    if (thirdColumn.hasClass('collapsed')) {
+    if (thirdColumn.hasClass(COLLAPSED)) {
         thirdColumn.animate({width: COLLAPSED_COL_WIDTH});
-        if (secondColumn.hasClass('collapsed')) {
+        if (secondColumn.hasClass(COLLAPSED)) {
             firstColumn.animate({width: wrapper.width() - 2 * COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH});
         } else {
             secondColumn.animate({width: wrapper.width() - firstColumn.width() - COLLAPSED_COL_WIDTH - 2 * SEPARATOR_WIDTH});
         }
     } else {
         var neededWidth = thirdColumnWidth - COLLAPSED_COL_WIDTH - (secondColumn.width() - secondColumn.data('min-width'));
-        if (secondColumn.hasClass('collapsed')) {
+        if (secondColumn.hasClass(COLLAPSED)) {
             firstColumn.animate({width: wrapper.width() - COLLAPSED_COL_WIDTH - thirdColumnWidth - 2 * SEPARATOR_WIDTH});
             thirdColumn.animate({width: thirdColumnWidth}, function() {resizeMap()});
         } else if (neededWidth > 0) {
@@ -349,14 +383,14 @@ function toggleThirdColumn() {
 }
 
 function toggleFirstSection() {
-    if (!firstSection.hasClass('collapsed')) {
+    if (!firstSection.hasClass(COLLAPSED)) {
         firstSectionHeight = firstSection.height();
     }
-    firstSection.toggleClass('collapsed');
-    firstSectionToggler.toggleClass('collapsed');
+    firstSection.toggleClass(COLLAPSED);
+    firstSectionToggler.toggleClass(COLLAPSED);
     verticalResizer.toggleClass('disabled');
 
-    if (firstSection.hasClass('collapsed')) {
+    if (firstSection.hasClass(COLLAPSED)) {
         secondSection.height(secondSection.height() + firstSectionHeight);
         secondSectionToggler.prop('disabled', true);
     } else {
@@ -366,14 +400,14 @@ function toggleFirstSection() {
 }
 
 function toggleSecondSection() {
-    if (!secondSection.hasClass('collapsed')) {
+    if (!secondSection.hasClass(COLLAPSED)) {
         secondSectionHeight = secondSection.height();
     }
-    secondSection.toggleClass('collapsed');
-    secondSectionToggler.toggleClass('collapsed');
+    secondSection.toggleClass(COLLAPSED);
+    secondSectionToggler.toggleClass(COLLAPSED);
     verticalResizer.toggleClass('disabled');
 
-    if (secondSection.hasClass('collapsed')) {
+    if (secondSection.hasClass(COLLAPSED)) {
         firstSection.height(firstSection.height() + secondSectionHeight);
         firstSectionToggler.prop('disabled', true);
     } else {
@@ -383,19 +417,19 @@ function toggleSecondSection() {
 }
 
 function expandFirstColumn() {
-    if ($('#firstColumnWrapper .columnExpandButton').length && firstColumn.hasClass('collapsed')) {
+    if ($('#firstColumnWrapper .columnExpandButton').length && firstColumn.hasClass(COLLAPSED)) {
         toggleFirstColumn();
     }
 }
 
 function expandSecondColumn() {
-    if (firstSectionToggler.length && secondColumn.hasClass('collapsed')) {
+    if (firstSectionToggler.length && secondColumn.hasClass(COLLAPSED)) {
         toggleSecondColumn();
     }
 }
 
 function expandThirdColumn() {
-    if ($('#thirdColumnWrapper .columnExpandButton').length && thirdColumn.hasClass('collapsed')) {
+    if ($('#thirdColumnWrapper .columnExpandButton').length && thirdColumn.hasClass(COLLAPSED)) {
         toggleThirdColumn();
     }
 }
@@ -419,3 +453,8 @@ function resizeMap() {
     }
 }
 
+function saveLayout() {
+    getStructureWidthInput().val(firstColumn.hasClass(COLLAPSED) ? 0 : firstColumn.width()/wrapper.width());
+    getMetadataWidthInput().val(secondColumn.hasClass(COLLAPSED) ? 0 : secondColumn.width()/wrapper.width());
+    getGalleryWidthInput().val(thirdColumn.hasClass(COLLAPSED) ? 0 : thirdColumn.width()/wrapper.width());
+}

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -87,6 +87,7 @@
                                    rendered="#{task.typeMetadata and process.blockedUser == null}"
                                    title="#{msgs.metadataEdit}">
                         <f:actionListener binding="#{CommentForm.setProcessById(task.process.id)}"/>
+                        <f:setPropertyActionListener target="#{DataEditorForm.templateTaskId}" value="#{CurrentTaskForm.getCorrespondingTemplateTaskId(task)}"/>
                         <h:outputText><i class="fa fa-list-alt"/> #{msgs.metadataEdit}</h:outputText>
                     </h:commandLink>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
@@ -64,5 +64,20 @@
                          iconPos="right"
                          style="margin-left: 16px;"
                          styleClass="secondary"/>
+        <h:form id="metadataEditorLayoutForm">
+            <p:commandButton onclick="saveLayout()"
+                             action="#{DataEditorForm.saveDataEditorSetting()}"
+                             title="#{msgs['dataEditor.saveLayout']}"
+                             rendered="#{DataEditorForm.dataEditorSetting ne null}"
+                             icon="fa fa-wrench"
+                             style="margin-left: 16px;"
+                             styleClass="secondary"/>
+            <h:inputHidden id="structureWidth"
+                           value="#{DataEditorForm.dataEditorSetting.structureWidth}"/>
+            <h:inputHidden id="metadataWidth"
+                           value="#{DataEditorForm.dataEditorSetting.metadataWidth}"/>
+            <h:inputHidden id="galleryWidth"
+                           value="#{DataEditorForm.dataEditorSetting.galleryWidth}"/>
+        </h:form>
     </p:panel>
 </ui:composition>

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -20,6 +20,9 @@
         xmlns:p="http://primefaces.org/ui">
 
     <f:metadata>
+        <!--@elvariable id="templateTaskId" type="int"-->
+        <f:viewParam name="templateTaskId"/>
+        <f:viewAction action="#{DataEditorForm.setTemplateTaskId(templateTaskId)}"/>
         <f:viewAction action="#{DataEditorForm.initMetadataEditor()}"/>
         <f:viewAction action="#{DataEditorForm.structurePanel.setActiveTabs(DataEditorForm.structurePanel.separateMedia ? '0,1' : '0')}"/>
     </f:metadata>

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -55,6 +55,7 @@ import org.kitodo.config.ConfigMain;
 import org.kitodo.data.database.beans.Authority;
 import org.kitodo.data.database.beans.Batch;
 import org.kitodo.data.database.beans.Client;
+import org.kitodo.data.database.beans.DataEditorSetting;
 import org.kitodo.data.database.beans.Docket;
 import org.kitodo.data.database.beans.Filter;
 import org.kitodo.data.database.beans.Folder;
@@ -205,6 +206,19 @@ public class MockDatabase {
         insertRoles();
         insertUsers();
         insertProjects();
+    }
+
+    /**
+     * Prepare database for tests.
+     * @throws Exception when preparation fails
+     */
+    public static void insertForDataEditorTesting() throws Exception {
+        insertRolesFull();
+        insertDockets();
+        insertRulesets();
+        insertProjects();
+        insertTemplates();
+        insertDataEditorSettings();
     }
 
     private static class ExtendedNode extends Node {
@@ -460,6 +474,32 @@ public class MockDatabase {
 
         Batch fourthBatch = new Batch();
         ServiceManager.getBatchService().save(fourthBatch);
+    }
+
+    private static void insertDataEditorSettings() throws DAOException {
+        DataEditorSetting firstSetting = new DataEditorSetting();
+        firstSetting.setUserId(1);
+        firstSetting.setTaskId(1);
+        firstSetting.setStructureWidth(0.2f);
+        firstSetting.setMetadataWidth(0.4f);
+        firstSetting.setGalleryWidth(0.4f);
+        ServiceManager.getDataEditorSettingService().saveToDatabase(firstSetting);
+
+        DataEditorSetting secondSetting = new DataEditorSetting();
+        secondSetting.setUserId(1);
+        secondSetting.setTaskId(2);
+        secondSetting.setStructureWidth(0f);
+        secondSetting.setMetadataWidth(0.5f);
+        secondSetting.setGalleryWidth(0.5f);
+        ServiceManager.getDataEditorSettingService().saveToDatabase(secondSetting);
+
+        DataEditorSetting thirdSetting = new DataEditorSetting();
+        thirdSetting.setUserId(1);
+        thirdSetting.setTaskId(4);
+        thirdSetting.setStructureWidth(1f);
+        thirdSetting.setMetadataWidth(0f);
+        thirdSetting.setGalleryWidth(0f);
+        ServiceManager.getDataEditorSettingService().saveToDatabase(thirdSetting);
     }
 
     public static void insertDockets() throws DAOException, DataException {

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/DataEditorSettingServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/DataEditorSettingServiceIT.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.DataEditorSetting;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.services.ServiceManager;
+
+public class DataEditorSettingServiceIT {
+
+    private static final DataEditorSettingService dataEditorSettingService = ServiceManager.getDataEditorSettingService();
+    private static final int EXPECTED_DATAEDITORSETTINGS_COUNT = 3;
+
+    /**
+     * Prepare database for tests.
+     * @throws Exception when preparation fails
+     */
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertForDataEditorTesting();
+        MockDatabase.setUpAwaitility();
+    }
+
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldCountAllDatabaseRowsForDataEditorSettings() throws DAOException {
+        Long amount = dataEditorSettingService.countDatabaseRows();
+        assertEquals("DataEditorSettings were not counted correctly!", Long.valueOf(3), amount);
+    }
+
+    @Test
+    public void shouldGetAllDataEditorSettings() throws DAOException {
+        List<DataEditorSetting> settings = dataEditorSettingService.getAll();
+        assertEquals("DataEditorSettings were not found in database!", EXPECTED_DATAEDITORSETTINGS_COUNT, settings.size());
+    }
+
+    @Test
+    public void shouldGetById() {
+        DataEditorSetting setting = dataEditorSettingService.loadDataEditorSetting(1, 4);
+        assertEquals("DataEditorSetting could not be found in database!", 3, setting.getId().intValue());
+    }
+
+    @Test
+    public void shouldNotGetById() {
+        DataEditorSetting setting = dataEditorSettingService.loadDataEditorSetting(1, 5);
+        assertNull("No setting should be found for these ids!", setting);
+    }
+}

--- a/Kitodo/src/test/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/hibernate.cfg.xml
@@ -58,6 +58,7 @@
         <mapping class="org.kitodo.data.database.beans.Batch"/>
         <mapping class="org.kitodo.data.database.beans.Client"/>
         <mapping class="org.kitodo.data.database.beans.Comment"/>
+        <mapping class="org.kitodo.data.database.beans.DataEditorSetting"/>
         <mapping class="org.kitodo.data.database.beans.Docket"/>
         <mapping class="org.kitodo.data.database.beans.Filter"/>
         <mapping class="org.kitodo.data.database.beans.Folder"/>

--- a/Kitodo/src/test/resources/selenium/resources/hibernate.cfg.xml
+++ b/Kitodo/src/test/resources/selenium/resources/hibernate.cfg.xml
@@ -61,6 +61,7 @@
         <mapping class="org.kitodo.data.database.beans.Batch"/>
         <mapping class="org.kitodo.data.database.beans.Client"/>
         <mapping class="org.kitodo.data.database.beans.Comment"/>
+        <mapping class="org.kitodo.data.database.beans.DataEditorSetting"/>
         <mapping class="org.kitodo.data.database.beans.Docket"/>
         <mapping class="org.kitodo.data.database.beans.Filter"/>
         <mapping class="org.kitodo.data.database.beans.Folder"/>


### PR DESCRIPTION
The new button (wrench icon) in the metadata editor's header allows the user to save his current layout as preset for the current task. (This option is only available when the current task can be determined.)
When the user reopens the editor his preset is used to configure the editor's layout.
The presets are saved for each user and each task. The task is identified via its corresponding template task so the user can use the same preset for every task based on the same template task. 
(E.g. each "task one" based on the same template uses the same user's preset.)