### PR TITLE
add metadataScript for copyToChildren

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
@@ -39,12 +39,13 @@ public class AddDataScript extends EditDataScript {
         Collection<Metadata> metadataCollection = getMetadataCollection(allIncludedStructuralElements);
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
 
-        MetadataEntry metadataEntry = new MetadataEntry();
-        metadataEntry.setKey(metadataScript.getGoal());
-        metadataEntry.setValue(metadataScript.getValue());
-        metadataEntry.setDomain(MdSec.DMD_SEC);
-        metadataCollection.add(metadataEntry);
-
+        for (String value : metadataScript.getValues()) {
+            MetadataEntry metadataEntry = new MetadataEntry();
+            metadataEntry.setKey(metadataScript.getGoal());
+            metadataEntry.setValue(value);
+            metadataEntry.setDomain(MdSec.DMD_SEC);
+            metadataCollection.add(metadataEntry);
+        }
         saveChanges(workpiece, process);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
@@ -43,10 +43,14 @@ public class DeleteDataScript extends EditDataScript {
         List<Metadata> metadataCollectionCopy = new ArrayList<>(metadataCollection);
         for (Metadata metadata : metadataCollectionCopy) {
             if (metadata.getKey().equals(metadataScript.getGoal())) {
-                if (Objects.isNull(metadataScript.getValue())) {
+                if (metadataScript.getValues().isEmpty()) {
                     metadataCollection.remove(metadata);
-                } else if (metadataScript.getValue().equals(((MetadataEntry) metadata).getValue())) {
-                    metadataCollection.remove(metadata);
+                } else {
+                    for (String value : metadataScript.getValues()) {
+                        if (value.equals(((MetadataEntry) metadata).getValue())) {
+                            metadataCollection.remove(metadata);
+                        }
+                    }
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -100,11 +100,11 @@ public abstract class EditDataScript {
      */
     public void generateValueForMetadataScript(MetadataScript metadataScript, Collection<Metadata> metadataCollection,
             Process process, LegacyMetsModsDigitalDocumentHelper metadataFile) {
-        if (Objects.isNull(metadataScript.getValue()) && Objects.nonNull(metadataScript.getRoot())) {
+        if (metadataScript.getValues().isEmpty() && Objects.nonNull(metadataScript.getRoot())) {
             if (metadataScript.getRoot().startsWith("@")) {
                 for (Metadata metadata : metadataCollection) {
                     if (metadata.getKey().equals(metadataScript.getRootName())) {
-                        metadataScript.setValue(((MetadataEntry) metadata).getValue());
+                        metadataScript.getValues().add(((MetadataEntry) metadata).getValue());
                     }
                 }
             } else if (metadataScript.getRoot().startsWith("$")) {
@@ -113,7 +113,7 @@ public abstract class EditDataScript {
                 VariableReplacer replacer = new VariableReplacer(metadataFile, legacyPrefsHelper, process, null);
 
                 String replaced = replacer.replace(metadataScript.getRootName());
-                metadataScript.setValue(replaced);
+                metadataScript.getValues().add(replaced);
             }
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -77,7 +77,12 @@ public abstract class EditDataScript {
     public abstract void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
                                        MetadataScript metadataScript);
 
-    private List<MetadataScript> parseScript(String script) {
+    /**
+     * Parses the given input to MetadataScripts.
+     * @param script the input, entered in frontend.
+     * @return the correlating MetadataScripts.
+     */
+    public List<MetadataScript> parseScript(String script) {
         String[] commands = script.split(";");
         List<MetadataScript> metadataScripts = new ArrayList<>();
         for (String command : commands) {
@@ -126,5 +131,20 @@ public abstract class EditDataScript {
         } catch (IOException | CustomResponseException | DataException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    /**
+     * Generates the value of the MetadatScript and from the parentProcess.
+     * @param metadataScript the script to generate the value for
+     * @param parentProcess the process to take the value from
+     */
+    public void generateValueFromParent(MetadataScript metadataScript, Process parentProcess) throws IOException {
+        LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
+                .readMetadataFile(parentProcess);
+        Workpiece workpiece = metadataFile.getWorkpiece();
+        List<IncludedStructuralElement> allIncludedStructuralElements = workpiece.getAllIncludedStructuralElements();
+
+        Collection<Metadata> metadataCollection = getMetadataCollection(allIncludedStructuralElements);
+        generateValueForMetadataScript(metadataScript, metadataCollection, parentProcess, metadataFile);
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/MetadataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/MetadataScript.java
@@ -11,13 +11,15 @@
 
 package org.kitodo.production.services.command;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class MetadataScript {
 
     private String goal;
     private String root;
-    private String value;
+    private List<String> values = new ArrayList<>();
 
     /**
      * Creates a MetadataScript with given command.
@@ -31,7 +33,7 @@ public class MetadataScript {
             if (rootOrValue.startsWith("@") || rootOrValue.startsWith("$")) {
                 root = rootOrValue;
             } else {
-                value = rootOrValue;
+                values.add(rootOrValue);
             }
         }
         else {
@@ -56,19 +58,11 @@ public class MetadataScript {
     }
 
     /**
-     * Get value.
-     * @return value.
+     * Get values.
+     * @return values.
      */
-    public String getValue() {
-        return value;
-    }
-
-    /**
-     * Set value.
-     * @param value the value to set.
-     */
-    public void setValue(String value) {
-        this.value = value;
+    public List<String> getValues() {
+        return values;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
@@ -37,11 +37,9 @@ public class OverwriteDataScript extends EditDataScript {
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
 
         for (Metadata metadatum : metadataCollection) {
-            if (metadatum instanceof MetadataEntry) {
-                if (metadatum.getKey().equals(metadataScript.getGoal())) {
-                    ((MetadataEntry) metadatum).setValue(metadataScript.getValue());
-                    break;
-                }
+            if (metadatum instanceof MetadataEntry && metadatum.getKey().equals(metadataScript.getGoal())) {
+                ((MetadataEntry) metadatum).setValue(metadataScript.getValues().get(0));
+                break;
             }
             if (metadatum instanceof MetadataGroup) {
                 Collection<Metadata> group = ((MetadataGroup) metadatum).getGroup();

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -603,11 +603,15 @@ public class MockDatabase {
         fifthProcess.setTitle("HierarchChildToKeep");
         fourthProcess.getChildren().add(fifthProcess);
         fifthProcess.setParent(fourthProcess);
+        fifthProcess.setProject(ServiceManager.getProjectService().getById(1));
+        fifthProcess.setRuleset(ServiceManager.getRulesetService().getById(1));
         ServiceManager.getProcessService().save(fifthProcess);
 
         Process sixthProcess = new Process();
         sixthProcess.setTitle("HierarchChildToRemove");
         fourthProcess.getChildren().add(sixthProcess);
+        sixthProcess.setRuleset(ServiceManager.getRulesetService().getById(1));
+        sixthProcess.setProject(ServiceManager.getProjectService().getById(1));
         sixthProcess.setParent(fourthProcess);
         ServiceManager.getProcessService().save(sixthProcess);
 

--- a/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
@@ -72,7 +72,7 @@ public class MetadataEditorIT {
         MetadataEditor.addLink(ServiceManager.getProcessService().getById(4), "0", 7);
 
         assertTrue("The link was not added correctly!",
-            isInternalMetsLink(FileUtils.readLines(metaXmlFile, StandardCharsets.UTF_8).get(35), 7));
+            isInternalMetsLink(FileUtils.readLines(metaXmlFile, StandardCharsets.UTF_8).get(36), 7));
 
         FileUtils.writeLines(metaXmlFile, StandardCharsets.UTF_8.toString(), metaXmlContentBefore);
         FileUtils.deleteQuietly(new File("src/test/resources/metadata/4/meta.xml.1"));

--- a/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
@@ -72,7 +72,7 @@ public class MetadataEditorIT {
         MetadataEditor.addLink(ServiceManager.getProcessService().getById(4), "0", 7);
 
         assertTrue("The link was not added correctly!",
-            isInternalMetsLink(FileUtils.readLines(metaXmlFile, StandardCharsets.UTF_8).get(36), 7));
+            isInternalMetsLink(FileUtils.readLines(metaXmlFile, StandardCharsets.UTF_8).get(37), 7));
 
         FileUtils.writeLines(metaXmlFile, StandardCharsets.UTF_8.toString(), metaXmlContentBefore);
         FileUtils.deleteQuietly(new File("src/test/resources/metadata/4/meta.xml.1"));

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -258,6 +258,51 @@ public class KitodoScriptServiceIT {
     }
 
     @Test
+    public void shouldCopyDataToChildren() throws Exception {
+        MockDatabase.insertProcessesForHierarchyTests();
+        backupHierarchieFiles();
+        Process process = ServiceManager.getProcessService().getById(4);
+        String metadataKey = "DigitalCollection";
+        HashMap<String, String> metadataSearchMap = new HashMap<>();
+        metadataSearchMap.put(metadataKey,"Kollektion");
+
+        final List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        Assert.assertEquals("should not contain metadata beforehand", 1, processByMetadata.size() );
+
+        String script = "action:copyDataToChildren " + metadataKey + "=@" + metadataKey;
+        List<Process> processes = new ArrayList<>();
+        processes.add(process);
+        KitodoScriptService kitodoScript = new KitodoScriptService();
+        kitodoScript.execute(processes, script);
+        Thread.sleep(2000);
+        final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
+                .findByMetadata(metadataSearchMap);
+        Assert.assertEquals("does not contain metadata", 3, processByMetadataAfter.size() );
+        restoreHierarchieFiles();
+    }
+
+    private void restoreHierarchieFiles() throws IOException, DataException, DAOException {
+
+        File copied = new File(
+                "src/test/resources/metadata/5/metaBackup.xml");
+        File original = new File(
+                "src/test/resources/metadata/5/meta.xml");
+        FileUtils.copyFile(copied, original);
+        FileUtils.deleteQuietly(copied);
+        Process process = ServiceManager.getProcessService().getById(5);
+        ServiceManager.getProcessService().save(process);
+
+        copied = new File(
+                "src/test/resources/metadata/6/metaBackup.xml");
+        original = new File(
+                "src/test/resources/metadata/6/meta.xml");
+        FileUtils.copyFile(copied, original);
+        FileUtils.deleteQuietly(copied);
+        process = ServiceManager.getProcessService().getById(6);
+        ServiceManager.getProcessService().save(process);
+    }
+
+    @Test
     public void shouldAddDataWithWhitespace() throws Exception {
         Process process = ServiceManager.getProcessService().getById(2);
         String metadataKey = "LegalNoteAndTermsOfUse";
@@ -529,5 +574,19 @@ public class KitodoScriptServiceIT {
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
         Assert.assertEquals("should contain new metadata value", 1, processByMetadata.size());
 
+    }
+
+    private void backupHierarchieFiles() throws IOException {
+        File copied = new File(
+                "src/test/resources/metadata/5/metaBackup.xml");
+        File original = new File(
+                "src/test/resources/metadata/5/meta.xml");
+        FileUtils.copyFile(original, copied);
+
+        copied = new File(
+                "src/test/resources/metadata/6/metaBackup.xml");
+        original = new File(
+                "src/test/resources/metadata/6/meta.xml");
+        FileUtils.copyFile(original, copied);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -258,20 +258,20 @@ public class KitodoScriptServiceIT {
     }
 
     @Test
-    public void shouldCopyDataToChildren() throws Exception {
+    public void shouldCopyMultipleDataToChildren() throws Exception {
         MockDatabase.insertProcessesForHierarchyTests();
         backupHierarchieFiles();
-        Process process = ServiceManager.getProcessService().getById(4);
         String metadataKey = "DigitalCollection";
         HashMap<String, String> metadataSearchMap = new HashMap<>();
-        metadataSearchMap.put(metadataKey,"Kollektion");
+        metadataSearchMap.put(metadataKey,"Kollektion1");
+        metadataSearchMap.put(metadataKey,"Kollektion2");
 
         final List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should not contain metadata beforehand", 1, processByMetadata.size() );
 
         String script = "action:copyDataToChildren " + metadataKey + "=@" + metadataKey;
         List<Process> processes = new ArrayList<>();
-        processes.add(process);
+        processes.add(ServiceManager.getProcessService().getById(4));
         KitodoScriptService kitodoScript = new KitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -202,7 +202,7 @@ public class ProcessServiceIT {
 
     @Test
     public void shouldFindByMetadata() throws DataException {
-        assertEquals(processNotFound, 2,
+        assertEquals(processNotFound, 4,
             processService.findByMetadata(Collections.singletonMap("TSL_ATS", "Proc")).size());
     }
 
@@ -219,7 +219,7 @@ public class ProcessServiceIT {
 
     @Test
     public void shouldFindByProjectTitleWithWildcard() throws DataException {
-        assertEquals(processNotFound, 4, processService.findByAnything("proj").size());
+        assertEquals(processNotFound, 6, processService.findByAnything("proj").size());
     }
 
     @Test

--- a/Kitodo/src/test/resources/metadata/4/meta.xml
+++ b/Kitodo/src/test/resources/metadata/4/meta.xml
@@ -21,7 +21,8 @@
                 <kitodo:kitodo>
                     <kitodo:metadata name="TitleDocMain">Second process</kitodo:metadata>
                     <kitodo:metadata name="TSL_ATS">Proc</kitodo:metadata>
-                    <kitodo:metadata name="DigitalCollection">Kollektion</kitodo:metadata>
+                    <kitodo:metadata name="DigitalCollection">Kollektion1</kitodo:metadata>
+                    <kitodo:metadata name="DigitalCollection">Kollektion2</kitodo:metadata>
                     <kitodo:metadata name="TitleDocMainShort">Second</kitodo:metadata>
                 </kitodo:kitodo>
             </mets:xmlData>

--- a/Kitodo/src/test/resources/metadata/4/meta.xml.2
+++ b/Kitodo/src/test/resources/metadata/4/meta.xml.2
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets
+        xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/mods.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/v10 http://www.loc.gov/standards/mix/mix10/mix10.xsd"
+        xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <mets:metsHdr CREATEDATE="2018-09-14T07:45:17">
+        <mets:agent OTHERTYPE="SOFTWARE" ROLE="CREATOR" TYPE="OTHER">
+            <mets:name>Kitodo - kitodo-ugh-3.0-SNAPSHOT - 18-April-2018 13:20:13</mets:name>
+            <mets:note>Kitodo</mets:note>
+        </mets:agent>
+    </mets:metsHdr>
+    <mets:dmdSec ID="DMDLOG_0000">
+        <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData>
+                <kitodo:kitodo xmlns:kitodo="http://meta.kitodo.org/v1/">
+                    <kitodo:metadata name="TitleDocMain">Second process</kitodo:metadata>
+                    <kitodo:metadata name="TitleDocMainShort">Second</kitodo:metadata>
+                    <kitodo:metadata name="TSL_ATS">Proc</kitodo:metadata>
+                    <kitodo:metadata name="DigitalCollection">Kollektion</kitodo:metadata>
+                </kitodo:kitodo>
+            </mets:xmlData>
+        </mets:mdWrap>
+    </mets:dmdSec>
+    <mets:dmdSec ID="DMDPHYS_0000">
+        <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData>
+                <kitodo:kitodo xmlns:kitodo="http://meta.kitodo.org/v1/">
+                    <kitodo:metadata name="pathimagefiles">file:/2/images/Sec_Proc_tif</kitodo:metadata>
+                </kitodo:kitodo>
+            </mets:xmlData>
+        </mets:mdWrap>
+    </mets:dmdSec>
+    <mets:structMap TYPE="LOGICAL">
+        <mets:div DMDID="DMDLOG_0000" ID="LOG_0000" TYPE="Monograph"/>
+    </mets:structMap>
+    <mets:structMap TYPE="PHYSICAL">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence"/>
+    </mets:structMap>
+    <mets:structLink>
+        <mets:smLink xlink:to="PHYS_0000" xlink:from="LOG_0000" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+    </mets:structLink>
+</mets:mets>

--- a/Kitodo/src/test/resources/metadata/6/meta.xml
+++ b/Kitodo/src/test/resources/metadata/6/meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:kitodo="http://meta.kitodo.org/v1/" xmlns:mets="http://www.loc.gov/METS/">
-    <mets:metsHdr CREATEDATE="2018-09-14T07:45:17.000+02:00" LASTMODDATE="2021-03-01T18:45:18.869+01:00">
+    <mets:metsHdr CREATEDATE="2018-09-14T07:45:17.000+02:00" LASTMODDATE="2021-03-01T09:24:55.628+01:00">
         <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
             <mets:name>Kitodo - kitodo-ugh-3.0-SNAPSHOT - 18-April-2018 13:20:13</mets:name>
             <mets:note>Kitodo</mets:note>
         </mets:agent>
     </mets:metsHdr>
-    <mets:dmdSec ID="uuid-83867038-fca7-3001-9e9c-2ca97bc1b168">
+    <mets:dmdSec ID="uuid-68e1c4c9-96b5-32b5-bda7-69844bfe039b">
         <mets:mdWrap>
             <mets:xmlData>
                 <kitodo:kitodo>
@@ -19,9 +19,8 @@
         <mets:mdWrap>
             <mets:xmlData>
                 <kitodo:kitodo>
-                    <kitodo:metadata name="TitleDocMain">Second process</kitodo:metadata>
                     <kitodo:metadata name="TSL_ATS">Proc</kitodo:metadata>
-                    <kitodo:metadata name="DigitalCollection">Kollektion</kitodo:metadata>
+                    <kitodo:metadata name="TitleDocMain">Second process</kitodo:metadata>
                     <kitodo:metadata name="TitleDocMainShort">Second</kitodo:metadata>
                 </kitodo:kitodo>
             </mets:xmlData>
@@ -29,14 +28,10 @@
     </mets:dmdSec>
     <mets:fileSec/>
     <mets:structMap TYPE="PHYSICAL">
-        <mets:div ID="PHYS_0000" DMDID="uuid-83867038-fca7-3001-9e9c-2ca97bc1b168" TYPE="physSequence"/>
+        <mets:div ID="PHYS_0000" DMDID="uuid-68e1c4c9-96b5-32b5-bda7-69844bfe039b" TYPE="physSequence"/>
     </mets:structMap>
     <mets:structMap TYPE="LOGICAL">
-        <mets:div ID="LOG_0000" DMDID="uuid-017a6d80-fde9-3445-a239-bc86ba0c9f14" TYPE="Monograph" ORDER="1">
-            <mets:div ID="uuid-0a7803be-1d54-455f-bea8-dfee41735e09">
-                <mets:mptr LOCTYPE="OTHER" OTHERLOCTYPE="Kitodo.Production" xlink:href="database://?process.id=7"/>
-            </mets:div>
-        </mets:div>
+        <mets:div ID="LOG_0000" DMDID="uuid-017a6d80-fde9-3445-a239-bc86ba0c9f14" TYPE="Monograph" ORDER="1"/>
     </mets:structMap>
     <mets:structLink>
         <mets:smLink xlink:to="PHYS_0000" xlink:from="LOG_0000"/>


### PR DESCRIPTION
Adds a MetadataScript (formerly known as CopyData) for copying Metadata from parent to children.