### PR TITLE
Enable default context menu for input and textarea elements

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -81,8 +81,9 @@ var metadataEditor = {
 
 metadataEditor.contextMenu = {
     listen() {
-        document.oncontextmenu = function() {
-            return false;
+        document.oncontextmenu = function(event) {
+            return event.target.tagName === "INPUT" || event.target.tagName === "TEXTAREA";
+
         };
         $(document).on("mousedown.thumbnail", ".thumbnail-parent", function(event) {
             if (event.originalEvent.button === 2) {


### PR DESCRIPTION
Enable the browser's default context menu for HTML elements of type "input" or "textarea" in metadata editor to allow copy and paste actions via mouse.

Fixes #4212 