### PR TITLE
Hide process link option with selected pages

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addDocStrucType.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addDocStrucType.xhtml
@@ -45,8 +45,9 @@
                 <br/>
 
                 <!-- option to link to existing process -->
-                <h:panelGrid>
+                <h:panelGrid rendered="#{not viewsSelected}">
                     <p:selectBooleanCheckbox itemLabel="#{msgs.link}"
+                                             title="#{msgs.link}"
                                              value="#{DataEditorForm.addDocStrucTypeDialog.linkSubDialogVisible}">
                         <p:ajax event="change"
                                 update="dialogAddDocStrucTypeFormContent" />


### PR DESCRIPTION
The option to link processes in the metadata editor has to be deactivated when pages are selected. Otherwise this option would suggest that the selected pages are assigned to the linked process, which is not possible in Kitodo (yet).

![Bildschirmfoto 2021-06-24 um 13 06 06](https://user-images.githubusercontent.com/19183925/123252807-f99b3180-d4ec-11eb-95ac-f71f06132de5.png)
