### PR TITLE
Prevent exception on import if no higherlevelidentifier is defined 

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/ConfigProject.java
+++ b/Kitodo/src/main/java/org/kitodo/config/ConfigProject.java
@@ -92,10 +92,9 @@ public class ConfigProject {
      */
     public String getDocType() throws DoctypeMissingException {
         try {
-            String paramString = getParamString(CREATE_NEW_PROCESS + ".defaultdoctype", ConfigOpac.getAllDoctypes().get(0).getTitle());
-            return paramString;
+            return getParamString(CREATE_NEW_PROCESS + ".defaultdoctype", ConfigOpac.getAllDoctypes().get(0).getTitle());
         } catch (IndexOutOfBoundsException e) {
-            throw new DoctypeMissingException("No doctypes configured in opac.xml");
+            throw new DoctypeMissingException("No doctypes configured in kitodo_opac.xml");
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -15,11 +15,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.faces.context.FacesContext;
 import javax.xml.parsers.ParserConfigurationException;
@@ -28,8 +26,6 @@ import javax.xml.xpath.XPathExpressionException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kitodo.api.MdSec;
-import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.externaldatamanagement.SingleHit;
 import org.kitodo.api.schemaconverter.ExemplarRecord;
@@ -82,7 +78,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
         this.createProcessForm.setProcesses(new LinkedList<>());
         getRecordById(Helper.getRequestParameter(ID_PARAMETER_NAME));
     }
-    
+
     /**
      * Get list of search fields.
      *
@@ -132,11 +128,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      * @return hits
      */
     public List<SingleHit> getHits() {
-        if (Objects.nonNull(this.hitModel)) {
-            return this.hitModel.getHits();
-        } else {
-            return new LinkedList<>();
-        }
+        return this.hitModel.getHits();
     }
 
     @Override
@@ -173,17 +165,8 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                         this.currentRecordId, opac, projectId, templateId, this.importDepth,
                         this.createProcessForm.getRulesetManagement().getFunctionalKeys(
                                 FunctionalMetadata.HIGHERLEVEL_IDENTIFIER));
-                this.createProcessForm.setProcesses(processes);
 
-                // Fill metadata fields in metadata tab with metadata values of first process on successful import
-                if (!processes.isEmpty() && processes.getFirst().getMetadataNodes().getLength() > 0) {
-                    TempProcess firstProcess = processes.getFirst();
-                    this.createProcessForm.getProcessDataTab().setDocType(
-                            firstProcess.getWorkpiece().getRootElement().getType());
-                    Collection<Metadata> metadata = ImportService.importMetadata(firstProcess.getMetadataNodes(),
-                            MdSec.DMD_SEC);
-                    createProcessForm.getProcessMetadataTab().getProcessDetails().setMetadata(metadata);
-                }
+                fillCreateProcessForm(processes);
 
                 String summary = Helper.getTranslation("newProcess.catalogueSearch.importSuccessfulSummary");
                 String detail = Helper.getTranslation("newProcess.catalogueSearch.importSuccessfulDetail",

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
@@ -92,29 +92,18 @@ public class FileUploadDialog extends MetadataImportDialog {
         Collection<String> higherLevelIdentifier = this.createProcessForm.getRulesetManagement()
                 .getFunctionalKeys(FunctionalMetadata.HIGHERLEVEL_IDENTIFIER);
 
-        ImportService importService = ServiceManager.getImportService();
-        String parentID = importService.getParentID(internalDocument, higherLevelIdentifier.toArray()[0].toString());
-        if (Objects.nonNull(parentID) && OPACConfig.isParentInRecord(selectedCatalog)) {
-            Document internalParentDocument = importService.convertDataRecordToInternal(
-                createRecordFromXMLElement(IOUtils.toString(uploadedFile.getInputstream(), Charset.defaultCharset())),
-                selectedCatalog, true);
-            TempProcess tempParentProcess = importService.createTempProcessFromDocument(internalParentDocument,
-                createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
-            return tempParentProcess;
+        if (higherLevelIdentifier.size() > 0) {
+            ImportService importService = ServiceManager.getImportService();
+            String parentID = importService.getParentID(internalDocument, higherLevelIdentifier.toArray()[0].toString());
+            if (Objects.nonNull(parentID) && OPACConfig.isParentInRecord(selectedCatalog)) {
+                Document internalParentDocument = importService.convertDataRecordToInternal(
+                        createRecordFromXMLElement(IOUtils.toString(uploadedFile.getInputstream(), Charset.defaultCharset())),
+                        selectedCatalog, true);
+                return importService.createTempProcessFromDocument(internalParentDocument,
+                        createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
+            }
         }
         return null;
-    }
-
-    private void fillCreateProcessForm(LinkedList<TempProcess> processes) {
-        this.createProcessForm.setProcesses(processes);
-        if (!processes.isEmpty() && processes.getFirst().getMetadataNodes().getLength() > 0) {
-            TempProcess firstProcess = processes.getFirst();
-            this.createProcessForm.getProcessDataTab()
-                    .setDocType(firstProcess.getWorkpiece().getRootElement().getType());
-            Collection<Metadata> metadata = ImportService.importMetadata(firstProcess.getMetadataNodes(),
-                MdSec.DMD_SEC);
-            createProcessForm.getProcessMetadataTab().getProcessDetails().setMetadata(metadata);
-        }
     }
 
     private DataRecord createRecordFromXMLElement(String xmlContent) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.forms.createprocess;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -20,10 +21,13 @@ import javax.faces.model.SelectItem;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kitodo.api.MdSec;
+import org.kitodo.api.Metadata;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.TempProcess;
 import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.data.ImportService;
 import org.omnifaces.util.Ajax;
 import org.primefaces.PrimeFaces;
 
@@ -107,6 +111,23 @@ public abstract class MetadataImportDialog {
         } catch (IllegalArgumentException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
             return new LinkedList<>();
+        }
+    }
+
+    /**
+     * Fill metadata fields in metadata tab with metadata values of first process in given list "processes"
+     * on successful import.
+     * @param processes list of TempProcess instances
+     */
+    void fillCreateProcessForm(LinkedList<TempProcess> processes) {
+        this.createProcessForm.setProcesses(processes);
+        if (!processes.isEmpty() && processes.getFirst().getMetadataNodes().getLength() > 0) {
+            TempProcess firstProcess = processes.getFirst();
+            this.createProcessForm.getProcessDataTab()
+                    .setDocType(firstProcess.getWorkpiece().getRootElement().getType());
+            Collection<Metadata> metadata = ImportService.importMetadata(firstProcess.getMetadataNodes(),
+                    MdSec.DMD_SEC);
+            createProcessForm.getProcessMetadataTab().getProcessDetails().setMetadata(metadata);
         }
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -35,7 +35,7 @@ public class WebDriverProvider {
     // https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
     // Please don't rely on the LATEST_RELEASE file without a version suffix.
     // It exists for backward compatibility only, and will be removed in the near future.
-    private static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_87";
+    private static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_89";
 
     private static UnArchiver zipUnArchiver = new ZipUnArchiver();
     private static UnArchiver tarGZipUnArchiver = new TarGZipUnArchiver();


### PR DESCRIPTION
- prevent `IndexOutOfBoundException` on import if no `HIGHERLEVEL_IDENTIFIER` is defined in current ruleset
- remove redundant variables
- move method `fillCreateProcessForm` to `MetadataImportDialog` to prevent code duplication
- Update Chrome Driver to version 89