### PR TITLE
Improve naming in ruleset module

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AbstractKeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AbstractKeyView.java
@@ -19,22 +19,20 @@ import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 /**
  * The abstract type view summarizes methods needed for both the views of keys
  * and views of complex types.
- * 
- * @param <U>
- *            the universal type
+ *
+ * @param <D>
+ *            the type of declaration
  */
-abstract class AbstractKeyView<U extends Labeled> implements MetadataViewInterface {
+abstract class AbstractKeyView<D extends Labeled> implements MetadataViewInterface {
     /**
-     * The underlying universal. This can be a universal key or a universal
-     * division, so this is just a matter of the universal and it depends on the
-     * calling class what it is ultimately about.
+     * The underlying declaration. This can be a key or a division declaration.
      */
-    protected final U universal;
+    protected final D declaration;
 
     /**
-     * The universal rule.
+     * The rule.
      */
-    protected UniversalRule universalRule;
+    protected Rule rule;
 
     /**
      * The wish list of the user regarding the human languages best understood
@@ -46,67 +44,66 @@ abstract class AbstractKeyView<U extends Labeled> implements MetadataViewInterfa
     protected final List<LanguageRange> priorityList;
 
     /**
-     * Creates an abstracted key view.
+     * Creates an abstract key view.
      *
-     * @param universal
-     *            the universal, either a universal division or a universal key,
-     *            as appropriate
+     * @param declaration
+     *            the declaration, either a division or a key declaration
      * @param priorityList
      *            wish language of the user
      */
-    protected AbstractKeyView(U universal, UniversalRule universalRule, List<LanguageRange> priorityList) {
-        this.universal = universal;
-        this.universalRule = universalRule;
+    protected AbstractKeyView(D declaration, Rule rule, List<LanguageRange> priorityList) {
+        this.declaration = declaration;
+        this.rule = rule;
         this.priorityList = priorityList;
     }
 
     /**
-     * Returns the identifier of the respective universal.
+     * Returns the identifier of the declaration.
      *
      * @return the identifier
      */
     @Override
     public String getId() {
-        return universal.getId();
+        return declaration.getId();
     }
 
     /**
-     * Gives the best matching label for the universal.
+     * Gives the best matching label for declaration.
      *
      * @return the label
      */
     @Override
     public String getLabel() {
-        return universal.getLabel(priorityList);
+        return declaration.getLabel(priorityList);
     }
 
     /**
      * Returns the maximum number of occurrences for this type of metadata.
-     * 
+     *
      * @return the maximum number
      */
     @Override
     public int getMaxOccurs() {
-        return universalRule.getMaxOccurs();
+        return rule.getMaxOccurs();
     }
 
     /**
      * Returns the minimum number of occurrences for this type of metadata.
-     * 
+     *
      * @return the minimum number
      */
     @Override
     public int getMinOccurs() {
-        return universalRule.getMinOccurs();
+        return rule.getMinOccurs();
     }
 
     /**
-     * Indicates whether the universal is undefined.
+     * Indicates whether the declaration is undefined.
      *
-     * @return whether the universal is undefined
+     * @return whether the declaration is undefined
      */
     @Override
     public boolean isUndefined() {
-        return universal.isUndefined();
+        return declaration.isUndefined();
     }
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AuxiliaryTableRow.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AuxiliaryTableRow.java
@@ -58,16 +58,15 @@ class AuxiliaryTableRow<T> {
     }
 
     /**
-     * The universal key provides information about the key.
+     * The key declaration provides information about the key.
      */
-    private UniversalKey universalKey;
+    private KeyDeclaration key;
 
     /**
      * The rule plays a role in terms of repeatability (e.g., single versus
-     * multiple choice) and possible restrictions on list of values. If there is
-     * one.
+     * multiple choice) and possible restrictions on list of values.
      */
-    private UniversalRule universalPermitRule;
+    private Rule rule;
 
     /**
      * If there are edit settings for this metadata type.
@@ -88,13 +87,13 @@ class AuxiliaryTableRow<T> {
     private Set<T> metaDataObjects = new HashSet<>();
 
     /**
-     * Creates a new data row object and enters a universal key into the table.
+     * Creates a new data row object and enters a key into the table.
      *
-     * @param universalKey
-     *            universal key for this row
+     * @param key
+     *            key for this row
      */
-    AuxiliaryTableRow(UniversalKey universalKey, Settings settings) {
-        this.universalKey = universalKey;
+    AuxiliaryTableRow(KeyDeclaration key, Settings settings) {
+        this.key = key;
         this.settings = settings;
     }
 
@@ -143,16 +142,16 @@ class AuxiliaryTableRow<T> {
      * @return the ID
      */
     String getId() {
-        return universalKey.getId();
+        return key.getId();
     }
 
     /**
-     * Returns the universal key for the key handled in this row.
+     * Returns the key handled in this row.
      *
-     * @return the universal key
+     * @return the key
      */
-    UniversalKey getUniversalKey() {
-        return universalKey;
+    KeyDeclaration getKey() {
+        return key;
     }
 
     /**
@@ -163,7 +162,7 @@ class AuxiliaryTableRow<T> {
      * @return the best fitting language label
      */
     String getLabel(List<LanguageRange> priorityList) {
-        return universalKey.getLabel(priorityList);
+        return key.getLabel(priorityList);
     }
 
     /**
@@ -172,13 +171,13 @@ class AuxiliaryTableRow<T> {
      * @return how many type views need to be generated in the result list
      */
     int getNumberOfTypeViewsToGenerate() {
-        if (settings.isExcluded(universalKey.getId())) {
+        if (settings.isExcluded(key.getId())) {
             return 0;
         }
         int objects = metaDataObjects.size();
         int fields = Math.max(
-            Math.max(settings.isAlwaysShowing(universalKey.getId()) ? 1 : 0, universalPermitRule.getMinOccurs()),
-            objects + (oneAdditionalField && universalPermitRule.getMaxOccurs() > objects ? 1 : 0));
+            Math.max(settings.isAlwaysShowing(key.getId()) ? 1 : 0, rule.getMinOccurs()),
+            objects + (oneAdditionalField && rule.getMaxOccurs() > objects ? 1 : 0));
         return isMultipleChoice() ? Math.min(fields, 1) : fields;
     }
 
@@ -190,7 +189,7 @@ class AuxiliaryTableRow<T> {
      * @return whether there are hidden values
      */
     boolean isContainingExcludedData() {
-        return settings.isExcluded(universalKey.getId()) && !metaDataObjects.isEmpty();
+        return settings.isExcluded(key.getId()) && !metaDataObjects.isEmpty();
     }
 
     /**
@@ -199,7 +198,7 @@ class AuxiliaryTableRow<T> {
      * @return whether the metadata type is a multiple choice
      */
     private boolean isMultipleChoice() {
-        return universalKey.isHavingOptions() && universalPermitRule.isRepeatable();
+        return key.isWithOptions() && rule.isRepeatable();
     }
 
     /**
@@ -212,30 +211,29 @@ class AuxiliaryTableRow<T> {
      */
     boolean isPossibleToExpandAnotherField() {
         int previous = oneAdditionalField ? metaDataObjects.size() + 1 : metaDataObjects.size();
-        if (settings.isExcluded(universalKey.getId()) || universalPermitRule.getMinOccurs() > previous
+        if (settings.isExcluded(key.getId()) || rule.getMinOccurs() > previous
                 || isMultipleChoice() && !metaDataObjects.isEmpty()) {
             return false;
         }
-        return universalPermitRule.getMaxOccurs() > previous;
+        return rule.getMaxOccurs() > previous;
     }
 
     /**
-     * Returns whether a complex or simple universal key is to be generated
-     * for this universal key.
+     * Returns whether a complex or simple key is to be generated for this key.
      *
-     * @return whether a complex universal key is to be generated
+     * @return whether a complex key is to be generated
      */
-    boolean isRequiringAComplexUniversalKey() {
-        return universalKey.isComplex();
+    boolean isComplexKey() {
+        return key.isComplex();
     }
 
     /**
-     * Set method for setting the universal permit rule if there is one.
+     * Set method for setting the rule if there is one.
      *
-     * @param universalPermitRule
-     *            universal permit rule to be set
+     * @param rule
+     *            rule to be set
      */
-    void setUniversalPermitRule(UniversalRule universalPermitRule) {
-        this.universalPermitRule = universalPermitRule;
+    void setRule(Rule rule) {
+        this.rule = rule;
     }
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/DivisionDeclaration.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/DivisionDeclaration.java
@@ -25,36 +25,36 @@ import org.kitodo.dataeditor.ruleset.xml.Key;
 import org.kitodo.dataeditor.ruleset.xml.Ruleset;
 
 /**
- * A universal division provides access to a division in the rule set.
+ * The division declaration provides access to a division in the rule set.
  */
-public class UniversalDivision extends UniversalKey {
+public class DivisionDeclaration extends KeyDeclaration {
     /**
      * A reference to the division, if there is any.
      */
     private Optional<Division> optionalDivision;
 
     /**
-     * Create a new universal division.
+     * Creates a new division declaration.
      *
      * @param ruleset
      *            the ruleset
      * @param division
      *            the division
      */
-    public UniversalDivision(Ruleset ruleset, Division division) {
+    public DivisionDeclaration(Ruleset ruleset, Division division) {
         super(ruleset, division.getId(), division.getLabels(), false);
         this.optionalDivision = Optional.of(division);
     }
 
     /**
-     * Create a new universal division for an unknown division.
+     * Creates a new division declaration for an unknown division.
      *
      * @param ruleset
      *            the ruleset
      * @param id
      *            the identifier of the division
      */
-    UniversalDivision(Ruleset ruleset, String id) {
+    DivisionDeclaration(Ruleset ruleset, String id) {
         super(ruleset, id, Collections.emptyList(), true);
         this.optionalDivision = Optional.empty();
     }
@@ -94,14 +94,14 @@ public class UniversalDivision extends UniversalKey {
         return filteredSubdivisions;
     }
 
-    Optional<UniversalKey> getDatesUniversalKey() {
+    Optional<KeyDeclaration> getDatesKey() {
         if (optionalDivision.isPresent()) {
             Division division = optionalDivision.get();
             Optional<String> optionalDatesKeyId = division.getDates();
             if (optionalDatesKeyId.isPresent()) {
                 Optional<Key> optionalKey = ruleset.getKey(optionalDatesKeyId.get());
                 if (optionalKey.isPresent()) {
-                    return Optional.of(new UniversalKey(ruleset, optionalKey.get()));
+                    return Optional.of(new KeyDeclaration(ruleset, optionalKey.get()));
                 }
             }
         }
@@ -118,14 +118,14 @@ public class UniversalDivision extends UniversalKey {
     }
 
     /**
-     * Returns universal divisions for the subdivisions by date.
+     * Returns division declarations for the subdivisions by date.
      *
-     * @return universal divisions for the subdivisions by date
+     * @return division declarations for the subdivisions by date
      */
-    public List<UniversalDivision> getUniversalDivisions() {
+    public List<DivisionDeclaration> getAllowedDivisionDeclarations() {
         if (optionalDivision.isPresent()) {
             return optionalDivision.get().getDivisions().stream()
-                    .map(division -> new UniversalDivision(ruleset, division)).collect(Collectors.toList());
+                    .map(division -> new DivisionDeclaration(ruleset, division)).collect(Collectors.toList());
         } else {
             return Collections.emptyList();
         }
@@ -177,7 +177,7 @@ public class UniversalDivision extends UniversalKey {
 
     /**
      * Gets the division.
-     * 
+     *
      * @return the division
      */
     public Division getDivision() {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/DivisionView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/DivisionView.java
@@ -24,25 +24,25 @@ import org.kitodo.dataeditor.ruleset.xml.Ruleset;
  * A division view gives us a sight of a division. The view qualifies according
  * to the division, acquisition stage and language(s).
  */
-class DivisionView extends NestedKeyView<UniversalDivision> implements StructuralElementViewInterface {
+class DivisionView extends NestedKeyView<DivisionDeclaration> implements StructuralElementViewInterface {
     /**
      * Creates a division view. The view qualifies according to the division,
      * acquisition stage and language(s).
      *
      * @param ruleset
      *            the ruleset
-     * @param universalDivision
-     *            the universal division
+     * @param divisionDeclaration
+     *            the division declaration
      * @param acquisitionStage
      *            the acquisition stage
      * @param priorityList
      *            the user's wish list for the best possible translation
      */
-    public DivisionView(Ruleset ruleset, UniversalDivision universalDivision, String acquisitionStage,
+    public DivisionView(Ruleset ruleset, DivisionDeclaration divisionDeclaration, String acquisitionStage,
             List<LanguageRange> priorityList) {
 
-        super(ruleset, universalDivision,
-                ruleset.getUniversalRestrictionRuleForDivision(universalDivision.getId()),
+        super(ruleset, divisionDeclaration,
+                ruleset.getRuleForDivision(divisionDeclaration.getId()),
                 ruleset.getSettings(acquisitionStage), priorityList, true);
     }
 
@@ -56,11 +56,11 @@ class DivisionView extends NestedKeyView<UniversalDivision> implements Structura
      */
     @Override
     public Map<String, String> getAllowedSubstructuralElements() {
-        boolean hasSubdivisionByDate = universal.hasSubdivisionByDate();
+        boolean hasSubdivisionByDate = declaration.hasSubdivisionByDate();
         Map<String, String> declaredDivisions = ruleset.getDivisions(priorityList, true, hasSubdivisionByDate);
-        Map<String, String> filteredDivisions = universalRule.getAllowedSubdivisions(declaredDivisions);
+        Map<String, String> filteredDivisions = rule.getAllowedSubdivisions(declaredDivisions);
         if (hasSubdivisionByDate) {
-            return universal.getAllowedSubdivisions(filteredDivisions);
+            return declaration.getAllowedSubdivisions(filteredDivisions);
         } else {
             return filteredDivisions;
         }
@@ -68,13 +68,13 @@ class DivisionView extends NestedKeyView<UniversalDivision> implements Structura
 
     @Override
     public Optional<DatesSimpleMetadataViewInterface> getDatesSimpleMetadata() {
-        Optional<UniversalKey> optionalUniversalKey = universal.getDatesUniversalKey();
-        if (optionalUniversalKey.isPresent()) {
-            KeyView datesKeyView = new KeyView(optionalUniversalKey.get(),
-                    universalRule.getUniversalPermitRuleForKey(optionalUniversalKey.get().getId(), division), settings,
+        Optional<KeyDeclaration> optionalDatesKey = declaration.getDatesKey();
+        if (optionalDatesKey.isPresent()) {
+            KeyView datesKeyView = new KeyView(optionalDatesKey.get(),
+                    rule.getRuleForKey(optionalDatesKey.get().getId(), division), settings,
                     priorityList);
-            datesKeyView.setScheme(universal.getScheme());
-            datesKeyView.setYearBegin(universal.getYearBegin());
+            datesKeyView.setScheme(declaration.getScheme());
+            datesKeyView.setYearBegin(declaration.getYearBegin());
             return Optional.of(datesKeyView);
         } else {
             return Optional.empty();
@@ -83,6 +83,6 @@ class DivisionView extends NestedKeyView<UniversalDivision> implements Structura
 
     @Override
     public Optional<String> getProcessTitle() {
-        return universal.getProcessTitle();
+        return declaration.getProcessTitle();
     }
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyDeclaration.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyDeclaration.java
@@ -29,32 +29,32 @@ import org.kitodo.dataeditor.ruleset.xml.Ruleset;
 import org.kitodo.dataeditor.ruleset.xml.Type;
 
 /**
- * A universal key provides access to a key in the ruleset. A key in the ruleset
- * can either be nestable or simple, both are both possible and have the same
- * universal key. Distinction is only view of the nested key view or normal key
- * view for it.
+ * A key declaration provides access to a key element in the ruleset. A key in
+ * the ruleset can either be nestable or simple, both are both possible and have
+ * the same declaration. Distinction is only view of the nested key view or
+ * normal key view for it.
  */
-class UniversalKey extends Labeled {
+class KeyDeclaration extends Labeled {
     /**
      * The key, if there is one.
      */
     private final Optional<Key> optionalKey;
 
     /**
-     * This constructor produces a universal key for a known key.
+     * Creates a key declaration for a known key.
      *
      * @param ruleset
      *            the ruleset
      * @param key
      *            the key
      */
-    UniversalKey(Ruleset ruleset, Key key) {
+    KeyDeclaration(Ruleset ruleset, Key key) {
         super(ruleset, key.getId(), key.getLabels(), false);
         optionalKey = Optional.of(key);
     }
 
     /**
-     * This constructor produces a universal key for a known key.
+     * Creates a key declaration for a known key.
      *
      * @param ruleset
      *            the ruleset
@@ -63,33 +63,31 @@ class UniversalKey extends Labeled {
      * @param undefined
      *            whether he is undefined or not
      */
-    UniversalKey(Ruleset ruleset, Key key, boolean undefined) {
+    KeyDeclaration(Ruleset ruleset, Key key, boolean undefined) {
         super(ruleset, key.getId(), key.getLabels(), undefined);
         optionalKey = Optional.of(key);
     }
 
     /**
-     * This constructor produces a universal key for an unknown key. A key is
-     * unknown if it is not in the ruleset (but it is in the data!) This, one
-     * must be able to handle and not the application crashes. Here we want to
-     * be better than before when nothing went.
+     * Creates a key declaration for an unknown known key. A key is unknown if
+     * it is not in the ruleset, but it is in the data. This case must be
+     * handled.
      *
      * @param ruleset
      *            the ruleset
      * @param id
      *            the identifier of the key
      */
-    UniversalKey(Ruleset ruleset, String id) {
+    KeyDeclaration(Ruleset ruleset, String id) {
         super(ruleset, id, Collections.emptyList(), true);
         optionalKey = Optional.empty();
     }
 
     /**
-     * Create a new universal division. This constructor is called by the
-     * universal division to create a fake universal key for a division. Because
-     * basically a division is nothing more than a nested key only with extra
-     * feature. Basically, most of the data is pretty much the same anyway, just
-     * different.
+     * Create a new division declaration. This constructor is called by the
+     * subclass {@link DivisionDeclaration} to create a division declaration,
+     * which is a subclass of a key declaration, because a division is a nested
+     * key with extra features.
      *
      * @param ruleset
      *            the ruleset
@@ -100,7 +98,7 @@ class UniversalKey extends Labeled {
      * @param undefined
      *            whether the division is unknown
      */
-    protected UniversalKey(Ruleset ruleset, String id, Collection<Label> labels, boolean undefined) {
+    protected KeyDeclaration(Ruleset ruleset, String id, Collection<Label> labels, boolean undefined) {
         super(ruleset, id, labels, undefined);
         optionalKey = Optional.of(ruleset.getFictiousRulesetKey());
     }
@@ -128,31 +126,31 @@ class UniversalKey extends Labeled {
     }
 
     /**
-     * Issues a universal key for a subkey (for nested keys).
+     * Returns a key declaration for a subkey (for nested keys).
      *
      * @param keyId
-     *            identifier of the required universal key
-     * @return a universal key for the subkey
+     *            identifier of the required key declaration
+     * @return a key declaration for the sub-key
      */
-    UniversalKey getUniversalKey(String keyId) {
+    KeyDeclaration getSubkeyDeclaration(String keyId) {
         if (optionalKey.isPresent()) {
             Optional<Key> keyInKey = optionalKey.get().getKeys().parallelStream()
                     .filter(key -> keyId.equals(key.getId())).findAny();
             if (keyInKey.isPresent()) {
-                return new UniversalKey(ruleset, keyInKey.get());
+                return new KeyDeclaration(ruleset, keyInKey.get());
             }
         }
-        return new UniversalKey(ruleset, keyId);
+        return new KeyDeclaration(ruleset, keyId);
     }
 
     /**
-     * Issues universal keys for all subkeys.
+     * Returns key declarations for all sub-keys.
      *
-     * @return a universal keys for all subkeys
+     * @return key declarations for all sub-keys
      */
-    Collection<UniversalKey> getUniversalKeys() {
+    Collection<KeyDeclaration> getKeyDeclarations() {
         if (optionalKey.isPresent()) {
-            return optionalKey.get().getKeys().parallelStream().map(key -> new UniversalKey(ruleset, key))
+            return optionalKey.get().getKeys().parallelStream().map(key -> new KeyDeclaration(ruleset, key))
                     .collect(Collectors.toList());
         } else {
             return Collections.emptyList();
@@ -160,7 +158,7 @@ class UniversalKey extends Labeled {
     }
 
     /**
-     * Returns the namespace of the key if there is one. This is needed for
+     * Returns the namespace of the key, if there is one. This is needed for
      * validation.
      *
      * @return the namespace of the key, if any
@@ -243,11 +241,11 @@ class UniversalKey extends Labeled {
     }
 
     /**
-     * Returns whether the universal key has options.
+     * Returns whether the key declaration has options.
      *
-     * @return whether the universal key has options
+     * @return whether the key declaration has options
      */
-    boolean isHavingOptions() {
+    boolean isWithOptions() {
         if (optionalKey.isPresent()) {
             return !optionalKey.get().getOptions().isEmpty();
         } else {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
@@ -32,7 +32,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.InputType;
 /**
  * A view on a key.
  */
-class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetadataViewInterface {
+class KeyView extends AbstractKeyView<KeyDeclaration> implements DatesSimpleMetadataViewInterface {
     /**
      * The schema in which the part of the date relevant to this division is
      * stored. Apart from the dates built into Java and interpreted by the
@@ -55,19 +55,19 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
     /**
      * A new key view is created.
      *
-     * @param universalKey
-     *            the universal key
-     * @param universalRule
-     *            the universal rule
+     * @param keyDeclaration
+     *            the key declaration
+     * @param rule
+     *            the rule
      * @param settings
      *            the settings
      * @param priorityList
      *            the user’s wish list for the preferred human language
      */
-    KeyView(UniversalKey universalKey, UniversalRule universalRule, Settings settings,
+    KeyView(KeyDeclaration keyDeclaration, Rule rule, Settings settings,
             List<LanguageRange> priorityList) {
 
-        super(universalKey, universalRule, priorityList);
+        super(keyDeclaration, rule, priorityList);
         this.settings = settings;
     }
 
@@ -78,7 +78,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
      */
     @Override
     public Collection<String> getDefaultItems() {
-        return universal.getDefaultItems();
+        return declaration.getDefaultItems();
     }
 
     /**
@@ -92,7 +92,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
          * If the metadata key has a type that requires a special input field,
          * return the corresponding field type.
          */
-        switch (universal.getType()) {
+        switch (declaration.getType()) {
             case ANY_URI:
                 return InputType.ONE_LINE_TEXT;
             case BOOLEAN:
@@ -109,11 +109,11 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
          * If the metadata key defines options, return the corresponding
          * selection type.
          */
-        if (universal.isHavingOptions()) {
-            if (universalRule.isRepeatable()) {
+        if (declaration.isWithOptions()) {
+            if (rule.isRepeatable()) {
                 return InputType.MULTIPLE_SELECTION;
             }
-            if (settings.isMultiline(universal.getId())) {
+            if (settings.isMultiline(declaration.getId())) {
                 return InputType.MULTI_LINE_SINGLE_SELECTION;
             } else {
                 return InputType.ONE_LINE_SINGLE_SELECTION;
@@ -121,7 +121,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
         }
 
         // otherwise, check if the key is required to have an enlarged text box
-        if (settings.isMultiline(universal.getId())) {
+        if (settings.isMultiline(declaration.getId())) {
             return InputType.MULTI_LINE_TEXT;
         } else {
             return InputType.ONE_LINE_TEXT;
@@ -143,7 +143,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
      */
     @Override
     public Map<String, String> getSelectItems() {
-        return universalRule.getSelectItems(universal.getSelectItems(priorityList));
+        return rule.getSelectItems(declaration.getSelectItems(priorityList));
     }
 
     @Override
@@ -153,7 +153,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
 
     @Override
     public boolean isEditable() {
-        return settings.isEditable(universal.getId());
+        return settings.isEditable(declaration.getId());
     }
 
     /**
@@ -175,7 +175,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
      *         specified
      */
     private boolean isLocatedInTheNamespace(String uri) {
-        Optional<String> optionalNamespace = universal.getNamespace();
+        Optional<String> optionalNamespace = declaration.getNamespace();
         if (optionalNamespace.isPresent()) {
             String namespaceAsStated = optionalNamespace.get();
             boolean endsWithSlash = namespaceAsStated.endsWith("/");
@@ -206,10 +206,10 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
          * This simplifies the examination considerably.
          */
         try {
-            if (Objects.isNull(universal) || Objects.isNull(value)) {
+            if (Objects.isNull(declaration) || Objects.isNull(value)) {
                 return false;
             }
-            switch (universal.getType()) {
+            switch (declaration.getType()) {
                 case ANY_URI:
                     if (!isLocatedInTheNamespace(value)) {
                         return false;
@@ -232,8 +232,8 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
         }
 
         // If the key has options, then the value must be in it.
-        if (universal.isHavingOptions()
-                && !universalRule.getSelectItems(universal.getSelectItems(priorityList)).containsKey(value)) {
+        if (declaration.isWithOptions()
+                && !rule.getSelectItems(declaration.getSelectItems(priorityList)).containsKey(value)) {
             return false;
         }
 
@@ -242,7 +242,7 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
          * tests can be combined with each other, then all conditions must
          * apply.
          */
-        Optional<Pattern> optionalPattern = universal.getPattern();
+        Optional<Pattern> optionalPattern = declaration.getPattern();
         if (!optionalPattern.isPresent()) {
             return true;
         }
@@ -259,6 +259,6 @@ class KeyView extends AbstractKeyView<UniversalKey> implements DatesSimpleMetada
 
     @Override
     public Optional<Domain> getDomain() {
-        return universal.getDomain();
+        return declaration.getDomain();
     }
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Labeled.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Labeled.java
@@ -135,8 +135,8 @@ public class Labeled {
 
     /**
      * Constructor for a provider for translated labels. This is protected and
-     * called only by subclass as part of it. Every universal key, also nesting
-     * keys and divisions are labeled and so that summarized.
+     * called only by subclasses, as part of them. Every key declaration, also
+     * nesting keys and divisions are labeled.
      *
      * @param ruleset
      *            the ruleset

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
@@ -41,7 +41,8 @@ public class Rule {
      * @return key is triple
      */
     private static Triple<String, String, String> formAKeyForARuleInATemporaryMap(RestrictivePermit restrictivePermit) {
-        return Triple.of(restrictivePermit.getDivision().orElse(null), restrictivePermit.getKey().orElse(null), restrictivePermit.getValue().orElse(null));
+        return Triple.of(restrictivePermit.getDivision().orElse(null), restrictivePermit.getKey().orElse(null),
+            restrictivePermit.getValue().orElse(null));
     }
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/RulesetManagement.java
@@ -82,8 +82,8 @@ public class RulesetManagement implements RulesetManagementInterface {
 
     @Override
     public Collection<String> getDivisionsWithNoWorkflow() {
-        Collection<UniversalDivision> universalDivisions = ruleset.getUniversalDivisions(true, true);
-        List<Division> divisions = universalDivisions.stream().map(UniversalDivision::getDivision)
+        Collection<DivisionDeclaration> divisionDeclarations = ruleset.getDivisionDeclarations(true, true);
+        List<Division> divisions = divisionDeclarations.stream().map(DivisionDeclaration::getDivision)
                 .collect(Collectors.toList());
         return getDivionsWithNoWorkflow(divisions);
     }
@@ -162,9 +162,9 @@ public class RulesetManagement implements RulesetManagementInterface {
             List<LanguageRange> priorityList) {
 
         Optional<Division> division = ruleset.getDivision(divisionId);
-        UniversalDivision universalDivision = division.isPresent() ? new UniversalDivision(ruleset, division.get())
-                : new UniversalDivision(ruleset, divisionId);
-        return new DivisionView(ruleset, universalDivision, acquisitionStage, priorityList);
+        DivisionDeclaration divisionDeclaration = division.isPresent() ? new DivisionDeclaration(ruleset, division.get())
+                : new DivisionDeclaration(ruleset, divisionId);
+        return new DivisionView(ruleset, divisionDeclaration, acquisitionStage, priorityList);
     }
 
     /**
@@ -179,11 +179,11 @@ public class RulesetManagement implements RulesetManagementInterface {
      * @return a view on a metadata
      */
     @Override
-    public NestedKeyView<UniversalKey> getMetadataView(String keyId, String acquisitionStage, List<LanguageRange> priorityList) {
+    public NestedKeyView<KeyDeclaration> getMetadataView(String keyId, String acquisitionStage, List<LanguageRange> priorityList) {
         Optional<Key> key = ruleset.getKey(keyId);
-        UniversalKey universalKey = key.isPresent() ? new UniversalKey(ruleset, key.get()) : new UniversalKey(ruleset, keyId);
-        UniversalRule universalRule = ruleset.getUniversalRestrictionRuleForKey(keyId);
-        return new NestedKeyView<>(ruleset, universalKey, universalRule, ruleset.getSettings(acquisitionStage), priorityList);
+        KeyDeclaration keyDeclaration = key.isPresent() ? new KeyDeclaration(ruleset, key.get()) : new KeyDeclaration(ruleset, keyId);
+        Rule rule = ruleset.getRuleForKey(keyId);
+        return new NestedKeyView<>(ruleset, keyDeclaration, rule, ruleset.getSettings(acquisitionStage), priorityList);
     }
 
     /**
@@ -200,8 +200,8 @@ public class RulesetManagement implements RulesetManagementInterface {
     public Optional<String> getTranslationForKey(String key, List<LanguageRange> priorityList) {
         Optional<Key> optionalKey = ruleset.getKey(key);
         if (optionalKey.isPresent()) {
-            UniversalKey universalKey = new UniversalKey(ruleset, optionalKey.get());
-            String label = universalKey.getLabel(priorityList);
+            KeyDeclaration keyDeclaration = new KeyDeclaration(ruleset, optionalKey.get());
+            String label = keyDeclaration.getLabel(priorityList);
             return Optional.of(label);
         } else {
             return Optional.empty();

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
@@ -21,21 +21,23 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 /**
- * A rule of the ruleset. The rules in the rule set differ in restriction and
- * permit rules, but basically it is the same object that is defined in this
- * rule class.
+ * A restrictive permit rule of the ruleset. The rules in the ruleset are
+ * written as {@code <restriction>} containing {@code <permit>} rules, but it is
+ * the same underlying object.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-public class Rule {
+public class RestrictivePermit {
+
     /**
      * Division to which this (restriction) rule applies, or division that is
-     * allowed (permit rule).
+     * allowed (for permit rule inside restriction rule).
      */
     @XmlAttribute
     private String division;
 
     /**
-     * Key that is allowed (permit rule).
+     * Key to which this (restriction) rule applies, or key that is allowed (for
+     * permit rule inside restriction rule).
      */
     @XmlAttribute
     private String key;
@@ -69,7 +71,7 @@ public class Rule {
      * List of permit rules. Recursion is possible.
      */
     @XmlElement(name = "permit", namespace = "http://names.kitodo.org/ruleset/v2")
-    private List<Rule> permits = new LinkedList<>();
+    private List<RestrictivePermit> permits = new LinkedList<>();
 
     /**
      * Returns the division to which this rule applies, or which is allowed.
@@ -114,7 +116,7 @@ public class Rule {
      *
      * @return the permission rules
      */
-    public List<Rule> getPermits() {
+    public List<RestrictivePermit> getPermits() {
         return permits;
     }
 
@@ -182,7 +184,7 @@ public class Rule {
      * @param permits
      *            permits to be set
      */
-    public void setPermits(List<Rule> permits) {
+    public void setPermits(List<RestrictivePermit> permits) {
         this.permits = permits;
     }
 

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Ruleset.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Ruleset.java
@@ -26,10 +26,10 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
+import org.kitodo.dataeditor.ruleset.DivisionDeclaration;
 import org.kitodo.dataeditor.ruleset.Labeled;
+import org.kitodo.dataeditor.ruleset.Rule;
 import org.kitodo.dataeditor.ruleset.Settings;
-import org.kitodo.dataeditor.ruleset.UniversalDivision;
-import org.kitodo.dataeditor.ruleset.UniversalRule;
 
 /**
  * This class maps the XML root element of the rule set. The ruleset is the
@@ -158,38 +158,45 @@ public class Ruleset {
      * @return all outline elements as map from IDs to labels
      */
     public Map<String, String> getDivisions(List<LanguageRange> priorityList, boolean all, boolean subdivisionsByDate) {
-        Collection<UniversalDivision> universalDivisions = getUniversalDivisions(all, subdivisionsByDate);
-        return all || !universalDivisions.isEmpty() ? Labeled.listByTranslatedLabel(this,
-            universalDivisions, UniversalDivision::getId, UniversalDivision::getLabels, priorityList)
+        Collection<DivisionDeclaration> divisionDeclarations = getDivisionDeclarations(all, subdivisionsByDate);
+        return all || !divisionDeclarations.isEmpty() ? Labeled.listByTranslatedLabel(this,
+            divisionDeclarations, DivisionDeclaration::getId, DivisionDeclaration::getLabels, priorityList)
                 : getDivisions(priorityList, true, subdivisionsByDate);
     }
 
     /**
-     * get all universalDivisions as Collection.
-     * @param all if all divisions should be respected.
-     * @param subdivisionsByDate if subdivisionsByDate should be respected.
-     * @return a collection of universalDivisions.
+     * Returns all division declarations as a collection.
+     *
+     * @param all
+     *            if true, returns all division declarations; if false, only
+     *            returns division declarations with {@code processTitle}
+     *            attribute set, which indicates that they are candidates for
+     *            the logical root type, which typically corresponds to the
+     *            media format
+     * @param subdivisionsByDate
+     *            if subdivisions by date should be included
+     * @return a collection of division declarations
      */
-    public Collection<UniversalDivision> getUniversalDivisions(boolean all, boolean subdivisionsByDate) {
-        Collection<UniversalDivision> universalDivisions = new LinkedList<>();
+    public Collection<DivisionDeclaration> getDivisionDeclarations(boolean all, boolean subdivisionsByDate) {
+        Collection<DivisionDeclaration> divisionDeclarations = new LinkedList<>();
         for (Division division : declaration.getDivisions()) {
-            UniversalDivision universalDivision = new UniversalDivision(this, division);
-            if (all || universalDivision.getProcessTitle().isPresent()) {
-                universalDivisions.add(universalDivision);
+            DivisionDeclaration divisionDeclaration = new DivisionDeclaration(this, division);
+            if (all || divisionDeclaration.getProcessTitle().isPresent()) {
+                divisionDeclarations.add(divisionDeclaration);
             }
             if (subdivisionsByDate) {
-                for (UniversalDivision subdivision : universalDivision.getUniversalDivisions()) {
+                for (DivisionDeclaration subdivision : divisionDeclaration.getAllowedDivisionDeclarations()) {
                     if (all || subdivision.getProcessTitle().isPresent()) {
-                        universalDivisions.add(subdivision);
+                        divisionDeclarations.add(subdivision);
                     }
                 }
             }
         }
-        return universalDivisions;
+        return divisionDeclarations;
     }
 
     /**
-     * This will allow a key to come out of the ruleset.
+     * Returns a key from the ruleset, if defined.
      *
      * @param keyId
      *            Identifier of the key
@@ -200,7 +207,7 @@ public class Ruleset {
     }
 
     /**
-     * So you can get the restriction on a key, if there is one.
+     * Returns the restriction on a key, if there is one.
      *
      * @param keyId
      *            key for which the restriction is to be given
@@ -212,9 +219,9 @@ public class Ruleset {
     }
 
     /**
-     * Returns the total list of all keys returned by the ruleset.
+     * Returns the complete list of all keys in this ruleset.
      *
-     * @return all keys of the rule set
+     * @return all keys in this ruleset
      */
     public List<Key> getKeys() {
         if (Objects.isNull(keys)) {
@@ -318,31 +325,28 @@ public class Ruleset {
     }
 
     /**
-     * Returns a universal restriction rule for a key. That can be empty but it
-     * works.
+     * Returns a rule for a key. The rule may be empty.
      *
      * @param keyId
-     *            key for which a universal restriction rule is to be returned
-     * @return universal restriction rule for key
+     *            key for which a rule is to be returned
+     * @return rule for the key
      */
-    public UniversalRule getUniversalRestrictionRuleForKey(String keyId) {
-        return new UniversalRule(this, this.getKeyRestriction(keyId));
+    public Rule getRuleForKey(String keyId) {
+        return new Rule(this, this.getKeyRestriction(keyId));
     }
 
     /**
-     * Returns a universal restriction rule for a division. That can be empty but
-     * it works.
+     * Returns a rule for a division. The rule may be empty.
      *
      * @param division
-     *            division for which a universal restriction rule is to be
-     *            returned
-     * @return universal restriction rule for division
+     *            division for which a rule is to be returned
+     * @return rule for division
      */
-    public UniversalRule getUniversalRestrictionRuleForDivision(String division) {
+    public Rule getRuleForDivision(String division) {
         if (Objects.isNull(division)) {
-            return new UniversalRule(this, this.getDivisionRestriction(""));
+            return new Rule(this, this.getDivisionRestriction(""));
         } else {
-            return new UniversalRule(this, this.getDivisionRestriction(division));
+            return new Rule(this, this.getDivisionRestriction(division));
         }
     }
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Ruleset.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Ruleset.java
@@ -57,7 +57,7 @@ public class Ruleset {
      */
     @XmlElementWrapper(name = "correlation", namespace = "http://names.kitodo.org/ruleset/v2")
     @XmlElement(name = "restriction", namespace = "http://names.kitodo.org/ruleset/v2")
-    private List<Rule> restrictions = new LinkedList<>();
+    private List<RestrictivePermit> restrictions = new LinkedList<>();
 
     /**
      * In the editing section settings for the editor concerning keys are
@@ -129,8 +129,9 @@ public class Ruleset {
      *            Division to search a restriction rule for
      * @return the restriction rule if there is one
      */
-    public Optional<Rule> getDivisionRestriction(String division) {
-        return restrictions.parallelStream().filter(rule -> division.equals(rule.getDivision().orElse(null)))
+    public Optional<RestrictivePermit> getDivisionRestriction(String division) {
+        return restrictions.parallelStream()
+                .filter(restriction -> division.equals(restriction.getDivision().orElse(null)))
                 .findFirst();
     }
 
@@ -205,8 +206,9 @@ public class Ruleset {
      *            key for which the restriction is to be given
      * @return the restriction on a key, if any
      */
-    public Optional<Rule> getKeyRestriction(String keyId) {
-        return restrictions.parallelStream().filter(rule -> keyId.equals(rule.getKey().orElse(null))).findAny();
+    public Optional<RestrictivePermit> getKeyRestriction(String keyId) {
+        return restrictions.parallelStream().filter(restriction -> keyId.equals(restriction.getKey().orElse(null)))
+                .findAny();
     }
 
     /**

--- a/Kitodo/rulesets/ruleset.xsd
+++ b/Kitodo/rulesets/ruleset.xsd
@@ -129,7 +129,7 @@
                 'technical' is to store internal data that must be saved during processing, for example scanner and OCR
                     settings. The area is sometimes referred to simply as properties.
 
-                'mets:div' writes the value in an attribute of the &tl;mets:div&gt; XML element. Only the "id"s
+                'mets:div' writes the value in an attribute of the &lt;mets:div&gt; XML element. Only the "id"s
                     'LABEL', 'ORDERLABEL' (type: character string) and 'CONTENTIDS' (type: any URI) are permitted here.
             </xs:documentation>
         </xs:annotation>
@@ -240,7 +240,7 @@
         <xs:attribute use="required" type="xs:string" name="value"/>
     </xs:complexType>
 
-    <xs:complexType name="Rule">
+    <xs:complexType name="RestrictivePermit">
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 With rules regarding &lt;restriction&gt;s and &lt;permit&gt;s on how divisions and metadata may be
@@ -255,7 +255,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:Rule"/>
+            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
         </xs:sequence>
         <xs:attribute type="xs:NMTOKEN" name="division"/>
         <xs:attribute type="xs:NMTOKEN" name="key"/>
@@ -282,7 +282,7 @@
                 <xs:element name="correlation" minOccurs="0" maxOccurs="1">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="restriction" minOccurs="1" maxOccurs="unbounded" type="ruleset:Rule"/>
+                            <xs:element name="restriction" minOccurs="1" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>


### PR DESCRIPTION
In the ruleset module, there was this strange naming of the “universals”. I called it that at the time, because I couldn't think of anything better, but now, looking at it with a time lag, this is clearly the simpler name, so I would like to change this. It's just renaming, not a functional difference.