### PR TITLE
set index action to indexed

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -208,6 +208,14 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
         if (!baseIndexedBeans.isEmpty()) {
             indexer.performMultipleRequests(baseIndexedBeans, type, true);
         }
+        setIndexColumToIndexed(baseIndexedBeans);
+    }
+
+    private void setIndexColumToIndexed(List<T> baseIndexedBeans) throws DAOException {
+        for (T baseIndexedBean : baseIndexedBeans) {
+            baseIndexedBean.setIndexAction(IndexAction.DONE);
+            saveToDatabase(baseIndexedBean);
+        }
     }
 
     /**


### PR DESCRIPTION
Index Column was not set to `INDEX` when indexing_all. so it was not possible to trigger "index_remaining" when indexing failed somewhere

fixes #3719 