### PR TITLE
Prevent creating elements from non-consecutive pages

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -589,7 +589,10 @@ public class DataEditorForm implements RulesetSetupInterface, Serializable {
     /**
      * Checks and returns if consecutive media units in one structure element are selected or not.
      */
-    boolean consecutivePagesSelected() {
+    public boolean consecutivePagesSelected() {
+        if (selectedMedia.isEmpty()) {
+            return false;
+        }
         int maxOrder = selectedMedia.stream().mapToInt(m -> m.getLeft().getOrder()).max().orElseThrow(NoSuchElementException::new);
         int minOrder = selectedMedia.stream().mapToInt(m -> m.getLeft().getOrder()).min().orElseThrow(NoSuchElementException::new);
         return selectedMedia.size() - 1 == maxOrder - minOrder

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -292,6 +292,7 @@ dataEditor.position.asLastChildOfCurrentElement=Als letztes Subelement des aktue
 dataEditor.position.asParentOfCurrentElement=Als Elternelement des aktuellen Elementes
 dataEditor.position.beforeCurrentElement=Vor dem aktuellen Element
 dataEditor.position.currentPosition=Aktuelle Position
+dataEditor.removeElement.noConsecutivePagesSelected=Strukturelemente k\u00F6nnen nur aus fortlaufenden Medien erstellt werden!
 dataEditor.selectMetadataTask=Aufgabe w\u00E4hlen
 dataEditor.unableToMoveError=Element konnte nicht verschoben werden!
 dataEditor.undefinedStructure=Die Einteilung ist im Regelsatz nicht bekannt

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -296,6 +296,7 @@ dataEditor.position.asLastChildOfCurrentElement=As last child of current element
 dataEditor.position.asParentOfCurrentElement=As parent of current element
 dataEditor.position.beforeCurrentElement=Before current element
 dataEditor.position.currentPosition=Current position
+dataEditor.removeElement.noConsecutivePagesSelected=Select consecutive pages to create structure elements!
 dataEditor.selectMetadataTask=Select task
 dataEditor.unableToMoveError=Unable to move structure element!
 dataEditor.undefinedStructure=The division isn't defined in the ruleset

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2490,6 +2490,10 @@ Column content
     border-style: dashed;
 }
 
+.thumbnail.discontinuous.selected + .thumbnail-container img {
+    border-color: grey;
+}
+
 .thumbnail.selected.last-selection + .thumbnail-container img {
     border-style: solid;
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -115,7 +115,7 @@
                                          styleClass="page-drop-area"/>
                                 <p:panel id="structuredPagePanel">
                                     <p:outputPanel styleClass="thumbnail-parent">
-                                        <p:outputPanel styleClass="thumbnail #{DataEditorForm.galleryPanel.isSelected(media, stripe) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, stripe) ? 'last-selection' : ''}"/>
+                                        <p:outputPanel styleClass="thumbnail #{DataEditorForm.consecutivePagesSelected() ? '' : 'discontinuous'} #{DataEditorForm.galleryPanel.isSelected(media, stripe) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, stripe) ? 'last-selection' : ''}"/>
                                         <p:outputPanel styleClass="thumbnail-container"
                                                        a:data-order="#{media.order}"
                                                        a:data-stripe="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe)}">
@@ -202,7 +202,7 @@
                                              styleClass="page-drop-area"/>
                                     <p:panel id="unstructuredMediaPanel">
                                         <h:panelGroup id="updateSelectedUnstructuredMediaLink" styleClass="thumbnail-parent">
-                                            <p:outputPanel styleClass="thumbnail #{DataEditorForm.galleryPanel.isSelected(media, DataEditorForm.galleryPanel.stripes.get(0)) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, DataEditorForm.galleryPanel.stripes.get(0)) ? 'last-selection' : ''}"/>
+                                            <p:outputPanel styleClass="thumbnail #{DataEditorForm.consecutivePagesSelected() ? '' : 'discontinuous'} #{DataEditorForm.galleryPanel.isSelected(media, DataEditorForm.galleryPanel.stripes.get(0)) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, DataEditorForm.galleryPanel.stripes.get(0)) ? 'last-selection' : ''}"/>
                                             <p:outputPanel styleClass="thumbnail-container"
                                                            a:data-order="#{media.order}"
                                                            a:data-stripe="0">
@@ -277,7 +277,7 @@
                      a:ondragstart="metadataEditor.handleDragStart(event)">
                     <ui:repeat value="#{DataEditorForm.galleryPanel.medias}"
                                var="media">
-                        <p:outputPanel styleClass="thumbnail #{DataEditorForm.galleryPanel.isSelected(media, null) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, null) ? 'last-selection' : ''}">
+                        <p:outputPanel styleClass="thumbnail #{DataEditorForm.consecutivePagesSelected() ? '' : 'discontinuous'} #{DataEditorForm.galleryPanel.isSelected(media, null) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, null) ? 'last-selection' : ''}">
                             <p:panel a:data-order="#{media.order}">
                                 <h:panelGroup layout="block" styleClass="thumbnail-container">
                                         <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
@@ -315,7 +315,7 @@
                                            var="media">
                                     <p:outputPanel>
                                         <h:panelGroup layout="block" styleClass="thumbnail-parent">
-                                            <p:outputPanel styleClass="thumbnail #{DataEditorForm.galleryPanel.isSelected(media, null) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, null) ? 'last-selection' : ''}"/>
+                                            <p:outputPanel styleClass="thumbnail #{DataEditorForm.consecutivePagesSelected() ? '' : 'discontinuous'} #{DataEditorForm.galleryPanel.isSelected(media, null) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, null) ? 'last-selection' : ''}"/>
                                             <p:outputPanel layout="block"
                                                            styleClass="thumbnail-container"
                                                            a:data-order="#{media.order}">
@@ -351,10 +351,10 @@
             <p:contextMenu id="mediaContextMenu"
                            widgetVar="mediaContextMenu"
                            for="contextMenuHiddenTrigger">
-                <p:menuitem value="#{msgs.addElement} #{msgs.assignMedia}"
+                <p:menuitem value="#{DataEditorForm.consecutivePagesSelected() ? msgs.addElement.concat(' ').concat(msgs.assignMedia) : msgs['dataEditor.removeElement.noConsecutivePagesSelected']}"
                             icon="fa fa-plus fa-sm"
                             styleClass="plain"
-                            disabled="#{readOnly}"
+                            disabled="#{readOnly or not DataEditorForm.consecutivePagesSelected()}"
                             action="#{DataEditorForm.addDocStrucTypeDialog.prepare}"
                             oncomplete="PF('dialogAddDocStrucType').show()"
                             update="dialogAddDocStrucTypeDialog">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -89,11 +89,11 @@
                         update="dialogAddDocStrucTypeDialog">
                 <f:actionListener binding="#{DataEditorForm.addDocStrucTypeDialog.preparePreselectedViews()}"/>
             </p:menuitem>
-            <p:menuitem value="#{msgs.addElement} #{msgs.assignMedia}"
+            <p:menuitem value="#{DataEditorForm.consecutivePagesSelected() ? msgs.addElement.concat(' ').concat(msgs.assignMedia) : msgs['dataEditor.removeElement.noConsecutivePagesSelected']}"
                         rendered="#{DataEditorForm.selectedMedia.size() ge 1}"
                         icon="fa fa-plus fa-sm"
                         styleClass="plain"
-                        disabled="#{readOnly}"
+                        disabled="#{readOnly or not DataEditorForm.consecutivePagesSelected()}"
                         action="#{DataEditorForm.addDocStrucTypeDialog.prepare}"
                         process="@this"
                         oncomplete="PF('dialogAddDocStrucType').show()"


### PR DESCRIPTION
This pull request disables the context menu option to create a new element from selected pages if the selection is not continuous. This is to prevent creating new structures from implicitly _changing_ the physical order of pages.

Additionally, discontinuously selected pages are marked with a **grey** border instead of a **green** border in the gallery to provide some immediate indication to the user in such situations.

<img width="756" alt="Bildschirmfoto 2021-05-28 um 10 40 06" src="https://user-images.githubusercontent.com/19183925/119956187-1cdfc900-bfa1-11eb-8c1d-bf4a76a49418.png">


This may fix #4368 and perhaps replaces the solution proposed in that issues desription (which is probably to expensive to implement). @subhhwendt would this sufficiently solve the mentioned issue in your eyes?

