### PR TITLE
Replace picklist icons to improve readability

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2678,6 +2678,36 @@ Workflow Editor
 }
 
 /*----------------------------------------------------------------------
+Role authority picklist
+----------------------------------------------------------------------*/
+
+.ui-picklist-buttons-cell .ui-button-icon-left.ui-icon {
+    background: none;
+    font-size: larger;
+    text-indent: 0;
+}
+
+.ui-picklist-buttons-cell .ui-button-icon-left::before {
+    font-family: FontAwesome;
+}
+
+.ui-picklist-buttons-cell .ui-picklist-button-add .ui-button-icon-left::before {
+    content: '\f105';
+}
+
+.ui-picklist-buttons-cell .ui-picklist-button-add-all .ui-button-icon-left::before {
+    content: '\f101';
+}
+
+.ui-picklist-buttons-cell .ui-picklist-button-remove .ui-button-icon-left::before {
+    content: '\f104';
+}
+
+.ui-picklist-buttons-cell .ui-picklist-button-remove-all .ui-button-icon-left::before {
+    content: '\f100';
+}
+
+/*----------------------------------------------------------------------
 System page
 ----------------------------------------------------------------------*/
 


### PR DESCRIPTION
Fixes #4215 

**Note**: I used `fa-angle-left` and `fa-angle-right` instead of the proposed `fa-caret-left` and `fa-caret-right` respectively, because I felt that resulted in a more coherent look.

So 
<img width="50" alt="Bildschirmfoto 2021-03-23 um 10 17 10" src="https://user-images.githubusercontent.com/19183925/112123619-b49bf200-8bc1-11eb-96eb-64c0e8a492e8.png">
instead of 
<img width="50" alt="Bildschirmfoto 2021-03-23 um 10 17 46" src="https://user-images.githubusercontent.com/19183925/112123651-ba91d300-8bc1-11eb-8e59-22d193e3a77a.png">

