### PR TITLE
fix adding metadata to empty collection

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
@@ -34,9 +34,8 @@ public class AddDataScript extends EditDataScript {
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
             MetadataScript metadataScript) {
         Workpiece workpiece = metadataFile.getWorkpiece();
-        List<IncludedStructuralElement> allIncludedStructuralElements = workpiece.getAllIncludedStructuralElements();
 
-        Collection<Metadata> metadataCollection = getMetadataCollection(allIncludedStructuralElements);
+        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();;
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
 
         for (String value : metadataScript.getValues()) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
@@ -35,9 +35,8 @@ public class DeleteDataScript extends EditDataScript {
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
                                MetadataScript metadataScript) {
         Workpiece workpiece = metadataFile.getWorkpiece();
-        List<IncludedStructuralElement> allIncludedStructuralElements = workpiece.getAllIncludedStructuralElements();
 
-        Collection<Metadata> metadataCollection = getMetadataCollection(allIncludedStructuralElements);
+        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();
 
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
         List<Metadata> metadataCollectionCopy = new ArrayList<>(metadataCollection);

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -56,16 +56,7 @@ public abstract class EditDataScript {
      * @return a list of metadata of a structural element selected from the list.
      */
     public Collection<Metadata> getMetadataCollection(List<IncludedStructuralElement> allIncludedStructuralElements) {
-        Collection<Metadata> metadataCollection = Collections.emptyList();
-        if (!allIncludedStructuralElements.isEmpty()) {
-            for (IncludedStructuralElement allIncludedStructuralElement : allIncludedStructuralElements) {
-                if (!allIncludedStructuralElement.getMetadata().isEmpty()) {
-                    metadataCollection = allIncludedStructuralElement.getMetadata();
-                    break;
-                }
-            }
-        }
-        return metadataCollection;
+        return allIncludedStructuralElements.isEmpty() ? new ArrayList<>() : allIncludedStructuralElements.get(0).getMetadata();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -51,15 +51,6 @@ public abstract class EditDataScript {
     }
 
     /**
-     * gets the corresponding metadata as collection.
-     * @param allIncludedStructuralElements the structural Elements to check.
-     * @return a list of metadata of a structural element selected from the list.
-     */
-    public Collection<Metadata> getMetadataCollection(List<IncludedStructuralElement> allIncludedStructuralElements) {
-        return allIncludedStructuralElements.isEmpty() ? new ArrayList<>() : allIncludedStructuralElements.get(0).getMetadata();
-    }
-
-    /**
      * Executes the given script on the given file for the given process.
      * @param metadataFile the file to edit
      * @param process the related process
@@ -133,9 +124,8 @@ public abstract class EditDataScript {
         LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                 .readMetadataFile(parentProcess);
         Workpiece workpiece = metadataFile.getWorkpiece();
-        List<IncludedStructuralElement> allIncludedStructuralElements = workpiece.getAllIncludedStructuralElements();
 
-        Collection<Metadata> metadataCollection = getMetadataCollection(allIncludedStructuralElements);
+        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();;
         generateValueForMetadataScript(metadataScript, metadataCollection, parentProcess, metadataFile);
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
@@ -29,10 +29,8 @@ public class OverwriteDataScript extends EditDataScript {
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
             MetadataScript metadataScript) {
         Workpiece workpiece = metadataFile.getWorkpiece();
-        List<IncludedStructuralElement> allIncludedStructuralElements = workpiece
-                .getAllIncludedStructuralElements();
 
-        Collection<Metadata> metadataCollection = getMetadataCollection(allIncludedStructuralElements);
+        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();
 
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
 


### PR DESCRIPTION
When adding metadata through metadatascript an error occured when metadata collection was empty.
There is no need, to check for empty collection, because metadata can be added in any case.