### PR TITLE
Fix filter removal

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -439,6 +439,7 @@ public class UserService extends ClientSearchDatabaseService<User, UserDAO> impl
      * @return list of filters
      */
     private List<String> getFiltersForUser(User user) {
+        refresh(user);
         List<String> userFilters = new ArrayList<>();
         List<Filter> filters = user.getFilters();
         for (Filter filter : filters) {


### PR DESCRIPTION
User filters in the task and process lists are not removed when clicking the corresponding icon next to the filter:
<img width="245" alt="Bildschirmfoto 2021-04-19 um 15 32 06" src="https://user-images.githubusercontent.com/19183925/115244826-9bd11e80-a124-11eb-988e-f4adac2a10fa.png">
This pull request fixes that. (see #3511)