### PR TITLE
Allow KitodoScript as action

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -287,10 +288,7 @@ public class ProcessForm extends TemplateBaseForm {
             this.process.setTitle(this.newProcessTitle);
 
             // remove Tiffwriter file
-            KitodoScriptService gs = new KitodoScriptService();
-            List<Process> pro = new ArrayList<>();
-            pro.add(this.process);
-            gs.deleteTiffHeaderFile(pro);
+            ServiceManager.getKitodoScriptService().deleteTiffHeaderFile(Arrays.asList(process));
         }
         return true;
     }
@@ -664,7 +662,7 @@ public class ProcessForm extends TemplateBaseForm {
     }
 
     private void executeKitodoScriptForProcesses(List<Process> processes, String kitodoScript) {
-        KitodoScriptService service = new KitodoScriptService();
+        KitodoScriptService service = ServiceManager.getKitodoScriptService();
         try {
             service.execute(processes, kitodoScript);
         } catch (DataException | IOException | InvalidImagesException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/ServiceManager.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/ServiceManager.java
@@ -14,6 +14,7 @@ package org.kitodo.production.services;
 import java.util.Objects;
 
 import org.kitodo.production.services.command.CommandService;
+import org.kitodo.production.services.command.KitodoScriptService;
 import org.kitodo.production.services.data.AuthorityService;
 import org.kitodo.production.services.data.BatchService;
 import org.kitodo.production.services.data.ClientService;
@@ -68,6 +69,7 @@ public class ServiceManager {
     private static ImageService imageService;
     private static ImportService importService;
     private static IndexingService indexingService;
+    private static KitodoScriptService kitodoScriptService;
     private static LdapGroupService ldapGroupService;
     private static LdapServerService ldapServerService;
     private static ListColumnService listColumnService;
@@ -130,6 +132,12 @@ public class ServiceManager {
     private static void initializeFilterService() {
         if (Objects.isNull(filterService)) {
             filterService = FilterService.getInstance();
+        }
+    }
+
+    private static void initializeKitodoScriptService() {
+        if (Objects.isNull(kitodoScriptService)) {
+            kitodoScriptService = KitodoScriptService.getInstance();
         }
     }
 
@@ -622,6 +630,17 @@ public class ServiceManager {
     public static FileStructureValidationService getFileStructureValidationService() {
         initializeFileStructureValidationService();
         return fileStructureValidationService;
+    }
+
+    /**
+     * Initialize KitodoScriptService if it is not yet initialized and next
+     * return it.
+     *
+     * @return KitodoScriptService object
+     */
+    public static KitodoScriptService getKitodoScriptService() {
+        initializeKitodoScriptService();
+        return kitodoScriptService;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -63,6 +63,30 @@ public class KitodoScriptService {
     private static final String ROLE = "role";
 
     /**
+     * Return the singleton instance of the Kitodo script service.
+     *
+     * @return singleton instance of the Kitodo script service
+     */
+    public static KitodoScriptService getInstance() {
+        KitodoScriptService localReference = instance;
+        if (Objects.isNull(localReference)) {
+            synchronized (KitodoScriptService.class) {
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new KitodoScriptService();
+                    instance = localReference;
+                }
+            }
+        }
+        return localReference;
+    }
+
+    /**
+     * Private constructor. Use {@link #getInstance()} to get the instance.
+     */
+    private KitodoScriptService() { }
+
+    /**
      * Start the script execution.
      *
      * @param processes
@@ -744,19 +768,5 @@ public class KitodoScriptService {
         } catch (DataException e) {
             Helper.setErrorMessage("Error while saving - " + processTitle, logger, e);
         }
-    }
-
-    public static KitodoScriptService getInstance() {
-        KitodoScriptService localReference = instance;
-        if (Objects.isNull(localReference)) {
-            synchronized (KitodoScriptService.class) {
-                localReference = instance;
-                if (Objects.isNull(localReference)) {
-                    localReference = new KitodoScriptService();
-                    instance = localReference;
-                }
-            }
-        }
-        return localReference;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -51,6 +51,7 @@ import org.kitodo.production.services.image.ImageGenerator;
 import org.kitodo.production.thread.TaskImageGeneratorThread;
 
 public class KitodoScriptService {
+    private static volatile KitodoScriptService instance = null;
     private Map<String, String> parameters;
     private static final Logger logger = LogManager.getLogger(KitodoScriptService.class);
     private final FileService fileService = ServiceManager.getFileService();
@@ -743,5 +744,19 @@ public class KitodoScriptService {
         } catch (DataException e) {
             Helper.setErrorMessage("Error while saving - " + processTitle, logger, e);
         }
+    }
+
+    public static KitodoScriptService getInstance() {
+        KitodoScriptService localReference = instance;
+        if (Objects.isNull(localReference)) {
+            synchronized (KitodoScriptService.class) {
+                localReference = instance;
+                if (Objects.isNull(localReference)) {
+                    localReference = new KitodoScriptService();
+                    instance = localReference;
+                }
+            }
+        }
+        return localReference;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -84,7 +84,8 @@ public class KitodoScriptService {
     /**
      * Private constructor. Use {@link #getInstance()} to get the instance.
      */
-    private KitodoScriptService() { }
+    private KitodoScriptService() {
+    }
 
     /**
      * Start the script execution.

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -28,7 +28,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kitodo.ExecutionPermission;
 import org.kitodo.MockDatabase;
@@ -109,7 +108,7 @@ public class KitodoScriptServiceIT {
         File max = new File(processHome, "jpgs/max");
         max.delete();
 
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
 
         String script = "action:createFolders";
         List<Process> processes = new ArrayList<>();
@@ -127,7 +126,7 @@ public class KitodoScriptServiceIT {
 
     @Test
     public void shouldExecuteAddRoleScript() throws Exception {
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
 
         Task task = ServiceManager.getTaskService().getById(8);
         int amountOfRoles = task.getRoles().size();
@@ -146,7 +145,7 @@ public class KitodoScriptServiceIT {
         MockDatabase.cleanDatabase();
         MockDatabase.insertProcessesFull();
 
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
 
         String script = "action:setStepStatus \"tasktitle:Progress\" status:3";
         List<Process> processes = new ArrayList<>();
@@ -159,7 +158,7 @@ public class KitodoScriptServiceIT {
 
     @Test
     public void shouldExecuteAddShellScriptToTaskScript() throws Exception {
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
 
         String script = "action:addShellScriptToStep \"tasktitle:Progress\" \"label:script\" \"script:/some/new/path\"";
         List<Process> processes = new ArrayList<>();
@@ -173,7 +172,7 @@ public class KitodoScriptServiceIT {
 
     @Test
     public void shouldExecuteSetPropertyTaskScript() throws Exception {
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
 
         String script = "action:setTaskProperty \"tasktitle:Closed\" property:validate value:true";
         List<Process> processes = new ArrayList<>();
@@ -186,7 +185,7 @@ public class KitodoScriptServiceIT {
 
     @Test
     public void shouldNotExecuteSetPropertyTaskScript() throws Exception {
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
 
         String script = "action:setTaskProperty \"tasktitle:Closed\" property:validate value:invalid";
         List<Process> processes = new ArrayList<>();
@@ -217,7 +216,7 @@ public class KitodoScriptServiceIT {
         processTwo.setTitle("SecondProcess");
         processes.add(processTwo);
 
-        new KitodoScriptService().execute(processes,
+        ServiceManager.getKitodoScriptService().execute(processes,
             "action:generateImages \"folders:jpgs/max,jpgs/thumbs\" images:all");
         EmptyTask taskImageGeneratorThread = TaskManager.getTaskList().get(0);
         while (taskImageGeneratorThread.isStartable() || taskImageGeneratorThread.isStoppable()) {
@@ -248,7 +247,7 @@ public class KitodoScriptServiceIT {
         String script = "action:addData " + metadataKey + "=PDM1.0";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
         final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
@@ -272,7 +271,7 @@ public class KitodoScriptServiceIT {
         String script = "action:copyDataToChildren " + metadataKey + "=@" + metadataKey;
         List<Process> processes = new ArrayList<>();
         processes.add(ServiceManager.getProcessService().getById(4));
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
         final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
@@ -315,7 +314,7 @@ public class KitodoScriptServiceIT {
         String script = "action:addData " + metadataKey + "=legal note";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
         final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
@@ -343,7 +342,7 @@ public class KitodoScriptServiceIT {
         List<Process> processes = new ArrayList<>();
         Process process = ServiceManager.getProcessService().getById(2);
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
         List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
@@ -366,7 +365,7 @@ public class KitodoScriptServiceIT {
         String script = "action:addData " + metadataKey + "=@TSL_ATS";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -387,7 +386,7 @@ public class KitodoScriptServiceIT {
         String script = "action:addData " + metadataKey + "=$(processid)";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -408,7 +407,7 @@ public class KitodoScriptServiceIT {
         String script = "action:deleteData " + metadataKey;
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -430,7 +429,7 @@ public class KitodoScriptServiceIT {
         String script = "action:deleteData " + metadataKey + "=SecondMetaShort";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -452,7 +451,7 @@ public class KitodoScriptServiceIT {
         String script = "action:deleteData " + metadataKey + "=@TitleDocMainShort";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -474,7 +473,7 @@ public class KitodoScriptServiceIT {
         String script = "action:deleteData" + metadataKey + "=SecondMetaLong";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -502,7 +501,7 @@ public class KitodoScriptServiceIT {
         String script = "action:overwriteData " + metadataKey + "=Overwritten";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -533,7 +532,7 @@ public class KitodoScriptServiceIT {
         String script = "action:overwriteData " + metadataKey + "=@TSL_ATS";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);
@@ -564,7 +563,7 @@ public class KitodoScriptServiceIT {
         String script = "action:overwriteData " + metadataKey + "=$(processid)";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
-        KitodoScriptService kitodoScript = new KitodoScriptService();
+        KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
 
         Thread.sleep(2000);


### PR DESCRIPTION
As the title says: If you specify a KitodoScript as a script in the workflow editor, this is executed using the `KitodoScriptService`. The distinguishing is done by that a KitodoScript always begins with the character string "action:" (which happens to be a semantically valid indicator for a protocol, by the way). In combination with the functionality from pull request #4450, this provides for writing media files to the METS file in the course of the workflow without having to open the metadata editor and click on <kbd>Save</kbd>, which was a long-cherished wish.

The `KitodoScriptService` was adapted so that it is provided via the `ServiceLoader` like all other services, so that we have a uniform procedure here.

_This feature is funded by Technische Universität Darmstadt._