### PR TITLE
Add basic authentication option to query import

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -283,11 +283,11 @@ public class OPACConfig {
     }
 
     /**
-     * Get FTP username.
-     * @param catalogName OPAC for which to get FTP username.
-     * @return FTP username
+     * Get username.
+     * @param catalogName OPAC for which to get username.
+     * @return username
      */
-    public static String getFtpUsername(String catalogName) {
+    public static String getUsername(String catalogName) {
         return getCatalog(catalogName).configurationAt("credentials").getString("username");
     }
 
@@ -296,7 +296,7 @@ public class OPACConfig {
      * @param catalogName OPAC for which to get FTP password.
      * @return FTP password
      */
-    public static String getFtpPassword(String catalogName) {
+    public static String getPassword(String catalogName) {
         return getCatalog(catalogName).configurationAt("credentials").getString("password");
     }
 


### PR DESCRIPTION
Adds basic authentication support for general query URL search interfaces (previously credentials where only supported when loading metadata from FTP servers).

To use this, add the following snippet to your OPAC configuration (with real credentials, of course):
```
<credentials>
    <username>[INSERT_USERNAME]</username>
    <password>[INSERT_PASSWORD]</password>
</credentials>
```