### PR TITLE
No longer load relatives looking up the base type

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1715,7 +1715,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      *          cannot be found in the index)
      */
     public String getBaseType(int processId) throws DataException {
-        ProcessDTO processDTO = findById(processId);
+        ProcessDTO processDTO = findById(processId, true);
         if (Objects.nonNull(processDTO)) {
             return processDTO.getBaseType();
         }


### PR DESCRIPTION
Fixes #4505

To display the type of child process, the child was loaded from the index, the parent was loaded into the child and all children were loaded into the parent. For each child. Also, every time ruleset was loaded from the index and docket. This can simply be turned off.