### PR TITLE
change workflowForm to ViewScoped

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
@@ -31,9 +31,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
+import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 
 import org.apache.commons.io.IOUtils;
@@ -57,7 +57,7 @@ import org.kitodo.production.workflow.model.Converter;
 import org.kitodo.production.workflow.model.Reader;
 
 @Named("WorkflowForm")
-@SessionScoped
+@ViewScoped
 public class WorkflowForm extends BaseForm {
 
     private static final Logger logger = LogManager.getLogger(WorkflowForm.class);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
@@ -299,8 +299,6 @@ public class WorkflowForm extends BaseForm {
      * @return page
      */
     public String newWorkflow() {
-        this.workflow = new Workflow();
-        this.workflow.setClient(ServiceManager.getUserService().getSessionClientOfAuthenticatedUser());
         return workflowEditPath + "&id=" + (Objects.isNull(this.workflow.getId()) ? 0 : this.workflow.getId());
     }
 
@@ -376,6 +374,9 @@ public class WorkflowForm extends BaseForm {
                 setWorkflow(workflow);
                 setWorkflowStatus(workflow.getStatus());
                 readXMLDiagram();
+            } else {
+                this.workflow = new Workflow();
+                this.workflow.setClient(ServiceManager.getUserService().getSessionClientOfAuthenticatedUser());
             }
             setSaveDisabled(false);
         } catch (DAOException e) {


### PR DESCRIPTION
After creating a workflow out of "migration" the migration boolean in the workflowForm is set to `true`
Every other call to workflowForm behaves incorrect after that, because it acts like being in migration.