### PR TITLE
Fix loading of config files

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/config/Config.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/Config.java
@@ -34,10 +34,10 @@ public abstract class Config {
      * @return the configuration
      */
     static PropertiesConfiguration getConfig(String configFile) {
-        if (Objects.isNull(config)) {
+        if (Objects.isNull(config) || !configFile.equals(config.getFileName())) {
             synchronized (Config.class) {
                 PropertiesConfiguration initialized = config;
-                if (Objects.isNull(initialized)) {
+                if (Objects.isNull(initialized) || !configFile.equals(initialized.getFileName())) {
                     AbstractConfiguration.setDefaultListDelimiter('&');
                     try {
                         initialized = new PropertiesConfiguration(configFile);


### PR DESCRIPTION
Fixes #4390 

`Config.getConfig(String configFile)` did not load a configuration file if _any_ configuration file was loaded into the static variable `config` previously but instead just reused that variable, effectively making the String-parameter `configFile` obsolete in all but the first call of this method. 

Therefore, custom values for password constraint relevant parameters like `length.min` were ignored (and the corresponding default value used instead) because they couldn't be found in the first config file loaded, which would always be `kitodo_config.properties` (meaning custom `password-rules.properties` files didn't have any chance to be loaded at all!).