### PR TITLE
Enable default values in OPAC import configuration

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -32,6 +32,8 @@ import org.kitodo.exceptions.ParameterNotFoundException;
 public class OPACConfig {
     private static final Logger logger = LogManager.getLogger(OPACConfig.class);
     private static XMLConfiguration config;
+    private static final String TRUE = "true";
+    private static final String DEFAULT = "[@default]";
 
     /**
      * Private constructor.
@@ -95,6 +97,38 @@ public class OPACConfig {
     }
 
     /**
+     * Retrieve the default "searchField" of the catalog identified by its title 'catalogName'. If multiple fields are
+     * configured as "default", the first is returned.
+     * @param catalogName String identifying the catalog by title
+     * @return String name of catalogs default "searchField" if it exists; empty String otherwise
+     */
+    public static String getDefaultSearchField(String catalogName) {
+        for (HierarchicalConfiguration searchField : getSearchFields(catalogName).configurationsAt("searchField")) {
+            if (TRUE.equals(searchField.getString(DEFAULT))) {
+                String defaultSearchField = searchField.getString("[@label]");
+                if (StringUtils.isNotBlank(defaultSearchField)) {
+                    return defaultSearchField;
+                }
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Retrieve the name of the default "catalog" configured in "kitodo_opac.xml". If no catalog is configured as
+     * default catalog, return an empty String.
+     * @return String name of default catalog or empty String if no default catalog is configured.
+     */
+    public static String getDefaultCatalog() {
+        for (String catalog : getCatalogs()) {
+            if (TRUE.equals(getCatalog(catalog).getString(DEFAULT))) {
+                return catalog;
+            }
+        }
+        return "";
+    }
+
+    /**
      * Retrieve the "urlParameters" of the catalog identified by its title.
      * @param catalogName String identifying the catalog by its title
      * @return HierarchicalConfiguration for catalog's "urlParameters"
@@ -148,7 +182,7 @@ public class OPACConfig {
      */
     public static String getParentIDElement(String catalogName) {
         for (HierarchicalConfiguration field : getSearchFields(catalogName).configurationsAt("searchField")) {
-            if ("true".equals(field.getString("[@parentElement]"))) {
+            if (TRUE.equals(field.getString("[@parentElement]"))) {
                 String parentIDElement = field.getString("[@label]");
                 if (StringUtils.isNotBlank(parentIDElement)) {
                     return parentIDElement;

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
@@ -31,6 +31,13 @@ public class LazyHitModel extends LazyDataModel<Object> {
 
     private SearchResult searchResult = null;
 
+    /**
+     * Empty default constructor. Sets default catalog and search field, if configured.
+     */
+    public LazyHitModel() {
+        this.setSelectedCatalog(ServiceManager.getImportService().getDefaultCatalog());
+    }
+
     @Override
     public Object getRowData(String rowKey) {
         return null;
@@ -85,12 +92,13 @@ public class LazyHitModel extends LazyDataModel<Object> {
     }
 
     /**
-     * Setter for selectedCatalog.
+     * Setter for selectedCatalog. This also sets the catalogs default search field, if configured.
      *
      * @param catalog as java.lang.String
      */
     public void setSelectedCatalog(String catalog) {
         this.selectedCatalog = catalog;
+        this.setSelectedField(ServiceManager.getImportService().getDefaultSearchField(catalog));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -232,6 +232,20 @@ public class ImportService {
     }
 
     /**
+     * Get first default search field for catalog 'opac'.
+     *
+     * @param opac catalog name
+     * @return name of default search field
+     */
+    public String getDefaultSearchField(String opac) {
+        if (SearchInterfaceType.FTP.equals(OPACConfig.getInterfaceType(opac))) {
+            return Helper.getTranslation("filename");
+        } else {
+            return OPACConfig.getDefaultSearchField(opac);
+        }
+    }
+
+    /**
      * Load catalog names from library catalog configuration file and return them as a list of Strings.
      *
      * @return list of catalog names
@@ -243,6 +257,15 @@ public class ImportService {
             logger.error(e.getLocalizedMessage());
             throw new IllegalArgumentException("Error: no supported OPACs found in configuration file!");
         }
+    }
+
+    /**
+     * Get first default catalog configured in 'kitodo_opac.xml'.
+     *
+     * @return name of first default catalog or empty String no default catalog is configured.
+     */
+    public String getDefaultCatalog() {
+        return OPACConfig.getDefaultCatalog();
     }
 
     private LinkedList<ExemplarRecord> extractExemplarRecords(DataRecord record, String opac) throws XPathExpressionException,

--- a/Kitodo/src/main/resources/kitodo_opac.xml
+++ b/Kitodo/src/main/resources/kitodo_opac.xml
@@ -16,7 +16,7 @@
         <type isPeriodical="false" isMultiVolume="false" rulesetType="" title="legacyDocType"/>
     </doctypes>
 
-    <catalogue title="GBV" description="Gemeinsamer Bibliotheksverbund">
+    <catalogue title="GBV" description="Gemeinsamer Bibliotheksverbund" default="true">
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>MARC</metadataFormat>
@@ -40,7 +40,7 @@
         </urlParameters>
         <searchFields>
             <searchField label="Titel" value="pica.tit"/>
-            <searchField label="PPN" value="pica.ppn"/>
+            <searchField label="PPN" value="pica.ppn" default="true"/>
             <searchField label="Author" value="pica.per"/>
             <searchField label="ISSN" value="pica.iss"/>
             <searchField label="ISBN" value="pica.isb"/>
@@ -69,7 +69,7 @@
         </urlParameters>
         <searchFields>
             <searchField label="Titel" value="pica.tit"/>
-            <searchField label="PPN" value="pica.ppn"/>
+            <searchField label="PPN" value="pica.ppn" default="true"/>
             <searchField label="Author" value="pica.per"/>
             <searchField label="ISSN" value="pica.iss"/>
             <searchField label="ISBN" value="pica.isb"/>
@@ -101,7 +101,7 @@
         </urlParameters>
         <searchFields>
             <searchField label="Titel" value="pica.tit"/>
-            <searchField label="PPN" value="pica.ppn"/>
+            <searchField label="PPN" value="pica.ppn" default="true"/>
             <searchField label="Author" value="pica.per"/>
             <searchField label="ISSN" value="pica.iss"/>
             <searchField label="ISBN" value="pica.isb"/>
@@ -135,7 +135,7 @@
         <searchFields>
             <searchField label="Title" value="ead.title" />
             <searchField label="Creator" value="ead.creator" />
-            <searchField label="Identifier" value="ead.id" />
+            <searchField label="Identifier" value="ead.id" default="true"/>
             <searchField label="Creation date" value="ead.creationdate.normal" />
             <searchField label="Genre" value="ead.genre" />
             <searchField label="Keyword" value="ead.keyword" />

--- a/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.selenium;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.selenium.testframework.BaseTestSelenium;
+import org.kitodo.selenium.testframework.Browser;
+import org.kitodo.selenium.testframework.Pages;
+import org.kitodo.selenium.testframework.pages.ProcessFromTemplatePage;
+import org.kitodo.selenium.testframework.pages.ProjectsPage;
+import org.openqa.selenium.support.ui.Select;
+
+public class ImportingST extends BaseTestSelenium {
+
+    private static final String PPN = "PPN";
+    private static final String K10PLUS = "K10Plus";
+    private static ProcessFromTemplatePage importPage;
+    private static ProjectsPage projectsPage;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        projectsPage = Pages.getProjectsPage();
+        importPage = Pages.getProcessFromTemplatePage();
+    }
+
+    @Before
+    public void login() throws Exception {
+        Pages.getLoginPage().goTo().performLoginAsAdmin();
+    }
+
+    @After
+    public void logout() throws Exception {
+        Pages.getTopNavigation().logout();
+        if (Browser.isAlertPresent()) {
+            Browser.getDriver().switchTo().alert().accept();
+        }
+    }
+
+    @Test
+    public void checkDefaultValuesTest() throws Exception {
+        projectsPage.createNewProcess();
+        Select catalogSelectMenu = new Select(importPage.getCatalogMenu());
+        assertEquals("Wrong default catalog selected", K10PLUS,
+                catalogSelectMenu.getFirstSelectedOption().getText());
+
+        importPage.selectGBV();
+        Select searchFieldSelectMenu = new Select(importPage.getSearchFieldMenu());
+        assertEquals("Wrong default search field selected", PPN,
+                searchFieldSelectMenu.getFirstSelectedOption().getText());
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
@@ -46,20 +46,21 @@ public class Browser {
     private static Actions actions;
     private static final String GECKO_DRIVER_VERSION = "0.19.1";
     private static boolean onTravis = false;
-    private static BrowserType browserType = BrowserType.CHROME;
+    private static final BrowserType browserType = BrowserType.CHROME;
     private static final String USER_DIR = System.getProperty("user.dir");
     public static final String DOWNLOAD_DIR = USER_DIR + "/target/downloads/";
     private static final String DRIVER_DIR = USER_DIR + "/target/extracts/";
 
-    private static int delayIndexing = 3000;
-    private static int delayAfterLogin = 2000;
-    private static int delayAfterLogout = 3000;
-    private static int delayMinAfterLinkClick = 500;
-    private static int delayMaxAfterLinkClick = 1500;
-    private static int delayAfterHoverMenu = 500;
-    private static int delayAfterNewItemClick = 500;
-    private static int delayAfterPickListClick = 1500;
-    private static int delayAfterDelete = 7000;
+    private static final int delayIndexing = 3000;
+    private static final int delayAfterLogin = 2000;
+    private static final int delayAfterLogout = 3000;
+    private static final int delayMinAfterLinkClick = 500;
+    private static final int delayMaxAfterLinkClick = 1500;
+    private static final int delayAfterHoverMenu = 500;
+    private static final int delayAfterNewItemClick = 500;
+    private static final int delayAfterPickListClick = 1500;
+    private static final int delayAfterDelete = 7000;
+    private static final int delayAfterCatalogSelection = 500;
 
     /**
      * Provides the web driver, sets timeout and window size.
@@ -319,6 +320,15 @@ public class Browser {
      */
     public static int getDelayAfterDelete() {
         return delayAfterDelete;
+    }
+
+    /**
+     * Get delayAfterCatalogSelection.
+     *
+     * @return value of delayAfterCatalogSelection
+     */
+    public static int getDelayAfterCatalogSelection() {
+        return delayAfterCatalogSelection;
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -120,6 +120,10 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
         return Browser.getDriver().findElementById(OPAC_SEARCH_FORM + ":fieldSelectMenu_input");
     }
 
+    /**
+     * Select GBV catalog.
+     * @throws InterruptedException when thread is interrupted
+     */
     public void selectGBV() throws InterruptedException {
         clickElement(catalogSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
         clickElement(Browser.getDriver().findElement(By.id(catalogSelect.getAttribute("id") + "_1")));

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.support.FindBy;
 public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
 
     private static final String TAB_VIEW = EDIT_FORM + ":processFromTemplateTabView";
+    private static final String OPAC_SEARCH_FORM = "catalogSearchForm";
     private static final String CSS_SELECTOR_DROPDOWN_TRIGGER =  ".ui-selectonemenu-trigger";
 
     @SuppressWarnings("unused")
@@ -64,7 +65,7 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
     private WebElement ppnDigitalInput;
 
     @SuppressWarnings("unused")
-    @FindBy(id = TAB_VIEW + ":catalogueSelectMenu")
+    @FindBy(id = OPAC_SEARCH_FORM + ":catalogueSelectMenu")
     private WebElement catalogSelect;
 
     @SuppressWarnings("unused")
@@ -72,7 +73,7 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
     private WebElement chooseParentSelect;
 
     @SuppressWarnings("unused")
-    @FindBy(id = TAB_VIEW + ":fieldSelectMenu")
+    @FindBy(id = OPAC_SEARCH_FORM + ":fieldSelectMenu")
     private WebElement fieldSelect;
 
     @SuppressWarnings("unused")
@@ -84,7 +85,7 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
     private WebElement searchParentButton;
 
     @SuppressWarnings("unused")
-    @FindBy(id = TAB_VIEW + ":searchTerm")
+    @FindBy(id = OPAC_SEARCH_FORM + ":searchTerm")
     private WebElement searchTermInput;
 
     @SuppressWarnings("unused")
@@ -109,6 +110,20 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
     @Override
     public ProcessFromTemplatePage goTo() {
         return null;
+    }
+
+    public WebElement getCatalogMenu() {
+        return Browser.getDriver().findElementById(OPAC_SEARCH_FORM + ":catalogueSelectMenu_input");
+    }
+
+    public WebElement getSearchFieldMenu() {
+        return Browser.getDriver().findElementById(OPAC_SEARCH_FORM + ":fieldSelectMenu_input");
+    }
+
+    public void selectGBV() throws InterruptedException {
+        clickElement(catalogSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
+        clickElement(Browser.getDriver().findElement(By.id(catalogSelect.getAttribute("id") + "_1")));
+        Thread.sleep(Browser.getDelayAfterCatalogSelection());
     }
 
     public String createProcess() throws Exception {

--- a/Kitodo/src/test/resources/kitodo_opac.xml
+++ b/Kitodo/src/test/resources/kitodo_opac.xml
@@ -66,6 +66,7 @@
             <param name="recordSchema" value="mods" />
         </urlParameters>
         <searchFields>
+            <searchField label="PPN" value="pica.ppn" default="true"/>
             <searchField label="Titel" value="pica.tit"/>
             <searchField label="Author" value="pica.per"/>
             <searchField label="ISSN" value="pica.iss"/>
@@ -105,7 +106,7 @@
             <searchField label="Keyword" value="ead.keyword" />
         </searchFields>
     </catalogue>
-    <catalogue title="K10Plus" description="K10Plus OPAC">
+    <catalogue title="K10Plus" description="K10Plus OPAC" default="true">
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <fileUpload>false</fileUpload>


### PR DESCRIPTION
Fixes #3561 

Default values for catalogs and search fields can be configured by adding the attibute `default="true"` to the corresponding XML elements in `kitodo_opac.xml`. If multiple fields are configured to be default, the first one is selected.

See changes in `Kitodo/src/main/resources/kitodo_opac.xml` for examples!

@subhhwendt, @andre-hohmann I have added these changes to the preview system so that you can test them.
