### PR TITLE
fix lockException

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
@@ -395,7 +395,6 @@ public class TemplateForm extends TemplateBaseForm {
             this.template.getTasks().clear();
             TemplateService templateService = ServiceManager.getTemplateService();
             templateService.save(template);
-            this.template = templateService.getById(template.getId());
         }
         Converter converter = new Converter(this.template.getWorkflow().getTitle());
         converter.convertWorkflowToTemplate(this.template);


### PR DESCRIPTION
After switching to `saveOrUpdate` ( #4415 )
The explicit fetching from database isn't needed anymore, but leads to "OptimisticLockExceptions"

This kind of behavior is probably on other places too. Think of it, when you get an `OptimisticLockException`