### PR TITLE
close parent processes on migration

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/HierarchyMigrationTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/HierarchyMigrationTask.java
@@ -44,6 +44,7 @@ import org.kitodo.production.services.data.ProcessService;
 import org.kitodo.production.services.dataeditor.DataEditorService;
 import org.kitodo.production.services.dataformat.MetsService;
 import org.kitodo.production.services.file.FileService;
+import org.kitodo.production.services.workflow.WorkflowControllerService;
 
 public class HierarchyMigrationTask extends EmptyTask {
     private static final Logger logger = LogManager.getLogger(HierarchyMigrationTask.class);
@@ -271,6 +272,9 @@ public class HierarchyMigrationTask extends EmptyTask {
         parentProcess.setTitle(title);
         workpiece.setId(parentProcess.getId().toString());
         ServiceManager.getMetsService().saveWorkpiece(workpiece,parentMetadataFilePath);
+        if (WorkflowControllerService.allChildrenClosed(parentProcess)) {
+            parentProcess.setSortHelperStatus("100000000");
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
@@ -59,6 +59,7 @@ import org.kitodo.production.services.data.ProcessService;
 import org.kitodo.production.services.dataeditor.DataEditorService;
 import org.kitodo.production.services.dataformat.MetsService;
 import org.kitodo.production.services.file.FileService;
+import org.kitodo.production.services.workflow.WorkflowControllerService;
 
 /**
  * Tool for converting newspaper processes from Production v. 2 format to
@@ -587,6 +588,9 @@ public class NewspaperProcessesMigrator {
             child.setParent(yearProcess);
             yearProcess.getChildren().add(child);
             processService.saveToDatabase(child);
+        }
+        if (WorkflowControllerService.allChildrenClosed(yearProcess)) {
+            yearProcess.setSortHelperStatus("100000000");
         }
         processService.saveToDatabase(yearProcess);
         addToBatch(yearProcess);

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -260,7 +260,12 @@ public class WorkflowControllerService {
         activateTasksForClosedTask(task);
     }
 
-    private boolean allChildrenClosed(Process process) {
+    /**
+     * Checks if all children of a process are closed.
+     * @param process the process to check
+     * @return true if all children are closed
+     */
+    public static boolean allChildrenClosed(Process process) {
         if (!process.getChildren().isEmpty()) {
             boolean allChildrenClosed = true;
             for (Process child : process.getChildren()) {


### PR DESCRIPTION
Newly created parent-processes on migration needs to be closed, when all children are closed.