### PR TITLE
Make default import depth configurable for each OPAC

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -14,10 +14,12 @@ package org.kitodo.config;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
@@ -34,6 +36,7 @@ public class OPACConfig {
     private static XMLConfiguration config;
     private static final String TRUE = "true";
     private static final String DEFAULT = "[@default]";
+    private static final int DEFAULT_IMPORT_DEPTH = 2;
 
     /**
      * Private constructor.
@@ -307,6 +310,19 @@ public class OPACConfig {
      */
     public static boolean isParentInRecord(String catalogName) {
         return StringUtils.isNotBlank(getXsltMappingFileForParentInRecord(catalogName));
+    }
+
+    /**
+     * Return default import depth of catalog 'catalogName' if configured. Return DEFAULT_IMPORT_DEPTH 2 otherwise.
+     * @param catalogName name of catalog
+     * @return default import depth of catalog
+     */
+    public static int getDefaultImportDepth(String catalogName) {
+        try {
+            return getCatalog(catalogName).getInt("defaultImportDepth");
+        } catch (NoSuchElementException | ConversionException e) {
+            return DEFAULT_IMPORT_DEPTH;
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -56,7 +56,6 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
     private static final int NUMBER_OF_CHILDREN_WARNING_THRESHOLD = 5;
 
     private String currentRecordId = "";
-    private int importDepth = 2;
     private boolean importChildren = false;
     private int numberOfChildren = 0;
     private String opacErrorMessage = "";
@@ -162,7 +161,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                 }
                 // import ancestors
                 LinkedList<TempProcess> processes = ServiceManager.getImportService().importProcessHierarchy(
-                        this.currentRecordId, opac, projectId, templateId, this.importDepth,
+                        this.currentRecordId, opac, projectId, templateId, this.hitModel.getImportDepth(),
                         this.createProcessForm.getRulesetManagement().getFunctionalKeys(
                                 FunctionalMetadata.HIGHERLEVEL_IDENTIFIER));
 
@@ -214,24 +213,6 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      */
     public LazyHitModel getHitModel() {
         return this.hitModel;
-    }
-
-    /**
-     * Get import depth.
-     *
-     * @return import depth
-     */
-    public int getImportDepth() {
-        return importDepth;
-    }
-
-    /**
-     * Set import depth.
-     *
-     * @param depth import depth
-     */
-    public void setImportDepth(int depth) {
-        importDepth = depth;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
@@ -28,6 +28,7 @@ public class LazyHitModel extends LazyDataModel<Object> {
     private String selectedCatalog = "";
     private String selectedField = "";
     private String searchTerm = "";
+    private int importDepth = 2;
 
     private SearchResult searchResult = null;
 
@@ -100,6 +101,7 @@ public class LazyHitModel extends LazyDataModel<Object> {
         this.selectedCatalog = catalog;
         if (!catalog.isEmpty()) {
             this.setSelectedField(ServiceManager.getImportService().getDefaultSearchField(catalog));
+            this.setImportDepth(ServiceManager.getImportService().getDefaultImportDepth(catalog));
         }
     }
 
@@ -137,5 +139,23 @@ public class LazyHitModel extends LazyDataModel<Object> {
      */
     public void setSelectedField(String field) {
         this.selectedField = field;
+    }
+
+    /**
+     * Get import depth.
+     *
+     * @return import depth
+     */
+    public int getImportDepth() {
+        return importDepth;
+    }
+
+    /**
+     * Set import depth.
+     *
+     * @param depth import depth
+     */
+    public void setImportDepth(int depth) {
+        importDepth = depth;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -246,6 +246,21 @@ public class ImportService {
     }
 
     /**
+     * Get default import depth for catalog 'opac.
+     *
+     * @param opac catalog name
+     * @return default import depth of catalog 'opac'
+     */
+    public int getDefaultImportDepth(String opac) {
+        int depth = OPACConfig.getDefaultImportDepth(opac);
+        if (depth < 0 || depth > 5) {
+            return 2;
+        } else {
+            return depth;
+        }
+    }
+
+    /**
      * Load catalog names from library catalog configuration file and return them as a list of Strings.
      *
      * @return list of catalog names

--- a/Kitodo/src/main/resources/kitodo_opac.xml
+++ b/Kitodo/src/main/resources/kitodo_opac.xml
@@ -48,6 +48,7 @@
             <searchField label="Erscheinungsjahr" value="pica.jah"/>
             <searchField label="Volltext" value="pica.txt"/>
         </searchFields>
+        <defaultImportDepth>1</defaultImportDepth>
     </catalogue>
 
     <catalogue title="K10Plus" description="K10Plus OPAC">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
@@ -73,7 +73,7 @@
                         <p:spinner id="importDepth"
                                    class="input"
                                    disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.selectedCatalog}"
-                                   value="#{CreateProcessForm.catalogImportDialog.importDepth}"
+                                   value="#{CreateProcessForm.catalogImportDialog.hitModel.importDepth}"
                                    min="1"
                                    max="5"/>
                     </div>


### PR DESCRIPTION
Allow configuring default import depths individually for each OPAC in `kitodo_opac.xml` with the new configuration parameter `defaultImportDepth`. This parameter is optional and the value defaults to the current standard "2" if the parameter is missing or not numeric, so current configuration files can still be used without changing anything.