### PR TITLE
change to proces from id

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -280,7 +280,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     public void saveToIndex(Process process, boolean forceRefresh)
             throws CustomResponseException, DataException, IOException {
         process.setMetadata(getMetadataForIndex(process));
-        process.setBaseType(getBaseType(process.getId()));
+        process.setBaseType(getBaseType(process));
         super.saveToIndex(process, forceRefresh);
     }
 


### PR DESCRIPTION
Base type needs to be retrieved from process, not id
fixes #4590 

base type was retrieved incorrectly, therefore the calendar/add button didn't match the types configured in the ruleset, so the button was disabled.
