### PR TITLE
respect already indexed objects

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
@@ -66,7 +66,7 @@ public class IndexWorker implements Runnable {
 
             if (amountToIndex < batchSize) {
                 if (indexAllObjects) {
-                    indexObjects(searchService.getAll());
+                    indexObjects(searchService.getAll(this.startIndexing, amountToIndex));
                 } else {
                     indexObjects(searchService.getAllNotIndexed());
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
@@ -68,7 +68,7 @@ public class IndexWorker implements Runnable {
                 if (indexAllObjects) {
                     indexObjects(searchService.getAll(this.startIndexing, amountToIndex));
                 } else {
-                    indexObjects(searchService.getAllNotIndexed());
+                    indexObjects(searchService.getAllNotIndexed(this.startIndexing, amountToIndex));
                 }
             } else {
                 if (amountToIndex > indexLimit) {


### PR DESCRIPTION
on multiple indexWorkers, if the last indexWorker contains less than the configured batchSize, it again triggers "getAll"
The startIndexing field should be respected there, which tracks what objects are already indexed.

fixes #4258 