### PR TITLE
raise indexlimit to given limit from elasticsearch

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/SearchRestClient.java
@@ -174,7 +174,7 @@ public class SearchRestClient extends KitodoRestClient {
         if (Objects.nonNull(size)) {
             sourceBuilder.size(size);
         } else {
-            sourceBuilder.size(1000);
+            sourceBuilder.size(10000);
         }
 
         SearchRequest searchRequest = new SearchRequest(this.index);


### PR DESCRIPTION
Elasticsearch is configured not to return more than 10'000 results (or to search behind that number).

It is not advised to change this value, but we can nevertheless get amounts up to this limit.
