### PR TITLE
Implement XML model for dependent value restrictions

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
@@ -11,12 +11,7 @@
 
 package org.kitodo.api;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class Metadata {
     /**
@@ -78,18 +73,5 @@ public class Metadata {
         Metadata metadata = (Metadata) o;
         return domain == metadata.domain
                 && Objects.equals(key, metadata.key);
-    }
-
-    /**
-     * Map Collection of Metadata objects to a Map of Metadata and String objects.
-     * @param metadataCollection Collection of Metadata objects
-     * @return Map of Metadata and String objects as java.util.Map
-     */
-    public static Map<Metadata, String> mapToKey(Collection<Metadata> metadataCollection) {
-        if (Objects.isNull(metadataCollection)) {
-            return Collections.emptyMap();
-        }
-        return metadataCollection.parallelStream()
-                .collect(Collectors.toMap(Function.identity(), Metadata::getKey, (duplicateOne, duplicateTwo) -> duplicateOne));
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/ComplexMetadataViewInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/ComplexMetadataViewInterface.java
@@ -13,7 +13,8 @@ package org.kitodo.api.dataeditor.rulesetmanagement;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+
+import org.kitodo.api.Metadata;
 
 /**
  * Provides an interface for the complex-type view service. The complex-type
@@ -32,7 +33,7 @@ public interface ComplexMetadataViewInterface extends MetadataViewInterface {
      *            metadata keys that the user has already selected
      * @return the metadata keys that the user can add
      */
-    Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> entered,
+    Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected);
 
     /**
@@ -50,8 +51,6 @@ public interface ComplexMetadataViewInterface extends MetadataViewInterface {
      * keys that the user has already manually added. The list is created and
      * then sorted according to the given sorting rules.
      *
-     * @param <T>
-     *            the type of metadata objects
      * @param entered
      *            metadata objects that have already been entered, along with
      *            their key
@@ -61,7 +60,7 @@ public interface ComplexMetadataViewInterface extends MetadataViewInterface {
      *         already filled with values, the values are returned here. If a
      *         key is a multiple-selection, values are grouped below it.
      */
-    <T> List<MetadataViewWithValuesInterface<T>> getSortedVisibleMetadata(Map<T, String> entered,
+    List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected);
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/MetadataViewWithValuesInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/MetadataViewWithValuesInterface.java
@@ -14,6 +14,8 @@ package org.kitodo.api.dataeditor.rulesetmanagement;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
+
 /**
  * Return value of the function
  * {@code ComplexMetadataViewInterface.getSortedVisibleMetadatas()}. The
@@ -26,11 +28,8 @@ import java.util.Optional;
  * is {@code List<Pair<MetadataViewInterface, Collection<T>>>}. Since the key
  * must be repeatable if there is more than one value but the key is not a
  * multiple choice, a map would be an inappropriate choice at this point.
- *
- * @param <T>
- *            type of data objects
  */
-public interface MetadataViewWithValuesInterface<T> {
+public interface MetadataViewWithValuesInterface {
     /**
      * Returns the key to be displayed at this point. The interface can return
      * entries where the key is {@code null} with values if there were values
@@ -48,5 +47,5 @@ public interface MetadataViewWithValuesInterface<T> {
      *
      * @return the values for the key
      */
-    Collection<T> getValues();
+    Collection<Metadata> getValues();
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AuxiliaryTableRow.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/AuxiliaryTableRow.java
@@ -19,22 +19,19 @@ import java.util.List;
 import java.util.Locale.LanguageRange;
 import java.util.Set;
 
+import org.kitodo.api.Metadata;
+
 /**
  * Class of the data row objects of the auxiliary table. You can imagine the
  * list of these objects in the metadata acquisition mask builder as a large
  * table in which all relevant information is entered, one row per metadata
  * type, in the order in which the metadata types must be displayed later.
- *
- * @param <T>
- *            the type of metadata objects
  */
-class AuxiliaryTableRow<T> {
+class AuxiliaryTableRow {
     /**
      * Returns the umpteenth set member as the only element of a list, if that
      * exists. Otherwise the empty list.
      *
-     * @param <T>
-     *            the type of the metadata objects
      * @param unnumbered
      *            unnumbered collection
      * @param fictitiousNumber
@@ -84,7 +81,7 @@ class AuxiliaryTableRow<T> {
      * which class these objects have, it still accepts them and provides for
      * possibly necessary grouping.
      */
-    private Set<T> metaDataObjects = new HashSet<>();
+    private Set<Metadata> metaDataObjects = new HashSet<>();
 
     /**
      * Creates a new data row object and enters a key into the table.
@@ -103,7 +100,7 @@ class AuxiliaryTableRow<T> {
      * @param metaDataObject
      *            valuable object added
      */
-    void add(T metaDataObject) {
+    void add(Metadata metaDataObject) {
         metaDataObjects.add(metaDataObject);
 
     }
@@ -126,7 +123,7 @@ class AuxiliaryTableRow<T> {
      *            which object should be returned
      * @return the data object(s)
      */
-    Collection<T> getDataObjects(int i) {
+    Collection<Metadata> getDataObjects(int i) {
         if (isMultipleChoice() || isContainingExcludedData()) {
             return metaDataObjects;
         } else {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/FormRow.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/FormRow.java
@@ -14,6 +14,7 @@ package org.kitodo.dataeditor.ruleset;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewWithValuesInterface;
 
@@ -21,11 +22,8 @@ import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewWithValuesInterfa
  * Return type for list entries consisting of a metadata key and a collection
  * of values. Instances of this class are returned by the metadata acquisition
  * mask builder and each represent a line of the metadata input mask.
- *
- * @param <T>
- *            type of metadata objects
  */
-class FormRow<T> implements MetadataViewWithValuesInterface<T> {
+class FormRow implements MetadataViewWithValuesInterface {
     /**
      * A possible view on the key. None, if it is hidden.
      */
@@ -34,9 +32,9 @@ class FormRow<T> implements MetadataViewWithValuesInterface<T> {
     /**
      * The values. This is always one at most, except for multiple selections.
      */
-    private Collection<T> values;
+    private Collection<Metadata> values;
 
-    FormRow(Optional<MetadataViewInterface> optionalKeyView, Collection<T> values) {
+    FormRow(Optional<MetadataViewInterface> optionalKeyView, Collection<Metadata> values) {
         this.optionalKeyView = optionalKeyView;
         this.values = values;
     }
@@ -58,7 +56,7 @@ class FormRow<T> implements MetadataViewWithValuesInterface<T> {
      * @return the values
      */
     @Override
-    public Collection<T> getValues() {
+    public Collection<Metadata> getValues() {
         return values;
     }
 

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
@@ -19,11 +19,10 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale.LanguageRange;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.TreeMap;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -64,7 +63,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *             in the ruleset.
      */
     private static final <V> void addFieldsForAdditionallySelectedKeys(Collection<String> additionallySelectedKeys,
-            LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable) {
+            LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable) {
 
         additionallySelectedKeys.parallelStream().map(auxiliaryTable::get)
                 .forEach(AuxiliaryTableRow::addOneAdditionalField);
@@ -74,17 +73,15 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * Appends the rows to the auxiliary table. Since the order of the rows is
      * relevant, you cannot parallelize here.
      *
-     * @param <V>
-     *            the type of metadata values
      * @param rows
      *            rows to append
      * @param auxiliaryTable
      *            auxiliary table to append to
      */
-    private static final <V> void appendRowsToAuxiliaryTable(Collection<AuxiliaryTableRow<V>> rows,
-            LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable) {
+    private static final void appendRowsToAuxiliaryTable(Collection<AuxiliaryTableRow> rows,
+            LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable) {
 
-        for (AuxiliaryTableRow<V> auxiliaryTableRow : rows) {
+        for (AuxiliaryTableRow auxiliaryTableRow : rows) {
             auxiliaryTable.put(auxiliaryTableRow.getId(), auxiliaryTableRow);
         }
     }
@@ -103,11 +100,11 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            the wish list of the user’s preferred human language
      * @return sorted list of fields
      */
-    private static final <V> Collection<AuxiliaryTableRow<V>> sort(
-            HashMap<String, AuxiliaryTableRow<V>> auxiliaryTableToBeSorted, List<LanguageRange> priorityList) {
+    private static final <V> Collection<AuxiliaryTableRow> sort(
+            HashMap<String, AuxiliaryTableRow> auxiliaryTableToBeSorted, List<LanguageRange> priorityList) {
 
-        TreeMap<String, AuxiliaryTableRow<V>> sorted = new TreeMap<>();
-        for (AuxiliaryTableRow<V> auxiliaryTableRow : auxiliaryTableToBeSorted.values()) {
+        TreeMap<String, AuxiliaryTableRow> sorted = new TreeMap<>();
+        for (AuxiliaryTableRow auxiliaryTableRow : auxiliaryTableToBeSorted.values()) {
             sorted.put(auxiliaryTableRow.getLabel(priorityList) + '\037' + auxiliaryTableRow.getId(),
                 auxiliaryTableRow);
         }
@@ -193,7 +190,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param auxiliaryTable
      *            auxiliary table
      */
-    private final <V> void addAnyRules(LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable) {
+    private final <V> void addAnyRules(LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable) {
 
         auxiliaryTable.entrySet().parallelStream().forEach(entry -> entry.getValue()
                 .setRule(rule.getRuleForKey(entry.getKey(), division)));
@@ -214,16 +211,16 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param toBeSorted
      *            write access to the list of keys to be sorted
      */
-    private final <V> void addAdditionalKeys(LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable,
+    private final <V> void addAdditionalKeys(LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable,
             Rule rule, Collection<String> additionalKeys,
-            HashMap<String, AuxiliaryTableRow<V>> toBeSorted) {
+            HashMap<String, AuxiliaryTableRow> toBeSorted) {
         for (String additionalKey : additionalKeys) {
             if (!auxiliaryTable.containsKey(additionalKey) && !toBeSorted.containsKey(additionalKey)) {
                 Optional<Key> optionalKey = rule.isUnspecifiedUnrestricted() ? Optional.empty()
                         : ruleset.getKey(additionalKey);
                 KeyDeclaration keyDeclaration = optionalKey.isPresent() ? new KeyDeclaration(ruleset, optionalKey.get())
                         : new KeyDeclaration(ruleset, additionalKey);
-                toBeSorted.put(additionalKey, new AuxiliaryTableRow<>(keyDeclaration, settings));
+                toBeSorted.put(additionalKey, new AuxiliaryTableRow(keyDeclaration, settings));
             }
         }
     }
@@ -241,11 +238,11 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param toBeSorted
      *            write access to the list of keys to be sorted
      */
-    private final <V> void addRemainingKeys(LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable,
-            Collection<KeyDeclaration> keyDeclarations, HashMap<String, AuxiliaryTableRow<V>> toBeSorted) {
+    private final <V> void addRemainingKeys(LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable,
+            Collection<KeyDeclaration> keyDeclarations, HashMap<String, AuxiliaryTableRow> toBeSorted) {
         for (KeyDeclaration keyDeclaration : keyDeclarations) {
             if (!auxiliaryTable.containsKey(keyDeclaration.getId())) {
-                toBeSorted.put(keyDeclaration.getId(), new AuxiliaryTableRow<>(keyDeclaration, settings));
+                toBeSorted.put(keyDeclaration.getId(), new AuxiliaryTableRow(keyDeclaration, settings));
             }
         }
     }
@@ -271,11 +268,11 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            which keys the user has additionally selected
      * @return an auxiliary table for additional keys yet to be sorted
      */
-    private final <V> HashMap<String, AuxiliaryTableRow<V>> cerateAuxiliaryTableWithKeysToBeSorted(
-            LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable, Rule rule,
+    private final <V> HashMap<String, AuxiliaryTableRow> cerateAuxiliaryTableWithKeysToBeSorted(
+            LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable, Rule rule,
             Collection<KeyDeclaration> keyDeclarations, Collection<String> additionalKeys) {
 
-        HashMap<String, AuxiliaryTableRow<V>> toBeSorted = new HashMap<>();
+        HashMap<String, AuxiliaryTableRow> toBeSorted = new HashMap<>();
 
         if (rule.isUnspecifiedUnrestricted()) {
             addRemainingKeys(auxiliaryTable, keyDeclarations, toBeSorted);
@@ -295,12 +292,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            which keys the user has additionally selected
      * @return A helper table for all metadata keys
      */
-    private <V> Collection<AuxiliaryTableRow<V>> createAuxiliaryTable(Map<V, String> currentEntries,
+    private Collection<AuxiliaryTableRow> createAuxiliaryTable(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys) {
 
-        LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable = createAuxiliaryTableWithPreSortedKeys(
+        LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable = createAuxiliaryTableWithPreSortedKeys(
             rule.getExplicitlyPermittedKeys(declaration));
-        HashMap<String, AuxiliaryTableRow<V>> auxiliaryTableToBeSorted = cerateAuxiliaryTableWithKeysToBeSorted(
+        HashMap<String, AuxiliaryTableRow> auxiliaryTableToBeSorted = cerateAuxiliaryTableWithKeysToBeSorted(
             auxiliaryTable, rule, declaration.getKeyDeclarations(), additionalKeys);
         storeValues(currentEntries, auxiliaryTable, auxiliaryTableToBeSorted);
         appendRowsToAuxiliaryTable(sort(auxiliaryTableToBeSorted, priorityList), auxiliaryTable);
@@ -318,12 +315,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            keys given in their order by the restriction rule
      * @return the auxiliary table
      */
-    private final <V> LinkedHashMap<String, AuxiliaryTableRow<V>> createAuxiliaryTableWithPreSortedKeys(
+    private final <V> LinkedHashMap<String, AuxiliaryTableRow> createAuxiliaryTableWithPreSortedKeys(
             List<KeyDeclaration> explicitlyPermittedKeys) {
 
-        LinkedHashMap<String, AuxiliaryTableRow<V>> auxiliaryTable = new LinkedHashMap<>();
+        LinkedHashMap<String, AuxiliaryTableRow> auxiliaryTable = new LinkedHashMap<>();
         for (KeyDeclaration keyDeclaration : explicitlyPermittedKeys) {
-            auxiliaryTable.put(keyDeclaration.getId(), new AuxiliaryTableRow<V>(keyDeclaration, settings));
+            auxiliaryTable.put(keyDeclaration.getId(), new AuxiliaryTableRow(keyDeclaration, settings));
         }
         return auxiliaryTable;
     }
@@ -332,8 +329,6 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * Here the addable metadata keys are fetched. To do this, the table must
      * first be made and then an output made.
      *
-     * @param <V>
-     *            the type of metadata objects
      * @param currentEntries
      *            metadata objects that have already been entered, along with
      *            their key
@@ -341,17 +336,17 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      *            metadata keys that the user has already selected
      */
     @Override
-    public Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> currentEntries,
+    public Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys) {
 
         return getPossibleMetadata(currentEntries, additionalKeys, false);
     }
 
-    private Collection<MetadataViewInterface> getPossibleMetadata(Map<?, String> currentEntries,
+    private Collection<MetadataViewInterface> getPossibleMetadata(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys, boolean all) {
 
         Collection<MetadataViewInterface> addableMetadata = new LinkedList<>();
-        for (AuxiliaryTableRow<?> auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
+        for (AuxiliaryTableRow auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
             if (all || auxiliaryTableRow.isPossibleToExpandAnotherField()) {
                 MetadataViewInterface keyView = auxiliaryTableRow
                         .isComplexKey()
@@ -373,7 +368,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      */
     @Override
     public Collection<MetadataViewInterface> getAllowedMetadata() {
-        return getPossibleMetadata(Collections.emptyMap(), Collections.emptySet(), true);
+        return getPossibleMetadata(Collections.emptyList(), Collections.emptySet(), true);
     }
 
     /**
@@ -403,8 +398,6 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * be sorted and therefore sometimes more fields are needed. Exceptions here
      * are multiple selections only once, and with multiple values.
      *
-     * @param <V>
-     *            the type of metadata objects
      * @param currentEntries
      *            metadata objects that have already been entered, along with
      *            heir key
@@ -413,12 +406,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @return mask
      */
     @Override
-    public <V> List<MetadataViewWithValuesInterface<V>> getSortedVisibleMetadata(Map<V, String> currentEntries,
+    public List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> currentEntries,
             Collection<String> additionalKeys) {
 
-        LinkedList<MetadataViewWithValuesInterface<V>> sortedVisibleMetadata = new LinkedList<>();
-        Collection<V> excludedDataObjects = new HashSet<>();
-        for (AuxiliaryTableRow<V> auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
+        LinkedList<MetadataViewWithValuesInterface> sortedVisibleMetadata = new LinkedList<>();
+        Collection<Metadata> excludedDataObjects = new HashSet<>();
+        for (AuxiliaryTableRow auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
             if (auxiliaryTableRow.isContainingExcludedData()) {
                 excludedDataObjects.addAll(auxiliaryTableRow.getDataObjects(0));
             } else {
@@ -430,12 +423,12 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
                                             rule.getRuleForKey(auxiliaryTableRow.getId(), division),
                                             settings, priorityList);
                     Optional<MetadataViewInterface> definedTypeView = Optional.of(typeView);
-                    sortedVisibleMetadata.add(new FormRow<>(definedTypeView, auxiliaryTableRow.getDataObjects(i)));
+                    sortedVisibleMetadata.add(new FormRow(definedTypeView, auxiliaryTableRow.getDataObjects(i)));
                 }
             }
         }
         if (!excludedDataObjects.isEmpty()) {
-            sortedVisibleMetadata.addFirst(new FormRow<>(Optional.empty(), excludedDataObjects));
+            sortedVisibleMetadata.addFirst(new FormRow(Optional.empty(), excludedDataObjects));
         }
         return sortedVisibleMetadata;
     }
@@ -452,27 +445,27 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
      * @param auxiliaryTableToBeSorted
      *            help table with rows that still have to be sorted
      */
-    private final <V> void storeValues(Map<V, String> enteredMetaData,
-            LinkedHashMap<String, AuxiliaryTableRow<V>> sortedAuxiliaryTable,
-            HashMap<String, AuxiliaryTableRow<V>> auxiliaryTableToBeSorted) {
+    private final void storeValues(Collection<Metadata> enteredMetaData,
+            LinkedHashMap<String, AuxiliaryTableRow> sortedAuxiliaryTable,
+            HashMap<String, AuxiliaryTableRow> auxiliaryTableToBeSorted) {
 
-        for (Entry<V, String> entry : enteredMetaData.entrySet()) {
-            String keyId = entry.getValue();
+        for (Metadata metadata : enteredMetaData) {
+            String keyId = metadata.getKey();
             if (sortedAuxiliaryTable.containsKey(keyId)) {
-                sortedAuxiliaryTable.get(keyId).add(entry.getKey());
+                sortedAuxiliaryTable.get(keyId).add(metadata);
             } else {
                 auxiliaryTableToBeSorted.computeIfAbsent(keyId,
                     missing -> retrieveOrCompute(keyId));
-                auxiliaryTableToBeSorted.get(keyId).add(entry.getKey());
+                auxiliaryTableToBeSorted.get(keyId).add(metadata);
             }
         }
     }
 
-    private <V> AuxiliaryTableRow<V> retrieveOrCompute(String keyId) {
+    private AuxiliaryTableRow retrieveOrCompute(String keyId) {
         Optional<Key> possibleKey = ruleset.getKey(keyId);
         KeyDeclaration keyDeclaration = possibleKey.isPresent() ? new KeyDeclaration(ruleset, possibleKey.get(), true)
                 : new KeyDeclaration(ruleset, keyId);
-        return new AuxiliaryTableRow<>(keyDeclaration, settings);
+        return new AuxiliaryTableRow(keyDeclaration, settings);
     }
 
     @Override

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
@@ -348,13 +348,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
         Collection<MetadataViewInterface> addableMetadata = new LinkedList<>();
         for (AuxiliaryTableRow auxiliaryTableRow : createAuxiliaryTable(currentEntries, additionalKeys)) {
             if (all || auxiliaryTableRow.isPossibleToExpandAnotherField()) {
-                MetadataViewInterface keyView = auxiliaryTableRow
-                        .isComplexKey()
-                                ? getNestedKeyView(auxiliaryTableRow.getId())
-                                : new KeyView(auxiliaryTableRow.getKey(),
-                                        rule.getRuleForKey(auxiliaryTableRow.getId(), division),
-                                        settings, priorityList);
-                addableMetadata.add(keyView);
+                addableMetadata.add(rowToView(auxiliaryTableRow));
             }
         }
         return addableMetadata;
@@ -372,9 +366,22 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
     }
 
     /**
-     * Creates a key view in a nest. This is the case when grouped keys, in the
-     * rule set XML file when {@code <key>} element occurs within {@code <key>}
-     * element.
+     * Creates a metadata view for one line of the auxiliary table.
+     *
+     * @param row
+     *            row to make a view for
+     * @return metadata view
+     */
+    private MetadataViewInterface rowToView(AuxiliaryTableRow row) {
+        MetadataViewInterface view = row.isComplexKey() ? getNestedKeyView(row.getId())
+                : new KeyView(row.getKey(), rule.getRuleForKey(row.getId(), division), settings, priorityList);
+        return view;
+    }
+
+    /**
+     * Creates a key view for a grouped key. This is the case when when
+     * {@code <key>} elements occur within another {@code <key>} element in the
+     * ruleset.
      *
      * @param keyId
      *            identifier for key in the nest
@@ -416,13 +423,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
                 excludedDataObjects.addAll(auxiliaryTableRow.getDataObjects(0));
             } else {
                 for (int i = 0; i < auxiliaryTableRow.getNumberOfTypeViewsToGenerate(); i++) {
-                    MetadataViewInterface typeView = auxiliaryTableRow
-                            .isComplexKey()
-                                    ? getNestedKeyView(auxiliaryTableRow.getId())
-                                    : new KeyView(auxiliaryTableRow.getKey(),
-                                            rule.getRuleForKey(auxiliaryTableRow.getId(), division),
-                                            settings, priorityList);
-                    Optional<MetadataViewInterface> definedTypeView = Optional.of(typeView);
+                    Optional<MetadataViewInterface> definedTypeView = Optional.of(rowToView(auxiliaryTableRow));
                     sortedVisibleMetadata.add(new FormRow(definedTypeView, auxiliaryTableRow.getDataObjects(i)));
                 }
             }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
@@ -20,7 +20,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Triple;
 import org.kitodo.dataeditor.ruleset.xml.RestrictivePermit;
 import org.kitodo.dataeditor.ruleset.xml.Ruleset;
 import org.kitodo.dataeditor.ruleset.xml.Unspecified;
@@ -31,20 +30,6 @@ import org.kitodo.dataeditor.ruleset.xml.Unspecified;
  * restrictions.
  */
 public class Rule {
-    /**
-     * Generates a triplet of rule with triple as a key. This is due to the
-     * problem because the rule is basically the key is three fields and applies
-     * everything.
-     *
-     * @param restrictivePermit
-     *            restrictive permit for which a hash key is to be formed
-     * @return key is triple
-     */
-    private static Triple<String, String, String> formAKeyForARuleInATemporaryMap(RestrictivePermit restrictivePermit) {
-        return Triple.of(restrictivePermit.getDivision().orElse(null), restrictivePermit.getKey().orElse(null),
-            restrictivePermit.getValue().orElse(null));
-    }
-
     /**
      * Maybe a rule, but maybe not.
      */
@@ -248,16 +233,15 @@ public class Rule {
                     : Unspecified.UNRESTRICTED);
 
         // for sub-rules, apply recursively
-        HashMap<Triple<String, String, String>, RestrictivePermit> anotherPermits = new LinkedHashMap<>();
+        HashMap<RestrictivePermit, RestrictivePermit> anotherPermits = new LinkedHashMap<>();
         for (RestrictivePermit anotherPermit : another.getPermits()) {
-            anotherPermits.put(formAKeyForARuleInATemporaryMap(anotherPermit), anotherPermit);
+            anotherPermits.put(anotherPermit, anotherPermit);
         }
         List<RestrictivePermit> mergedPermits = new LinkedList<>();
         for (RestrictivePermit onePermit : one.getPermits()) {
-            Triple<String, String, String> key = formAKeyForARuleInATemporaryMap(onePermit);
-            if (anotherPermits.containsKey(key)) {
-                mergedPermits.add(merge(onePermit, anotherPermits.get(key)));
-                anotherPermits.remove(key);
+            if (anotherPermits.containsKey(onePermit)) {
+                mergedPermits.add(merge(onePermit, anotherPermits.get(onePermit)));
+                anotherPermits.remove(onePermit);
             } else {
                 mergedPermits.add(onePermit);
             }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Condition.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Condition.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.dataeditor.ruleset.xml;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * A {@code <condition>}, which can be defined inside a {@code <restriction>}
+ * and contains conditional {@code <permit>} rules, which only apply if the
+ * condition is met.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Condition {
+    /**
+     * Key to which this (restriction) rule applies, or key that is allowed (for
+     * permit rule inside restriction rule).
+     */
+    @XmlAttribute(required = true)
+    private String key;
+
+    /**
+     * Value that the metadata entry must have for the condition to apply.
+     */
+    @XmlAttribute(required = true)
+    private String equals;
+
+    /**
+     * List of conditional permits.
+     */
+    @XmlElement(name = "permit", namespace = "http://names.kitodo.org/ruleset/v2")
+    private List<RestrictivePermit> permits = new LinkedList<>();
+
+    /**
+     * List of (nested) conditions.
+     */
+    @XmlElement(name = "condition", namespace = "http://names.kitodo.org/ruleset/v2")
+    private List<Condition> conditions = new LinkedList<>();
+}

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
@@ -74,6 +74,12 @@ public class RestrictivePermit {
     private List<RestrictivePermit> permits = new LinkedList<>();
 
     /**
+     * List of (nested) conditions.
+     */
+    @XmlElement(name = "condition", namespace = "http://names.kitodo.org/ruleset/v2")
+    private List<Condition> conditions = new LinkedList<>();
+
+    /**
      * Returns the division to which this rule applies, or which is allowed.
      *
      * @return the division to which this rule applies, or which is allowed

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
@@ -207,4 +207,47 @@ public class RestrictivePermit {
     public void setValue(Optional<String> value) {
         this.value = value.orElse(null);
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((division == null) ? 0 : division.hashCode());
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RestrictivePermit)) {
+            return false;
+        }
+        RestrictivePermit other = (RestrictivePermit) obj;
+        if (division == null) {
+            if (other.division != null) {
+                return false;
+            }
+        } else if (!division.equals(other.division)) {
+            return false;
+        }
+        if (key == null) {
+            if (other.key != null) {
+                return false;
+            }
+        } else if (!key.equals(other.key)) {
+            return false;
+        }
+        if (value == null) {
+            if (other.value != null) {
+                return false;
+            }
+        } else if (!value.equals(other.value)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -27,10 +27,10 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Month;
 import java.time.MonthDay;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale.LanguageRange;
@@ -40,6 +40,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
+import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.DatesSimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
@@ -94,7 +96,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testAvailabilityOfPresets.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("defaultStringKey", "anyURIKey", "booleanKey", "dateKey", "namespaceDefaultAnyURIKey",
                 "namespaceStringKey"));
 
@@ -144,7 +146,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testAvailabilityOfSubkeyViews.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList("contributor"));
 
         MetadataViewInterface contributorMvi = mvwviList.get(0).getMetadata().get();
@@ -154,7 +156,7 @@ public class RulesetManagementIT {
         assertTrue(contributorMvi instanceof ComplexMetadataViewInterface);
         ComplexMetadataViewInterface contributorCmvi = (ComplexMetadataViewInterface) contributorMvi;
 
-        Collection<MetadataViewInterface> mvic = contributorCmvi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mvic = contributorCmvi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         Iterator<MetadataViewInterface> mvici = mvic.iterator();
@@ -209,13 +211,13 @@ public class RulesetManagementIT {
 
         // 1. options are sorted as to their labels alphabetically
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         StructuralElementViewInterface seviDe = underTest.getStructuralElementView(BOOK, "",
             LanguageRange.parse("de"));
-        List<MetadataViewWithValuesInterface<Void>> mvwviListDe = seviDe
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> mvwviListDe = seviDe.getSortedVisibleMetadata(Collections.emptyList(),
+            Collections.emptyList());
 
         assertThat(((SimpleMetadataViewInterface) mvwviList.get(0).getMetadata().get()).getSelectItems().keySet(),
             contains("dan", "dut", "eng", "fre", "ger"));
@@ -228,7 +230,7 @@ public class RulesetManagementIT {
         assertThat(ids(mvwviList), contains("mandatoryMultiLineSingleSelection", "mandatoryOneLineSingleSelection",
             "mandatoryMultipleSelection"));
 
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         assertThat(ids(mviColl), contains("optionalMultiLineSingleSelection", "optionalOneLineSingleSelection",
@@ -259,7 +261,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testCorrectValidationOfOptions.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         SimpleMetadataViewInterface smvi = (SimpleMetadataViewInterface) mviColl.iterator().next();
         assertTrue(smvi.isValid(OPT));
@@ -275,7 +277,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testCorrectValidationOfRegularExpressions.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Void>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("defaultStringKey", "anyURIKey", "booleanKey", "dateKey", "namespaceDefaultAnyURIKey",
                 "namespaceStringKey", "integerKey", "optionsKey"));
 
@@ -353,8 +355,8 @@ public class RulesetManagementIT {
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "The acquisition stage", ENGL);
 
         // always showing
-        List<MetadataViewWithValuesInterface<Void>> mvwviListAlwaysShowing = sevi
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> mvwviListAlwaysShowing = sevi
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertThat(
             mvwviListAlwaysShowing.stream().map(mvwvi -> mvwvi.getMetadata().get().getId())
                     .collect(Collectors.toList()),
@@ -362,13 +364,23 @@ public class RulesetManagementIT {
                 "alwaysShowingTrueOtherchanges", "alwaysShowingTrueTrue", "multilineTrueOtherchanges"));
 
         // excluded
-        Map<Object, String> metadataForExcluded = new HashMap<>();
-        metadataForExcluded.put("exclude1", "excludedUnchangedTrue");
-        metadataForExcluded.put("exclude2", "excludedTrueUnchanged");
-        metadataForExcluded.put("exclude3", "excludedTrueOtherchanges");
-        metadataForExcluded.put("exclude4", "excludedTrueTrue");
-        metadataForExcluded.put("n#*703=]", "excludedTrueFalse");
-        List<MetadataViewWithValuesInterface<Object>> mvwviListExcluded = sevi
+        Collection<Metadata> metadataForExcluded = new ArrayList<>();
+        Metadata metadataOne = new MetadataEntry();
+        metadataOne.setKey("excludedUnchangedTrue");
+        metadataForExcluded.add(metadataOne);
+        Metadata metadataTwo = new MetadataEntry();
+        metadataTwo.setKey("excludedTrueUnchanged");
+        metadataForExcluded.add(metadataTwo);
+        Metadata metadataThree = new MetadataEntry();
+        metadataThree.setKey("excludedTrueOtherchanges");
+        metadataForExcluded.add(metadataThree);
+        Metadata metadataFour = new MetadataEntry();
+        metadataFour.setKey("excludedTrueTrue");
+        metadataForExcluded.add(metadataFour);
+        Metadata metadataFive = new MetadataEntry();
+        metadataFive.setKey("excludedTrueFalse");
+        metadataForExcluded.add(metadataFive);
+        List<MetadataViewWithValuesInterface> mvwviListExcluded = sevi
                 .getSortedVisibleMetadata(metadataForExcluded, Collections.emptyList());
         assertTrue(mvwviListExcluded.stream().filter(mvwvi -> mvwvi.getMetadata().isPresent())
                 .map(mvwvi -> mvwvi.getMetadata().get().getId()).filter(keyId -> keyId.startsWith("excluded"))
@@ -383,7 +395,7 @@ public class RulesetManagementIT {
                 .collect(Collectors.toList()).contains("excludedTrueFalse"));
 
         // editable
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("editableUnchangedFalse", "editableFalseUnchanged", "editableFalseOtherchanges",
                 "editableFalseFalse", "editableFalseTrue", "multilineUnchangedTrue", "multilineTrueUnchanged",
                 "multilineTrueOtherchanges", "multilineTrueTrue", "multilineTrueFalse"));
@@ -425,14 +437,14 @@ public class RulesetManagementIT {
         // 1. Without metadata, and without additional fields being selected,
         // you should see exactly the fields that are always showing, minus
         // those that are excluded (excluded overrules always showing).
-        List<MetadataViewWithValuesInterface<Void>> mvwviListNoMetadata = sevi
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> mvwviListNoMetadata = sevi
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertThat(ids(mvwviListNoMetadata),
             containsInAnyOrder("testAlwaysShowing", "testAlwaysShowingEditable", "testAlwaysShowingMultiline"));
 
         // 2. All fields except those that are excluded should be allowed to be
         // added.
-        Collection<MetadataViewInterface> mviCollNoMetadata = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviCollNoMetadata = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertThat(ids(mviCollNoMetadata), containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline",
             "testAlwaysShowingEditable", "testAlwaysShowingMultiline", "testEditableMultiline", "testNestedSettings",
@@ -441,39 +453,61 @@ public class RulesetManagementIT {
         // 1a. In the nested metadata field, the only value that should be
         // visible is the one marked as always showing. The field has to be
         // added first:
-        List<MetadataViewWithValuesInterface<Void>> mvwviListNestedSettings = sevi
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.singletonList("testNestedSettings"));
+        List<MetadataViewWithValuesInterface> mvwviListNestedSettings = sevi
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.singletonList("testNestedSettings"));
         ComplexMetadataViewInterface nestedSettings = (ComplexMetadataViewInterface) mvwviListNestedSettings.stream()
                 .filter(mvwvi -> mvwvi.getMetadata().get().getId().equals("testNestedSettings")).findAny().get()
                 .getMetadata().get();
-        List<MetadataViewWithValuesInterface<Void>> nestedMvwviList = nestedSettings
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> nestedMvwviList = nestedSettings
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertEquals(1, nestedMvwviList.size());
         assertEquals("testAlwaysShowing", nestedMvwviList.get(0).getMetadata().get().getId());
 
         // 2a. Also with nested metadata, all fields except those that are
         // excluded should be allowed to be added.
-        Collection<MetadataViewInterface> nestedMviColl = nestedSettings.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> nestedMviColl = nestedSettings.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertThat(ids(nestedMviColl), containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline"));
 
         // 3. With metadata, all fields should be visible except those that are
         // excluded. There should be an entry without a key in the list
         // containing the values of the excluded keys.
-        Map<Object, String> metadata = new HashMap<>();
-        metadata.put("udv-q@bC", "testAlwaysShowing");
-        metadata.put("/F5Mu=/1", "testEditable");
-        metadata.put("exclude1", "testExcluded");
-        metadata.put("WP&~O$YV", "testMultiline");
-        metadata.put("n#*703=]", "testAlwaysShowingEditable");
-        metadata.put("exclude2", "testAlwaysShowingExcluded");
-        metadata.put("Mu{lp'n1", "testAlwaysShowingMultiline");
-        metadata.put("exclude3", "testEditableExcluded");
-        metadata.put("qP'Jc:.R", "testEditableMultiline");
-        metadata.put("exclude4", "testExcludedMultiline");
-        metadata.put("4J[~UgHp", "testNestedSettings");
+        Collection<Metadata> metadata = new ArrayList<>();
+        Metadata metadataOne = new MetadataEntry();
+        metadataOne.setKey("testAlwaysShowing");
+        metadata.add(metadataOne);
+        Metadata metadataTwo = new MetadataEntry();
+        metadataTwo.setKey("testEditable");
+        metadata.add(metadataTwo);
+        Metadata metadataThree = new MetadataEntry();
+        metadataThree.setKey("testExcluded");
+        metadata.add(metadataThree);
+        Metadata metadataFour = new MetadataEntry();
+        metadataFour.setKey("testMultiline");
+        metadata.add(metadataFour);
+        Metadata metadataFive = new MetadataEntry();
+        metadataFive.setKey("testAlwaysShowingEditable");
+        metadata.add(metadataFive);
+        Metadata metadataSix = new MetadataEntry();
+        metadataSix.setKey("testAlwaysShowingExcluded");
+        metadata.add(metadataSix);
+        Metadata metadataSeven = new MetadataEntry();
+        metadataSeven.setKey("testAlwaysShowingMultiline");
+        metadata.add(metadataSeven);
+        Metadata metadataEight = new MetadataEntry();
+        metadataEight.setKey("testEditableExcluded");
+        metadata.add(metadataEight);
+        Metadata metadataNine = new MetadataEntry();
+        metadataNine.setKey("testEditableMultiline");
+        metadata.add(metadataNine);
+        Metadata metadataTen = new MetadataEntry();
+        metadataTen.setKey("testExcludedMultiline");
+        metadata.add(metadataTen);
+        Metadata metadataEleven = new MetadataEntry();
+        metadataEleven.setKey("testNestedSettings");
+        metadata.add(metadataEleven);
 
-        List<MetadataViewWithValuesInterface<Object>> mvwviListWithMetadata = sevi.getSortedVisibleMetadata(metadata,
+        List<MetadataViewWithValuesInterface> mvwviListWithMetadata = sevi.getSortedVisibleMetadata(metadata,
             Collections.emptyList());
         assertThat(ids(mvwviListWithMetadata), containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline",
             "testAlwaysShowingEditable", "testAlwaysShowingMultiline", "testEditableMultiline", "testNestedSettings"));
@@ -483,13 +517,13 @@ public class RulesetManagementIT {
             containsInAnyOrder("exclude1", "exclude2", "exclude3", "exclude4"));
 
         // 3a. Also with nested metadata, that should work that way.
-        Map<Object, String> nestedMetadata = new HashMap<>();
-        nestedMetadata.put("udv-q@bC", "testAlwaysShowing");
-        nestedMetadata.put("/F5Mu=/1", "testEditable");
-        nestedMetadata.put("excluded", "testExcluded");
-        nestedMetadata.put("WP&~O$YV", "testMultiline");
+        Collection<Metadata> nestedMetadata = new ArrayList<>();
+        nestedMetadata.add(metadataOne);
+        nestedMetadata.add(metadataTwo);
+        nestedMetadata.add(metadataThree);
+        nestedMetadata.add(metadataFour);
 
-        List<MetadataViewWithValuesInterface<Object>> nestedMvwviListWithMetadata = nestedSettings
+        List<MetadataViewWithValuesInterface> nestedMvwviListWithMetadata = nestedSettings
                 .getSortedVisibleMetadata(nestedMetadata, Collections.emptyList());
         assertThat(ids(nestedMvwviListWithMetadata),
             containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline"));
@@ -583,14 +617,14 @@ public class RulesetManagementIT {
         // Now a first view on a book
         StructuralElementViewInterface view = underTest.getStructuralElementView(BOOK, "", ENGL);
         assertEquals(1, view.getAllowedSubstructuralElements().entrySet().size());
-        assertEquals(5 + 3, view.getAddableMetadata(Collections.emptyMap(), Collections.emptyList()).size());
+        assertEquals(5 + 3, view.getAddableMetadata(Collections.emptyList(), Collections.emptyList()).size());
         assertTrue(view.isComplex());
         assertFalse(view.isUndefined());
 
         // Now a nonsense view
         StructuralElementViewInterface nonsenseView = underTest.getStructuralElementView("bosh", "", ENGL);
         assertEquals(1, nonsenseView.getAllowedSubstructuralElements().entrySet().size());
-        assertEquals(5 + 3, nonsenseView.getAddableMetadata(Collections.emptyMap(), Collections.emptyList()).size());
+        assertEquals(5 + 3, nonsenseView.getAddableMetadata(Collections.emptyList(), Collections.emptyList()).size());
         assertTrue(nonsenseView.isUndefined());
     }
 
@@ -688,7 +722,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testFieldsWithMinOccursGreaterZeroAreAlwaysShown.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         assertThat(ids(mvwviList), contains("test1", "test2", "test2", "test2options"));
@@ -730,9 +764,11 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testKeysReturnTheSpecifiedDomain.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Map<Object, String> metadata = new HashMap<>();
-        metadata.put("....", "unspecifiedKey");
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(metadata, Arrays.asList(
+        Collection<Metadata> metadata = new ArrayList<>();
+        Metadata metadataOne = new MetadataEntry();
+        metadataOne.setKey("unspecifiedKey");
+        metadata.add(metadataOne);
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(metadata, Arrays.asList(
             "description", "digitalProvenance", "noDomainSpecified", "rights", "source", "technical", "metsDiv"));
 
         SimpleMetadataViewInterface description = getSmvi(mvwviList, "description");
@@ -770,11 +806,11 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testRulesAreCorrectlyMerged.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList("personContributor"));
         ComplexMetadataViewInterface personContributor = getCmvi(mvwviList, "personContributor");
-        List<MetadataViewWithValuesInterface<Object>> visible = personContributor
-                .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
+        List<MetadataViewWithValuesInterface> visible = personContributor
+                .getSortedVisibleMetadata(Collections.emptyList(), Collections.emptyList());
         assertThat(ids(visible), contains("role", "gndRecord", "givenName", "surname"));
         assertThat(getSmvi(visible, "role").getSelectItems().keySet(), contains("author", "editor"));
     }
@@ -788,7 +824,7 @@ public class RulesetManagementIT {
         RulesetManagement underTest = new RulesetManagement();
         underTest.load(new File("src/test/resources/testRulesRemoveKeysWithZeroMaxOccurs.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertTrue(ids(mviColl).contains("keep"));
     }
@@ -802,7 +838,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testTheDisplayModeIsSetUsingTheCodomain.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("defaultString", "anyURI", "boolean", "date", "integer", "namespace", "namespaceString"));
 
         assertEquals(InputType.ONE_LINE_TEXT, getSmvi(mvwviList, "defaultString").getInputType());
@@ -835,7 +871,7 @@ public class RulesetManagementIT {
         RulesetManagement underTest = new RulesetManagement();
         underTest.load(new File("src/test/resources/testUnspecifiedForbiddenRulesRestrictKeys.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
         assertTrue(ids(mviColl).contains("allowed"));
     }
@@ -850,7 +886,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testUnspecifiedForbiddenRulesRestrictOptions.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
 
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
         assertThat(test.getSelectItems().keySet(), contains(OPT, "opt3", "opt5", "opt7"));
@@ -868,7 +904,7 @@ public class RulesetManagementIT {
             new File("src/test/resources/testUnspecifiedForbiddenRulesRestrictOptionsAlsoInTheValidation.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
 
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
         assertTrue(test.isValid(OPT));
@@ -911,7 +947,7 @@ public class RulesetManagementIT {
         underTest.load(
             new File("src/test/resources/testUnspecifiedUnrestrictedRulesSortKeysWithoutRestrictingThem.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView("article", "", ENGL);
-        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
+        Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyList(),
             Collections.emptyList());
 
         assertThat(ids(mviColl), contains("author", "year", "title", "journal", "journalAbbr", "issue", "abstract",
@@ -928,7 +964,7 @@ public class RulesetManagementIT {
         underTest.load(
             new File("src/test/resources/testUnspecifiedUnrestrictedRulesSortOptionsWithoutRestrictingThem.xml"));
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
         assertThat(test.getSelectItems().keySet(), contains("opt4", "opt7", OPT, "opt2", "opt3", "opt5", "opt6"));
@@ -943,7 +979,7 @@ public class RulesetManagementIT {
         underTest.load(new File("src/test/resources/testValidationByCodomain.xml"));
 
         StructuralElementViewInterface sevi = underTest.getStructuralElementView(BOOK, "", ENGL);
-        List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
+        List<MetadataViewWithValuesInterface> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyList(),
             Arrays.asList("default", "defaultOpt", "anyUri", "boolean", "date", "integer", "namespaceDefault",
                 "namespaceString", "namespaceDefaultOpt", "namespaceStringOpt", "namespaceDefaultExternal",
                 "namespaceStringExternal"));
@@ -1010,7 +1046,7 @@ public class RulesetManagementIT {
      *            ID of key to extract
      * @return metadata key
      */
-    private SimpleMetadataViewInterface getSmvi(List<MetadataViewWithValuesInterface<Object>> mvwviList, String keyId) {
+    private SimpleMetadataViewInterface getSmvi(List<MetadataViewWithValuesInterface> mvwviList, String keyId) {
         return (SimpleMetadataViewInterface) mvwviList.stream().filter(mvwvi -> mvwvi.getMetadata().isPresent())
                 .filter(mvwvi -> keyId.equals(mvwvi.getMetadata().get().getId())).findAny().get().getMetadata().get();
     }
@@ -1026,7 +1062,7 @@ public class RulesetManagementIT {
      * @return metadata key
      */
     private ComplexMetadataViewInterface getCmvi(
-            List<MetadataViewWithValuesInterface<Object>> metadataViewWithValuesInterfaceList, String keyId) {
+            List<MetadataViewWithValuesInterface> metadataViewWithValuesInterfaceList, String keyId) {
         return (ComplexMetadataViewInterface) metadataViewWithValuesInterfaceList.stream()
                 .filter(mvwvi -> mvwvi.getMetadata().isPresent())
                 .filter(metadataViewWithValuesInterface -> keyId
@@ -1056,7 +1092,7 @@ public class RulesetManagementIT {
      *            the metadata keys from
      * @return the IDs of the metadata keys
      */
-    private <T> List<String> ids(List<MetadataViewWithValuesInterface<T>> metadataViewWithValuesInterfaceList) {
+    private List<String> ids(List<MetadataViewWithValuesInterface> metadataViewWithValuesInterfaceList) {
         return metadataViewWithValuesInterfaceList.stream()
                 .filter(metadataViewWithValuesInterface -> metadataViewWithValuesInterface.getMetadata().isPresent())
                 .map(metadataViewWithValuesInterface -> metadataViewWithValuesInterface.getMetadata().get().getId())

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -365,17 +365,21 @@ public class RulesetManagementIT {
 
         // excluded
         Collection<Metadata> metadataForExcluded = new ArrayList<>();
-        Metadata metadataOne = new MetadataEntry();
+        MetadataEntry metadataOne = new MetadataEntry();
         metadataOne.setKey("excludedUnchangedTrue");
+        metadataOne.setValue("exclude1");
         metadataForExcluded.add(metadataOne);
-        Metadata metadataTwo = new MetadataEntry();
+        MetadataEntry metadataTwo = new MetadataEntry();
         metadataTwo.setKey("excludedTrueUnchanged");
+        metadataTwo.setValue("exclude2");
         metadataForExcluded.add(metadataTwo);
-        Metadata metadataThree = new MetadataEntry();
+        MetadataEntry metadataThree = new MetadataEntry();
         metadataThree.setKey("excludedTrueOtherchanges");
+        metadataThree.setValue("exclude3");
         metadataForExcluded.add(metadataThree);
-        Metadata metadataFour = new MetadataEntry();
+        MetadataEntry metadataFour = new MetadataEntry();
         metadataFour.setKey("excludedTrueTrue");
+        metadataFour.setValue("exclude4");
         metadataForExcluded.add(metadataFour);
         Metadata metadataFive = new MetadataEntry();
         metadataFive.setKey("excludedTrueFalse");
@@ -387,7 +391,9 @@ public class RulesetManagementIT {
                 .collect(Collectors.toList()).contains("excludedTrueFalse"));
         assertThat(
             mvwviListExcluded.stream().filter(mvwvi -> !mvwvi.getMetadata().isPresent())
-                    .flatMap(mvwvi -> mvwvi.getValues().stream()).collect(Collectors.toList()),
+                    .flatMap(
+                        mvwvi -> mvwvi.getValues().stream().map(MetadataEntry.class::cast).map(MetadataEntry::getValue))
+                    .collect(Collectors.toList()),
             containsInAnyOrder("exclude1", "exclude2", "exclude3", "exclude4"));
         Collection<MetadataViewInterface> mviCollExcluded = sevi.getAddableMetadata(metadataForExcluded,
             Collections.emptyList());
@@ -479,8 +485,9 @@ public class RulesetManagementIT {
         Metadata metadataTwo = new MetadataEntry();
         metadataTwo.setKey("testEditable");
         metadata.add(metadataTwo);
-        Metadata metadataThree = new MetadataEntry();
+        MetadataEntry metadataThree = new MetadataEntry();
         metadataThree.setKey("testExcluded");
+        metadataThree.setValue("exclude1");
         metadata.add(metadataThree);
         Metadata metadataFour = new MetadataEntry();
         metadataFour.setKey("testMultiline");
@@ -488,20 +495,23 @@ public class RulesetManagementIT {
         Metadata metadataFive = new MetadataEntry();
         metadataFive.setKey("testAlwaysShowingEditable");
         metadata.add(metadataFive);
-        Metadata metadataSix = new MetadataEntry();
+        MetadataEntry metadataSix = new MetadataEntry();
         metadataSix.setKey("testAlwaysShowingExcluded");
+        metadataSix.setValue("exclude2");
         metadata.add(metadataSix);
         Metadata metadataSeven = new MetadataEntry();
         metadataSeven.setKey("testAlwaysShowingMultiline");
         metadata.add(metadataSeven);
-        Metadata metadataEight = new MetadataEntry();
+        MetadataEntry metadataEight = new MetadataEntry();
         metadataEight.setKey("testEditableExcluded");
+        metadataEight.setValue("exclude3");
         metadata.add(metadataEight);
         Metadata metadataNine = new MetadataEntry();
         metadataNine.setKey("testEditableMultiline");
         metadata.add(metadataNine);
-        Metadata metadataTen = new MetadataEntry();
+        MetadataEntry metadataTen = new MetadataEntry();
         metadataTen.setKey("testExcludedMultiline");
+        metadataTen.setValue("exclude4");
         metadata.add(metadataTen);
         Metadata metadataEleven = new MetadataEntry();
         metadataEleven.setKey("testNestedSettings");
@@ -513,7 +523,9 @@ public class RulesetManagementIT {
             "testAlwaysShowingEditable", "testAlwaysShowingMultiline", "testEditableMultiline", "testNestedSettings"));
         assertThat(
             mvwviListWithMetadata.stream().filter(mvwvi -> !mvwvi.getMetadata().isPresent())
-                    .flatMap(mvwvi -> mvwvi.getValues().stream()).collect(Collectors.toList()),
+                    .flatMap(
+                        mvwvi -> mvwvi.getValues().stream().map(MetadataEntry.class::cast).map(MetadataEntry::getValue))
+                    .collect(Collectors.toList()),
             containsInAnyOrder("exclude1", "exclude2", "exclude3", "exclude4"));
 
         // 3a. Also with nested metadata, that should work that way.
@@ -528,7 +540,9 @@ public class RulesetManagementIT {
         assertThat(ids(nestedMvwviListWithMetadata),
             containsInAnyOrder("testAlwaysShowing", "testEditable", "testMultiline"));
         assertTrue(nestedMvwviListWithMetadata.stream().filter(mvwvi -> !mvwvi.getMetadata().isPresent())
-                .flatMap(mvwvi -> mvwvi.getValues().stream()).collect(Collectors.toList()).contains("excluded"));
+                .flatMap(
+                    mvwvi -> mvwvi.getValues().stream().map(MetadataEntry.class::cast).map(MetadataEntry::getValue))
+                .collect(Collectors.toList()).contains("exclude1"));
 
         // 4. The property ‘multiline’ should manipulate the input type
         SimpleMetadataViewInterface testAlwaysShowing = getSmvi(mvwviListWithMetadata, "testAlwaysShowing");

--- a/Kitodo-DataEditor/src/test/resources/ruleset.xsd
+++ b/Kitodo-DataEditor/src/test/resources/ruleset.xsd
@@ -22,6 +22,19 @@
            targetNamespace="http://names.kitodo.org/ruleset/v2">
 
     <xs:complexType name="AcquisitionStage">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Acquisition levels are used to define which metadata must be recorded in which levels. There are
+                currently two hard-coded levels called "create" and "edit", "create" is when creating a new process in
+                the system, "edit" is when editing the metadata in the metadata editor. (The development goal here is
+                that any data entry level names can be used in the ruleset, which can then be assigned to individual
+                workflow steps in the workflow editor. This is not yet possible as of October 2020.) For each
+                acquisition stage, the &lt;settings/&gt; ("alwaysShowing", "editable", "excluded", "multiline") can be
+                determined individually. The &lt;settings/&gt; in the current acquisition stage go before the general
+                &lt;settings/&gt; of the ruleset. This makes it possible, for example, to edit a metadata entry when
+                creating the process, but only to be able to display it later or even to hide it without losing it.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="setting" minOccurs="1" maxOccurs="unbounded" type="ruleset:Setting"/>
         </xs:sequence>
@@ -29,11 +42,52 @@
     </xs:complexType>
 
     <xs:complexType name="CodomainElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The codomain defines which technical value range a metadata entry can accept. If no codomain is
+                defined, the internal type is a character string. If a namespace is specified, the internal type is any
+                URI; if the type is specified, this applies. If a namespace has been specified, Production looks for an
+                XML file in the same directory whose file name is the same as the last segment of the namespace URI
+                and, if it finds it, makes the namespace elements available as a selection list.
+            </xs:documentation>
+        </xs:annotation>
         <xs:attribute type="ruleset:Type" name="type"/>
         <xs:attribute type="xs:anyURI" name="namespace"/>
     </xs:complexType>
+    
+    <xs:complexType name="Condition">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A &lt;condition&gt; can be defined within a &lt;restriction&gt; and allows the elements listed therein,
+                if the &lt;condition&gt; is met. &lt;condition&gt;s can be nested, if multiple condition checks are
+                necessary.
+                
+                The attribute "key" indicates on which key’s value the additional permits depend. with nested keys, a
+                preceding '../' refers to a higher-level key. (The syntax is based on XPath, but "key" is not an XPath,
+                the '../' is the only permissible modifier.) It can be repeated.
+                
+                In addition, exactly one of the following attributes must be specified, which formulates the condition
+                for the value:
+
+                "equals": the value must be the same as the specified character string. Comparison is case-sensitive.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
+            <xs:element name="condition" minOccurs="0" maxOccurs="unbounded" type="ruleset:Condition"/>
+        </xs:sequence>
+        <xs:attribute use="required" type="xs:string" name="key"/>
+        <xs:attribute use="required" type="xs:string" name="equals"/>
+    </xs:complexType>
 
     <xs:complexType name="DeclarationElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                In section &lt;declaration&gt;, the divisions and metadata keys defined by therule set are declared
+                (announced to the system). Both the divisions and the metadata keys have an "id" that must be unique;
+                the same "id" may be used both once for a division and once for a metadata key.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="division" minOccurs="1" maxOccurs="unbounded" type="ruleset:Division" />
             <xs:element name="key" minOccurs="0" maxOccurs="unbounded" type="ruleset:Key"/>
@@ -41,6 +95,30 @@
     </xs:complexType>
 
     <xs:complexType name="Division">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Divisions (&lt;mets:div&gt;) serve to subdivide the logical or physical structure of the medium being
+                described. A division is considered a possible root of the logical description if it has an attribute
+                "processTitle". The value of the attribute consists of fixed text in single quotation marks (') and
+                metadata keys, the values of which are to be inserted, separated by pluses (+). It can also be empty
+                if the process title should be entered manually. In this case, the attribute "withWorkflow" has an
+                effect if it is "false". (A work usually has a workflow, but this can be switched off for a
+                higher-level unit, for example a series.) The "use" attribute can be used to define a technical use of
+                the value. Several uses are to be recorded in ONE attribute with several values separated ​​by spaces.
+                
+                If a division is defined within &lt;subdivisionByDate&gt;, the attribute "dates" indicates in which
+                metadata key is stored, when this division dates, and the attribute "scheme" indicates the pattern
+                (date format). 'yyyy' stands for a year, 'yyyy/yyyy' for a period of two consecutive years, 'MM' for
+                the month and 'dd' for the day. The number of letters defines a minimum length of the number (leading
+                zeros).
+                
+                The root of the physical structure must be called "physSequence". There are three structures for
+                physical objects, a "page" for the page of a bound or stitched publication, "track" for an aural or
+                audiovisual recording, and "other" for another linked physical entity. In between there can be
+                intermediate levels that describe the physical structure, for example boxes and folders. This can be
+                freely designed.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element type="ruleset:Label" minOccurs="1" maxOccurs="unbounded" name="label"/>
             <xs:element type="ruleset:SubdivisionByDateElement" minOccurs="0" maxOccurs="1" name="subdivisionByDate"/>
@@ -54,6 +132,32 @@
     </xs:complexType>
 
     <xs:simpleType name="DomainAttribute">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The attribute specifies in which section of the METS file the metadata key is stored. The areas have a
+                rough semantic meaning:
+                
+                'description' is the standard value, the metadata entry is written to the &lt;dmdSec&gt;. It describes
+                    the digital resource, sometimes referred to as workpiece properties.
+
+                'digitalProvenance' is rarely needed. Information on the further development of the digital resource is
+                    stored in this area if this happens after the original creation process of the digital resource,
+                    for example if video was converted into another format. (This is mostly outside the scope of
+                    Production).
+
+                'rights' describes the legal situation, i.e. how far the digital resource may be made publicly
+                    accessible.
+
+                'source' stores information on the digitized template of the digital work is stored. The area is
+                    sometimes referred to as the template properties.
+
+                'technical' is to store internal data that must be saved during processing, for example scanner and OCR
+                    settings. The area is sometimes referred to simply as properties.
+
+                'mets:div' writes the value in an attribute of the &lt;mets:div&gt; XML element. Only the "id"s
+                    'LABEL', 'ORDERLABEL' (type: character string) and 'CONTENTIDS' (type: any URI) are permitted here.
+            </xs:documentation>
+        </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:enumeration value="description"/>
             <xs:enumeration value="digitalProvenance"/>
@@ -65,6 +169,12 @@
     </xs:simpleType>
 
     <xs:complexType name="EditingElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Section &lt;editing&gt; defines how the individual metadata entries can be edited in the metadata
+                editor.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="setting" minOccurs="0" maxOccurs="unbounded" type="ruleset:Setting"/>
             <xs:element name="acquisitionStage" minOccurs="0" maxOccurs="unbounded" type="ruleset:AcquisitionStage"/>
@@ -72,6 +182,27 @@
     </xs:complexType>
 
     <xs:complexType name="Key">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A possible metadata key is defined with the &lt;key&gt; element. A key must have an "id" that is
+                unique. For the key, attribute "domain" can be used to determine in which domain (area of ​​the METS
+                file) it is saved, and attribute "use" whether it has a specific technical use. Multiple usages must be
+                coded in the same attribute "use" as being separated by spaces.
+
+                Each key must have at least one &lt;label&gt;. Several &lt;label&gt;s can be specified in different
+                languages. Element &lt;codomain&gt; can be used to define a technical set of values ​​(e.g. 'integer',
+                'anyURI' or a valid calendar 'date'). The application then offers appropriate input controls. If a
+                selection is to be made from a value list, the individual values ​​must be recorded as &lt;option&gt;
+                elements. The element &lt;pattern&gt; can be used to specify a regular expression that entered values
+                must meet. The element &lt;preset&gt; can be used to specify a value (in the case of the multiple
+                selection type, several) that should be automatically entered when adding the metadata entry.
+
+                Alternatively, keys can be nested. In this case the above elements except &lt;label&gt; are omitted,
+                instead the lt;key&gt; contains several &lt;key&gt; elements. If &lt;key&gt;s are nested, the "id" of a
+                subkey within the key must be unique, but multiple keys can have subkeys with the same "id" as it
+                appears in another key.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="label" minOccurs="1" maxOccurs="unbounded" type="ruleset:Label"/>
             <xs:element name="codomain" minOccurs="0" maxOccurs="1" type="ruleset:CodomainElement"/>
@@ -86,6 +217,14 @@
     </xs:complexType>
 
     <xs:complexType name="Label">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The &lt;division&gt;s and metadata &lt;key&gt;s are labeled with &lt;label&gt;s; labels can optionally
+                be assigned for &lt;option&gt;s. A label without a "lang" attribute defines the standard case, which is
+                English, unless otherwise specified. For other languages, further variants of the label with a "lang"
+                attribute can be specified.
+            </xs:documentation>
+        </xs:annotation>
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute type="xs:string" name="lang"/>
@@ -94,6 +233,16 @@
     </xs:complexType>
 
     <xs:element name="namespace">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The elements of a namespace can be stored in a &lt;namespace&gt; file in order to be offered as a
+                selection. The attribute "about" indicates which namespace is described in the file. The file must have
+                the same name as the last segment of the URI and be in the rule set directory. (Example: for the
+                namespace 'http://id.loc.gov/vocabulary/relators/', the file must be called relators.xml.) If a
+                reference is made to the namespace from a ruleset with the element &lt;codomain namespace="..."/&gt;,
+                this file is searched for and the elements are offered as a selection list.
+            </xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="option" minOccurs="0" maxOccurs="unbounded" type="ruleset:Option"/>
@@ -103,15 +252,37 @@
     </xs:element>
 
     <xs:complexType name="Option">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                With the &lt;option&gt; element, the possible options of a selection list are offered. The "value" to
+                be set must be specified as an attribute; &lt;label&gt;s, also in multiple languages, can optionally be
+                specified for the display.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="label" minOccurs="0" maxOccurs="unbounded" type="ruleset:Label"/>
         </xs:sequence>
         <xs:attribute use="required" type="xs:string" name="value"/>
     </xs:complexType>
 
-    <xs:complexType name="Rule">
+    <xs:complexType name="RestrictivePermit">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                With rules regarding &lt;restriction&gt;s and &lt;permit&gt;s on how divisions and metadata may be
+                combined, the input options of the operator can be restricted to meaningful combinations. A rule
+                describes either a &lt;restriction&gt; or &lt;permit&gt; of a "division", a metadata "key" or an option
+                "value". The attributes "minOccurs" and "maxOccurs" indicate the minimum and maximum number of
+                occurrences of a metadata key, the attribute "unspecified" indicates whether the divisions, keys or
+                options not mentioned are 'forbidden' and may not be offered, or whether they are 'unrestricted', and
+                are to be arranged afterwards to explicitly named entries. This allows the few regularly used entries
+                of a large set of values, for example a namespace, to be placed at the top without completely
+                blocking the other entries. &lt;condition&gt;s provide for conditional permits, which depend on
+                metadata values in other fields.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
-            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:Rule"/>
+            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
+            <xs:element name="condition" minOccurs="0" maxOccurs="unbounded" type="ruleset:Condition"/>
         </xs:sequence>
         <xs:attribute type="xs:NMTOKEN" name="division"/>
         <xs:attribute type="xs:NMTOKEN" name="key"/>
@@ -122,13 +293,23 @@
     </xs:complexType>
 
     <xs:element name="ruleset">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A &lt;ruleset&gt; technically describes the description of digital objects in structure and the
+                assignment of metadata. The assumed default language of &lt;label&gt;s without the "lang" attribute is
+                English, unless another language is specified as default with the "lang" attribute here. Section
+                &lt;declaration&gt; defines the possible &lt;division&gt;s and metadata &lt;key&gt;s. In section
+                &lt;restriction&gt;, the possible combinations of the former can be restricted. In section
+                &lt;editing&gt;, settings for displaying the input fields in the metadata editor can be made.
+            </xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="declaration" minOccurs="1" maxOccurs="1" type="ruleset:DeclarationElement"/>
                 <xs:element name="correlation" minOccurs="0" maxOccurs="1">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="restriction" minOccurs="1" maxOccurs="unbounded" type="ruleset:Rule"/>
+                            <xs:element name="restriction" minOccurs="1" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -139,6 +320,19 @@
     </xs:element>
 
     <xs:complexType name="Setting">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A &lt;setting&gt; describes how the input field for a specific metadata "key" should be displayed. With
+                "alwaysShowing", it can be requested that an empty input field is automatically offered. Usually, you
+                have to manually add a field that does not yet exist. With "editable" a field can be set as read-only.
+                This can be used if a certain metadata entry must not be changed at a certain point in time. (If no
+                changes are to be made to the metadata in its whole, this should be mapped via the authorization
+                management, not via the ruleset.) With "excluded", a metadata entry can be hidden. It is not deleted,
+                it is simply not displayed. With "multiline", a larger input box can be requested for a metadata key.
+                This makes sense for entries that contain a lot of text, for example an abstract. Settings must be
+                nested in order to define properties of subkeys.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="setting" minOccurs="0" maxOccurs="unbounded" type="ruleset:Setting"/>
         </xs:sequence>
@@ -150,8 +344,19 @@
     </xs:complexType>
 
     <xs:complexType name="SubdivisionByDateElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                For regular publications, the issues of which are identified by a calendar date, for example
+                newspapers, a logical root &lt;division&gt; can be subdivided with divisions by date. It takes three of
+                them, one for the year, one for the month and one for the day. In this case, the "use" attribute with
+                the value 'createChildrenWithCalendar' at the root division can be used to activate the mass creation
+                of processes with the calendar selection. The attribute "yearBegin" specifies the calendar day on which
+                the year change takes place, if a business year does not start on January 1ˢᵗ. THE SAME VALUE MUST BE
+                SET IN when using the calendar selection.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
-            <xs:element name="division" minOccurs="1" maxOccurs="unbounded" type="ruleset:Division"/>
+            <xs:element name="division" minOccurs="3" maxOccurs="3" type="ruleset:Division"/>
         </xs:sequence>
         <xs:attribute name="yearBegin">
             <xs:simpleType>
@@ -163,6 +368,25 @@
     </xs:complexType>
 
     <xs:simpleType name="Type">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Production supports the following data types as a range of values for metadata keys:
+
+                'anyURI' allows any valid URI to be entered (e.g. URL, URN, ...). It is also selected automatically
+                    if a "namespace" is specified.
+
+                'boolean' is a truth value, either present or absent, with a fixed value. Exactly one &lt;option&gt;
+                    element with the "value" that is written in the case of selection must be specified for 'boolean'.
+                    A switch for input will appear.
+
+                'date' allows any valid calendar dates to be entered. A calendar is displayed for input support.
+
+                'integer' requires an integer. In combination with the &lt;pattern&gt; element, this can be limited
+                    to positive values. A spinner is displayed as the input element.
+
+                'string' is the default, meaning any values can be entered.
+            </xs:documentation>
+        </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:enumeration value="anyURI"/>
             <xs:enumeration value="boolean"/>
@@ -173,6 +397,16 @@
     </xs:simpleType>
 
     <xs:simpleType name="Unspecified">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The attribute "unspecified" inicates whether the divisions, keys or options not mentioned in a
+                &lt;restriction&gt; or &lt;permit&gt; are 'forbidden' and may not be offered, or whether they are
+                'unrestricted', and are to be arranged afterwards to explicitly named entries. The latter allows the
+                few regularly used entries of a large set of values, for example a namespace, to be placed at the top
+                without completely blocking the other entries, or to define a &lt;permit&gt; on a sub-key without
+                having to name all the other sub-keys of its parent key.
+            </xs:documentation>
+        </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:enumeration value="unrestricted"/>
             <xs:enumeration value="forbidden"/>
@@ -180,6 +414,28 @@
     </xs:simpleType>
 
     <xs:simpleType name="KeyUseAttribute">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A key can have the following automated uses in the application:
+
+                'authorLastName' The value is used as the author's last name to form the author-title key.
+
+                'dataSource' Internal identifier of the data source in order to be able to update the imported
+                    metadata entries from the data source later.
+
+                'displaySummary' will be displayed as summary on the Title Record Link tab when creating a new process.
+
+                'higherlevelIdentifier' must be available when fetching a data record from a data source in order to
+                    fetch a higher-level data record as well.
+
+                'processTitle' The generated author-title key is written in this field.
+
+                'recordIdentifier' Identifier of the data record fetched from an external data source, so that the
+                    imported metadata entries from the data source can be updated later.
+
+                'title' This field is used as the title to form the author-title key.
+            </xs:documentation>
+        </xs:annotation>
         <xs:restriction>
             <xs:simpleType>
                 <xs:list>
@@ -201,6 +457,19 @@
     </xs:simpleType>
 
     <xs:simpleType name="DivisionUseAttribute">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A division can have the following automated uses in the application:
+
+                'createChildrenFromParent' This division is a superordinate unit to which child processes can be
+                    created directly. This makes sense for a hierarchical superordinate type, such as a serial
+                    publication (serial, multi-volume work).
+
+                'createChildrenWithCalendar' This division is a superordinate unit to which child processes with a
+                    calendar structure can be created. This attribute can only be set on a division that has a
+                    &lt;subdivisionByDate&gt;.
+            </xs:documentation>
+        </xs:annotation>
         <xs:restriction>
             <xs:simpleType>
                 <xs:list>

--- a/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
+++ b/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentHashMap.KeySetView;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -170,9 +169,9 @@ public class MetadataValidation implements MetadataValidationInterface {
         Collection<ValidationResult> results = new ArrayList<>();
         StructuralElementViewInterface divisionView = ruleset.getStructuralElementView(type, null,
                 metadataLanguage);
-        results.add(checkForMandatoryQuantitiesOfTheMetadataRecursive(Metadata.mapToKey(metadata),
+        results.add(checkForMandatoryQuantitiesOfTheMetadataRecursive(metadata,
                 divisionView, elementString.concat(": "), translations));
-        results.add(checkForDetailsInTheMetadataRecursive(Metadata.mapToKey(metadata),
+        results.add(checkForDetailsInTheMetadataRecursive(metadata,
                 divisionView, elementString.concat(": "), translations));
         return results;
     }
@@ -254,7 +253,7 @@ public class MetadataValidation implements MetadataValidationInterface {
      * @return the validation result
      */
     private static ValidationResult checkForMandatoryQuantitiesOfTheMetadataRecursive(
-            Map<Metadata, String> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
+            Collection<Metadata> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
             String location, Map<String, String> translations) {
         boolean error = false;
         boolean warning = false;
@@ -286,7 +285,7 @@ public class MetadataValidation implements MetadataValidationInterface {
                 for (Metadata metadata : metadataViewWithValues.getValue()) {
                     if (metadata instanceof MetadataGroup) {
                         ValidationResult validationResult = checkForMandatoryQuantitiesOfTheMetadataRecursive(
-                            Metadata.mapToKey(((MetadataGroup) metadata).getGroup()),
+                            ((MetadataGroup) metadata).getGroup(),
                             (ComplexMetadataViewInterface) metadataView, location + metadataView.getLabel() + " - ",
                             translations);
                         if (validationResult.getState().equals(State.WARNING)) {
@@ -320,14 +319,14 @@ public class MetadataValidation implements MetadataValidationInterface {
      * @return the validation result
      */
     private static ValidationResult checkForDetailsInTheMetadataRecursive(
-            Map<Metadata, String> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
+            Collection<Metadata> containedMetadata, ComplexMetadataViewInterface containingMetadataView,
             String location, Map<String, String> translations) {
         boolean error = false;
         Collection<String> messages = new HashSet<>();
 
-        List<MetadataViewWithValuesInterface<Metadata>> metadataViewsWithValues = containingMetadataView
+        List<MetadataViewWithValuesInterface> metadataViewsWithValues = containingMetadataView
                 .getSortedVisibleMetadata(containedMetadata, Collections.emptyList());
-        for (MetadataViewWithValuesInterface<Metadata> metadataViewWithValues : metadataViewsWithValues) {
+        for (MetadataViewWithValuesInterface metadataViewWithValues : metadataViewsWithValues) {
             Optional<MetadataViewInterface> optionalMetadataView = metadataViewWithValues.getMetadata();
             if (!optionalMetadataView.isPresent()) {
                 continue;
@@ -345,7 +344,7 @@ public class MetadataValidation implements MetadataValidationInterface {
                 } else if (metadata instanceof MetadataGroup
                         && metadataView instanceof ComplexMetadataViewInterface) {
                     ValidationResult validationResult = checkForDetailsInTheMetadataRecursive(
-                        Metadata.mapToKey(((MetadataGroup) metadata).getGroup()),
+                        ((MetadataGroup) metadata).getGroup(),
                         (ComplexMetadataViewInterface) metadataView, location + metadataView.getLabel() + " - ",
                         translations);
                     if (validationResult.getState().equals(State.ERROR)) {
@@ -402,9 +401,9 @@ public class MetadataValidation implements MetadataValidationInterface {
      * @return merged lines of identical type
      */
     private static Map<MetadataViewInterface, Collection<Metadata>> squash(
-            List<MetadataViewWithValuesInterface<Metadata>> metadataViewsWithValues) {
+            List<MetadataViewWithValuesInterface> metadataViewsWithValues) {
         Map<MetadataViewInterface, Collection<Metadata>> squashed = new HashMap<>();
-        for (MetadataViewWithValuesInterface<Metadata> metadataViewWithValues : metadataViewsWithValues) {
+        for (MetadataViewWithValuesInterface metadataViewWithValues : metadataViewsWithValues) {
             Optional<MetadataViewInterface> optionalMetadataView = metadataViewWithValues.getMetadata();
             if (!optionalMetadataView.isPresent()) {
                 continue;

--- a/Kitodo/rulesets/ruleset.xsd
+++ b/Kitodo/rulesets/ruleset.xsd
@@ -54,6 +54,31 @@
         <xs:attribute type="ruleset:Type" name="type"/>
         <xs:attribute type="xs:anyURI" name="namespace"/>
     </xs:complexType>
+    
+    <xs:complexType name="Condition">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A &lt;condition&gt; can be defined within a &lt;restriction&gt; and allows the elements listed therein,
+                if the &lt;condition&gt; is met. &lt;condition&gt;s can be nested, if multiple condition checks are
+                necessary.
+                
+                The attribute "key" indicates on which key’s value the additional permits depend. with nested keys, a
+                preceding '../' refers to a higher-level key. (The syntax is based on XPath, but "key" is not an XPath,
+                the '../' is the only permissible modifier.) It can be repeated.
+                
+                In addition, exactly one of the following attributes must be specified, which formulates the condition
+                for the value:
+
+                "equals": the value must be the same as the specified character string. Comparison is case-sensitive.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
+            <xs:element name="condition" minOccurs="0" maxOccurs="unbounded" type="ruleset:Condition"/>
+        </xs:sequence>
+        <xs:attribute use="required" type="xs:string" name="key"/>
+        <xs:attribute use="required" type="xs:string" name="equals"/>
+    </xs:complexType>
 
     <xs:complexType name="DeclarationElement">
         <xs:annotation>
@@ -247,15 +272,17 @@
                 combined, the input options of the operator can be restricted to meaningful combinations. A rule
                 describes either a &lt;restriction&gt; or &lt;permit&gt; of a "division", a metadata "key" or an option
                 "value". The attributes "minOccurs" and "maxOccurs" indicate the minimum and maximum number of
-                occurrences of a metadata key, the attribute "unspecified" inicates whether the divisions, keys or
+                occurrences of a metadata key, the attribute "unspecified" indicates whether the divisions, keys or
                 options not mentioned are 'forbidden' and may not be offered, or whether they are 'unrestricted', and
                 are to be arranged afterwards to explicitly named entries. This allows the few regularly used entries
                 of a large set of values, for example a namespace, to be placed at the top without completely
-                blocking the other entries.
+                blocking the other entries. &lt;condition&gt;s provide for conditional permits, which depend on
+                metadata values in other fields.
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
+            <xs:element name="condition" minOccurs="0" maxOccurs="unbounded" type="ruleset:Condition"/>
         </xs:sequence>
         <xs:attribute type="xs:NMTOKEN" name="division"/>
         <xs:attribute type="xs:NMTOKEN" name="key"/>
@@ -435,7 +462,8 @@
                 A division can have the following automated uses in the application:
 
                 'createChildrenFromParent' This division is a superordinate unit to which child processes can be
-                    created directly. This makes sense for a hierarchical superordinate type, such as a serial publication (serial, multi-volume work).
+                    created directly. This makes sense for a hierarchical superordinate type, such as a serial
+                    publication (serial, multi-volume work).
 
                 'createChildrenWithCalendar' This division is a superordinate unit to which child processes with a
                     calendar structure can be created. This attribute can only be set on a division that has a

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -18,12 +18,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.list.UnmodifiableList;
 import org.apache.commons.lang3.tuple.Pair;
@@ -168,13 +165,12 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
      */
     private void createMetadataTable() {
         // the existing metadata is passed to the rule set, which sorts it
-        Map<Metadata, String> metadataWithKeys = Metadata.mapToKey(addLabels(metadata));
-        List<MetadataViewWithValuesInterface<Metadata>> tableData = metadataView
-                .getSortedVisibleMetadata(metadataWithKeys, additionallySelectedFields);
+        List<MetadataViewWithValuesInterface> tableData = metadataView
+                .getSortedVisibleMetadata(addLabels(metadata), additionallySelectedFields);
 
         treeNode.getChildren().clear();
         hiddenMetadata = Collections.emptyList();
-        for (MetadataViewWithValuesInterface<Metadata> rowData : tableData) {
+        for (MetadataViewWithValuesInterface rowData : tableData) {
             Optional<MetadataViewInterface> optionalMetadataView = rowData.getMetadata();
             Collection<Metadata> values = rowData.getValues();
             if (optionalMetadataView.isPresent()) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -21,15 +21,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.faces.model.SelectItem;
@@ -513,14 +510,14 @@ public class AddDocStrucTypeDialog {
     public void prepareSelectAddableMetadataTypesItems(boolean currentElement, List<TreeNode> metadataNodes) {
         selectAddableMetadataTypesItems = new ArrayList<>();
         setSelectAddableMetadataTypesSelectedItem("");
-        Map<Metadata, String> existingMetadata = Collections.emptyMap();
+        Collection<Metadata> existingMetadata = Collections.emptyList();
         StructuralElementViewInterface structure;
         Collection<MetadataViewInterface> addableMetadata;
         TreeNode selectedMetadataTreeNode = dataEditor.getMetadataPanel().getSelectedMetadataTreeNode();
         try {
             if (Objects.nonNull(selectedMetadataTreeNode)
                     && Objects.nonNull(selectedMetadataTreeNode.getData())) {
-                existingMetadata = Metadata.mapToKey(((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadata());
+                existingMetadata = ((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadata();
                 ComplexMetadataViewInterface metadataView = dataEditor.getRulesetManagement().getMetadataView(
                         ((ProcessFieldedMetadata) selectedMetadataTreeNode.getData()).getMetadataID(),
                         dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
@@ -562,21 +559,22 @@ public class AddDocStrucTypeDialog {
         prepareSelectAddableMetadataTypesItems(currentElement, Collections.emptyList());
     }
 
-    private Map<Metadata, String> getExistingMetadataRows(List<TreeNode> metadataTreeNodes) throws InvalidMetadataValueException {
-        Map<Metadata, String> existingMetadataRows = new HashMap<>();
+    private Collection<Metadata> getExistingMetadataRows(List<TreeNode> metadataTreeNodes)
+            throws InvalidMetadataValueException {
+        Collection<Metadata> existingMetadataRows = new ArrayList<>();
 
         for (TreeNode metadataNode : metadataTreeNodes) {
             if (metadataNode.getData() instanceof ProcessDetail) {
                 try {
                     for (Metadata metadata : ((ProcessDetail) metadataNode.getData()).getMetadata()) {
-                        existingMetadataRows.put(metadata, metadata.getKey());
+                        existingMetadataRows.add(metadata);
                     }
                 } catch (NullPointerException e) {
                     logger.error(e);
                 }
             }
             if (metadataNode.getChildCount() > 0) {
-                existingMetadataRows.putAll(getExistingMetadataRows(metadataNode.getChildren()));
+                existingMetadataRows.addAll(getExistingMetadataRows(metadataNode.getChildren()));
             }
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyLogicalDocStructHelper.java
@@ -19,11 +19,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale.LanguageRange;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -86,9 +83,8 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Override
     @Deprecated
     public void addMetadata(LegacyMetadataHelper metadata) {
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
         Optional<MetadataViewInterface> optionalKeyView = divisionView
-                .getAddableMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList()).parallelStream()
+                .getAddableMetadata(includedStructuralElement.getMetadata(), Collections.emptyList()).parallelStream()
                 .filter(keyView -> keyView.getId().equals(metadata.getMetadataType().getName())).findFirst();
         Optional<Domain> optionalDomain = optionalKeyView.isPresent() ? optionalKeyView.get().getDomain()
                 : Optional.empty();
@@ -133,8 +129,8 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Override
     @Deprecated
     public List<LegacyMetadataTypeHelper> getAddableMetadataTypes() {
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
-        Collection<MetadataViewInterface> addableKeys = divisionView.getAddableMetadata(metadataEntriesMappedToKeyNames,
+        Collection<MetadataViewInterface> addableKeys = divisionView.getAddableMetadata(
+            includedStructuralElement.getMetadata(),
             Collections.emptyList());
         ArrayList<LegacyMetadataTypeHelper> addableMetadataTypes = new ArrayList<>(addableKeys.size());
         for (MetadataViewInterface key : addableKeys) {
@@ -157,10 +153,9 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Deprecated
     public List<LegacyMetadataHelper> getAllMetadata() {
         List<LegacyMetadataHelper> allMetadata = new LinkedList<>();
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
-        List<MetadataViewWithValuesInterface<Metadata>> entryViews = divisionView
-                .getSortedVisibleMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList());
-        for (MetadataViewWithValuesInterface<Metadata> entryView : entryViews) {
+        List<MetadataViewWithValuesInterface> entryViews = divisionView
+                .getSortedVisibleMetadata(includedStructuralElement.getMetadata(), Collections.emptyList());
+        for (MetadataViewWithValuesInterface entryView : entryViews) {
             Optional<MetadataViewInterface> optionalMetadata = entryView.getMetadata();
             if (optionalMetadata.isPresent()) {
                 MetadataViewInterface key = optionalMetadata.get();
@@ -179,10 +174,9 @@ public class LegacyLogicalDocStructHelper implements LegacyDocStructHelperInterf
     @Deprecated
     public List<LegacyMetadataHelper> getAllMetadataByType(LegacyMetadataTypeHelper metadataType) {
         List<LegacyMetadataHelper> allMetadata = new LinkedList<>();
-        Map<Metadata, String> metadataEntriesMappedToKeyNames = Metadata.mapToKey(includedStructuralElement.getMetadata());
-        List<MetadataViewWithValuesInterface<Metadata>> entryViews = divisionView
-                .getSortedVisibleMetadata(metadataEntriesMappedToKeyNames, Collections.emptyList());
-        for (MetadataViewWithValuesInterface<Metadata> entryView : entryViews) {
+        List<MetadataViewWithValuesInterface> entryViews = divisionView
+                .getSortedVisibleMetadata(includedStructuralElement.getMetadata(), Collections.emptyList());
+        for (MetadataViewWithValuesInterface entryView : entryViews) {
             if (entryView.getMetadata().isPresent()) {
                 Optional<MetadataViewInterface> optionalMetadata = entryView.getMetadata();
                 MetadataViewInterface key = optionalMetadata.get();

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
@@ -97,8 +97,8 @@ public class LegacyPrefsHelper {
                 }
                 StructuralElementViewInterface divisionView = ruleset.getStructuralElementView("", "edit",
                     priorityList);
-                List<MetadataViewWithValuesInterface<Void>> entryViews = divisionView
-                        .getSortedVisibleMetadata(Collections.emptyMap(), Arrays.asList(identifier));
+                List<MetadataViewWithValuesInterface> entryViews = divisionView
+                        .getSortedVisibleMetadata(Collections.emptyList(), Arrays.asList(identifier));
                 MetadataViewInterface resultKeyView = entryViews.parallelStream()
                         .map(MetadataViewWithValuesInterface::getMetadata).filter(Optional::isPresent).map(Optional::get)
                         .filter(keyView -> keyView.getId().equals(identifier)).findFirst()
@@ -109,7 +109,7 @@ public class LegacyPrefsHelper {
 
     /**
      * Returns the ruleset of the legacy prefs helper.
-     * 
+     *
      * @return the ruleset
      */
     @Deprecated

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.exceptions.UnreachableCodeException;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;
 
@@ -228,7 +229,7 @@ public class IndividualIssue {
      * @return a list of pairs, each consisting of the metadata type name and
      *         the value
      */
-    public Iterable<Pair<String, String>> getMetadata(int monthOfYear, int dayOfMonth) {
+    public Iterable<MetadataEntry> getMetadata(int monthOfYear, int dayOfMonth) {
         return getMetadata(MonthDay.of(monthOfYear, dayOfMonth));
     }
 
@@ -241,12 +242,15 @@ public class IndividualIssue {
      * @return a list of pairs, each consisting of the metadata type name and
      *         the value
      */
-    public Iterable<Pair<String, String>> getMetadata(MonthDay yearStart) {
-        List<Pair<String, String>> result = new ArrayList<>();
+    public Iterable<MetadataEntry> getMetadata(MonthDay yearStart) {
+        List<MetadataEntry> result = new ArrayList<>();
         Pair<LocalDate, Issue> selectedIssue = Pair.of(date, issue);
         for (CountableMetadata counter : block.getMetadata(selectedIssue, null)) {
             String value = counter.getValue(selectedIssue, yearStart);
-            result.add(Pair.of(counter.getMetadataType(), value));
+            MetadataEntry entry = new MetadataEntry();
+            entry.setKey(counter.getMetadataType());
+            entry.setValue(value);
+            result.add(entry);
         }
         return result;
     }

--- a/Kitodo/src/test/java/org/kitodo/DummyMetadataView.java
+++ b/Kitodo/src/test/java/org/kitodo/DummyMetadataView.java
@@ -13,9 +13,9 @@ package org.kitodo;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -27,7 +27,7 @@ public class DummyMetadataView implements ComplexMetadataViewInterface {
     }
 
     @Override
-    public Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> entered,
+    public Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }
@@ -38,7 +38,7 @@ public class DummyMetadataView implements ComplexMetadataViewInterface {
     }
 
     @Override
-    public <T> List<MetadataViewWithValuesInterface<T>> getSortedVisibleMetadata(Map<T, String> entered,
+    public List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> entered,
                                                                                  Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }

--- a/Kitodo/src/test/java/org/kitodo/DummyStructuralElementView.java
+++ b/Kitodo/src/test/java/org/kitodo/DummyStructuralElementView.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.DatesSimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -31,7 +32,7 @@ public class DummyStructuralElementView implements StructuralElementViewInterfac
     }
 
     @Override
-    public Collection<MetadataViewInterface> getAddableMetadata(Map<?, String> entered,
+    public Collection<MetadataViewInterface> getAddableMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }
@@ -42,7 +43,7 @@ public class DummyStructuralElementView implements StructuralElementViewInterfac
     }
 
     @Override
-    public <T> List<MetadataViewWithValuesInterface<T>> getSortedVisibleMetadata(Map<T, String> entered,
+    public List<MetadataViewWithValuesInterface> getSortedVisibleMetadata(Collection<Metadata> entered,
             Collection<String> additionallySelected) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
First part of #4229. In this pull request, the XML model for rulesets is expanded so that condition blocks can be defined.

This is a follow-up pull request to #4329, [immediate diff](https://github.com/matthias-ronge/kitodo-production/compare/matthias-ronge:metadata-in-ruleset...issue-4229_1.1)