### PR TITLE
Show error messages only once instead of twice

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import javax.faces.model.SelectItem;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.MediaUnit;

--- a/Kitodo/src/main/webapp/WEB-INF/templates/baseEditView.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/baseEditView.xhtml
@@ -25,7 +25,7 @@
                     </ui:insert>
                 </p:panel>
                 <ui:insert name="messages">
-                    <p:messages id="error-messages" showIcon="false" showDetail="true" closable="true">
+                    <p:messages id="error-messages" showIcon="false" closable="true">
                         <p:autoUpdate/>
                     </p:messages>
                 </ui:insert>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/baseListView.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/baseListView.xhtml
@@ -25,7 +25,7 @@
                     <h3>Kitodo.Production</h3>
                 </ui:insert>
             </p:panel>
-            <p:messages id="error-messages" showIcon="false" showDetail="true" closable="true">
+            <p:messages id="error-messages" showIcon="false" closable="true">
                 <p:autoUpdate/>
             </p:messages>
 

--- a/Kitodo/src/main/webapp/pages/desktop.xhtml
+++ b/Kitodo/src/main/webapp/pages/desktop.xhtml
@@ -19,7 +19,7 @@
 
     <ui:define name="content">
         <h:outputScript name="desktop.js" target="body" library="js"/>
-        <p:messages id="error-messages" showIcon="false" showDetail="true" closable="true">
+        <p:messages id="error-messages" showIcon="false" closable="true">
             <p:autoUpdate/>
         </p:messages>
         <ui:fragment rendered="#{SessionClientController.currentSessionClient ne null or not SessionClientController.shouldUserChangeSessionClient()}">

--- a/Kitodo/src/main/webapp/pages/workflowEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/workflowEdit.xhtml
@@ -38,7 +38,7 @@
               value="#{not isEditMode and not isDuplicateMode and not isCreateMode and SecurityAccessController.hasAuthorityToViewWorkflow()}"/>
 
     <ui:define name="messages">
-        <p:messages id="error-messages" showIcon="false" showDetail="false" closable="true">
+        <p:messages id="error-messages" showIcon="false" closable="true">
             <p:autoUpdate/>
         </p:messages>
     </ui:define>


### PR DESCRIPTION
The `p:message` components in Kitodo.Production 3 are configured to show message details, but currently we never provide separate message details. This results in all messages being displayed twice, once as message summary and once as message details, which doesn't look very nice:

**_Process locked:_**
![Bildschirmfoto 2021-06-25 um 17 00 48](https://user-images.githubusercontent.com/19183925/123445709-73f4b000-d5d8-11eb-9931-b37de4e0992e.png)

**_Password constraints not met:_**
<img width="1403" alt="Bildschirmfoto 2021-06-25 um 17 13 37" src="https://user-images.githubusercontent.com/19183925/123445980-b61df180-d5d8-11eb-8942-2a6dea7d7230.png">

**_Missing form input:_**
![Bildschirmfoto 2021-06-25 um 17 03 17](https://user-images.githubusercontent.com/19183925/123445729-7820cd80-d5d8-11eb-98d0-c41eb4bd312a.png)

Therefor this PR removes the details from the error message to improve the rendering of our error messages:

**_Process locked:_**
![Bildschirmfoto 2021-06-25 um 17 19 10](https://user-images.githubusercontent.com/19183925/123446878-9affb180-d5d9-11eb-9117-2fb9e318b59c.png)

**_Password constraints not met:_**
![Bildschirmfoto 2021-06-25 um 17 18 20](https://user-images.githubusercontent.com/19183925/123446881-9b984800-d5d9-11eb-99dd-f095949f28cb.png)

**_Missing form input:_**
![Bildschirmfoto 2021-06-25 um 17 17 50](https://user-images.githubusercontent.com/19183925/123446885-9c30de80-d5d9-11eb-9d26-3f692629306e.png)

Should we ever have a case where separate message details are required, we can easily add a second `p:messages` tag with `showDetail=true` that can be targeted in such a case.