### PR TITLE
Restrict metadata editor functions according to corresponding permissions

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/controller/SecurityAccessController.java
+++ b/Kitodo/src/main/java/org/kitodo/production/controller/SecurityAccessController.java
@@ -915,6 +915,24 @@ public class SecurityAccessController {
     }
 
     /**
+     * Check if the current user has the authority to edit the process pagination.
+     *
+     * @return true if the current user has the authority to edit the process pagination
+     */
+    public boolean hasAuthorityToEditProcessPagination() {
+        return securityAccessService.hasAuthorityToEditProcessPagination();
+    }
+
+    /**
+     * Check if the current user has the authority to view the process pagination.
+     *
+     * @return true if the current user has the authority to view the process pagination
+     */
+    public boolean hasAuthorityToViewProcessPagination() {
+        return securityAccessService.hasAuthorityToViewProcessPagination();
+    }
+
+    /**
      * Check if the current user has the authority to open the metadata editor.
      * Access to the metadata editor is granted if the user has the authority to
      * view or edit data in any part of the editor.
@@ -928,7 +946,9 @@ public class SecurityAccessController {
                 || securityAccessService.hasAuthorityToViewProcessStructureData()
                 || securityAccessService.hasAuthorityToEditProcessStructureData()
                 || securityAccessService.hasAuthorityToViewProcessImages()
-                || securityAccessService.hasAuthorityToEditProcessImages();
+                || securityAccessService.hasAuthorityToEditProcessImages()
+                || securityAccessService.hasAuthorityToViewProcessPagination()
+                || securityAccessService.hasAuthorityToEditProcessPagination();
 
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
@@ -869,6 +869,24 @@ public class SecurityAccessService extends SecurityAccess {
     }
 
     /**
+     * Check if the current user has the authority to edit the process pagination.
+     *
+     * @return true if the current user has the authority to edit the process pagination
+     */
+    public boolean hasAuthorityToEditProcessPagination() {
+        return hasAuthorityForClient("editProcessPagination");
+    }
+
+    /**
+     * Check if the current user has the authority to view the process pagination.
+     *
+     * @return true if the current user has the authority to view the process pagination
+     */
+    public boolean hasAuthorityToViewProcessPagination() {
+        return hasAuthorityForClient("viewProcessPagination");
+    }
+
+    /**
      * Check if the current user has the authority to view the database statistics.
      *
      * @return true if the current user has the authority to view database statistics

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/pagination.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/pagination.xhtml
@@ -27,6 +27,7 @@
                             <p:commandButton id="createPaginationButton"
                                              action="#{DataEditorForm.paginationPanel.createPagination()}"
                                              value="#{msgs.paginationRead}"
+                                             rendered="#{SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                              icon="fa fa-magic fa-lg"
                                              iconPos="right"
                                              styleClass="secondary"
@@ -39,6 +40,7 @@
                                               value="#{DataEditorForm.paginationPanel.paginationSelectionSelectedItems}"
                                               required="true"
                                               requiredMessage="#{msgs.paginationNoPagesSelected}"
+                                              disabled="#{not SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                               filter="true"
                                               filterMatchMode="contains"
                                               showCheckbox="true">
@@ -52,6 +54,7 @@
                             <p:outputLabel for="paginationTypeSelect"
                                            value="#{msgs.pagination}"/>
                             <p:selectOneMenu id="paginationTypeSelect"
+                                             disabled="#{not SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                              value="#{DataEditorForm.paginationPanel.paginationTypeSelectSelectedItem}">
                                 <f:selectItems value="#{DataEditorForm.paginationPanel.paginationTypeSelectItems.entrySet()}"
                                                var="type"
@@ -66,6 +69,7 @@
                             <p:inputText id="paginationStartValue"
                                            padControl="false"
                                            required="true"
+                                           disabled="#{not SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                            value="#{DataEditorForm.paginationPanel.paginationStartValue}"
                                            label="#{msgs.paginationStartValue}"
                                            class="input"
@@ -158,6 +162,7 @@
                             <p:outputLabel value="#{msgs.paginationScope}:"
                                            for="selectPaginationScope"/>
                             <p:selectOneMenu id="selectPaginationScope"
+                                             disabled="#{not SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                              autoWidth="false"
                                              value="#{DataEditorForm.paginationPanel.selectPaginationScopeSelectedItem}">
                                 <f:selectItems value="#{DataEditorForm.paginationPanel.selectPaginationScopeItems.entrySet()}"
@@ -171,6 +176,7 @@
                                            for="selectPaginationMode"/>
                             <p:selectOneMenu
                                     value="#{DataEditorForm.paginationPanel.selectPaginationModeSelectedItem}"
+                                    disabled="#{not SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                     converter="#{IllustratedSelectItemConverter}"
                                     panelStyle="width:25%;"
                                     var="mode"
@@ -195,6 +201,7 @@
                                     value="#{msgs.insertNewImages}"
                                     for="newPagesCount"/>
                             <p:inputText id="newPagesCount"
+                                         disabled="#{not SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                          value="#{DataEditorForm.paginationPanel.newPagesCountValue}"
                                          styleClass="input-with-button"
                                          style="width: calc(100% - 95px);"
@@ -205,6 +212,7 @@
                             <p:commandButton id="generateDummyImagesButton"
                                              value="#{msgs.insert}"
                                              styleClass="secondary right"
+                                             rendered="#{SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                              type="button"
                                              style="margin: 0;"
                                              action="#{DataEditorForm.paginationPanel.generateDummyImagesButtonClick()}"
@@ -215,6 +223,7 @@
                             <p:outputLabel for="fictitiousCheckbox"
                                            value="#{msgs.paginationFictitious}"/>
                             <p:selectBooleanCheckbox id="fictitiousCheckbox"
+                                                     disabled="#{not SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                                                      styleClass="input switch"
                                                      style="margin-bottom: 0;"
                                                      value="#{DataEditorForm.paginationPanel.fictitiousCheckboxChecked}"/>
@@ -223,6 +232,7 @@
                 </p:panelGrid>
             </p:panel>
             <h:panelGroup layout="block"
+                          rendered="#{SecurityAccessController.hasAuthorityToEditProcessPagination()}"
                           styleClass="dialogButtonWrapper">
                 <p:commandButton id="apply"
                                  action="#{DataEditorForm.paginationPanel.startPaginationClick()}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
@@ -20,7 +20,8 @@
     <ui:param name="mayWrite" value="#{
                                     SecurityAccessController.hasAuthorityToEditProcessMetaData() or
                                     SecurityAccessController.hasAuthorityToEditProcessImages() or
-                                    SecurityAccessController.hasAuthorityToEditProcessStructureData()}"/>
+                                    SecurityAccessController.hasAuthorityToEditProcessStructureData() or
+                                    SecurityAccessController.hasAuthorityToEditProcessPagination()}"/>
     <p:panel styleClass="content-header">
         <h3 id="headerText">
             <h:outputText value="#{DataEditorForm.processTitle} (#{msgs.id}: #{DataEditorForm.process.id})"
@@ -32,8 +33,7 @@
                          value="#{msgs.saveExit}"
                          icon="fa fa-floppy-o fa-lg"
                          iconPos="right"
-                         styleClass="#{mayWrite ? '' : 'disabled'}"
-                         disabled="#{not mayWrite}"
+                         rendered="#{mayWrite}"
                          style="margin-left: 16px;"
                          onclick="setConfirmUnload(false);PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','detail':'#{msgs.youWillBeRedirected}','severity':'info'});"
                          update="notifications"/>
@@ -43,8 +43,8 @@
                          value="#{msgs.save}"
                          icon="fa fa-floppy-o fa-lg"
                          iconPos="right"
-                         styleClass="#{mayWrite ? '' : 'disabled'} secondary"
-                         disabled="#{not mayWrite}"
+                         styleClass="secondary"
+                         rendered="#{mayWrite}"
                          style="margin-left: 16px;"
                          onclick="PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','severity':'info'});$('loadingScreen').show()"
                          oncomplete="$('#structureTreeForm\\:physicalTree li[aria-selected=\'true\']').click();setConfirmUnload(false);"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -25,8 +25,8 @@
                 styleClass="focusable"
                 selectionMode="single"
                 selection="#{DataEditorForm.structurePanel.selectedLogicalNode}"
-                draggable="#{not readOnly}"
-                droppable="#{not readOnly}"
+                draggable="#{not readOnly and SecurityAccessController.hasAuthorityToEditProcessStructureData()}"
+                droppable="#{not readOnly and SecurityAccessController.hasAuthorityToEditProcessStructureData()}"
                 dragdropScope="logicalTree">
             <p:ajax event="select"
                     listener="#{DataEditorForm.structurePanel.treeLogicalSelect}"
@@ -53,6 +53,7 @@
                             physicalTree
                             metadataAccordion:logicalMetadataWrapperPanel"/>
             <p:ajax event="dragdrop"
+                    disabled="#{not SecurityAccessController.hasAuthorityToEditProcessStructureData()}"
                     listener="#{DataEditorForm.structurePanel.onDragDrop}"
                     update="logicalTree
                             contextMenuLogicalTree

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
@@ -25,8 +25,8 @@
                 styleClass="focusable"
                 selectionMode="single"
                 selection="#{DataEditorForm.structurePanel.selectedPhysicalNode}"
-                draggable="#{not readOnly}"
-                droppable="#{not readOnly}"
+                draggable="#{not readOnly and SecurityAccessController.hasAuthorityToEditProcessStructureData()}"
+                droppable="#{not readOnly and SecurityAccessController.hasAuthorityToEditProcessStructureData()}"
                 dragdropScope="physicalTree">
             <p:ajax event="select"
                     listener="#{DataEditorForm.structurePanel.treePhysicalSelect}"
@@ -49,6 +49,7 @@
                                 logicalTree
                                 metadataAccordion:physicalMetadataWrapperPanel"/>
             <p:ajax event="dragdrop"
+                    disabled="#{not SecurityAccessController.hasAuthorityToEditProcessStructureData()}"
                     listener="#{DataEditorForm.structurePanel.onDragDrop}"
                     update="physicalTree
                             metadataAccordion:physicalMetadataWrapperPanel"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -138,6 +138,7 @@
                 <h:panelGroup rendered="#{item.input eq 'toggleSwitch'}"
                               title="#{item.active.toString()}">
                     <p:selectBooleanCheckbox id="selectBooleanCheckbox"
+                                             disabled="#{not item.editable or readOnly}"
                                              value="#{item.active}">
                         <p:ajax event="change" oncomplete="#{request.requestURI.contains('metadataEditor') ? 'preserveMetadata()' : ''}"/>
                     </p:selectBooleanCheckbox>
@@ -145,7 +146,7 @@
 
                 <!-- button to add metadata to group -->
                 <h:panelGroup title="#{DataEditorForm.metadataPanel.metadataAddableToGroup(node) ? msgs['dataEditor.addMetadata.toGroup'] : msgs['dataEditor.addMetadata.noMetadataAddableToGroup']}"
-                              rendered="#{request.requestURI.contains('metadataEditor') and item.input eq 'dataTable'}"
+                              rendered="#{request.requestURI.contains('metadataEditor') and item.input eq 'dataTable' and not readOnly}"
                               styleClass="ui-button">
                     <p:commandButton id="addMetadataToGroup"
                                      action="#{DataEditorForm.addMetadataDialog.prepareAddableMetadataForGroup(node)}"

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -35,6 +35,8 @@
         <ui:param name="viewStructure" value="#{SecurityAccessController.hasAuthorityToViewProcessStructureData()}"/>
         <!--@elvariable id="viewMetadata" type="boolean"-->
         <ui:param name="viewMetadata" value="#{SecurityAccessController.hasAuthorityToViewProcessMetaData()}"/>
+        <!--@elvariable id="viewPagination" type="boolean"-->
+        <ui:param name="viewPagination" value="#{SecurityAccessController.hasAuthorityToViewProcessPagination()}"/>
         <!--@elvariable id="viewImages" type="boolean"-->
         <ui:param name="viewImages" value="#{SecurityAccessController.hasAuthorityToViewProcessImages()}"/>
         <!--@elvariable id="commentsNumber" type="Integer"-->
@@ -119,7 +121,7 @@
                             <i class="fa fa-compress fa-lg"/>
                         </button>
                         <div class="columnHeadingWrapper">
-                            <ui:fragment rendered="#{viewMetadata}">
+                            <ui:fragment rendered="#{viewMetadata and viewPagination}">
                                 <button id="firstSectionSecondColumnToggler" onclick="toggleFirstSectionSecondColumn()">
                                     <i class="fa fa-chevron-circle-up fa-lg"/>
                                 </button>
@@ -146,16 +148,19 @@
                             <div id="verticalResizerSecondColumn"></div>
 
                             <div class="columnHeadingWrapper">
-                                <ui:fragment rendered="#{viewMetadata}">
+                                <ui:fragment rendered="#{viewMetadata and viewPagination}">
                                     <button id="secondSectionSecondColumnToggler" onclick="toggleSecondSectionSecondColumn()">
                                         <i class="fa fa-chevron-circle-up fa-lg"/>
                                     </button>
                                 </ui:fragment>
                                 <h:outputText value="#{msgs.pagination}"/>
                             </div>
-                            <div id="paginationPanel" data-min-height="100">
+                            <!-- 'collapsed' class is inverted by javascript function on page load -->
+                            <h:panelGroup id="paginationPanel"
+                                          data-min-height="100"
+                                          layout="block" styleClass="#{not viewMetadata ? 'collapsed' : ''}">
                                 <ui:include src="/WEB-INF/templates/includes/metadataEditor/dialogs/pagination.xhtml"/>
-                            </div>
+                            </h:panelGroup>
                         </p:panel>
                     </h:panelGroup>
 


### PR DESCRIPTION
This pull request adds the missing permission checks for the individual metadata editor components:
- hide 'Add Metadata +' button in metadata panel for metadata groups if user does not have 'editMetadata' permission
- disable remaining metadata input fields (checkbox etc.) if user does not have 'editMetadata' persmission
- hide Metadata panel if user does not have 'viewMetadata' permission
- disable drag'n'drop in structure trees if user does not have 'editStructure' permission