### PR TITLE
Implement business logic for dependent value restrictions

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
@@ -12,10 +12,13 @@
 package org.kitodo.api.dataeditor.rulesetmanagement;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang.StringUtils;
+import org.kitodo.api.MetadataEntry;
 
 /**
  * Provides an interface for the metadata key view service. The metadata key
@@ -32,7 +35,7 @@ public interface SimpleMetadataViewInterface extends MetadataViewInterface {
      */
     default Optional<String> convertBoolean(boolean value) {
         if (value) {
-            return getSelectItems().keySet().stream().filter(StringUtils::isNotEmpty).findAny();
+            return getSelectItems(Collections.emptyList()).keySet().stream().filter(StringUtils::isNotEmpty).findAny();
         } else {
             return Optional.empty();
         }
@@ -74,11 +77,21 @@ public interface SimpleMetadataViewInterface extends MetadataViewInterface {
     InputType getInputType();
 
     /**
-     * Returns the possible values if the metadata key is a list of values.
+     * Returns the possible values if the metadata key is a list of values. For
+     * the maps of metadata entries, the function should only read the map keys,
+     * and should set the map value to {@link Boolean#TRUE} for those metadata
+     * entries that do have an influence on the showing select items, to let the
+     * caller know that it must update the select items in case this metadata
+     * entry changes.
      *
+     * @param metadata
+     *            metadata entries. Conditional select items may depend on their
+     *            values. For nested keys, order of arguments is top-down, i.e.
+     *            first grand-grandparent, then grandparent, then parent, last
+     *            sibling.
      * @return the possible values
      */
-    Map<String, String> getSelectItems();
+    Map<String, String> getSelectItems(List<Map<MetadataEntry, Boolean>> metadata);
 
     /**
      * Returns {@code false}. A simple metadata key is not complex.
@@ -106,8 +119,12 @@ public interface SimpleMetadataViewInterface extends MetadataViewInterface {
      *
      * @param value
      *            value to be tested
+     * @param metadata
+     *            metadata entries. The available options for conditional select
+     *            items depend on their values. For nested keys, order of
+     *            arguments is top-down, i.e. from grand-grandparent to sibling.
      * @return whether the value corresponds to the value range
      */
-    boolean isValid(String value);
+    boolean isValid(String value, List<Map<MetadataEntry, Boolean>> metadata);
 
 }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.DatesSimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.InputType;
@@ -133,17 +134,9 @@ class KeyView extends AbstractKeyView<KeyDeclaration> implements DatesSimpleMeta
         return scheme;
     }
 
-    /**
-     * Returns the possible values if the metadata key is a list of values.
-     * Depending on the operating mode, the values are either re-sorted or
-     * restricted based on the specified values in the presence of a permit
-     * rule.
-     *
-     * @return the possible values
-     */
     @Override
-    public Map<String, String> getSelectItems() {
-        return rule.getSelectItems(declaration.getSelectItems(priorityList));
+    public Map<String, String> getSelectItems(List<Map<MetadataEntry, Boolean>> metadata) {
+        return rule.getSelectItems(declaration.getSelectItems(priorityList), metadata);
     }
 
     @Override
@@ -198,7 +191,7 @@ class KeyView extends AbstractKeyView<KeyDeclaration> implements DatesSimpleMeta
      * @return whether a value is valid
      */
     @Override
-    public boolean isValid(String value) {
+    public boolean isValid(String value, List<Map<MetadataEntry, Boolean>> metadata) {
         /*
          * Some data types are easily validated by Java built-in functions. We
          * will not implement it here again but try to create a corresponding
@@ -233,7 +226,7 @@ class KeyView extends AbstractKeyView<KeyDeclaration> implements DatesSimpleMeta
 
         // If the key has options, then the value must be in it.
         if (declaration.isWithOptions()
-                && !rule.getSelectItems(declaration.getSelectItems(priorityList)).containsKey(value)) {
+                && !rule.getSelectItems(declaration.getSelectItems(priorityList), metadata).containsKey(value)) {
             return false;
         }
 

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
@@ -11,16 +11,22 @@
 
 package org.kitodo.dataeditor.ruleset;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kitodo.api.MetadataEntry;
+import org.kitodo.dataeditor.ruleset.xml.Condition;
+import org.kitodo.dataeditor.ruleset.xml.ConditionsMapInterface;
 import org.kitodo.dataeditor.ruleset.xml.RestrictivePermit;
 import org.kitodo.dataeditor.ruleset.xml.Ruleset;
 import org.kitodo.dataeditor.ruleset.xml.Unspecified;
@@ -31,19 +37,7 @@ import org.kitodo.dataeditor.ruleset.xml.Unspecified;
  * restrictions.
  */
 public class Rule {
-    /**
-     * Generates a triplet of rule with triple as a key. This is due to the
-     * problem because the rule is basically the key is three fields and applies
-     * everything.
-     *
-     * @param restrictivePermit
-     *            restrictive permit for which a hash key is to be formed
-     * @return key is triple
-     */
-    private static Triple<String, String, String> formAKeyForARuleInATemporaryMap(RestrictivePermit restrictivePermit) {
-        return Triple.of(restrictivePermit.getDivision().orElse(null), restrictivePermit.getKey().orElse(null),
-            restrictivePermit.getValue().orElse(null));
-    }
+    private static final Logger logger = LogManager.getLogger(Rule.class);
 
     /**
      * Maybe a rule, but maybe not.
@@ -70,46 +64,6 @@ public class Rule {
     }
 
     /**
-     * A filter to generate the possibilities based on a rule. This is because
-     * the rule restricts the possibilities and gives order to elements, Or does
-     * not restrict and gives order anyway for elements where mentioned and rest
-     * is just like that. We have that twice for subdivisions and options so
-     * this is summarized here and only getter is fetched from outside.
-     *
-     * @param possibilities
-     *            list of possibilities unfiltered
-     * @param getter
-     *            which field to read
-     * @return list is filtered
-     */
-    private Map<String, String> filterPossibilitiesBasedOnRule(Map<String, String> possibilities,
-            Function<RestrictivePermit, Optional<String>> getter) {
-        if (optionalRestrictivePermit.isPresent()) {
-            Map<String, String> filteredPossibilities = new LinkedHashMap<>();
-            RestrictivePermit restrictivePermit = optionalRestrictivePermit.get();
-            for (RestrictivePermit permit : restrictivePermit.getPermits()) {
-                Optional<String> getterResult = getter.apply(permit);
-                if (getterResult.isPresent()) {
-                    String entry = getterResult.get();
-                    if (possibilities.containsKey(entry)) {
-                        filteredPossibilities.put(entry, possibilities.get(entry));
-                    }
-                }
-            }
-            if (restrictivePermit.getUnspecified().equals(Unspecified.UNRESTRICTED)) {
-                for (Entry<String, String> entryPair : possibilities.entrySet()) {
-                    if (!filteredPossibilities.containsKey(entryPair.getKey())) {
-                        filteredPossibilities.put(entryPair.getKey(), entryPair.getValue());
-                    }
-                }
-            }
-            return filteredPossibilities;
-        } else {
-            return possibilities;
-        }
-    }
-
-    /**
      * Returns only the allowed sub-divisions by rule, possibly only resorted.
      *
      * @param divisions
@@ -117,7 +71,28 @@ public class Rule {
      * @return exit
      */
     Map<String, String> getAllowedSubdivisions(Map<String, String> divisions) {
-        return filterPossibilitiesBasedOnRule(divisions, RestrictivePermit::getDivision);
+        if (!optionalRestrictivePermit.isPresent()) {
+            return divisions;
+        }
+            Map<String, String> filteredPossibilities = new LinkedHashMap<>();
+            RestrictivePermit restrictivePermit = optionalRestrictivePermit.get();
+            for (RestrictivePermit permit : restrictivePermit.getPermits()) {
+            Optional<String> getterResult = permit.getDivision();
+                if (getterResult.isPresent()) {
+                    String entry = getterResult.get();
+                if (divisions.containsKey(entry)) {
+                    filteredPossibilities.put(entry, divisions.get(entry));
+                    }
+                }
+            }
+            if (restrictivePermit.getUnspecified().equals(Unspecified.UNRESTRICTED)) {
+            for (Entry<String, String> entryPair : divisions.entrySet()) {
+                    if (!filteredPossibilities.containsKey(entryPair.getKey())) {
+                        filteredPossibilities.put(entryPair.getKey(), entryPair.getValue());
+                    }
+                }
+            }
+            return filteredPossibilities;
     }
 
     /**
@@ -190,10 +165,86 @@ public class Rule {
      *
      * @param selectItems
      *            the selection items
+     * @param metadata
+     *            metadata, for conditional select items
      * @return the selection items
      */
-    Map<String, String> getSelectItems(Map<String, String> selectItems) {
-        return filterPossibilitiesBasedOnRule(selectItems, RestrictivePermit::getValue);
+    Map<String, String> getSelectItems(Map<String, String> selectItems, List<Map<MetadataEntry, Boolean>> metadata) {
+        if (!optionalRestrictivePermit.isPresent()) {
+            return selectItems;
+        }
+        Map<String, String> filteredPossibilities = new LinkedHashMap<>();
+        RestrictivePermit restrictivePermit = optionalRestrictivePermit.get();
+        for (RestrictivePermit permit : getConditionalPermits(restrictivePermit, metadata)) {
+            Optional<String> getterResult = permit.getValue();
+            if (getterResult.isPresent()) {
+                String entry = getterResult.get();
+                if (selectItems.containsKey(entry)) {
+                    filteredPossibilities.put(entry, selectItems.get(entry));
+                }
+            }
+        }
+        if (restrictivePermit.getUnspecified().equals(Unspecified.UNRESTRICTED)) {
+            for (Entry<String, String> entryPair : selectItems.entrySet()) {
+                if (!filteredPossibilities.containsKey(entryPair.getKey())) {
+                    filteredPossibilities.put(entryPair.getKey(), entryPair.getValue());
+                }
+            }
+        }
+        return filteredPossibilities;
+    }
+
+    private static Collection<RestrictivePermit> getConditionalPermits(RestrictivePermit restrictivePermit,
+            List<Map<MetadataEntry, Boolean>> metadata) {
+
+        Collection<RestrictivePermit> result = new ArrayList<>(restrictivePermit.getPermits());
+        Map<String, Optional<MetadataEntry>> metadataCache = new HashMap<>();
+        getConditionalPermitsRecursive(restrictivePermit, metadataCache, metadata, result);
+        return result;
+    }
+
+    private static void getConditionalPermitsRecursive(ConditionsMapInterface conditionsMapInterface,
+            Map<String, Optional<MetadataEntry>> metadataCache, List<Map<MetadataEntry, Boolean>> metadata,
+            Collection<RestrictivePermit> result) {
+
+        for (String conditionKey : conditionsMapInterface.getConditionKeys()) {
+            Optional<MetadataEntry> possibleMetadata = metadataCache.computeIfAbsent(conditionKey,
+                key -> getMetadataEntryForKey(key, metadata));
+            if (possibleMetadata.isPresent()) {
+                Condition condition = conditionsMapInterface.getCondition(conditionKey, possibleMetadata.get().getValue());
+                if (Objects.nonNull(condition)) {
+                    result.addAll(condition.getPermits());
+                    getConditionalPermitsRecursive(condition, metadataCache, metadata, result);
+                }
+            }
+        }
+    }
+
+    private static Optional<MetadataEntry> getMetadataEntryForKey(final String key,
+            final List<Map<MetadataEntry, Boolean>> metadata) {
+        String effectiveKey = key;
+        int metadataIndex = metadata.size() - 1;
+        while (effectiveKey.startsWith("../")) {
+            effectiveKey = effectiveKey.substring(3);
+            metadataIndex--;
+        }
+        if (metadataIndex < 0) {
+            logger.warn("<condition key=\"{}\"> can never be met because metadata has only {} layers", key,
+                metadata.size());
+            return Optional.empty();
+        }
+
+        Map<MetadataEntry, Boolean> effectiveMetadata = metadata.get(metadataIndex);
+        MetadataEntry found = null;
+        for (Entry<MetadataEntry, Boolean> mapEntry : effectiveMetadata.entrySet()) {
+            MetadataEntry metadataEntry = mapEntry.getKey();
+            if (metadataEntry.getKey().equals(effectiveKey)) {
+                found = metadataEntry;
+                mapEntry.setValue(Boolean.TRUE);
+                break;
+            }
+        }
+        return Optional.ofNullable(found);
     }
 
     /**
@@ -248,16 +299,15 @@ public class Rule {
                     : Unspecified.UNRESTRICTED);
 
         // for sub-rules, apply recursively
-        HashMap<Triple<String, String, String>, RestrictivePermit> anotherPermits = new LinkedHashMap<>();
+        HashMap<RestrictivePermit, RestrictivePermit> anotherPermits = new LinkedHashMap<>();
         for (RestrictivePermit anotherPermit : another.getPermits()) {
-            anotherPermits.put(formAKeyForARuleInATemporaryMap(anotherPermit), anotherPermit);
+            anotherPermits.put(anotherPermit, anotherPermit);
         }
         List<RestrictivePermit> mergedPermits = new LinkedList<>();
         for (RestrictivePermit onePermit : one.getPermits()) {
-            Triple<String, String, String> key = formAKeyForARuleInATemporaryMap(onePermit);
-            if (anotherPermits.containsKey(key)) {
-                mergedPermits.add(merge(onePermit, anotherPermits.get(key)));
-                anotherPermits.remove(key);
+            if (anotherPermits.containsKey(onePermit)) {
+                mergedPermits.add(merge(onePermit, anotherPermits.get(onePermit)));
+                anotherPermits.remove(onePermit);
             } else {
                 mergedPermits.add(onePermit);
             }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
@@ -74,25 +74,25 @@ public class Rule {
         if (!optionalRestrictivePermit.isPresent()) {
             return divisions;
         }
-            Map<String, String> filteredPossibilities = new LinkedHashMap<>();
-            RestrictivePermit restrictivePermit = optionalRestrictivePermit.get();
-            for (RestrictivePermit permit : restrictivePermit.getPermits()) {
+        Map<String, String> filteredPossibilities = new LinkedHashMap<>();
+        RestrictivePermit restrictivePermit = optionalRestrictivePermit.get();
+        for (RestrictivePermit permit : restrictivePermit.getPermits()) {
             Optional<String> getterResult = permit.getDivision();
-                if (getterResult.isPresent()) {
-                    String entry = getterResult.get();
+            if (getterResult.isPresent()) {
+                String entry = getterResult.get();
                 if (divisions.containsKey(entry)) {
                     filteredPossibilities.put(entry, divisions.get(entry));
-                    }
                 }
             }
-            if (restrictivePermit.getUnspecified().equals(Unspecified.UNRESTRICTED)) {
+        }
+        if (restrictivePermit.getUnspecified().equals(Unspecified.UNRESTRICTED)) {
             for (Entry<String, String> entryPair : divisions.entrySet()) {
-                    if (!filteredPossibilities.containsKey(entryPair.getKey())) {
-                        filteredPossibilities.put(entryPair.getKey(), entryPair.getValue());
-                    }
+                if (!filteredPossibilities.containsKey(entryPair.getKey())) {
+                    filteredPossibilities.put(entryPair.getKey(), entryPair.getValue());
                 }
             }
-            return filteredPossibilities;
+        }
+        return filteredPossibilities;
     }
 
     /**

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Condition.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Condition.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.dataeditor.ruleset.xml;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * A {@code <condition>}, which can be defined inside a {@code <restriction>}
+ * and contains conditional {@code <permit>} rules, which only apply if the
+ * condition is met.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Condition implements ConditionsMapInterface {
+    /**
+     * Key to which this (restriction) rule applies, or key that is allowed (for
+     * permit rule inside restriction rule).
+     */
+    @XmlAttribute(required = true)
+    private String key;
+
+    /**
+     * Value that the metadata entry must have for the condition to apply.
+     */
+    @XmlAttribute(required = true)
+    private String equals;
+
+    /**
+     * List of conditional permits.
+     */
+    @XmlElement(name = "permit", namespace = "http://names.kitodo.org/ruleset/v2")
+    private List<RestrictivePermit> permits = new LinkedList<>();
+
+    /**
+     * List of (nested) conditions.
+     */
+    @XmlElement(name = "condition", namespace = "http://names.kitodo.org/ruleset/v2")
+    private List<Condition> conditions = new LinkedList<>();
+
+    private transient ConditionsMap conditionsMap;
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getEquals() {
+        return equals;
+    }
+
+    public List<RestrictivePermit> getPermits() {
+        return permits;
+    }
+
+    @Override
+    public Condition getCondition(String key, String value) {
+        return conditionsMap.getCondition(key, value);
+    }
+
+    @Override
+    public Iterable<String> getConditionKeys() {
+        if (Objects.isNull(conditionsMap)) {
+            conditionsMap = new ConditionsMap(conditions);
+        }
+        return conditionsMap.keySet();
+    }
+}

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/ConditionsMap.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/ConditionsMap.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.dataeditor.ruleset.xml;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class ConditionsMap extends HashMap<String, Map<String, Condition>> implements ConditionsMapInterface {
+
+    public ConditionsMap(List<Condition> conditions) {
+        for (Condition condition : conditions) {
+            super.computeIfAbsent(condition.getKey(), unused -> new HashMap<>()).put(condition.getEquals(), condition);
+        }
+    }
+
+    @Override
+    public Iterable<String> getConditionKeys() {
+        return super.keySet();
+    }
+
+    @Override
+    public Condition getCondition(String key, String value) {
+        return super.getOrDefault(key, Collections.emptyMap()).get(value);
+    }
+}

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/ConditionsMapInterface.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/ConditionsMapInterface.java
@@ -1,0 +1,19 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.dataeditor.ruleset.xml;
+
+public interface ConditionsMapInterface {
+
+    Iterable<String> getConditionKeys();
+
+    Condition getCondition(String key, String value);
+}

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/RestrictivePermit.java
@@ -13,6 +13,7 @@ package org.kitodo.dataeditor.ruleset.xml;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -26,7 +27,7 @@ import javax.xml.bind.annotation.XmlElement;
  * the same underlying object.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-public class RestrictivePermit {
+public class RestrictivePermit implements ConditionsMapInterface {
 
     /**
      * Division to which this (restriction) rule applies, or division that is
@@ -74,6 +75,14 @@ public class RestrictivePermit {
     private List<RestrictivePermit> permits = new LinkedList<>();
 
     /**
+     * List of (nested) conditions.
+     */
+    @XmlElement(name = "condition", namespace = "http://names.kitodo.org/ruleset/v2")
+    private List<Condition> conditions = new LinkedList<>();
+
+    private transient ConditionsMap conditionsMap;
+
+    /**
      * Returns the division to which this rule applies, or which is allowed.
      *
      * @return the division to which this rule applies, or which is allowed
@@ -118,6 +127,19 @@ public class RestrictivePermit {
      */
     public List<RestrictivePermit> getPermits() {
         return permits;
+    }
+
+    @Override
+    public Condition getCondition(String key, String value) {
+        return conditionsMap.getCondition(key, value);
+    }
+
+    @Override
+    public Iterable<String> getConditionKeys() {
+        if (Objects.isNull(conditionsMap)) {
+            conditionsMap = new ConditionsMap(conditions);
+        }
+        return conditionsMap.keySet();
     }
 
     /**
@@ -206,5 +228,48 @@ public class RestrictivePermit {
      */
     public void setValue(Optional<String> value) {
         this.value = value.orElse(null);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((division == null) ? 0 : division.hashCode());
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RestrictivePermit)) {
+            return false;
+        }
+        RestrictivePermit other = (RestrictivePermit) obj;
+        if (division == null) {
+            if (other.division != null) {
+                return false;
+            }
+        } else if (!division.equals(other.division)) {
+            return false;
+        }
+        if (key == null) {
+            if (other.key != null) {
+                return false;
+            }
+        } else if (!key.equals(other.key)) {
+            return false;
+        }
+        if (value == null) {
+            if (other.value != null) {
+                return false;
+            }
+        } else if (!value.equals(other.value)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -180,8 +180,8 @@ public class RulesetManagementIT {
                 case 1:
                     assertEquals("role", smvi.getId());
                     assertEquals("Role", smvi.getLabel());
-                    assertThat(smvi.getSelectItems(), hasEntry("aut", "Author"));
-                    assertThat(smvi.getSelectItems(), hasEntry("edt", "Editor"));
+                    assertThat(smvi.getSelectItems(Collections.emptyList()), hasEntry("aut", "Author"));
+                    assertThat(smvi.getSelectItems(Collections.emptyList()), hasEntry("edt", "Editor"));
                     break;
                 case 2:
                     assertEquals("surname", smvi.getId());
@@ -217,9 +217,13 @@ public class RulesetManagementIT {
         List<MetadataViewWithValuesInterface<Void>> mvwviListDe = seviDe
                 .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
 
-        assertThat(((SimpleMetadataViewInterface) mvwviList.get(0).getMetadata().get()).getSelectItems().keySet(),
+        assertThat(
+            ((SimpleMetadataViewInterface) mvwviList.get(0).getMetadata().get()).getSelectItems(Collections.emptyList())
+                    .keySet(),
             contains("dan", "dut", "eng", "fre", "ger"));
-        assertThat(((SimpleMetadataViewInterface) mvwviListDe.get(0).getMetadata().get()).getSelectItems().keySet(),
+        assertThat(
+            ((SimpleMetadataViewInterface) mvwviListDe.get(0).getMetadata().get())
+                    .getSelectItems(Collections.emptyList()).keySet(),
             contains("dan", "ger", "eng", "fre", "dut"));
 
         // 2. The input elements that have a minimum occurrence greater than
@@ -262,8 +266,8 @@ public class RulesetManagementIT {
         Collection<MetadataViewInterface> mviColl = sevi.getAddableMetadata(Collections.emptyMap(),
             Collections.emptyList());
         SimpleMetadataViewInterface smvi = (SimpleMetadataViewInterface) mviColl.iterator().next();
-        assertTrue(smvi.isValid(OPT));
-        assertFalse(smvi.isValid(StringUtils.capitalize(OPT)));
+        assertTrue(smvi.isValid(OPT, Collections.emptyList()));
+        assertFalse(smvi.isValid(StringUtils.capitalize(OPT), Collections.emptyList()));
     }
 
     /**
@@ -283,62 +287,67 @@ public class RulesetManagementIT {
         assertFalse(booleanMvi.isComplex());
         assertTrue(booleanMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface booleanSmvi = (SimpleMetadataViewInterface) booleanMvi;
-        assertTrue(booleanSmvi.isValid(booleanSmvi.convertBoolean(true).get()));
-        assertFalse(booleanSmvi.isValid(""));
-        assertFalse(booleanSmvi.isValid("botch"));
+        assertTrue(booleanSmvi.isValid(booleanSmvi.convertBoolean(true).get(), Collections.emptyList()));
+        assertFalse(booleanSmvi.isValid("", Collections.emptyList()));
+        assertFalse(booleanSmvi.isValid("botch", Collections.emptyList()));
 
         MetadataViewInterface dateMvi = mvwviList.get(1).getMetadata().get();
         assertFalse(dateMvi.isComplex());
         assertTrue(dateMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface dateSmvi = (SimpleMetadataViewInterface) dateMvi;
-        assertFalse(dateSmvi.isValid(""));
-        assertFalse(dateSmvi.isValid("1803-05-12"));
-        assertTrue(dateSmvi.isValid("1993-09-01"));
+        assertFalse(dateSmvi.isValid("", Collections.emptyList()));
+        assertFalse(dateSmvi.isValid("1803-05-12", Collections.emptyList()));
+        assertTrue(dateSmvi.isValid("1993-09-01", Collections.emptyList()));
 
         MetadataViewInterface defaultStringMvi = mvwviList.get(2).getMetadata().get();
         assertFalse(defaultStringMvi.isComplex());
         assertTrue(defaultStringMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface defaultStringSmvi = (SimpleMetadataViewInterface) defaultStringMvi;
-        assertFalse(defaultStringSmvi.isValid(HELLO_WORLD));
-        assertTrue(defaultStringSmvi.isValid("1234567X"));
+        assertFalse(defaultStringSmvi.isValid(HELLO_WORLD, Collections.emptyList()));
+        assertTrue(defaultStringSmvi.isValid("1234567X", Collections.emptyList()));
 
         MetadataViewInterface integerMvi = mvwviList.get(3).getMetadata().get();
         assertFalse(integerMvi.isComplex());
         assertTrue(integerMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface integerSmvi = (SimpleMetadataViewInterface) integerMvi;
-        assertFalse(integerSmvi.isValid("22"));
-        assertTrue(integerSmvi.isValid("1748"));
+        assertFalse(integerSmvi.isValid("22", Collections.emptyList()));
+        assertTrue(integerSmvi.isValid("1748", Collections.emptyList()));
 
         MetadataViewInterface namespaceDefaultAnyURIMvi = mvwviList.get(4).getMetadata().get();
         assertFalse(namespaceDefaultAnyURIMvi.isComplex());
         assertTrue(namespaceDefaultAnyURIMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface namespaceDefaultAnyURISmvi = (SimpleMetadataViewInterface) namespaceDefaultAnyURIMvi;
         assertFalse(namespaceDefaultAnyURISmvi
-                .isValid("http://test.example/non-existent-namespace/%22Hello,_World!%22_program"));
+                .isValid("http://test.example/non-existent-namespace/%22Hello,_World!%22_program",
+                    Collections.emptyList()));
         assertTrue(
-            namespaceDefaultAnyURISmvi.isValid("http://test.example/non-existent-namespace/Hello_World_program"));
+            namespaceDefaultAnyURISmvi.isValid("http://test.example/non-existent-namespace/Hello_World_program",
+                Collections.emptyList()));
 
         MetadataViewInterface namespaceStringMvi = mvwviList.get(5).getMetadata().get();
         assertFalse(namespaceStringMvi.isComplex());
         assertTrue(namespaceStringMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface namespaceStringSmvi = (SimpleMetadataViewInterface) namespaceStringMvi;
         assertFalse(
-            namespaceStringSmvi.isValid("http://test.example/non-existent-namespace/%22Hello,_World!%22_program"));
-        assertTrue(namespaceStringSmvi.isValid("http://test.example/non-existent-namespace/Hello_World_program"));
+            namespaceStringSmvi.isValid("http://test.example/non-existent-namespace/%22Hello,_World!%22_program",
+                Collections.emptyList()));
+        assertTrue(namespaceStringSmvi.isValid("http://test.example/non-existent-namespace/Hello_World_program",
+            Collections.emptyList()));
 
         MetadataViewInterface optionsMvi = mvwviList.get(6).getMetadata().get();
         assertFalse(optionsMvi.isComplex());
         assertTrue(optionsMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface optionsSmvi = (SimpleMetadataViewInterface) optionsMvi;
-        assertFalse(optionsSmvi.isValid("opt88"));
-        assertTrue(optionsSmvi.isValid("opt2"));
+        assertFalse(optionsSmvi.isValid("opt88", Collections.emptyList()));
+        assertTrue(optionsSmvi.isValid("opt2", Collections.emptyList()));
 
         MetadataViewInterface anyURIMvi = mvwviList.get(7).getMetadata().get();
         assertFalse(anyURIMvi.isComplex());
         assertTrue(anyURIMvi instanceof SimpleMetadataViewInterface);
         SimpleMetadataViewInterface anyURISmvi = (SimpleMetadataViewInterface) anyURIMvi;
-        assertFalse(anyURISmvi.isValid("mailto:e-mail@example.org"));
-        assertTrue(anyURISmvi.isValid("https://en.wikipedia.org/wiki/%22Hello,_World!%22_program"));
+        assertFalse(anyURISmvi.isValid("mailto:e-mail@example.org", Collections.emptyList()));
+        assertTrue(
+            anyURISmvi.isValid("https://en.wikipedia.org/wiki/%22Hello,_World!%22_program", Collections.emptyList()));
     }
 
     /**
@@ -776,7 +785,8 @@ public class RulesetManagementIT {
         List<MetadataViewWithValuesInterface<Object>> visible = personContributor
                 .getSortedVisibleMetadata(Collections.emptyMap(), Collections.emptyList());
         assertThat(ids(visible), contains("role", "gndRecord", "givenName", "surname"));
-        assertThat(getSmvi(visible, "role").getSelectItems().keySet(), contains("author", "editor"));
+        assertThat(getSmvi(visible, "role").getSelectItems(Collections.emptyList()).keySet(),
+            contains("author", "editor"));
     }
 
     /**
@@ -853,7 +863,7 @@ public class RulesetManagementIT {
         List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
-        assertThat(test.getSelectItems().keySet(), contains(OPT, "opt3", "opt5", "opt7"));
+        assertThat(test.getSelectItems(Collections.emptyList()).keySet(), contains(OPT, "opt3", "opt5", "opt7"));
 
     }
 
@@ -871,14 +881,14 @@ public class RulesetManagementIT {
         List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
-        assertTrue(test.isValid(OPT));
-        assertFalse(test.isValid("opt2"));
-        assertTrue(test.isValid("opt3"));
-        assertFalse(test.isValid("opt4"));
-        assertTrue(test.isValid("opt5"));
-        assertFalse(test.isValid("opt6"));
-        assertTrue(test.isValid("opt7"));
-        assertFalse(test.isValid("mischief"));
+        assertTrue(test.isValid(OPT, Collections.emptyList()));
+        assertFalse(test.isValid("opt2", Collections.emptyList()));
+        assertTrue(test.isValid("opt3", Collections.emptyList()));
+        assertFalse(test.isValid("opt4", Collections.emptyList()));
+        assertTrue(test.isValid("opt5", Collections.emptyList()));
+        assertFalse(test.isValid("opt6", Collections.emptyList()));
+        assertTrue(test.isValid("opt7", Collections.emptyList()));
+        assertFalse(test.isValid("mischief", Collections.emptyList()));
     }
 
     /**
@@ -931,7 +941,8 @@ public class RulesetManagementIT {
         List<MetadataViewWithValuesInterface<Object>> mvwviList = sevi.getSortedVisibleMetadata(Collections.emptyMap(),
             Collections.singletonList(TEST));
         SimpleMetadataViewInterface test = getSmvi(mvwviList, TEST);
-        assertThat(test.getSelectItems().keySet(), contains("opt4", "opt7", OPT, "opt2", "opt3", "opt5", "opt6"));
+        assertThat(test.getSelectItems(Collections.emptyList()).keySet(),
+            contains("opt4", "opt7", OPT, "opt2", "opt3", "opt5", "opt6"));
     }
 
     /**
@@ -949,55 +960,60 @@ public class RulesetManagementIT {
                 "namespaceStringExternal"));
 
         SimpleMetadataViewInterface defaultMv = getSmvi(mvwviList, "default");
-        assertTrue(defaultMv.isValid(HELLO_WORLD));
+        assertTrue(defaultMv.isValid(HELLO_WORLD, Collections.emptyList()));
 
         SimpleMetadataViewInterface defaultOpt = getSmvi(mvwviList, "defaultOpt");
-        assertTrue(defaultOpt.isValid("val1"));
-        assertFalse(defaultOpt.isValid("val9"));
+        assertTrue(defaultOpt.isValid("val1", Collections.emptyList()));
+        assertFalse(defaultOpt.isValid("val9", Collections.emptyList()));
 
         SimpleMetadataViewInterface anyUri = getSmvi(mvwviList, "anyUri");
-        assertTrue(anyUri.isValid("https://www.kitodo.org/software/kitodoproduction/"));
-        assertTrue(anyUri.isValid("mailto:contact@kitodo.org"));
-        assertTrue(anyUri.isValid("urn:nbn:de-9999-12345678X"));
-        assertFalse(anyUri.isValid(HELLO_WORLD));
+        assertTrue(anyUri.isValid("https://www.kitodo.org/software/kitodoproduction/", Collections.emptyList()));
+        assertTrue(anyUri.isValid("mailto:contact@kitodo.org", Collections.emptyList()));
+        assertTrue(anyUri.isValid("urn:nbn:de-9999-12345678X", Collections.emptyList()));
+        assertFalse(anyUri.isValid(HELLO_WORLD, Collections.emptyList()));
 
         SimpleMetadataViewInterface booleanMv = getSmvi(mvwviList, "boolean");
-        assertTrue(booleanMv.isValid("on"));
-        assertFalse(booleanMv.isValid(HELLO_WORLD));
+        assertTrue(booleanMv.isValid("on", Collections.emptyList()));
+        assertFalse(booleanMv.isValid(HELLO_WORLD, Collections.emptyList()));
 
         SimpleMetadataViewInterface date = getSmvi(mvwviList, "date");
-        assertTrue(date.isValid("1492-10-12"));
-        assertFalse(date.isValid("1900-02-29"));
+        assertTrue(date.isValid("1492-10-12", Collections.emptyList()));
+        assertFalse(date.isValid("1900-02-29", Collections.emptyList()));
 
         SimpleMetadataViewInterface integer = getSmvi(mvwviList, "integer");
-        assertTrue(integer.isValid("1234567"));
-        assertFalse(integer.isValid("1 + 1i"));
+        assertTrue(integer.isValid("1234567", Collections.emptyList()));
+        assertFalse(integer.isValid("1 + 1i", Collections.emptyList()));
 
         SimpleMetadataViewInterface namespaceDefault = getSmvi(mvwviList, "namespaceDefault");
-        assertTrue(namespaceDefault.isValid("http://test.example/testValidation/alice"));
-        assertFalse(namespaceDefault.isValid("http://test.example/testValidation#bob"));
-        assertFalse(namespaceDefault.isValid("https://www.wdrmaus.de/"));
+        assertTrue(namespaceDefault.isValid("http://test.example/testValidation/alice", Collections.emptyList()));
+        assertFalse(namespaceDefault.isValid("http://test.example/testValidation#bob", Collections.emptyList()));
+        assertFalse(namespaceDefault.isValid("https://www.wdrmaus.de/", Collections.emptyList()));
 
         SimpleMetadataViewInterface namespaceString = getSmvi(mvwviList, "namespaceString");
-        assertTrue(namespaceString.isValid("http://test.example/testValidation/alice"));
-        assertTrue(namespaceString.isValid("{http://test.example/testValidation/}bob"));
-        assertFalse(namespaceString.isValid("https://www.wdrmaus.de/"));
+        assertTrue(namespaceString.isValid("http://test.example/testValidation/alice", Collections.emptyList()));
+        assertTrue(namespaceString.isValid("{http://test.example/testValidation/}bob", Collections.emptyList()));
+        assertFalse(namespaceString.isValid("https://www.wdrmaus.de/", Collections.emptyList()));
 
         SimpleMetadataViewInterface namespaceOpt = getSmvi(mvwviList, "namespaceDefaultOpt");
-        assertTrue(namespaceOpt.isValid("http://test.example/testValidation/value1"));
-        assertFalse(namespaceOpt.isValid("http://test.example/testValidation/value4"));
+        assertTrue(namespaceOpt.isValid("http://test.example/testValidation/value1", Collections.emptyList()));
+        assertFalse(namespaceOpt.isValid("http://test.example/testValidation/value4, Collections.emptyList()",
+            Collections.emptyList()));
 
         SimpleMetadataViewInterface namespaceStrOpt = getSmvi(mvwviList, "namespaceStringOpt");
-        assertTrue(namespaceStrOpt.isValid("http://test.example/testValidation/value1"));
-        assertFalse(namespaceStrOpt.isValid("http://test.example/testValidation/value4"));
+        assertTrue(namespaceStrOpt.isValid("http://test.example/testValidation/value1", Collections.emptyList()));
+        assertFalse(namespaceStrOpt.isValid("http://test.example/testValidation/value4", Collections.emptyList()));
 
         SimpleMetadataViewInterface namespaceExt = getSmvi(mvwviList, "namespaceDefaultExternal");
-        assertTrue(namespaceExt.isValid("http://test.example/testValidationByCodomainNamespace#val1"));
-        assertFalse(namespaceExt.isValid("http://test.example/testValidationByCodomainNamespace#val4"));
+        assertTrue(namespaceExt.isValid("http://test.example/testValidationByCodomainNamespace#val1",
+            Collections.emptyList()));
+        assertFalse(namespaceExt.isValid("http://test.example/testValidationByCodomainNamespace#val4",
+            Collections.emptyList()));
 
         SimpleMetadataViewInterface namespaceStrExt = getSmvi(mvwviList, "namespaceStringExternal");
-        assertTrue(namespaceStrExt.isValid("http://test.example/testValidationByCodomainNamespace#val1"));
-        assertFalse(namespaceStrExt.isValid("http://test.example/testValidationByCodomainNamespace#val4"));
+        assertTrue(namespaceStrExt.isValid("http://test.example/testValidationByCodomainNamespace#val1",
+            Collections.emptyList()));
+        assertFalse(namespaceStrExt.isValid("http://test.example/testValidationByCodomainNamespace#val4",
+            Collections.emptyList()));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
@@ -113,7 +113,7 @@ public class ProcessBooleanMetadata extends ProcessSimpleMetadata implements Ser
     @Override
     public boolean isValid() {
         Optional<String> value = settings.convertBoolean(active);
-        return !value.isPresent() || settings.isValid(value.get());
+        return !value.isPresent() || settings.isValid(value.get(), container.getListForLeadingMetadataFields());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDetail.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDetail.java
@@ -57,6 +57,12 @@ public abstract class ProcessDetail implements Serializable {
     protected final String label;
 
     /**
+     * Whether this metadata entry is leading for options of other metadata
+     * entries.
+     */
+    protected boolean leading = false;
+
+    /**
      * Creates a new metadata panel row.
      *
      * @param label
@@ -139,6 +145,18 @@ public abstract class ProcessDetail implements Serializable {
             throws InvalidMetadataValueException, NoSuchMetadataFieldException;
 
     /**
+     * Returns whether this metadata entry is leading for options of other
+     * metadata entries. If true, the application must refresh the metadata
+     * panel after this entry was changed to reflect the option changes in other
+     * metadata entries.
+     *
+     * @return whether this metadata entry is leading
+     */
+    public boolean isLeading() {
+        return leading;
+    }
+
+    /**
      * Returns if the field is not defined by the rule set. The front-end should
      * show some kind of warning sign then.
      *
@@ -158,4 +176,14 @@ public abstract class ProcessDetail implements Serializable {
      * @return if the field is valid
      */
     public abstract boolean isValid();
+
+    /**
+     * Sets whether this metadata entry is leading for options of other metadata
+     * entries. Set to true to tell the application to refresh the metadata
+     * panel after this entry was changed, to reflect the option changes in
+     * other metadata entries.
+     */
+    public void setLeading() {
+        this.leading = true;
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -64,7 +64,9 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     ProcessSelectMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings,
             Collection<MetadataEntry> selected) {
         super(container, settings, settings.getLabel());
-        this.items = toItems(settings.getSelectItems());
+        List<Map<MetadataEntry, Boolean>> leadingMetadataFields = container.getListForLeadingMetadataFields();
+        this.items = toItems(settings.getSelectItems(leadingMetadataFields));
+        container.markLeadingMetadataFields(leadingMetadataFields);
         if (selected.isEmpty()) {
             selectedItems.addAll(settings.getDefaultItems());
         } else {
@@ -118,7 +120,7 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
         String key = settings.getId();
         MdSec domain = DOMAIN_TO_MDSEC.get(settings.getDomain().orElse(Domain.DESCRIPTION));
         for (String selectedItem : selectedItems) {
-            if (!settings.isValid(selectedItem)) {
+            if (!settings.isValid(selectedItem, container.getListForLeadingMetadataFields())) {
                 throw new InvalidMetadataValueException(label, selectedItem);
             }
             MetadataEntry entry = new MetadataEntry();
@@ -153,7 +155,7 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
             throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
             String value = String.join(" ", selectedItems);
-            if (!settings.isValid(value)) {
+            if (!settings.isValid(value, container.getListForLeadingMetadataFields())) {
                 throw new InvalidMetadataValueException(label, value);
             }
             return Pair.of(super.getStructureFieldSetters(settings), value);
@@ -165,7 +167,7 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     @Override
     public boolean isValid() {
         for (String selectedItem : selectedItems) {
-            if (!settings.isValid(selectedItem)) {
+            if (!settings.isValid(selectedItem, container.getListForLeadingMetadataFields())) {
                 return false;
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -92,7 +92,7 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
             throws InvalidMetadataValueException, NoSuchMetadataFieldException {
 
         if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
-            if (!settings.isValid(value)) {
+            if (!settings.isValid(value, container.getListForLeadingMetadataFields())) {
                 throw new InvalidMetadataValueException(label, value);
             }
             return Pair.of(super.getStructureFieldSetters(settings), value);
@@ -106,7 +106,7 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
         if (Objects.isNull(value) || value.isEmpty()) {
             return false;
         }
-        return settings.isValid(value);
+        return settings.isValid(value, container.getListForLeadingMetadataFields());
     }
 
     /**


### PR DESCRIPTION
Second part of #4229

In this pull request, the business logic to calculate dependent value restrictions is implemented. Since a large amount of values has to be checked here (> 10,000 values per entry in the present case), this was implemented with `HashMap`s (class `ConditionMap`), which is initialized once, and then always used.

A special task is to return from the output of selection elements in the ruleset which fields they depend on, so that the application knows when these text fields are changed, that it has to refresh the selection elements. This is done with the `Map` to `Boolean`, whereby the element-generating function sets the boolean to true if this metadata entry is leading, i.e. changing this metadata entry must trigger a refresh.

In this pull request, refresh is not yet implemented in the XHTML.

This is a follow-up pull request to #4333, [immediate diff](https://github.com/matthias-ronge/kitodo-production/compare/matthias-ronge:issue-4229_1.1...issue-4229_2.1)