### PR TITLE
Don't save related

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
@@ -301,7 +301,7 @@ public class BatchForm extends BaseForm {
         try {
             for (Batch selectedBatch : this.selectedBatches) {
                 selectedBatch.getProcesses().addAll(this.selectedProcesses);
-                ServiceManager.getBatchService().save(selectedBatch);
+                ServiceManager.getBatchService().save(selectedBatch, true);
                 if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.BATCHES_LOG_CHANGES)) {
                     addCommentsToBatchProcesses(Helper.getTranslation("addToBatch",
                             ServiceManager.getBatchService().getLabel(selectedBatch)));
@@ -326,7 +326,7 @@ public class BatchForm extends BaseForm {
 
         for (Batch selectedBatch : this.selectedBatches) {
             selectedBatch.getProcesses().removeAll(this.selectedProcesses);
-            ServiceManager.getBatchService().save(selectedBatch);
+            ServiceManager.getBatchService().save(selectedBatch, true);
             if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.BATCHES_LOG_CHANGES)) {
                 addCommentsToBatchProcesses(Helper.getTranslation("removeFromBatch",
                         ServiceManager.getBatchService().getLabel(selectedBatch)));
@@ -388,7 +388,7 @@ public class BatchForm extends BaseForm {
                 batch = new Batch(selectedProcesses);
             }
 
-            ServiceManager.getBatchService().save(batch);
+            ServiceManager.getBatchService().save(batch, true);
             if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.BATCHES_LOG_CHANGES)) {
                 addCommentsToBatchProcesses(Helper.getTranslation("addToBatch", ServiceManager.getBatchService().getLabel(batch)));
                 ServiceManager.getProcessService().saveList(selectedProcesses);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -111,7 +111,7 @@ public class CurrentTaskForm extends BaseForm {
         } else {
             this.workflowControllerService.assignTaskToUser(this.currentTask);
             try {
-                ServiceManager.getTaskService().save(this.currentTask);
+                ServiceManager.getTaskService().save(this.currentTask, false);
             } catch (DataException e) {
                 Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.TASK.getTranslationSingular() }, logger,
                     e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -111,7 +111,7 @@ public class CurrentTaskForm extends BaseForm {
         } else {
             this.workflowControllerService.assignTaskToUser(this.currentTask);
             try {
-                ServiceManager.getTaskService().save(this.currentTask, false);
+                ServiceManager.getTaskService().save(this.currentTask);
             } catch (DataException e) {
                 Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.TASK.getTranslationSingular() }, logger,
                     e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -187,7 +187,7 @@ public class ProcessForm extends TemplateBaseForm {
             }
 
             try {
-                ServiceManager.getProcessService().save(this.process);
+                ServiceManager.getProcessService().save(this.process, true);
                 return processesPage;
             } catch (DataException e) {
                 Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
@@ -249,7 +249,7 @@ public class ProjectForm extends BaseForm {
                 }
                 this.deletedTemples = new ArrayList<>();
 
-                ServiceManager.getProjectService().save(this.project);
+                ServiceManager.getProjectService().save(this.project, true);
 
                 return projectsPage;
             } catch (DAOException | DataException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/TemplateBaseForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/TemplateBaseForm.java
@@ -29,7 +29,7 @@ class TemplateBaseForm extends ProcessListBaseView {
 
     void saveTask(Task task, BaseBean baseBean, String message, SearchDatabaseService searchDatabaseService) {
         try {
-            ServiceManager.getTaskService().save(task);
+            ServiceManager.getTaskService().save(task, true);
             ServiceManager.getTaskService().evict(task);
             reload(baseBean, message, searchDatabaseService);
         } catch (DataException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
@@ -142,7 +142,7 @@ public class TemplateForm extends TemplateBaseForm {
             this.template.getProjects().addAll(assignedProjects);
 
             try {
-                ServiceManager.getTemplateService().save(this.template);
+                ServiceManager.getTemplateService().save(this.template, true);
                 template = ServiceManager.getTemplateService().getById(this.template.getId());
                 new WorkflowControllerService().activateNextTasks(template.getTasks());
             } catch (DataException | IOException | DAOException e) {
@@ -394,7 +394,7 @@ public class TemplateForm extends TemplateBaseForm {
         if (!templateTasks.isEmpty()) {
             this.template.getTasks().clear();
             TemplateService templateService = ServiceManager.getTemplateService();
-            templateService.save(template);
+            templateService.save(template, true);
         }
         Converter converter = new Converter(this.template.getWorkflow().getTitle());
         converter.convertWorkflowToTemplate(this.template);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
@@ -289,7 +289,7 @@ public class WorkflowForm extends BaseForm {
 
     private void saveWorkflow() {
         try {
-            ServiceManager.getWorkflowService().save(this.workflow);
+            ServiceManager.getWorkflowService().save(this.workflow, true);
         } catch (DataException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -412,7 +412,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
         // TODO: do the same 'ensureNonEmptyTitles' for child processes?
         if (ImportService.ensureNonEmptyTitles(this.processes)) {
             // saving the main process automatically saves it's parent and ancestor processes as well!
-            ServiceManager.getProcessService().save(getMainProcess());
+            ServiceManager.getProcessService().save(getMainProcess(), true);
         }
 
         // add links between child processes and main process

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -400,7 +400,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
         processAncestors();
         processChildren();
         // main process and it's ancestors need to be saved so they have IDs before creating their process directories
-        ServiceManager.getProcessService().save(getMainProcess());
+        ServiceManager.getProcessService().save(getMainProcess(), true);
         if (!createProcessesLocation(this.processes)) {
             throw new IOException("Unable to create directories for process hierarchy!");
         }
@@ -435,7 +435,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
                 MetadataEditor.addLink(this.processes.get(i + 1).getProcess(), "0", tempProcess.getProcess().getId());
             }
         }
-        ServiceManager.getProcessService().save(getMainProcess());
+        ServiceManager.getProcessService().save(getMainProcess(), true);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
@@ -724,7 +724,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         String title = makeTitle(yearTitleDefinition.orElse("+'_'+#YEAR"), genericFields);
         getGeneratedProcess().setTitle(title);
         ProcessService.checkTasks(getGeneratedProcess(), yearType);
-        processService.save(getGeneratedProcess());
+        processService.save(getGeneratedProcess(), true);
         processService.refresh(getGeneratedProcess());
 
         getGeneratedProcess().setParent(overallProcess);

--- a/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
@@ -513,11 +513,11 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
 
         String title = makeTitle(issueDivisionView.getProcessTitle().orElse("+'_'+#YEAR+#MONTH+#DAY+#ISSU"), genericFields);
         getGeneratedProcess().setTitle(title);
-        processService.save(getGeneratedProcess());
+        processService.save(getGeneratedProcess(), true);
         processService.refresh(getGeneratedProcess());
         getGeneratedProcess().setParent(yearProcess);
         yearProcess.getChildren().add(getGeneratedProcess());
-        processService.save(getGeneratedProcess());
+        processService.save(getGeneratedProcess(), true);
         createMetadataFileForProcess(individualIssuesForProcess, title);
 
         if (logger.isTraceEnabled()) {
@@ -658,7 +658,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
 
         metsService.saveWorkpiece(yearWorkpiece, yearMetadataFileUri);
         ProcessService.checkTasks(yearProcess, yearWorkpiece.getRootElement().getType());
-        processService.save(yearProcess);
+        processService.save(yearProcess, true);
 
         this.yearProcess = null;
         this.yearWorkpiece = null;
@@ -729,7 +729,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
 
         getGeneratedProcess().setParent(overallProcess);
         overallProcess.getChildren().add(getGeneratedProcess());
-        processService.save(getGeneratedProcess());
+        processService.save(getGeneratedProcess(), true);
 
         fileService.createProcessLocation(getGeneratedProcess());
         final URI metadataFileUri = processService.getMetadataFileUri(getGeneratedProcess());
@@ -790,7 +790,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         }
         metsService.saveWorkpiece(overallWorkpiece, overallMetadataFileUri);
         ProcessService.checkTasks(overallProcess, overallWorkpiece.getRootElement().getType());
-        processService.save(overallProcess);
+        processService.save(overallProcess,true);
 
         if (logger.isTraceEnabled()) {
             logger.trace("Finish took {} ms", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - begin));

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -1056,7 +1056,7 @@ public class ImportService {
             }
             processTempProcess(tempProcess, template, managementInterface, acquisitionStage, priorityList);
             Process childProcess = tempProcess.getProcess();
-            ServiceManager.getProcessService().save(childProcess);
+            ServiceManager.getProcessService().save(childProcess, true);
             ProcessService.setParentRelations(mainProcess, childProcess);
         }
     }
@@ -1182,7 +1182,7 @@ public class ImportService {
             tempProcess = processList.get(0);
             processTempProcess(tempProcess, template,
                 ServiceManager.getRulesetService().openRuleset(template.getRuleset()), "create", priorityList);
-            ServiceManager.getProcessService().save(tempProcess.getProcess());
+            ServiceManager.getProcessService().save(tempProcess.getProcess(), true);
             URI processBaseUri = ServiceManager.getFileService().createProcessLocation(tempProcess.getProcess());
             tempProcess.getProcess().setProcessBaseUri(processBaseUri);
             OutputStream out = ServiceManager.getFileService()

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -280,7 +280,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     public void saveToIndex(Process process, boolean forceRefresh)
             throws CustomResponseException, DataException, IOException {
         process.setMetadata(getMetadataForIndex(process));
-        process.setBaseType(getBaseType(process));
+        process.setBaseType(getBaseType(process.getId()));
         super.saveToIndex(process, forceRefresh);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -261,6 +261,11 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
             throws CustomResponseException, DAOException, DataException, IOException {
     }
 
+
+    public void save(T object) throws DataException {
+        save(object, false);
+    }
+
     /**
      * Method saves object to database and document to the index of Elastic Search.
      * This method binds three other methods: save to database, save to index and
@@ -280,14 +285,16 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      * @param baseIndexedBean
      *            object
      */
-    public void save(T baseIndexedBean) throws DataException {
+    public void save(T baseIndexedBean, boolean saveRelated) throws DataException {
         try {
             baseIndexedBean.setIndexAction(IndexAction.INDEX);
             saveToDatabase(baseIndexedBean);
             // TODO: find out why properties lists are save double
             T savedBean = getById(baseIndexedBean.getId());
             saveToIndex(savedBean, true);
-            manageDependenciesForIndex(savedBean);
+            if (saveRelated) {
+                manageDependenciesForIndex(savedBean);
+            }
             savedBean.setIndexAction(IndexAction.DONE);
             saveToDatabase(savedBean);
         } catch (DAOException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -261,7 +261,10 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
             throws CustomResponseException, DAOException, DataException, IOException {
     }
 
-
+    /**
+     * calls save method with default updateRelatedObjectsInIndex=false.
+     * @param object the object to save
+     */
     public void save(T object) throws DataException {
         save(object, false);
     }
@@ -284,15 +287,17 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      *
      * @param baseIndexedBean
      *            object
+     *
+     * @param updateRelatedObjectsInIndex if relatedObjects need to be updated in Index
      */
-    public void save(T baseIndexedBean, boolean saveRelated) throws DataException {
+    public void save(T baseIndexedBean, boolean updateRelatedObjectsInIndex) throws DataException {
         try {
             baseIndexedBean.setIndexAction(IndexAction.INDEX);
             saveToDatabase(baseIndexedBean);
             // TODO: find out why properties lists are save double
             T savedBean = getById(baseIndexedBean.getId());
             saveToIndex(savedBean, true);
-            if (saveRelated) {
+            if (updateRelatedObjectsInIndex) {
                 manageDependenciesForIndex(savedBean);
             }
             savedBean.setIndexAction(IndexAction.DONE);

--- a/Kitodo/src/main/java/org/kitodo/production/services/migration/MigrationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/migration/MigrationService.java
@@ -191,11 +191,11 @@ public class MigrationService {
                 process.getTitle(), 100 * currentProcess / numberOfProcesses);
             process.setTemplate(template);
             projects.put(process.getProject(),"");
-            ServiceManager.getProcessService().save(process);
+            ServiceManager.getProcessService().save(process, true);
         }
         template.getProjects().addAll(projects.keySet());
         template.getProcesses().addAll(processesToAddToTemplate);
-        ServiceManager.getTemplateService().save(template);
+        ServiceManager.getTemplateService().save(template, true);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -761,7 +761,7 @@ public class WorkflowControllerService {
         for (Process processForStatus : processes) {
             try {
                 setTasksStatusDown(processForStatus);
-                ServiceManager.getProcessService().save(processForStatus);
+                ServiceManager.getProcessService().save(processForStatus, true);
                 updateProcessSortHelperStatus(processForStatus);
             } catch (DataException e) {
                 Helper.setErrorMessage("errorChangeTaskStatus",

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -658,7 +658,7 @@ public class MockDatabase {
         firstTemplate.setDocket(ServiceManager.getDocketService().getById(2));
         firstTemplate.getProjects().add(project);
         firstTemplate.setRuleset(ServiceManager.getRulesetService().getById(1));
-        ServiceManager.getTemplateService().save(firstTemplate);
+        ServiceManager.getTemplateService().save(firstTemplate, true);
 
         Project thirdProject = ServiceManager.getProjectService().getById(3);
         Template secondTemplate = new Template();
@@ -670,7 +670,7 @@ public class MockDatabase {
         secondTemplate.getProjects().add(thirdProject);
         thirdProject.getTemplates().add(secondTemplate);
         secondTemplate.setRuleset(ServiceManager.getRulesetService().getById(2));
-        ServiceManager.getTemplateService().save(secondTemplate);
+        ServiceManager.getTemplateService().save(secondTemplate, true);
 
         thirdProject = ServiceManager.getProjectService().getById(3);
         Template thirdTemplate = new Template();
@@ -682,7 +682,7 @@ public class MockDatabase {
         thirdTemplate.getProjects().add(thirdProject);
         thirdProject.getTemplates().add(thirdTemplate);
         thirdTemplate.setRuleset(ServiceManager.getRulesetService().getById(1));
-        ServiceManager.getTemplateService().save(thirdTemplate);
+        ServiceManager.getTemplateService().save(thirdTemplate, true);
 
         Template fourthTemplate = new Template();
         fourthTemplate.setTitle("Fourth template");
@@ -693,7 +693,7 @@ public class MockDatabase {
         fourthTemplate.getProjects().add(project);
         fourthTemplate.getProjects().add(thirdProject);
         fourthTemplate.setRuleset(ServiceManager.getRulesetService().getById(2));
-        ServiceManager.getTemplateService().save(fourthTemplate);
+        ServiceManager.getTemplateService().save(fourthTemplate, true);
     }
 
     private static void insertProcessProperties() throws DAOException, DataException {
@@ -1009,7 +1009,7 @@ public class MockDatabase {
                 task.setProcessingUser(secondUser);
                 secondUser.getProcessingTasks().add(task);
             }
-            ServiceManager.getTaskService().save(task);
+            ServiceManager.getTaskService().save(task, true);
         }
 
         ServiceManager.getUserService().saveToDatabase(firstUser);
@@ -1031,7 +1031,7 @@ public class MockDatabase {
         eleventhTask.setScriptPath("../type/automatic/script/path");
         eleventhTask.getRoles().add(role);
         role.getTasks().add(eleventhTask);
-        ServiceManager.getTaskService().save(eleventhTask);
+        ServiceManager.getTaskService().save(eleventhTask, true);
         firstUser.getProcessingTasks().add(eleventhTask);
         ServiceManager.getTaskService().saveToIndex(eleventhTask, true);
 
@@ -1046,7 +1046,7 @@ public class MockDatabase {
         twelfthTask.setProcess(secondProcess);
         twelfthTask.getRoles().add(role);
         role.getTasks().add(twelfthTask);
-        ServiceManager.getTaskService().save(twelfthTask);
+        ServiceManager.getTaskService().save(twelfthTask, true);
         firstUser.getProcessingTasks().add(twelfthTask);
         ServiceManager.getUserService().saveToDatabase(firstUser);
         ServiceManager.getTaskService().saveToIndex(twelfthTask, true);
@@ -1061,7 +1061,7 @@ public class MockDatabase {
         thirteenTask.setProcess(secondProcess);
         thirteenTask.getRoles().add(role);
         role.getTasks().add(thirteenTask);
-        ServiceManager.getTaskService().save(thirteenTask);
+        ServiceManager.getTaskService().save(thirteenTask, true);
 
         ServiceManager.getRoleService().saveToDatabase(role);
     }


### PR DESCRIPTION
Related objects in Index are now only updated if explicitly called.
This hugely reduces the indexing overhead on saving.

INFO: Releated objects are always stored in Database, because this is handled by hibernate. Relations to objects which are only represented in DB (e.g. properties) are not harmed by this.