### PR TITLE
Let the ruleset module know about metadata

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
@@ -11,12 +11,7 @@
 
 package org.kitodo.api;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class Metadata {
     /**
@@ -78,18 +73,5 @@ public class Metadata {
         Metadata metadata = (Metadata) o;
         return domain == metadata.domain
                 && Objects.equals(key, metadata.key);
-    }
-
-    /**
-     * Map Collection of Metadata objects to a Map of Metadata and String objects.
-     * @param metadataCollection Collection of Metadata objects
-     * @return Map of Metadata and String objects as java.util.Map
-     */
-    public static Map<Metadata, String> mapToKey(Collection<Metadata> metadataCollection) {
-        if (Objects.isNull(metadataCollection)) {
-            return Collections.emptyMap();
-        }
-        return metadataCollection.parallelStream()
-                .collect(Collectors.toMap(Function.identity(), Metadata::getKey, (duplicateOne, duplicateTwo) -> duplicateOne));
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/ComplexMetadataViewInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/ComplexMetadataViewInterface.java
@@ -13,7 +13,8 @@ package org.kitodo.api.dataeditor.rulesetmanagement;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+
+import org.kitodo.api.Metadata;
 
 /**
  * Provides an interface for the complex-type view service. The complex-type
@@ -32,7 +33,7 @@ public interface ComplexMetadataViewInterface extends MetadataViewInterface {
      *            metadata keys that the user has already selected
      * @return the metadata keys that the user can add
      */
-    Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> entered,
+    Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected);
 
     /**
@@ -50,8 +51,6 @@ public interface ComplexMetadataViewInterface extends MetadataViewInterface {
      * keys that the user has already manually added. The list is created and
      * then sorted according to the given sorting rules.
      *
-     * @param <T>
-     *            the type of metadata objects
      * @param entered
      *            metadata objects that have already been entered, along with
      *            their key
@@ -61,7 +60,7 @@ public interface ComplexMetadataViewInterface extends MetadataViewInterface {
      *         already filled with values, the values are returned here. If a
      *         key is a multiple-selection, values are grouped below it.
      */
-    <T> List<MetadataViewWithValuesInterface<T>> getSortedVisibleMetadata(Map<T, String> entered,
+    List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected);
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/MetadataViewWithValuesInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/MetadataViewWithValuesInterface.java
@@ -14,6 +14,8 @@ package org.kitodo.api.dataeditor.rulesetmanagement;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
+
 /**
  * Return value of the function
  * {@code ComplexMetadataViewInterface.getSortedVisibleMetadatas()}. The
@@ -26,11 +28,8 @@ import java.util.Optional;
  * is {@code List<Pair<MetadataViewInterface, Collection<T>>>}. Since the key
  * must be repeatable if there is more than one value but the key is not a
  * multiple choice, a map would be an inappropriate choice at this point.
- *
- * @param <T>
- *            type of data objects
  */
-public interface MetadataViewWithValuesInterface<T> {
+public interface MetadataViewWithValuesInterface {
     /**
      * Returns the key to be displayed at this point. The interface can return
      * entries where the key is {@code null} with values if there were values
@@ -48,5 +47,5 @@ public interface MetadataViewWithValuesInterface<T> {
      *
      * @return the values for the key
      */
-    Collection<T> getValues();
+    Collection<Metadata> getValues();
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AuxiliaryTableRow.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AuxiliaryTableRow.java
@@ -19,22 +19,19 @@ import java.util.List;
 import java.util.Locale.LanguageRange;
 import java.util.Set;
 
+import org.kitodo.api.Metadata;
+
 /**
  * Class of the data row objects of the auxiliary table. You can imagine the
  * list of these objects in the metadata acquisition mask builder as a large
  * table in which all relevant information is entered, one row per metadata
  * type, in the order in which the metadata types must be displayed later.
- *
- * @param <T>
- *            the type of metadata objects
  */
-class AuxiliaryTableRow<T> {
+class AuxiliaryTableRow {
     /**
      * Returns the umpteenth set member as the only element of a list, if that
      * exists. Otherwise the empty list.
      *
-     * @param <T>
-     *            the type of the metadata objects
      * @param unnumbered
      *            unnumbered collection
      * @param fictitiousNumber
@@ -84,7 +81,7 @@ class AuxiliaryTableRow<T> {
      * which class these objects have, it still accepts them and provides for
      * possibly necessary grouping.
      */
-    private Set<T> metaDataObjects = new HashSet<>();
+    private Set<Metadata> metaDataObjects = new HashSet<>();
 
     /**
      * Creates a new data row object and enters a key into the table.
@@ -103,7 +100,7 @@ class AuxiliaryTableRow<T> {
      * @param metaDataObject
      *            valuable object added
      */
-    void add(T metaDataObject) {
+    void add(Metadata metaDataObject) {
         metaDataObjects.add(metaDataObject);
 
     }
@@ -126,7 +123,7 @@ class AuxiliaryTableRow<T> {
      *            which object should be returned
      * @return the data object(s)
      */
-    Collection<T> getDataObjects(int i) {
+    Collection<Metadata> getDataObjects(int i) {
         if (isMultipleChoice() || isContainingExcludedData()) {
             return metaDataObjects;
         } else {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/FormRow.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/FormRow.java
@@ -14,6 +14,7 @@ package org.kitodo.dataeditor.ruleset;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewWithValuesInterface;
 
@@ -21,11 +22,8 @@ import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewWithValuesInterfa
  * Return type for list entries consisting of a metadata key and a collection
  * of values. Instances of this class are returned by the metadata acquisition
  * mask builder and each represent a line of the metadata input mask.
- *
- * @param <T>
- *            type of metadata objects
  */
-class FormRow<T> implements MetadataViewWithValuesInterface<T> {
+class FormRow implements MetadataViewWithValuesInterface {
     /**
      * A possible view on the key. None, if it is hidden.
      */
@@ -34,9 +32,9 @@ class FormRow<T> implements MetadataViewWithValuesInterface<T> {
     /**
      * The values. This is always one at most, except for multiple selections.
      */
-    private Collection<T> values;
+    private Collection<Metadata> values;
 
-    FormRow(Optional<MetadataViewInterface> optionalKeyView, Collection<T> values) {
+    FormRow(Optional<MetadataViewInterface> optionalKeyView, Collection<Metadata> values) {
         this.optionalKeyView = optionalKeyView;
         this.values = values;
     }
@@ -58,7 +56,7 @@ class FormRow<T> implements MetadataViewWithValuesInterface<T> {
      * @return the values
      */
     @Override
-    public Collection<T> getValues() {
+    public Collection<Metadata> getValues() {
         return values;
     }
 

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
@@ -19,11 +19,10 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale.LanguageRange;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.TreeMap;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -64,7 +63,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *             in the ruleset.
      */
     private static final <V> void addFieldsForAdditionallySelectedKeys(Collection<String> additionallySelectedKeys,
-            LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable) {
+            LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable) {
 
         additionallySelectedKeys.parallelStream().map(auxiliaryTable::get)
                 .forEach(AuxiliaryTableRow::addOneAdditionalField);
@@ -74,17 +73,15 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * Appends the rows to the auxiliary table. Since the order of the rows is
      * relevant, you cannot parallelize here.
      *
-     * @param <V>
-     *            the type of metadata values
      * @param rows
      *            rows to append
      * @param auxiliaryTable
      *            auxiliary table to append to
      */
-    private static final <V> void appendRowsToAuxiliaryTable(Collection<AuxiliaryTableRow<V>> rows,
-            LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable) {
+    private static final void appendRowsToAuxiliaryTable(Collection<AuxiliaryTableRow> rows,
+            LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable) {
 
-        for (AuxiliaryTableRow<V> auxiliaryTableRow : rows) {
+        for (AuxiliaryTableRow auxiliaryTableRow : rows) {
             auxiliaryTable.put(auxiliaryTableRow.getId(), auxiliaryTableRow);
         }
     }
@@ -103,11 +100,11 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            the wish list of the user’s preferred human language
      * @return sorted list of fields
      */
-    private static final <V> Collection<AuxiliaryTableRow<V>> sort(
-            HashMap<String, AuxiliaryTableRow<V>> auxiliaryTableToBeSorted, List<LanguageRange> priorityList) {
+    private static final <V> Collection<AuxiliaryTableRow> sort(
+            HashMap<String, AuxiliaryTableRow> auxiliaryTableToBeSorted, List<LanguageRange> priorityList) {
 
-        TreeMap<String, AuxiliaryTableRow<V>> sorted = new TreeMap<>();
-        for (AuxiliaryTableRow<V> auxiliaryTableRow : auxiliaryTableToBeSorted.values()) {
+        TreeMap<String, AuxiliaryTableRow> sorted = new TreeMap<>();
+        for (AuxiliaryTableRow auxiliaryTableRow : auxiliaryTableToBeSorted.values()) {
             sorted.put(auxiliaryTableRow.getLabel(priorityList) + '\037' + auxiliaryTableRow.getId(),
                 auxiliaryTableRow);
         }
@@ -193,7 +190,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param auxiliaryTable
      *            auxiliary table
      */
-    private final <V> void addAnyRules(LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable) {
+    private final <V> void addAnyRules(LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable) {
 
         auxiliaryTable.entrySet().parallelStream().forEach(entry -> entry.getValue()
                 .setRule(rule.getRuleForKey(entry.getKey(), division)));
@@ -214,16 +211,16 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param toBeSorted
      *            write access to the list of keys to be sorted
      */
-    private final <V> void addAdditionalKeys(LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable,
+    private final <V> void addAdditionalKeys(LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable,
             Rule rule, Collection<String> additionalKeys,
-            HashMap<String, AuxiliaryTableRow<V>> toBeSorted) {
+            HashMap<String, AuxiliaryTableRow> toBeSorted) {
         for (String additionalKey : additionalKeys) {
             if (!auxiliaryTable.containsKey(additionalKey) && !toBeSorted.containsKey(additionalKey)) {
                 Optional<Key> optionalKey = rule.isUnspecifiedUnrestricted() ? Optional.empty()
                         : ruleset.getKey(additionalKey);
                 KeyDeclaration keyDeclaration = optionalKey.isPresent() ? new KeyDeclaration(ruleset, optionalKey.get())
                         : new KeyDeclaration(ruleset, additionalKey);
-                toBeSorted.put(additionalKey, new AuxiliaryTableRow<>(keyDeclaration, settings));
+                toBeSorted.put(additionalKey, new AuxiliaryTableRow(keyDeclaration, settings));
             }
         }
     }
@@ -241,11 +238,11 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param toBeSorted
      *            write access to the list of keys to be sorted
      */
-    private final <V> void addRemainingKeys(LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable,
-            Collection<KeyDeclaration> keyDeclarations, HashMap<String, AuxiliaryTableRow<V>> toBeSorted) {
+    private final <V> void addRemainingKeys(LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable,
+            Collection<KeyDeclaration> keyDeclarations, HashMap<String, AuxiliaryTableRow> toBeSorted) {
         for (KeyDeclaration keyDeclaration : keyDeclarations) {
             if (!auxiliaryTable.containsKey(keyDeclaration.getId())) {
-                toBeSorted.put(keyDeclaration.getId(), new AuxiliaryTableRow<>(keyDeclaration, settings));
+                toBeSorted.put(keyDeclaration.getId(), new AuxiliaryTableRow(keyDeclaration, settings));
             }
         }
     }
@@ -271,11 +268,11 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            which keys the user has additionally selected
      * @return an auxiliary table for additional keys yet to be sorted
      */
-    private final <V> HashMap<String, AuxiliaryTableRow<V>> cerateAuxiliaryTableWithKeysToBeSorted(
-            LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable, Rule rule,
+    private final <V> HashMap<String, AuxiliaryTableRow> cerateAuxiliaryTableWithKeysToBeSorted(
+            LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable, Rule rule,
             Collection<KeyDeclaration> keyDeclarations, Collection<String> additionalKeys) {
 
-        HashMap<String, AuxiliaryTableRow<V>> toBeSorted = new HashMap<>();
+        HashMap<String, AuxiliaryTableRow> toBeSorted = new HashMap<>();
 
         if (rule.isUnspecifiedUnrestricted()) {
             addRemainingKeys(auxiliaryTable, keyDeclarations, toBeSorted);
@@ -295,12 +292,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            which keys the user has additionally selected
      * @return A helper table for all metadata keys
      */
-    private <V> Collection<AuxiliaryTableRow<V>> createAuxiliaryTable(Map<V, String> currentEntries,
+    private Collection<AuxiliaryTableRow> createAuxiliaryTable(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys) {
 
-        LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable = createAuxiliaryTableWithPreSortedKeys(
+        LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable = createAuxiliaryTableWithPreSortedKeys(
             rule.getExplicitlyPermittedKeys(declaration));
-        HashMap<String, AuxiliaryTableRow<V>> auxiliaryTableToBeSorted = cerateAuxiliaryTableWithKeysToBeSorted(
+        HashMap<String, AuxiliaryTableRow> auxiliaryTableToBeSorted = cerateAuxiliaryTableWithKeysToBeSorted(
             auxiliaryTable, rule, declaration.getKeyDeclarations(), additionalKeys);
         storeValues(currentEntries, auxiliaryTable, auxiliaryTableToBeSorted);
         appendRowsToAuxiliaryTable(sort(auxiliaryTableToBeSorted, priorityList), auxiliaryTable);
@@ -318,12 +315,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            keys given in their order by the restriction rule
      * @return the auxiliary table
      */
-    private final <V> LinkedHashMap<String, AuxiliaryTableRow<V>> createAuxiliaryTableWithPreSortedKeys(
+    private final <V> LinkedHashMap<String, AuxiliaryTableRow> createAuxiliaryTableWithPreSortedKeys(
             List<KeyDeclaration> explicitlyPermittedKeys) {
 
-        LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable = new LinkedHashMap<>();
+        LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable = new LinkedHashMap<>();
         for (KeyDeclaration keyDeclaration : explicitlyPermittedKeys) {
-            auxiliaryTable.put(keyDeclaration.getId(), new AuxiliaryTableRow<V>(keyDeclaration, settings));
+            auxiliaryTable.put(keyDeclaration.getId(), new AuxiliaryTableRow(keyDeclaration, settings));
         }
         return auxiliaryTable;
     }
@@ -332,8 +329,6 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * Here the addable metadata keys are fetched. To do this, the table must
      * first be made and then an output made.
      *
-     * @param <V>
-     *            the type of metadata objects
      * @param currentEntries
      *            metadata objects that have already been entered, along with
      *            their key
@@ -341,17 +336,17 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            metadata keys that the user has already selected
      */
     @Override
-    public Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> currentEntries,
+    public Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys) {
 
         return getPossibleMetadata(currentEntries, additionalKeys, false);
     }
 
-    private Collection<MetadataViewInterface> getPossibleMetadata(Map<?, String> currentEntries,
+    private Collection<MetadataViewInterface> getPossibleMetadata(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys, boolean all) {
 
         Collection<MetadataViewInterface> addableMetadata = new LinkedList<>();
-        for (AuxiliaryTableRow<?> auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
+        for (AuxiliaryTableRow auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
             if (all || auxiliaryTableRow.isPossibleToExpandAnotherField()) {
                 MetadataViewInterface keyView = auxiliaryTableRow
                         .isComplexKey()
@@ -373,7 +368,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      */
     @Override
     public Collection<MetadataViewInterface> getAllowedMetadata() {
-        return getPossibleMetadata(Collections.emptyMap(), Collections.emptySet(), true);
+        return getPossibleMetadata(Collections.emptyList(), Collections.emptySet(), true);
     }
 
     /**
@@ -403,8 +398,6 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * be sorted and therefore sometimes more fields are needed. Exceptions here
      * are multiple selections only once, and with multiple values.
      *
-     * @param <V>
-     *            the type of metadata objects
      * @param currentEntries
      *            metadata objects that have already been entered, along with
      *            heir key
@@ -413,12 +406,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @return mask
      */
     @Override
-    public <V> List<MetadataViewWithValuesInterface<V>> getSortedVisibleMetadata(Map<V, String> currentEntries,
+    public List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys) {
 
-        LinkedList<MetadataViewWithValuesInterface<V>> sortedVisibleMetadata = new LinkedList<>();
-        Collection<V> excludedDataObjects = new HashSet<>();
-        for (AuxiliaryTableRow<V> auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
+        LinkedList<MetadataViewWithValuesInterface> sortedVisibleMetadata = new LinkedList<>();
+        Collection<Metadata> excludedDataObjects = new HashSet<>();
+        for (AuxiliaryTableRow auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
             if (auxiliaryTableRow.isContainingExcludedData()) {
                 excludedDataObjects.addAll(auxiliaryTableRow.getDataObjects(0));
             } else {
@@ -430,12 +423,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
                                             rule.getRuleForKey(auxiliaryTableRow.getId(), division),
                                             settings, priorityList);
                     Optional<MetadataViewInterface> definedTypeView = Optional.of(typeView);
-                    sortedVisibleMetadata.add(new FormRow<>(definedTypeView, auxiliaryTableRow.getDataObjects(i)));
+                    sortedVisibleMetadata.add(new FormRow(definedTypeView, auxiliaryTableRow.getDataObjects(i)));
                 }
             }
         }
         if (!excludedDataObjects.isEmpty()) {
-            sortedVisibleMetadata.addFirst(new FormRow<>(Optional.empty(), excludedDataObjects));
+            sortedVisibleMetadata.addFirst(new FormRow(Optional.empty(), excludedDataObjects));
         }
         return sortedVisibleMetadata;
     }
@@ -452,27 +445,27 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param auxiliaryTableToBeSorted
      *            help table with rows that still have to be sorted
      */
-    private final <V> void storeValues(Map<V, String> enteredMetaData,
-            LinkedHashMap<String, AuxiliaryTableRow<V>> sortedAuxiliaryTable,
-            HashMap<String, AuxiliaryTableRow<V>> auxiliaryTableToBeSorted) {
+    private final void storeValues(Collection<Metadata> enteredMetaData,
+            LinkedHashMap<String, AuxiliaryTableRow> sortedAuxiliaryTable,
+            HashMap<String, AuxiliaryTableRow> auxiliaryTableToBeSorted) {
 
-        for (Entry<V, String> entry : enteredMetaData.entrySet()) {
-            String keyId = entry.getValue();
+        for (Metadata metadata : enteredMetaData) {
+            String keyId = metadata.getKey();
             if (sortedAuxiliaryTable.containsKey(keyId)) {
-                sortedAuxiliaryTable.get(keyId).add(entry.getKey());
+                sortedAuxiliaryTable.get(keyId).add(metadata);
             } else {
                 auxiliaryTableToBeSorted.computeIfAbsent(keyId,
                     missing -> retrieveOrCompute(keyId));
-                auxiliaryTableToBeSorted.get(keyId).add(entry.getKey());
+                auxiliaryTableToBeSorted.get(keyId).add(metadata);
             }
         }
     }
 
-    private <V> AuxiliaryTableRow<V> retrieveOrCompute(String keyId) {
+    private AuxiliaryTableRow retrieveOrCompute(String keyId) {
         Optional<Key> possibleKey = ruleset.getKey(keyId);
         KeyDeclaration keyDeclaration = possibleKey.isPresent() ? new KeyDeclaration(ruleset, possibleKey.get(), true)
                 : new KeyDeclaration(ruleset, keyId);
-        return new AuxiliaryTableRow<>(keyDeclaration, settings);
+        return new AuxiliaryTableRow(keyDeclaration, settings);
     }
 
     @Override

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
@@ -20,7 +20,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Triple;
 import org.kitodo.dataeditor.ruleset.xml.RestrictivePermit;
 import org.kitodo.dataeditor.ruleset.xml.Ruleset;
 import org.kitodo.dataeditor.ruleset.xml.Unspecified;
@@ -31,20 +30,6 @@ import org.kitodo.dataeditor.ruleset.xml.Unspecified;
  * restrictions.
  */
 public class Rule {
-    /**
-     * Generates a triplet of rule with triple as a key. This is due to the
-     * problem because the rule is basically the key is three fields and applies
-     * everything.
-     *
-     * @param restrictivePermit
-     *            restrictive permit for which a hash key is to be formed
-     * @return key is triple
-     */
-    private static Triple<String, String, String> formAKeyForARuleInATemporaryMap(RestrictivePermit restrictivePermit) {
-        return Triple.of(restrictivePermit.getDivision().orElse(null), restrictivePermit.getKey().orElse(null),
-            restrictivePermit.getValue().orElse(null));
-    }
-
     /**
      * Maybe a rule, but maybe not.
      */
@@ -248,16 +233,15 @@ public class Rule {
                     : Unspecified.UNRESTRICTED);
 
         // for sub-rules, apply recursively
-        HashMap<Triple<String, String, String>, RestrictivePermit> anotherPermits = new LinkedHashMap<>();
+        HashMap<RestrictivePermit, RestrictivePermit> anotherPermits = new LinkedHashMap<>();
         for (RestrictivePermit anotherPermit : another.getPermits()) {
-            anotherPermits.put(formAKeyForARuleInATemporaryMap(anotherPermit), anotherPermit);
+            anotherPermits.put(anotherPermit, anotherPermit);
         }
         List<RestrictivePermit> mergedPermits = new LinkedList<>();
         for (RestrictivePermit onePermit : one.getPermits()) {
-            Triple<String, String, String> key = formAKeyForARuleInATemporaryMap(onePermit);
-            if (anotherPermits.containsKey(key)) {
-                mergedPermits.add(merge(onePermit, anotherPermits.get(key)));
-                anotherPermits.remove(key);
+            if (anotherPermits.containsKey(onePermit)) {
+                mergedPermits.add(merge(onePermit, anotherPermits.get(onePermit)));
+                anotherPermits.remove(onePermit);
             } else {
                 mergedPermits.add(onePermit);
             }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
@@ -207,4 +207,47 @@ public class RestrictivePermit {
     public void setValue(Optional<String> value) {
         this.value = value.orElse(null);
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((division == null) ? 0 : division.hashCode());
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RestrictivePermit)) {
+            return false;
+        }
+        RestrictivePermit other = (RestrictivePermit) obj;
+        if (division == null) {
+            if (other.division != null) {
+                return false;
+            }
+        } else if (!division.equals(other.division)) {
+            return false;
+        }
+        if (key == null) {
+            if (other.key != null) {
+                return false;
+            }
+        } else if (!key.equals(other.key)) {
+            return false;
+        }
+        if (value == null) {
+            if (other.value != null) {
+                return false;
+            }
+        } else if (!value.equals(other.value)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -27,10 +27,10 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Month;
 import java.time.MonthDay;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale.LanguageRange;
@@ -40,6 +40,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
+import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.DatesSimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
@@ -94,7 +96,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testAvailabilityOfPresets.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("defaultStringKey", "anyURIKey", "booleanKey", "dateKey", "namespaceDefaultAnyURIKey",
                 "namespaceStringKey"));
 
@@ -144,7 +146,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testAvailabilityOfSubkeyViews.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList("contributor"));
 
         MetadataViewInterface contributorMvi = mvwviList.get(0).getMetadata().get();
@@ -154,7 +156,7 @@ public class RulesetManagementIT {
         assertTrue(contributorMvi instanceof ComplexMetadataViewInterface);
         ComplexMetadataViewInterface contributorCmvi = (ComplexMetadataViewInterface) contributorMvi;
 
-        Collection<MetadataViewInterface> mvic = contributorCmvi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mvic = contributorCmvi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         Iterator<MetadataViewInterface> mvici = mvic.iterator();
@@ -209,13 +211,13 @@ public class RulesetManagementIT {
 
         // 1. options are sorted as to their labels alphabetically
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         StructuralElementViewInterface seviDe = underTest.getStructuralElementView(BOOK, "",
             LanguageRange.parse("de"));
-        List<MetadataViewWithValuesInterface<Void>> mvwviListDe = seviDe
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> mvwviListDe = seviDe.getSortedVisibleMetadata(Collections.emptyList(),
+            Collections.emptyList());
 
         assertThat(((SimpleMetadataViewInterface) mvwviList.get(0).getMetadata().get()).getSelectItems().keySet(),
             contains("dan", "dut", "eng", "fre", "ger"));
@@ -228,7 +230,7 @@ public class RulesetManagementIT {
         assertThat(ids(mvwviList), contains("mandatoryMultiLineSingleSelection", "mandatoryOneLineSingleSelection",
             "mandatoryMultipleSelection"));
 
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         assertThat(ids(mviColl), contains("optionalMultiLineSingleSelection", "optionalOneLineSingleSelection",
@@ -259,7 +261,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testCorrectValidationOfOptions.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         SimpleMetadataViewInterface smvi = (SimpleMetadataViewInterface) mviColl.iterator().next();
         assertTrue(smvi.isValid(OPT));
@@ -275,7 +277,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testCorrectValidationOfRegularExpressions.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("defaultStringKey", "anyURIKey", "booleanKey", "dateKey", "namespaceDefaultAnyURIKey",
                 "namespaceStringKey", "integerKey", "optionsKey"));
 
@@ -353,8 +355,8 @@ public class RulesetManagementIT {
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "The acquisition stage", ENGL);
 
         // always showing
-        List<MetadataViewWithValuesInterface<Void>> mvwviListAlwaysShowing = sevi
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> mvwviListAlwaysShowing = sevi
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertThat(
             mvwviListAlwaysShowing.stream().map(mvwvi -> mvwvi.getMetadata().get().getId())
                     .collect(Collectors.toList()),
@@ -362,13 +364,23 @@ public class RulesetManagementIT {
                 "alwaysShowingTrueOtherchanges", "alwaysShowingTrueTrue", "multilineTrueOtherchanges"));
 
         // excluded
-        Map<Object, String> metadataForExcluded = new HashMap<>();
-        metadataForExcluded.put("exclude1", "excludedUnchangedTrue");
-        metadataForExcluded.put("exclude2", "excludedTrueUnchanged");
-        metadataForExcluded.put("exclude3", "excludedTrueOtherchanges");
-        metadataForExcluded.put("exclude4", "excludedTrueTrue");
-        metadataForExcluded.put("n#*703=]", "excludedTrueFalse");
-        List<MetadataViewWithValuesInterface<Object>> mvwviListExcluded = sevi
+        Collection<Metadata> metadataForExcluded = new ArrayList<>();
+        Metadata metadataOne = new MetadataEntry();
+        metadataOne.setKey("excludedUnchangedTrue");
+        metadataForExcluded.add(metadataOne);
+        Metadata metadataTwo = new MetadataEntry();
+        metadataTwo.setKey("excludedTrueUnchanged");
+        metadataForExcluded.add(metadataTwo);
+        Metadata metadataThree = new MetadataEntry();
+        metadataThree.setKey("excludedTrueOtherchanges");
+        metadataForExcluded.add(metadataThree);
+        Metadata metadataFour = new MetadataEntry();
+        metadataFour.setKey("excludedTrueTrue");
+        metadataForExcluded.add(metadataFour);
+        Metadata metadataFive = new MetadataEntry();
+        metadataFive.setKey("excludedTrueFalse");
+        metadataForExcluded.add(metadataFive);
+        List<MetadataViewWithValuesInterface> mvwviListExcluded = sevi
                 .getSortedVisibleMetadata(metadataForExcluded, Collections.emptyList());
         assertTrue(mvwviListExcluded.stream().filter(mvwvi -> mvwvi.getMetadata().isPresent())
                 .map(mvwvi -> mvwvi.getMetadata().get().getId()).filter(keyId -> keyId.startsWith("excluded"))
@@ -383,7 +395,7 @@ public class RulesetManagementIT {
                 .collect(Collectors.toList()).contains("excludedTrueFalse"));
 
         // editable
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("editableUnchangedFalse", "editableFalseUnchanged", "editableFalseOtherchanges",
                 "editableFalseFalse", "editableFalseTrue", "multilineUnchangedTrue", "multilineTrueUnchanged",
                 "multilineTrueOtherchanges", "multilineTrueTrue", "multilineTrueFalse"));
@@ -425,14 +437,14 @@ public class RulesetManagementIT {
         // 1. Without metadata, and without additional fields being selected,
         // you should see exactly the fields that are always showing, minus
         // those that are excluded (excluded overrules always showing).
-        List<MetadataViewWithValuesInterface<Void>> mvwviListNoMetadata = sevi
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> mvwviListNoMetadata = sevi
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertThat(ids(mvwviListNoMetadata),
             containsInAnyOrder("testAlwaysShowing", "testAlwaysShowingEditable", "testAlwaysShowingMultiline"));
 
         // 2. All fields except those that are excluded should be allowed to be
         // added.
-        Collection<MetadataViewInterface> mviCollNoMetadata = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviCollNoMetadata = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertThat(ids(mviCollNoMetadata), containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline",
             "testAlwaysShowingEditable", "testAlwaysShowingMultiline", "testEditableMultiline", "testNestedSettings",
@@ -441,39 +453,61 @@ public class RulesetManagementIT {
         // 1a. In the nested metadata field, the only value that should be
         // visible is the one marked as always showing. The field has to be
         // added first:
-        List<MetadataViewWithValuesInterface<Void>> mvwviListNestedSettings = sevi
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.singletonList("testNestedSettings"));
+        List<MetadataViewWithValuesInterface> mvwviListNestedSettings = sevi
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.singletonList("testNestedSettings"));
         ComplexMetadataViewInterface nestedSettings = (ComplexMetadataViewInterface) mvwviListNestedSettings.stream()
                 .filter(mvwvi -> mvwvi.getMetadata().get().getId().equals("testNestedSettings")).findAny().get()
                 .getMetadata().get();
-        List<MetadataViewWithValuesInterface<Void>> nestedMvwviList = nestedSettings
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> nestedMvwviList = nestedSettings
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertEquals(1, nestedMvwviList.size());
         assertEquals("testAlwaysShowing", nestedMvwviList.get(0).getMetadata().get().getId());
 
         // 2a. Also with nested metadata, all fields except those that are
         // excluded should be allowed to be added.
-        Collection<MetadataViewInterface> nestedMviColl = nestedSettings.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> nestedMviColl = nestedSettings.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertThat(ids(nestedMviColl), containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline"));
 
         // 3. With metadata, all fields should be visible except those that are
         // excluded. There should be an entry without a key in the list
         // containing the values of the excluded keys.
-        Map<Object, String> metadata = new HashMap<>();
-        metadata.put("udv-q@bC", "testAlwaysShowing");
-        metadata.put("/F5Mu=/1", "testEditable");
-        metadata.put("exclude1", "testExcluded");
-        metadata.put("WP&~O$YV", "testMultiline");
-        metadata.put("n#*703=]", "testAlwaysShowingEditable");
-        metadata.put("exclude2", "testAlwaysShowingExcluded");
-        metadata.put("Mu{lp'n1", "testAlwaysShowingMultiline");
-        metadata.put("exclude3", "testEditableExcluded");
-        metadata.put("qP'Jc:.R", "testEditableMultiline");
-        metadata.put("exclude4", "testExcludedMultiline");
-        metadata.put("4J[~UgHp", "testNestedSettings");
+        Collection<Metadata> metadata = new ArrayList<>();
+        Metadata metadataOne = new MetadataEntry();
+        metadataOne.setKey("testAlwaysShowing");
+        metadata.add(metadataOne);
+        Metadata metadataTwo = new MetadataEntry();
+        metadataTwo.setKey("testEditable");
+        metadata.add(metadataTwo);
+        Metadata metadataThree = new MetadataEntry();
+        metadataThree.setKey("testExcluded");
+        metadata.add(metadataThree);
+        Metadata metadataFour = new MetadataEntry();
+        metadataFour.setKey("testMultiline");
+        metadata.add(metadataFour);
+        Metadata metadataFive = new MetadataEntry();
+        metadataFive.setKey("testAlwaysShowingEditable");
+        metadata.add(metadataFive);
+        Metadata metadataSix = new MetadataEntry();
+        metadataSix.setKey("testAlwaysShowingExcluded");
+        metadata.add(metadataSix);
+        Metadata metadataSeven = new MetadataEntry();
+        metadataSeven.setKey("testAlwaysShowingMultiline");
+        metadata.add(metadataSeven);
+        Metadata metadataEight = new MetadataEntry();
+        metadataEight.setKey("testEditableExcluded");
+        metadata.add(metadataEight);
+        Metadata metadataNine = new MetadataEntry();
+        metadataNine.setKey("testEditableMultiline");
+        metadata.add(metadataNine);
+        Metadata metadataTen = new MetadataEntry();
+        metadataTen.setKey("testExcludedMultiline");
+        metadata.add(metadataTen);
+        Metadata metadataEleven = new MetadataEntry();
+        metadataEleven.setKey("testNestedSettings");
+        metadata.add(metadataEleven);
 
-        List<MetadataViewWithValuesInterface<Object>> mvwviListWithMetadata = sevi.getSortedVisibleMetadata(metadata,
+        List<MetadataViewWithValuesInterface> mvwviListWithMetadata = sevi.getSortedVisibleMetadata(metadata,
             Collections.emptyList());
         assertThat(ids(mvwviListWithMetadata), containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline",
             "testAlwaysShowingEditable", "testAlwaysShowingMultiline", "testEditableMultiline", "testNestedSettings"));
@@ -483,13 +517,13 @@ public class RulesetManagementIT {
             containsInAnyOrder("exclude1", "exclude2", "exclude3", "exclude4"));
 
         // 3a. Also with nested metadata, that should work that way.
-        Map<Object, String> nestedMetadata = new HashMap<>();
-        nestedMetadata.put("udv-q@bC", "testAlwaysShowing");
-        nestedMetadata.put("/F5Mu=/1", "testEditable");
-        nestedMetadata.put("excluded", "testExcluded");
-        nestedMetadata.put("WP&~O$YV", "testMultiline");
+        Collection<Metadata> nestedMetadata = new ArrayList<>();
+        nestedMetadata.add(metadataOne);
+        nestedMetadata.add(metadataTwo);
+        nestedMetadata.add(metadataThree);
+        nestedMetadata.add(metadataFour);
 
-        List<MetadataViewWithValuesInterface<Object>> nestedMvwviListWithMetadata = nestedSettings
+        List<MetadataViewWithValuesInterface> nestedMvwviListWithMetadata = nestedSettings
                 .getSortedVisibleMetadata(nestedMetadata, Collections.emptyList());
         assertThat(ids(nestedMvwviListWithMetadata),
             containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline"));
@@ -583,14 +617,14 @@ public class RulesetManagementIT {
         // Now a first view on a book
         StructuralElementViewInterface view = underTest.getStructuralElementView(BOOK, "", ENGL);
         assertEquals(1, view.getAllowedSubstructuralElements().entrySet().size());
-        assertEquals(5 + 3, view.getAddableMetadata(Collections.emptyMap(), Collections.emptyList()).size());
+        assertEquals(5 + 3, view.getAddableMetadata(Collections.emptyList(), Collections.emptyList()).size());
         assertTrue(view.isComplex());
         assertFalse(view.isUndefined());
 
         // Now a nonsense view
         StructuralElementViewInterface nonsenseView = underTest.getStructuralElementView("bosh", "", ENGL);
         assertEquals(1, nonsenseView.getAllowedSubstructuralElements().entrySet().size());
-        assertEquals(5 + 3, nonsenseView.getAddableMetadata(Collections.emptyMap(), Collections.emptyList()).size());
+        assertEquals(5 + 3, nonsenseView.getAddableMetadata(Collections.emptyList(), Collections.emptyList()).size());
         assertTrue(nonsenseView.isUndefined());
     }
 
@@ -688,7 +722,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testFieldsWithMinOccursGreaterZeroAreAlwaysShown.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         assertThat(ids(mvwviList), contains("test1", "test2", "test2", "test2options"));
@@ -730,9 +764,11 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testKeysReturnTheSpecifiedDomain.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Map<Object, String> metadata = new HashMap<>();
-        metadata.put("....", "unspecifiedKey");
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(metadata, Arrays.asList(
+        Collection<Metadata> metadata = new ArrayList<>();
+        Metadata metadataOne = new MetadataEntry();
+        metadataOne.setKey("unspecifiedKey");
+        metadata.add(metadataOne);
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(metadata, Arrays.asList(
             "description", "digitalProvenance", "noDomainSpecified", "rights", "source", "technical", "metsDiv"));
 
         SimpleMetadataViewInterface description = getSmvi(mvwviList, "description");
@@ -770,11 +806,11 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testRulesAreCorrectlyMerged.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList("personContributor"));
         ComplexMetadataViewInterface personContributor = getCmvi(mvwviList, "personContributor");
-        List<MetadataViewWithValuesInterface<Object>> visible = personContributor
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> visible = personContributor
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertThat(ids(visible), contains("role", "gndRecord", "givenName", "surname"));
         assertThat(getSmvi(visible, "role").getSelectItems().keySet(), contains("author", "editor"));
     }
@@ -788,7 +824,7 @@ public class RulesetManagementIT {
         RulesetManagement underTest = new RulesetManagement();
         underTest.load(new File("src/test/resources/testRulesRemoveKeysWithZeroMaxOccurs.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertTrue(ids(mviColl).contains("keep"));
     }
@@ -802,7 +838,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testTheDisplayModeIsSetUsingTheCodomain.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("defaultString", "anyURI", "boolean", "date", "integer", "namespace", "namespaceString"));
 
         assertEquals(InputType.ONE_LINE_TEXT, getSmvi(mvwviList, "defaultString").getInputType());
@@ -835,7 +871,7 @@ public class RulesetManagementIT {
         RulesetManagement underTest = new RulesetManagement();
         underTest.load(new File("src/test/resources/testUnspecifiedForbiddenRulesRestrictKeys.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertTrue(ids(mviColl).contains("allowed"));
     }
@@ -850,7 +886,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testUnspecifiedForbiddenRulesRestrictOptions.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
 
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
         assertThat(test.getSelectItems().keySet(), contains(OPT, "opt3", "opt5", "opt7"));
@@ -868,7 +904,7 @@ public class RulesetManagementIT {
             new File("src/test/resources/testUnspecifiedForbiddenRulesRestrictOptionsAlsoInTheValidation.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
 
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
         assertTrue(test.isValid(OPT));
@@ -911,7 +947,7 @@ public class RulesetManagementIT {
         underTest.load(
             new File("src/test/resources/testUnspecifiedUnrestrictedRulesSortKeysWithoutRestrictingThem.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView("article", "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         assertThat(ids(mviColl), contains("author", "year", "title", "journal", "journalAbbr", "issue", "abstract",
@@ -928,7 +964,7 @@ public class RulesetManagementIT {
         underTest.load(
             new File("src/test/resources/testUnspecifiedUnrestrictedRulesSortOptionsWithoutRestrictingThem.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
         assertThat(test.getSelectItems().keySet(), contains("opt4", "opt7", OPT, "opt2", "opt3", "opt5", "opt6"));
@@ -943,7 +979,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testValidationByCodomain.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("default", "defaultOpt", "anyUri", "boolean", "date", "integer", "namespaceDefault",
                 "namespaceString", "namespaceDefaultOpt", "namespaceStringOpt", "namespaceDefaultExternal",
                 "namespaceStringExternal"));
@@ -1010,7 +1046,7 @@ public class RulesetManagementIT {
      *            ID of key to extract
      * @return metadata key
      */
-    private SimpleMetadataViewInterface getSmvi(List<MetadataViewWithValuesInterface<Object>> mvwviList, String keyId) {
+    private SimpleMetadataViewInterface getSmvi(List<MetadataViewWithValuesInterface> mvwviList, String keyId) {
         return (SimpleMetadataViewInterface) mvwviList.stream().filter(mvwvi -> mvwvi.getMetadata().isPresent())
                 .filter(mvwvi -> keyId.equals(mvwvi.getMetadata().get().getId())).findAny().get().getMetadata().get();
     }
@@ -1026,7 +1062,7 @@ public class RulesetManagementIT {
      * @return metadata key
      */
     private ComplexMetadataViewInterface getCmvi(
-            List<MetadataViewWithValuesInterface<Object>> metadataViewWithValuesInterfaceList, String keyId) {
+            List<MetadataViewWithValuesInterface> metadataViewWithValuesInterfaceList, String keyId) {
         return (ComplexMetadataViewInterface) metadataViewWithValuesInterfaceList.stream()
                 .filter(mvwvi -> mvwvi.getMetadata().isPresent())
                 .filter(metadataViewWithValuesInterface -> keyId
@@ -1056,7 +1092,7 @@ public class RulesetManagementIT {
      *            the metadata keys from
      * @return the IDs of the metadata keys
      */
-    private <T> List<String> ids(List<MetadataViewWithValuesInterface<T>> metadataViewWithValuesInterfaceList) {
+    private List<String> ids(List<MetadataViewWithValuesInterface> metadataViewWithValuesInterfaceList) {
         return metadataViewWithValuesInterfaceList.stream()
                 .filter(metadataViewWithValuesInterface -> metadataViewWithValuesInterface.getMetadata().isPresent())
                 .map(metadataViewWithValuesInterface -> metadataViewWithValuesInterface.getMetadata().get().getId())

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -365,17 +365,21 @@ public class RulesetManagementIT {
 
         // excluded
         Collection<Metadata> metadataForExcluded = new ArrayList<>();
-        Metadata metadataOne = new MetadataEntry();
+        MetadataEntry metadataOne = new MetadataEntry();
         metadataOne.setKey("excludedUnchangedTrue");
+        metadataOne.setValue("exclude1");
         metadataForExcluded.add(metadataOne);
-        Metadata metadataTwo = new MetadataEntry();
+        MetadataEntry metadataTwo = new MetadataEntry();
         metadataTwo.setKey("excludedTrueUnchanged");
+        metadataTwo.setValue("exclude2");
         metadataForExcluded.add(metadataTwo);
-        Metadata metadataThree = new MetadataEntry();
+        MetadataEntry metadataThree = new MetadataEntry();
         metadataThree.setKey("excludedTrueOtherchanges");
+        metadataThree.setValue("exclude3");
         metadataForExcluded.add(metadataThree);
-        Metadata metadataFour = new MetadataEntry();
+        MetadataEntry metadataFour = new MetadataEntry();
         metadataFour.setKey("excludedTrueTrue");
+        metadataFour.setValue("exclude4");
         metadataForExcluded.add(metadataFour);
         Metadata metadataFive = new MetadataEntry();
         metadataFive.setKey("excludedTrueFalse");
@@ -387,7 +391,9 @@ public class RulesetManagementIT {
                 .collect(Collectors.toList()).contains("excludedTrueFalse"));
         assertThat(
             mvwviListExcluded.stream().filter(mvwvi -> !mvwvi.getMetadata().isPresent())
-                    .flatMap(mvwvi -> mvwvi.getValues().stream()).collect(Collectors.toList()),
+                    .flatMap(
+                        mvwvi -> mvwvi.getValues().stream().map(MetadataEntry.class::cast).map(MetadataEntry::getValue))
+                    .collect(Collectors.toList()),
             containsInAnyOrder("exclude1", "exclude2", "exclude3", "exclude4"));
         Collection<MetadataViewInterface> mviCollExcluded = sevi.getAddableMetadata(metadataForExcluded,
             Collections.emptyList());
@@ -479,8 +485,9 @@ public class RulesetManagementIT {
         Metadata metadataTwo = new MetadataEntry();
         metadataTwo.setKey("testEditable");
         metadata.add(metadataTwo);
-        Metadata metadataThree = new MetadataEntry();
+        MetadataEntry metadataThree = new MetadataEntry();
         metadataThree.setKey("testExcluded");
+        metadataThree.setValue("exclude1");
         metadata.add(metadataThree);
         Metadata metadataFour = new MetadataEntry();
         metadataFour.setKey("testMultiline");
@@ -488,20 +495,23 @@ public class RulesetManagementIT {
         Metadata metadataFive = new MetadataEntry();
         metadataFive.setKey("testAlwaysShowingEditable");
         metadata.add(metadataFive);
-        Metadata metadataSix = new MetadataEntry();
+        MetadataEntry metadataSix = new MetadataEntry();
         metadataSix.setKey("testAlwaysShowingExcluded");
+        metadataSix.setValue("exclude2");
         metadata.add(metadataSix);
         Metadata metadataSeven = new MetadataEntry();
         metadataSeven.setKey("testAlwaysShowingMultiline");
         metadata.add(metadataSeven);
-        Metadata metadataEight = new MetadataEntry();
+        MetadataEntry metadataEight = new MetadataEntry();
         metadataEight.setKey("testEditableExcluded");
+        metadataEight.setValue("exclude3");
         metadata.add(metadataEight);
         Metadata metadataNine = new MetadataEntry();
         metadataNine.setKey("testEditableMultiline");
         metadata.add(metadataNine);
-        Metadata metadataTen = new MetadataEntry();
+        MetadataEntry metadataTen = new MetadataEntry();
         metadataTen.setKey("testExcludedMultiline");
+        metadataTen.setValue("exclude4");
         metadata.add(metadataTen);
         Metadata metadataEleven = new MetadataEntry();
         metadataEleven.setKey("testNestedSettings");
@@ -513,7 +523,9 @@ public class RulesetManagementIT {
             "testAlwaysShowingEditable", "testAlwaysShowingMultiline", "testEditableMultiline", "testNestedSettings"));
         assertThat(
             mvwviListWithMetadata.stream().filter(mvwvi -> !mvwvi.getMetadata().isPresent())
-                    .flatMap(mvwvi -> mvwvi.getValues().stream()).collect(Collectors.toList()),
+                    .flatMap(
+                        mvwvi -> mvwvi.getValues().stream().map(MetadataEntry.class::cast).map(MetadataEntry::getValue))
+                    .collect(Collectors.toList()),
             containsInAnyOrder("exclude1", "exclude2", "exclude3", "exclude4"));
 
         // 3a. Also with nested metadata, that should work that way.
@@ -528,7 +540,9 @@ public class RulesetManagementIT {
         assertThat(ids(nestedMvwviListWithMetadata),
             containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline"));
         assertTrue(nestedMvwviListWithMetadata.stream().filter(mvwvi -> !mvwvi.getMetadata().isPresent())
-                .flatMap(mvwvi -> mvwvi.getValues().stream()).collect(Collectors.toList()).contains("excluded"));
+                .flatMap(
+                    mvwvi -> mvwvi.getValues().stream().map(MetadataEntry.class::cast).map(MetadataEntry::getValue))
+                .collect(Collectors.toList()).contains("exclude1"));
 
         // 4. The property ‘multiline’ should manipulate the input type
         SimpleMetadataViewInterface testAlwaysShowing = getSmvi(mvwviListWithMetadata, "testAlwaysShowing");

--- a/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
+++ b/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentHashMap.KeySetView;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -170,9 +169,9 @@ public class MetadataValidation implements MetadataValidationInterface {
         Collection<ValidationResult> results = new ArrayList<>();
         StructuralElementViewInterface divisionView = ruleset.getStructuralElementView(type, null,
                 metadataLanguage);
-        results.add(checkForMandatoryQuantitiesOfTheMetadataRecursive(Metadata.mapToKey(metadata),
+        results.add(checkForMandatoryQuantitiesOfTheMetadataRecursive(metadata,
                 divisionView, elementString.concat(": "), translations));
-        results.add(checkForDetailsInTheMetadataRecursive(Metadata.mapToKey(metadata),
+        results.add(checkForDetailsInTheMetadataRecursive(metadata,
                 divisionView, elementString.concat(": "), translations));
         return results;
     }
@@ -254,7 +253,7 @@ public class MetadataValidation implements MetadataValidationInterface {
      * @return the validation result
      */
     private static ValidationResult checkForMandatoryQuantitiesOfTheMetadataRecursive(
-            Map<Metadata, String> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
+            Collection<Metadata> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
             String location, Map<String, String> translations) {
         boolean error = false;
         boolean warning = false;
@@ -286,7 +285,7 @@ public class MetadataValidation implements MetadataValidationInterface {
                 for (Metadata metadata : metadataViewWithValues.getValue()) {
                     if (metadata instanceof MetadataGroup) {
                         ValidationResult validationResult = checkForMandatoryQuantitiesOfTheMetadataRecursive(
-                            Metadata.mapToKey(((MetadataGroup) metadata).getGroup()),
+                            ((MetadataGroup) metadata).getGroup(),
                             (ComplexMetadataViewInterface) metadataView, location + metadataView.getLabel() + " - ",
                             translations);
                         if (validationResult.getState().equals(State.WARNING)) {
@@ -320,14 +319,14 @@ public class MetadataValidation implements MetadataValidationInterface {
      * @return the validation result
      */
     private static ValidationResult checkForDetailsInTheMetadataRecursive(
-            Map<Metadata, String> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
+            Collection<Metadata> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
             String location, Map<String, String> translations) {
         boolean error = false;
         Collection<String> messages = new HashSet<>();
 
-        List<MetadataViewWithValuesInterface<Metadata>> metadataViewsWithValues = containingMetadataView
+        List<MetadataViewWithValuesInterface> metadataViewsWithValues = containingMetadataView
                 .getSortedVisibleMetadata(containedMetadata, Collections.emptyList());
-        for (MetadataViewWithValuesInterface<Metadata> metadataViewWithValues : metadataViewsWithValues) {
+        for (MetadataViewWithValuesInterface metadataViewWithValues : metadataViewsWithValues) {
             Optional<MetadataViewInterface> optionalMetadataView = metadataViewWithValues.getMetadata();
             if (!optionalMetadataView.isPresent()) {
                 continue;
@@ -345,7 +344,7 @@ public class MetadataValidation implements MetadataValidationInterface {
                 } else if (metadata instanceof MetadataGroup
                         && metadataView instanceof ComplexMetadataViewInterface) {
                     ValidationResult validationResult = checkForDetailsInTheMetadataRecursive(
-                        Metadata.mapToKey(((MetadataGroup) metadata).getGroup()),
+                        ((MetadataGroup) metadata).getGroup(),
                         (ComplexMetadataViewInterface) metadataView, location + metadataView.getLabel() + " - ",
                         translations);
                     if (validationResult.getState().equals(State.ERROR)) {
@@ -402,9 +401,9 @@ public class MetadataValidation implements MetadataValidationInterface {
      * @return merged lines of identical type
      */
     private static Map<MetadataViewInterface, Collection<Metadata>> squash(
-            List<MetadataViewWithValuesInterface<Metadata>> metadataViewsWithValues) {
+            List<MetadataViewWithValuesInterface> metadataViewsWithValues) {
         Map<MetadataViewInterface, Collection<Metadata>> squashed = new HashMap<>();
-        for (MetadataViewWithValuesInterface<Metadata> metadataViewWithValues : metadataViewsWithValues) {
+        for (MetadataViewWithValuesInterface metadataViewWithValues : metadataViewsWithValues) {
             Optional<MetadataViewInterface> optionalMetadataView = metadataViewWithValues.getMetadata();
             if (!optionalMetadataView.isPresent()) {
                 continue;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -18,12 +18,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.list.UnmodifiableList;
 import org.apache.commons.lang3.tuple.Pair;
@@ -168,13 +165,12 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
      */
     private void createMetadataTable() {
         // the existing metadata is passed to the rule set, which sorts it
-        Map<Metadata, String> metadataWithKeys = Metadata.mapToKey(addLabels(metadata));
-        List<MetadataViewWithValuesInterface<Metadata>> tableData = metadataView
-                .getSortedVisibleMetadata(metadataWithKeys, additionallySelectedFields);
+        List<MetadataViewWithValuesInterface> tableData = metadataView
+                .getSortedVisibleMetadata(addLabels(metadata), additionallySelectedFields);
 
         treeNode.getChildren().clear();
         hiddenMetadata = Collections.emptyList();
-        for (MetadataViewWithValuesInterface<Metadata> rowData : tableData) {
+        for (MetadataViewWithValuesInterface rowData : tableData) {
             Optional<MetadataViewInterface> optionalMetadataView = rowData.getMetadata();
             Collection<Metadata> values = rowData.getValues();
             if (optionalMetadataView.isPresent()) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -21,15 +21,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.faces.model.SelectItem;
@@ -513,14 +510,14 @@ public class AddDocStrucTypeDialog {
     public void prepareSelectAddableMetadataTypesItems(boolean currentElement, List<TreeNode> metadataNodes) {
         selectAddableMetadataTypesItems = new ArrayList<>();
         setSelectAddableMetadataTypesSelectedItem("");
-        Map<Metadata, String> existingMetadata = Collections.emptyMap();
+        Collection<Metadata> existingMetadata = Collections.emptyList();
         StructuralElementViewInterface structure;
         Collection<MetadataViewInterface> addableMetadata;
         TreeNode selectedMetadataTreeNode = dataEditor.getMetadataPanel().getSelectedMetadataTreeNode();
         try {
             if (Objects.nonNull(selectedMetadataTreeNode)
                     && Objects.nonNull(selectedMetadataTreeNode.getData())) {
-                existingMetadata = Metadata.mapToKey(((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadata());
+                existingMetadata = ((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadata();
                 ComplexMetadataViewInterface metadataView = dataEditor.getRulesetManagement().getMetadataView(
                         ((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadataID(),
                         dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
@@ -562,21 +559,22 @@ public class AddDocStrucTypeDialog {
         prepareSelectAddableMetadataTypesItems(currentElement, Collections.emptyList());
     }
 
-    private Map<Metadata, String> getExistingMetadataRows(List<TreeNode> metadataTreeNodes) throws InvalidMetadataValueException {
-        Map<Metadata, String> existingMetadataRows = new HashMap<>();
+    private Collection<Metadata> getExistingMetadataRows(List<TreeNode> metadataTreeNodes)
+            throws InvalidMetadataValueException {
+        Collection<Metadata> existingMetadataRows = new ArrayList<>();
 
         for (TreeNode metadataNode : metadataTreeNodes) {
             if (metadataNode.getData() instanceof ProcessDetail) {
                 try {
                     for (Metadata metadata : ((ProcessDetail) metadataNode.getData()).getMetadata()) {
-                        existingMetadataRows.put(metadata, metadata.getKey());
+                        existingMetadataRows.add(metadata);
                     }
                 } catch (NullPointerException e) {
                     logger.error(e);
                 }
             }
             if (metadataNode.getChildCount() > 0) {
-                existingMetadataRows.putAll(getExistingMetadataRows(metadataNode.getChildren()));
+                existingMetadataRows.addAll(getExistingMetadataRows(metadataNode.getChildren()));
             }
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
@@ -19,11 +19,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale.LanguageRange;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -86,9 +83,8 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Override
     @Deprecated
     public void addMetadata(LegacyMetadataHelper metadata) {
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
         Optional<MetadataViewInterface> optionalKeyView = divisionView
-                .getAddableMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList()).parallelStream()
+                .getAddableMetadata(includedStructuralElement.getMetadata(), Collections.emptyList()).parallelStream()
                 .filter(keyView -> keyView.getId().equals(metadata.getMetadataType().getName())).findFirst();
         Optional<Domain> optionalDomain = optionalKeyView.isPresent() ? optionalKeyView.get().getDomain()
                 : Optional.empty();
@@ -133,8 +129,8 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Override
     @Deprecated
     public List<LegacyMetadataTypeHelper> getAddableMetadataTypes() {
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
-        Collection<MetadataViewInterface> addableKeys = divisionView.getAddableMetadata(metadataEntriesMappedToKeyNames,
+        Collection<MetadataViewInterface> addableKeys = divisionView.getAddableMetadata(
+            includedStructuralElement.getMetadata(),
             Collections.emptyList());
         ArrayList<LegacyMetadataTypeHelper> addableMetadataTypes = new ArrayList<>(addableKeys.size());
         for (MetadataViewInterface key : addableKeys) {
@@ -157,10 +153,9 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Deprecated
     public List<LegacyMetadataHelper> getAllMetadata() {
         List<LegacyMetadataHelper> allMetadata = new LinkedList<>();
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
-        List<MetadataViewWithValuesInterface<Metadata>> entryViews = divisionView
-                .getSortedVisibleMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList());
-        for (MetadataViewWithValuesInterface<Metadata> entryView : entryViews) {
+        List<MetadataViewWithValuesInterface> entryViews = divisionView
+                .getSortedVisibleMetadata(includedStructuralElement.getMetadata(), Collections.emptyList());
+        for (MetadataViewWithValuesInterface entryView : entryViews) {
             Optional<MetadataViewInterface> optionalMetadata = entryView.getMetadata();
             if (optionalMetadata.isPresent()) {
                 MetadataViewInterface key = optionalMetadata.get();
@@ -179,10 +174,9 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Deprecated
     public List<LegacyMetadataHelper> getAllMetadataByType(LegacyMetadataTypeHelper metadataType) {
         List<LegacyMetadataHelper> allMetadata = new LinkedList<>();
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
-        List<MetadataViewWithValuesInterface<Metadata>> entryViews = divisionView
-                .getSortedVisibleMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList());
-        for (MetadataViewWithValuesInterface<Metadata> entryView : entryViews) {
+        List<MetadataViewWithValuesInterface> entryViews = divisionView
+                .getSortedVisibleMetadata(includedStructuralElement.getMetadata(), Collections.emptyList());
+        for (MetadataViewWithValuesInterface entryView : entryViews) {
             if (entryView.getMetadata().isPresent()) {
                 Optional<MetadataViewInterface> optionalMetadata = entryView.getMetadata();
                 MetadataViewInterface key = optionalMetadata.get();

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
@@ -97,8 +97,8 @@ public class LegacyPrefsHelper {
                 }
                 StructuralElementViewInterface divisionView = ruleset.getStructuralElementView("", "edit",
                     priorityList);
-                List<MetadataViewWithValuesInterface<Void>> entryViews = divisionView
-                        .getSortedVisibleMetadata(Collections.emptyMap(), Arrays.asList(identifier));
+                List<MetadataViewWithValuesInterface> entryViews = divisionView
+                        .getSortedVisibleMetadata(Collections.emptyList(), Arrays.asList(identifier));
                 MetadataViewInterface resultKeyView = entryViews.parallelStream()
                         .map(MetadataViewWithValuesInterface::getMetadata).filter(Optional::isPresent).map(Optional::get)
                         .filter(keyView -> keyView.getId().equals(identifier)).findFirst()
@@ -109,7 +109,7 @@ public class LegacyPrefsHelper {
 
     /**
      * Returns the ruleset of the legacy prefs helper.
-     * 
+     *
      * @return the ruleset
      */
     @Deprecated

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.exceptions.UnreachableCodeException;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;
 
@@ -228,7 +229,7 @@ public class IndividualIssue {
      * @return a list of pairs, each consisting of the metadata type name and
      *         the value
      */
-    public Iterable<Pair<String, String>> getMetadata(int monthOfYear, int dayOfMonth) {
+    public Iterable<MetadataEntry> getMetadata(int monthOfYear, int dayOfMonth) {
         return getMetadata(MonthDay.of(monthOfYear, dayOfMonth));
     }
 
@@ -241,12 +242,15 @@ public class IndividualIssue {
      * @return a list of pairs, each consisting of the metadata type name and
      *         the value
      */
-    public Iterable<Pair<String, String>> getMetadata(MonthDay yearStart) {
-        List<Pair<String, String>> result = new ArrayList<>();
+    public Iterable<MetadataEntry> getMetadata(MonthDay yearStart) {
+        List<MetadataEntry> result = new ArrayList<>();
         Pair<LocalDate, Issue> selectedIssue = Pair.of(date, issue);
         for (CountableMetadata counter : block.getMetadata(selectedIssue, null)) {
             String value = counter.getValue(selectedIssue, yearStart);
-            result.add(Pair.of(counter.getMetadataType(), value));
+            MetadataEntry entry = new MetadataEntry();
+            entry.setKey(counter.getMetadataType());
+            entry.setValue(value);
+            result.add(entry);
         }
         return result;
     }

--- a/Kitodo/src/test/java/org/kitodo/DummyMetadataView.java
+++ b/Kitodo/src/test/java/org/kitodo/DummyMetadataView.java
@@ -13,9 +13,9 @@ package org.kitodo;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -27,7 +27,7 @@ public class DummyMetadataView implements ComplexMetadataViewInterface {
     }
 
     @Override
-    public Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> entered,
+    public Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }
@@ -38,7 +38,7 @@ public class DummyMetadataView implements ComplexMetadataViewInterface {
     }
 
     @Override
-    public <T> List<MetadataViewWithValuesInterface<T>> getSortedVisibleMetadata(Map<T, String> entered,
+    public List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> entered,
                                                                                  Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }

--- a/Kitodo/src/test/java/org/kitodo/DummyStructuralElementView.java
+++ b/Kitodo/src/test/java/org/kitodo/DummyStructuralElementView.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.DatesSimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -31,7 +32,7 @@ public class DummyStructuralElementView implements StructuralElementViewInterfac
     }
 
     @Override
-    public Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> entered,
+    public Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }
@@ -42,7 +43,7 @@ public class DummyStructuralElementView implements StructuralElementViewInterfac
     }
 
     @Override
-    public <T> List<MetadataViewWithValuesInterface<T>> getSortedVisibleMetadata(Map<T, String> entered,
+    public List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
In the past, it was first decided to make the individual modules independent of another, which also means that the ruleset module was independent of the metadata that it processed. In the meantime, that has become more relaxed, metadata is part of the API and can be used in modules. So, this now introduces metadata into ruleset module. This makes a lot of things easier and more understandable in the code, and is a prerequisite for further development. It also gets rid of complicated type parameters.

In the future, it can also be resolved that complex metadata could not be mapped if not defined in the ruleset, because the ruleset module could not be aware of it (#3762). Now it is, so that this problem, too, is easy to solve in a follow-up to this pull request.