### PR TITLE
Fix child process import via SRU interfaces

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/externaldatamanagement/SearchInterfaceType.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/externaldatamanagement/SearchInterfaceType.java
@@ -12,29 +12,31 @@
 package org.kitodo.api.externaldatamanagement;
 
 public enum SearchInterfaceType {
-    SRU("sru", "http://www.loc.gov/zing/srw/", "record", "startRecord",
+    SRU("sru", "http://www.loc.gov/zing/srw/", "record", "startRecord", "1",
             "maximumRecords", "query", "numberOfRecords",
             ".//*[local-name()='diagnostic']/*[local-name()='message']/text()"),
-    OAI("oai", "http://www.openarchives.org/OAI/2.0/", "record", null,
+    OAI("oai", "http://www.openarchives.org/OAI/2.0/", "record", null, null,
             null, null, null, ".//*[local-name()='error']/text()"),
-    FTP("ftp", null, null, null, null, null, null,
+    FTP("ftp", null, null, null, null,null, null, null,
             null);
 
     private final String typeString;
     private final String namespace;
     private final String recordString;
     private final String startRecordString;
+    private final String defaultStartValue;
     private final String maxRecordsString;
     private final String queryString;
     private final String numberOfRecordsString;
     private final String errorMessageXpath;
 
-    SearchInterfaceType(String type, String namespace, String record, String startRecord, String maxRecords,
-                        String query, String numberOfRecords, String errorMessageXpath) {
+    SearchInterfaceType(String type, String namespace, String record, String startRecord, String defaultStartValue,
+                        String maxRecords, String query, String numberOfRecords, String errorMessageXpath) {
         this.typeString = type;
         this.namespace = namespace;
         this.recordString = record;
         this.startRecordString = startRecord;
+        this.defaultStartValue = defaultStartValue;
         this.maxRecordsString = maxRecords;
         this.queryString = query;
         this.numberOfRecordsString = numberOfRecords;
@@ -71,5 +73,14 @@ public enum SearchInterfaceType {
 
     public String getErrorMessageXpath() {
         return this.errorMessageXpath;
+    }
+
+    /**
+     * Get defaultStartIndex.
+     *
+     * @return value of defaultStartIndex
+     */
+    public String getDefaultStartValue() {
+        return defaultStartValue;
     }
 }

--- a/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
+++ b/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
@@ -99,6 +99,7 @@ public class QueryURLImport implements ExternalDataImportInterface {
     private static final String HTTPS_PROTOCOL = "https";
     private static final String FTP_PROTOCOL = "ftp";
     private static final String equalsOperand = "=";
+    private static final String AND = "&";
 
     private SearchInterfaceType interfaceType;
     private String protocol;
@@ -157,13 +158,15 @@ public class QueryURLImport implements ExternalDataImportInterface {
 
             try {
                 URI queryURL = createQueryURI(queryParameters);
-                String queryString = queryURL + "&";
+                String queryString = queryURL + AND;
                 if (Objects.nonNull(interfaceType)) {
-                    if (Objects.nonNull(interfaceType.getStartRecordString())) {
-                        queryString = queryString + interfaceType.getStartRecordString() + equalsOperand + "0&";
+                    if (Objects.nonNull(interfaceType.getStartRecordString())
+                            && Objects.nonNull(interfaceType.getDefaultStartValue())) {
+                        queryString = queryString + interfaceType.getStartRecordString() + equalsOperand
+                                + interfaceType.getDefaultStartValue() + AND;
                     }
                     if (Objects.nonNull(interfaceType.getMaxRecordsString())) {
-                        queryString = queryString + interfaceType.getMaxRecordsString() + equalsOperand + rows + "&";
+                        queryString = queryString + interfaceType.getMaxRecordsString() + equalsOperand + rows + AND;
                     }
                     if (Objects.nonNull(interfaceType.getQueryString())) {
                         queryString = queryString + interfaceType.getQueryString() + equalsOperand;
@@ -269,7 +272,7 @@ public class QueryURLImport implements ExternalDataImportInterface {
     }
 
     private DataRecord performQueryToRecord(String queryURL, String identifier) throws NoRecordFoundException {
-        String fullUrl = queryURL + "&";
+        String fullUrl = queryURL + AND;
         if (Objects.nonNull(interfaceType)) {
             if (Objects.nonNull(interfaceType.getMaxRecordsString())) {
                 fullUrl = fullUrl + interfaceType.getMaxRecordsString() + equalsOperand + "1&";
@@ -365,13 +368,14 @@ public class QueryURLImport implements ExternalDataImportInterface {
         LinkedHashMap<String, String> searchFieldMap = getSearchFieldMap(searchParameters);
         try {
             URI queryURL = createQueryURI(queryParameters);
-            String queryString = queryURL + "&";
+            String queryString = queryURL + AND;
             if (Objects.nonNull(interfaceType)) {
                 if (start > 0 && Objects.nonNull(interfaceType.getStartRecordString())) {
-                    queryString += interfaceType.getStartRecordString() + equalsOperand + start + "&";
+                    queryString += interfaceType.getStartRecordString() + equalsOperand + start + AND;
                 }
                 if (Objects.nonNull(interfaceType.getMaxRecordsString())) {
-                    queryString = queryString + interfaceType.getMaxRecordsString() + equalsOperand + numberOfRecords + "&";
+                    queryString = queryString + interfaceType.getMaxRecordsString() + equalsOperand + numberOfRecords
+                            + AND;
                 }
                 if (Objects.nonNull(interfaceType.getQueryString())) {
                     queryString = queryString + interfaceType.getQueryString() + equalsOperand;


### PR DESCRIPTION
Kitodo.Production allows the automatic import of child processes if an OPAC interface supports search queries by "parent id". This functionality is currently bugged when using SRU interfaces since it sets the SRU query parameter `startRecord` to the invalid default value `0` during child process import (https://www.loc.gov/standards/sru/sru-1-2.html).

This pull request adds default start values to the `SearchInterfaceType` enum to resolve the issue.