### PR TITLE
select level for metadataScript

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
@@ -12,13 +12,10 @@
 package org.kitodo.production.services.command;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 import org.kitodo.api.MdSec;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
-import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
@@ -34,8 +31,7 @@ public class AddDataScript extends EditDataScript {
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
             MetadataScript metadataScript) {
         Workpiece workpiece = metadataFile.getWorkpiece();
-
-        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();;
+        Collection<Metadata> metadataCollection = getMetadataCollection(metadataScript, workpiece);
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
 
         for (String value : metadataScript.getValues()) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
@@ -13,13 +13,10 @@ package org.kitodo.production.services.command;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
-import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
@@ -36,7 +33,7 @@ public class DeleteDataScript extends EditDataScript {
                                MetadataScript metadataScript) {
         Workpiece workpiece = metadataFile.getWorkpiece();
 
-        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();
+        Collection<Metadata> metadataCollection = getMetadataCollection(metadataScript, workpiece);
 
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
         List<Metadata> metadataCollectionCopy = new ArrayList<>(metadataCollection);

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -125,7 +125,43 @@ public abstract class EditDataScript {
                 .readMetadataFile(parentProcess);
         Workpiece workpiece = metadataFile.getWorkpiece();
 
-        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();;
+        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();
         generateValueForMetadataScript(metadataScript, metadataCollection, parentProcess, metadataFile);
+    }
+
+    /**
+     * Gets the metadataCollection where the metadata should be edited.
+     * May be specifyed by type in the script.
+     * @param metadataScript the metadataScript
+     * @param workpiece the workpiece to get the collection from.
+     * @return the metadataCollection.
+     */
+    public Collection<Metadata> getMetadataCollection(MetadataScript metadataScript, Workpiece workpiece) {
+        Collection<Metadata> metadataCollection;
+
+        if (Objects.nonNull(metadataScript.getTypeTarget())) {
+            IncludedStructuralElement structuralElement = getStructuralElementWithType(metadataScript.getTypeTarget(),
+                workpiece.getRootElement());
+            metadataCollection = Objects.isNull(structuralElement) ? null : structuralElement.getMetadata();
+        } else {
+            metadataCollection = workpiece.getRootElement().getMetadata();
+        }
+        return metadataCollection;
+    }
+
+    private IncludedStructuralElement getStructuralElementWithType(String typeTarget,
+            IncludedStructuralElement structuralElement) {
+        if (typeTarget.equals(structuralElement.getType())) {
+            return structuralElement;
+        } else {
+            for (IncludedStructuralElement structuralElementChild : structuralElement.getChildren()) {
+                IncludedStructuralElement structuralElementWithType = getStructuralElementWithType(typeTarget,
+                    structuralElementChild);
+                if (Objects.nonNull(structuralElementWithType)) {
+                    return structuralElementWithType;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/MetadataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/MetadataScript.java
@@ -19,6 +19,7 @@ public class MetadataScript {
 
     private String goal;
     private String root;
+    private String typeTarget;
     private List<String> values = new ArrayList<>();
 
     /**
@@ -26,10 +27,17 @@ public class MetadataScript {
      * @param command the given command.
      */
     public MetadataScript(String command) {
-        if (command.contains("=")) {
-            String[] commandParts = command.split("=");
-            goal = commandParts[0];
-            String rootOrValue = commandParts[1];
+        String metadataCommand = command;
+        String typeCommand = "";
+        if (command.contains("+")) {
+            String[] commandParts = command.split("\\+");
+            metadataCommand = commandParts[0];
+            typeCommand = commandParts[1];
+        }
+        if (metadataCommand.contains("=")) {
+            String[] metadataParts = metadataCommand.split("=");
+            goal = metadataParts[0];
+            String rootOrValue = metadataParts[1];
             if (rootOrValue.startsWith("@") || rootOrValue.startsWith("$")) {
                 root = rootOrValue;
             } else {
@@ -38,6 +46,9 @@ public class MetadataScript {
         }
         else {
             goal = command;
+        }
+        if (typeCommand.contains("=")) {
+            typeTarget = typeCommand.split("=")[1];
         }
     }
 
@@ -71,5 +82,13 @@ public class MetadataScript {
      */
     public String getRootName() {
         return Objects.isNull(root) ? null : root.substring(1);
+    }
+
+    /**
+     * Get typeTarget.
+     * @return typeTarget
+     */
+    public String getTypeTarget() {
+        return typeTarget;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
@@ -12,13 +12,10 @@
 package org.kitodo.production.services.command;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.MetadataGroup;
-import org.kitodo.api.dataformat.IncludedStructuralElement;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
@@ -30,7 +27,7 @@ public class OverwriteDataScript extends EditDataScript {
             MetadataScript metadataScript) {
         Workpiece workpiece = metadataFile.getWorkpiece();
 
-        Collection<Metadata> metadataCollection = workpiece.getRootElement().getMetadata();
+        Collection<Metadata> metadataCollection = getMetadataCollection(metadataScript, workpiece);
 
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);
 


### PR DESCRIPTION
This enables the MetadataScript to select a specific type of structural eleent to add the metadata to.
Example:

`action:addData singleDigCollection="New Digital collection"+type=PeriodicalIssue`