### PR TITLE
Rewrite VariableReplacer

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -386,7 +386,7 @@ public class ExportDms extends ExportMets {
         Collection<Subfolder> processDirs = process.getProject().getFolders().parallelStream()
                 .filter(Folder::isCopyFolder).map(folder -> new Subfolder(process, folder))
                 .collect(Collectors.toList());
-        VariableReplacer variableReplacer = new VariableReplacer(null, null, process, null);
+        VariableReplacer variableReplacer = new VariableReplacer(null, process, null);
 
         String uriToDestination = destination.toString();
         if (!uriToDestination.endsWith("/")) {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -40,9 +40,9 @@ public class VariableReplacer {
 
     private static final Logger logger = LogManager.getLogger(VariableReplacer.class);
 
-    private static final Pattern VARIABLE_FINDER_REGEX = Pattern
-            .compile(
-                "(\\$?)\\((?:(prefs|processid|processtitle|projectid|stepid|stepname)|(?:(meta|process|product|template)\\.(?:(firstchild|topstruct)\\.)?([^)]+)))\\)");
+    private static final Pattern VARIABLE_FINDER_REGEX = Pattern.compile(
+                "(\\$?)\\((?:(prefs|processid|processtitle|projectid|stepid|stepname)|"
+                + "(?:(meta|process|product|template)\\.(?:(firstchild|topstruct)\\.)?([^)]+)))\\)");
 
     private static Map<String, String> legacyVariablesMap;
     private static Pattern legacyVariablesPattern;
@@ -52,20 +52,20 @@ public class VariableReplacer {
     private Task task;
 
     /**
-     * Constructor.
+     * Creates a new Variable Replacer.
      *
      * @param workpiece
-     *            DigitalDocument object
-     * @param p
-     *            Process object
-     * @param s
-     *            Task object
+     *            Workpiece to read metadata values from
+     * @param process
+     *            Process to read values from
+     * @param task
+     *            Task to read values from
      */
-    public VariableReplacer(Workpiece workpiece, Process p, Task s) {
+    public VariableReplacer(Workpiece workpiece, Process process, Task task) {
         initializeLegacyVariablesPreprocessor();
         this.workpiece = workpiece;
-        this.process = p;
-        this.task = s;
+        this.process = process;
+        this.task = task;
     }
 
     private final void initializeLegacyVariablesPreprocessor() {
@@ -93,21 +93,21 @@ public class VariableReplacer {
     }
 
     /**
-     * Variablen innerhalb eines Strings ersetzen. Dabei vergleichbar zu Ant die
-     * Variablen durchlaufen und aus dem Digital Document holen
+     * Replace variables within a string. Like an ant, run through the variables
+     * and fetch them from the digital document.
      *
-     * @param inString
-     *            to replacement
-     * @return replaced String
+     * @param stringWithVariables
+     *            a string maybe holding variables
+     * @return string with variables replaced
      */
-    public String replace(String inString) {
-        if (Objects.isNull(inString)) {
+    public String replace(String stringWithVariables) {
+        if (Objects.isNull(stringWithVariables)) {
             return "";
         }
 
-        inString = invokeLegacyVariableReplacer(inString);
+        stringWithVariables = invokeLegacyVariableReplacer(stringWithVariables);
 
-        Matcher variableFinder = VARIABLE_FINDER_REGEX.matcher(inString);
+        Matcher variableFinder = VARIABLE_FINDER_REGEX.matcher(stringWithVariables);
         boolean stringChanged = false;
         StringBuffer replacedStringBuffer = null;
         while (variableFinder.find()) {
@@ -121,7 +121,7 @@ public class VariableReplacer {
             variableFinder.appendTail(replacedStringBuffer);
             return replacedStringBuffer.toString();
         } else {
-            return inString;
+            return stringWithVariables;
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -51,7 +51,7 @@ public class VariableReplacer {
     private static final Logger logger = LogManager.getLogger(VariableReplacer.class);
 
     private static final Pattern VARIABLE_FINDER_REGEX = Pattern
-            .compile("\\((prefs|processid|processtitle|projectid|stepid|stepname))");
+            .compile("(\\$?)\\((prefs|processid|processtitle|projectid|stepid|stepname)\\)");
 
     private LegacyMetsModsDigitalDocumentHelper dd;
     private LegacyPrefsHelper prefs;
@@ -151,19 +151,20 @@ public class VariableReplacer {
     }
 
     private String determineReplacement(Matcher variableFinder) {
-        switch (variableFinder.group(1)) {
+        switch (variableFinder.group(2)) {
             case "prefs":
-                return ConfigCore.getParameter(ParameterCore.DIR_RULESETS).concat(process.getRuleset().getFile());
+                return variableFinder.group(1) + ConfigCore.getParameter(ParameterCore.DIR_RULESETS)
+                        + process.getRuleset().getFile();
             case "processid":
-                return process.getId().toString();
+                return variableFinder.group(1) + process.getId().toString();
             case "processtitle":
-                return process.getTitle();
+                return variableFinder.group(1) + process.getTitle();
             case "projectid":
-                return process.getProject().getId().toString();
+                return variableFinder.group(1) + process.getProject().getId().toString();
             case "stepid":
-                return String.valueOf(task.getId());
+                return variableFinder.group(1) + String.valueOf(task.getId());
             case "stepname":
-                return task.getTitle();
+                return variableFinder.group(1) + task.getTitle();
             default:
                 return variableFinder.group();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -28,11 +28,7 @@ import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Task;
-import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.metadata.MetadataEditor;
-import org.kitodo.production.services.ServiceManager;
-import org.kitodo.production.services.data.ProcessService;
-import org.kitodo.production.services.file.FileService;
 
 public class VariableReplacer {
 
@@ -48,40 +44,31 @@ public class VariableReplacer {
             .compile(
                 "(\\$?)\\((?:(prefs|processid|processtitle|projectid|stepid|stepname)|(?:(meta|process|product|template)\\.(?:(firstchild|topstruct)\\.)?([^)]+)))\\)");
 
-    private Workpiece workpiece;
-    private LegacyPrefsHelper prefs;
-    // $(meta.abc)
-    private static final String NAMESPACE_META = "\\$\\(meta\\.([\\w.-]*)\\)";
+    private static Map<String, String> legacyVariablesMap;
+    private static Pattern legacyVariablesPattern;
 
+    private Workpiece workpiece;
     private Process process;
     private Task task;
-    private final FileService fileService = ServiceManager.getFileService();
-    private final ProcessService processService = ServiceManager.getProcessService();
 
     /**
      * Constructor.
      *
-     * @param inDigitalDocument
+     * @param workpiece
      *            DigitalDocument object
-     * @param inPrefs
-     *            Prefs object
      * @param p
      *            Process object
      * @param s
      *            Task object
      */
-    public VariableReplacer(Workpiece workpiece, LegacyPrefsHelper inPrefs, Process p, Task s) {
+    public VariableReplacer(Workpiece workpiece, Process p, Task s) {
         initializeLegacyVariablesPreprocessor();
         this.workpiece = workpiece;
-        this.prefs = inPrefs;
         this.process = p;
         this.task = s;
     }
 
-    Map<String, String> legacyVariablesMap;
-    Pattern legacyVariablesPattern;
-
-    private void initializeLegacyVariablesPreprocessor() {
+    private final void initializeLegacyVariablesPreprocessor() {
         StringBuilder regexBuilder = null;
         boolean useLegacyVariablesPreprocessor = false;
         for (Iterator<String> iterator = ConfigCore.getConfig().getKeys(); iterator.hasNext();) {
@@ -104,7 +91,6 @@ public class VariableReplacer {
             legacyVariablesPattern = Pattern.compile(regexBuilder.toString());
         }
     }
-
 
     /**
      * Variablen innerhalb eines Strings ersetzen. Dabei vergleichbar zu Ant die

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -129,9 +129,9 @@ public class VariableReplacer {
         inString = replaceString(inString, "(prefs)", prefs);
 
         inString = replaceString(inString, "(processtitle)", this.process.getTitle());
-        inString = replaceString(inString, "(processid)", String.valueOf(this.process.getId().intValue()));
+        inString = replaceString(inString, "(processid)", process.getId().toString());
 
-        inString = replaceString(inString, "(projectid)", String.valueOf(this.process.getProject().getId().intValue()));
+        inString = replaceString(inString, "(projectid)", process.getProject().getId().toString());
 
         inString = replaceStringForTask(inString);
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -58,13 +58,6 @@ public class VariableReplacer {
     private final FileService fileService = ServiceManager.getFileService();
     private final ProcessService processService = ServiceManager.getProcessService();
 
-    protected VariableReplacer() {
-    }
-
-    VariableReplacer(Process process) {
-        this.process = process;
-    }
-
     /**
      * Constructor.
      *

--- a/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
@@ -92,7 +92,7 @@ public class Subfolder {
     public Subfolder(Process process, Folder folder) {
         this.process = process;
         this.folder = folder;
-        this.variableReplacer = new VariableReplacer(null, null, process, null);
+        this.variableReplacer = new VariableReplacer(null, process, null);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -110,7 +110,7 @@ public abstract class EditDataScript {
             } else if (metadataScript.getRoot().startsWith("$")) {
                 LegacyPrefsHelper legacyPrefsHelper = ServiceManager.getRulesetService()
                         .getPreferences(process.getRuleset());
-                VariableReplacer replacer = new VariableReplacer(metadataFile, legacyPrefsHelper, process, null);
+                VariableReplacer replacer = new VariableReplacer(metadataFile.getWorkpiece(), process, null);
 
                 String replaced = replacer.replace(metadataScript.getRootName());
                 metadataScript.getValues().add(replaced);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -457,7 +457,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
         } catch (IOException e2) {
             logger.error(e2);
         }
-        VariableReplacer replacer = new VariableReplacer(dd, prefs, po, task);
+        VariableReplacer replacer = new VariableReplacer(dd.getWorkpiece(), po, task);
 
         script = replacer.replace(script);
         boolean executedSuccessful = false;

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -33,7 +33,6 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.enums.LinkingMode;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.helper.VariableReplacer;
-import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.model.Subfolder;
@@ -74,9 +73,7 @@ public class SchemaService {
          */
         // Replace all paths with the given VariableReplacer, also the file
         // group paths!
-        VariableReplacer vp = new VariableReplacer(
-                new LegacyMetsModsDigitalDocumentHelper(prefs.getRuleset(), workpiece), prefs,
-                process, null);
+        VariableReplacer vp = new VariableReplacer(workpiece, process, null);
 
         addVirtualFileGroupsToMetsMods(workpiece.getMediaUnit(), process);
         replaceFLocatForExport(workpiece, process);
@@ -142,7 +139,7 @@ public class SchemaService {
 
     private void replaceFLocatForExport(Workpiece workpiece, Process process) throws URISyntaxException {
         List<Folder> folders = process.getProject().getFolders();
-        VariableReplacer variableReplacer = new VariableReplacer(null, null, process, null);
+        VariableReplacer variableReplacer = new VariableReplacer(null, process, null);
         for (MediaUnit mediaUnit : workpiece.getAllMediaUnits()) {
             for (Entry<MediaVariant, URI> mediaFileForMediaVariant : mediaUnit.getMediaFiles().entrySet()) {
                 for (Folder folder : folders) {
@@ -287,8 +284,7 @@ public class SchemaService {
         LinkedMetsResource link = structure.getLink();
         link.setLoctype("URL");
         String uriWithVariables = process.getProject().getMetsPointerPath();
-        VariableReplacer variableReplacer = new VariableReplacer(
-                new LegacyMetsModsDigitalDocumentHelper(prefs.getRuleset(), workpiece), prefs, process, null);
+        VariableReplacer variableReplacer = new VariableReplacer(workpiece, process, null);
         String linkUri = variableReplacer.replace(uriWithVariables);
         link.setUri(URI.create(linkUri));
         structure.setType(ServiceManager.getProcessService().getBaseType(process));

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -668,7 +668,7 @@ public class WorkflowControllerService {
         LegacyMetsModsDigitalDocumentHelper legacyMetsModsDigitalDocumentHelper = ServiceManager.getProcessService()
                 .readMetadataFile(ServiceManager.getFileService().getMetadataFilePath(process), legacyPrefsHelper)
                 .getDigitalDocument();
-        VariableReplacer replacer = new VariableReplacer(legacyMetsModsDigitalDocumentHelper, legacyPrefsHelper,
+        VariableReplacer replacer = new VariableReplacer(legacyMetsModsDigitalDocumentHelper.getWorkpiece(),
                 process, null);
 
         script = replacer.replace(script);

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -103,6 +103,31 @@ importUseOldConfiguration=false
 # set if Master-Images-Folder 'orig_' should be used at all
 useOrigFolder=true
 
+# Version 2 of Production included a number of hard-coded folder paths derived
+# from the settings above. The folder management has been made more flexible in
+# Production 3, so that these paths do no longer function, unless you configure
+# the folder structure of your projects exactly as before. They have therefore
+# been removed from the program text. To ensure congruence with the previous
+# version, you can continue to use hard-coded variables after you have defined
+# them here.
+# Please adjust the paths accordingly if you have made changes to the above
+# settings.
+# Note that ON WINDOWS the paths of variables with names ending in "...url"
+# used forward slashes (imageurl=file:/K:/metadata/...), while the rest of the
+# paths used backslashes (imagepath=K:\\metadata\\...). 
+
+replace.processpath=/usr/local/kitodo/metadata/(processid)/
+replace.imagepath=/usr/local/kitodo/metadata/(processid)/images/
+replace.imageurl=file://usr/local/kitodo/metadata/(processid)/images/
+replace.metaFile=/usr/local/kitodo/metadata/(processid)/meta.xml
+replace.ocrbasispath=/usr/local/kitodo/metadata/(processid)/ocr/
+replace.ocrplaintextpath=/usr/local/kitodo/metadata/(processid)/ocr/(processtitle)_txt/
+replace.origpath=/usr/local/kitodo/metadata/(processid)/images/master_(processtitle)_media/
+replace.origurl=file://usr/local/kitodo/metadata/(processid)/images/master_(processtitle)_media/
+replace.sourcepath=/usr/local/kitodo/metadata/(processid)/images/(processtitle)_source/
+replace.tifpath=/usr/local/kitodo/metadata/(processid)/images/(processtitle)_media/
+replace.tifurl=file://usr/local/kitodo/metadata/(processid)/images/(processtitle)_media/
+
 
 # -----------------------------------
 # Directory and symbolic link management

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -116,17 +116,17 @@ useOrigFolder=true
 # used forward slashes (imageurl=file:/K:/metadata/...), while the rest of the
 # paths used backslashes (imagepath=K:\\metadata\\...). 
 
-replace.processpath=/usr/local/kitodo/metadata/(processid)/
-replace.imagepath=/usr/local/kitodo/metadata/(processid)/images/
-replace.imageurl=file://usr/local/kitodo/metadata/(processid)/images/
-replace.metaFile=/usr/local/kitodo/metadata/(processid)/meta.xml
-replace.ocrbasispath=/usr/local/kitodo/metadata/(processid)/ocr/
-replace.ocrplaintextpath=/usr/local/kitodo/metadata/(processid)/ocr/(processtitle)_txt/
-replace.origpath=/usr/local/kitodo/metadata/(processid)/images/master_(processtitle)_media/
-replace.origurl=file://usr/local/kitodo/metadata/(processid)/images/master_(processtitle)_media/
-replace.sourcepath=/usr/local/kitodo/metadata/(processid)/images/(processtitle)_source/
-replace.tifpath=/usr/local/kitodo/metadata/(processid)/images/(processtitle)_media/
-replace.tifurl=file://usr/local/kitodo/metadata/(processid)/images/(processtitle)_media/
+variable.processpath=/usr/local/kitodo/metadata/(processid)/
+variable.imagepath=/usr/local/kitodo/metadata/(processid)/images/
+variable.imageurl=file://usr/local/kitodo/metadata/(processid)/images/
+variable.metaFile=/usr/local/kitodo/metadata/(processid)/meta.xml
+variable.ocrbasispath=/usr/local/kitodo/metadata/(processid)/ocr/
+variable.ocrplaintextpath=/usr/local/kitodo/metadata/(processid)/ocr/(processtitle)_txt/
+variable.origpath=/usr/local/kitodo/metadata/(processid)/images/master_(processtitle)_media/
+variable.origurl=file://usr/local/kitodo/metadata/(processid)/images/master_(processtitle)_media/
+variable.sourcepath=/usr/local/kitodo/metadata/(processid)/images/(processtitle)_source/
+variable.tifpath=/usr/local/kitodo/metadata/(processid)/images/(processtitle)_media/
+variable.tifurl=file://usr/local/kitodo/metadata/(processid)/images/(processtitle)_media/
 
 
 # -----------------------------------

--- a/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
@@ -26,7 +26,7 @@ public class VariableReplacerTest {
 
     @Test
     public void shouldReplaceTitle() {
-        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
+        VariableReplacer variableReplacer = new VariableReplacer(null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-title (processtitle) -hardcoded test");
         String expected = "-title Replacement -hardcoded test";
@@ -36,7 +36,7 @@ public class VariableReplacerTest {
 
     @Test
     public void shouldReplacePrefs() {
-        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
+        VariableReplacer variableReplacer = new VariableReplacer(null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-prefs (prefs) -hardcoded test");
         String expected = "-prefs src/test/resources/rulesets/ruleset_test.xml -hardcoded test";
@@ -46,7 +46,7 @@ public class VariableReplacerTest {
 
     @Test
     public void shouldReplaceProcessPath() {
-        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
+        VariableReplacer variableReplacer = new VariableReplacer(null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-processpath (processpath) -hardcoded test");
         String expected = "-processpath 2 -hardcoded test";
@@ -56,7 +56,7 @@ public class VariableReplacerTest {
 
     @Test
     public void shouldReplaceProjectId() {
-        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
+        VariableReplacer variableReplacer = new VariableReplacer(null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-processpath (projectid) -hardcoded test");
         String expected = "-processpath " + projectId + " -hardcoded test";

--- a/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
@@ -11,9 +11,9 @@
 
 package org.kitodo.production.helper;
 
-import java.net.URI;
-
 import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
 
 import org.junit.Test;
 import org.kitodo.data.database.beans.Process;
@@ -21,12 +21,12 @@ import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Ruleset;
 
 public class VariableReplacerTest {
-    
+
     int projectId = 12;
 
     @Test
     public void shouldReplaceTitle() {
-        VariableReplacer variableReplacer = new VariableReplacer(prepareProcess());
+        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-title (processtitle) -hardcoded test");
         String expected = "-title Replacement -hardcoded test";
@@ -36,7 +36,7 @@ public class VariableReplacerTest {
 
     @Test
     public void shouldReplacePrefs() {
-        VariableReplacer variableReplacer = new VariableReplacer(prepareProcess());
+        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-prefs (prefs) -hardcoded test");
         String expected = "-prefs src/test/resources/rulesets/ruleset_test.xml -hardcoded test";
@@ -46,17 +46,17 @@ public class VariableReplacerTest {
 
     @Test
     public void shouldReplaceProcessPath() {
-        VariableReplacer variableReplacer = new VariableReplacer(prepareProcess());
+        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-processpath (processpath) -hardcoded test");
         String expected = "-processpath 2 -hardcoded test";
 
         assertEquals("String was replaced incorrectly!", expected, replaced);
     }
-    
+
     @Test
     public void shouldReplaceProjectId() {
-        VariableReplacer variableReplacer = new VariableReplacer(prepareProcess());
+        VariableReplacer variableReplacer = new VariableReplacer(null, null, prepareProcess(), null);
 
         String replaced = variableReplacer.replace("-processpath (projectid) -hardcoded test");
         String expected = "-processpath " + projectId + " -hardcoded test";

--- a/Kitodo/src/test/java/org/kitodo/production/services/image/MockVariableReplacer.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/image/MockVariableReplacer.java
@@ -16,7 +16,7 @@ import org.kitodo.production.helper.VariableReplacer;
 /**
  * A replacement for the variable replacer, which simply replaces the process
  * title.
- * 
+ *
  * <p>
  * The variable replacer fetches the process data directory from the process
  * service. If the latter does not find a process base URI in the process object
@@ -34,7 +34,7 @@ public class MockVariableReplacer extends VariableReplacer {
     private final String processtitle;
 
     MockVariableReplacer(String processtitle) {
-        super();
+        super(null, null, null);
         this.processtitle = processtitle;
     }
 

--- a/Kitodo/src/test/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/kitodo_config.properties
@@ -68,3 +68,5 @@ taskProcessPropertyColumns=
 
 # Configure whether each process needs to have a unique title or not
 uniqueProcessTitles=true
+
+variable.processpath=(processid)


### PR DESCRIPTION
This pull request implements the `VariableReplacer` in a new way. It was still based on the old UGH classes, and it was very inefficient because the string was parsed for every possible variable and all possible replacements were calculated even when they weren't needed. This will be remedied with this pull request. The string is examined only one more time with the regular expression, and then only the replacements that are required are determined. In addition, meaningful warnings are issued in the log if a value cannot be determined.

There were a lot of hard-coded variables from 2.x in `VariableReplacer` that no longer make sense with the flexible folder model. I would have liked to have removed these completely, but @henning-gerhardt said they should be retained for backwards compatibility (see the discussion in issue #3718). I have outsourced these to the configuration. With the specified configuration entries, the obsolete variables continue to function with the same semantics as in 2.x.

If I see it correctly this fixes #3718.

PS: Look at the new `VariableReplacer` as it, is and not at the diff. There is practically nothing left of the old class, and the diff tries hard to bring things together that don't belong together. It's totally misleading.