### PR TITLE
Use batch type to find newspaper batches

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Batch.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Batch.java
@@ -19,12 +19,15 @@ import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
+import org.kitodo.data.database.enums.BatchType;
 import org.kitodo.data.database.persistence.BatchDAO;
 
 /**
@@ -44,6 +47,13 @@ public class Batch extends BaseIndexedBean {
      */
     @Column(name = "title")
     private String title;
+
+    /**
+     * The field type holds the batch type.
+     */
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    private BatchType type;
 
     /**
      * Holds the processes that belong to the batch.
@@ -113,6 +123,15 @@ public class Batch extends BaseIndexedBean {
      */
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    /**
+     * Returns the batch type.
+     *
+     * @return the batch type
+     */
+    public BatchType getType() {
+        return type;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/BatchType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/BatchType.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.database.enums;
+
+/**
+ * Enum for batch type. Type of batch:
+ *
+ * <dl>
+ * <dt>LOGISTIC</dt>
+ * <dd>facilitates the logistics of excavation and processing in the
+ * digitisation centre</dd>
+ * <dt>NEWSPAPER</dt>
+ * <dd>forms the complete edition of a newspaper</dd>
+ * <dt>SERIAL</dt>
+ * <dd>forms the complete edition of a serial publication</dd>
+ * </dl>
+ */
+public enum BatchType {
+    LOGISTIC,
+    NEWSPAPER,
+    SERIAL
+}

--- a/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
@@ -40,6 +40,7 @@ import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Batch;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.enums.BatchType;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
@@ -213,37 +214,11 @@ public class NewspaperProcessesMigrator {
     public static List<Batch> getNewspaperBatches() throws DAOException, IOException {
         List<Batch> newspaperBatches = new ArrayList<>();
         for (Batch batch : batchService.getAll()) {
-            if (isNewspaperBatch(batch)) {
+            if (BatchType.NEWSPAPER.equals(batch.getType())) {
                 newspaperBatches.add(batch);
             }
         }
         return newspaperBatches;
-    }
-
-    /**
-     * Returns whether the batch is a newspaper batch. A
-     * batch is a newspaper batch, if all of its processes are newspaper
-     * processes. A process is a newspaper process if it has a
-     * {@code meta_year.xml} file.
-     *
-     * @param batch
-     *            the batch to check
-     * @return whether the batch is a newspaper batch
-     * @throws IOException
-     *             if an I/O error occurs when accessing the file system
-     */
-    private static boolean isNewspaperBatch(Batch batch) throws IOException {
-
-        logger.trace("Examining batch {}...", batch.getTitle());
-        boolean newspaperBatch = true;
-        for (Process process : batch.getProcesses()) {
-            if (!fileService.processOwnsYearXML(process)) {
-                newspaperBatch = false;
-                break;
-            }
-        }
-        logger.trace("{} {} newspaper batch.", batch.getTitle(), newspaperBatch ? "is a" : "is not a");
-        return newspaperBatch;
     }
 
     /**


### PR DESCRIPTION
As @henning-gerhardt suggested in https://github.com/kitodo/kitodo-production/pull/4417#issuecomment-844019633, the batch type should be used to determine whether a batch is a newspaper batch.