### PR TITLE
Update getting-started docs with instructions for Java v11

### DIFF
--- a/docs/developer/gettingstarted/demo.md
+++ b/docs/developer/gettingstarted/demo.md
@@ -3,7 +3,7 @@ How to run Kitodo.Production in demo mode
 
 Prerequisites:
 --------------
-* Make sure you have [Java SE Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html) in at least version 8 installed
+* Make sure you have [Java SE Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html) in at least version 11 installed
 * Make sure you have [Git](https://git-scm.com/downloads) installed
 * Make sure you have [Maven](https://maven.apache.org/download.cgi) installed
 

--- a/docs/developer/gettingstarted/development-version.md
+++ b/docs/developer/gettingstarted/development-version.md
@@ -22,17 +22,24 @@ sudo apt install -y dirmngr
 sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5 && echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7" | sudo tee -a /etc/apt/sources.list.d/mysql-5.7.list
 ```
 
-### Install packages openjdk-8, maven, mysql-community-server and zip
+### Install openjdk-11
+
+```
+echo 'deb http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+sudo apt update && sudo apt install -y openjdk-11-jdk
+```
+
+### Install packages maven, mysql-community-server and zip
 
 ```
 sudo debconf-set-selections <<< "mysql-community-server mysql-community-server/root-pass password "
 sudo debconf-set-selections <<< "mysql-community-server mysql-community-server/re-root-pass password "
-sudo apt update && sudo apt install -y openjdk-8-jdk maven mysql-community-server zip
+sudo apt update && sudo apt install -y maven mysql-community-server zip
 ```
 ### Change java security config (for cloud environments)
 
 ```
-sudo sed -i 's/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/' /etc/java-8-openjdk/security/java.security
+sudo sed -i 's/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/' /etc/java-11-openjdk/security/java.security
 ```
 
 ### Build development version and modules

--- a/docs/developer/gettingstarted/eclipse-windows.md
+++ b/docs/developer/gettingstarted/eclipse-windows.md
@@ -3,7 +3,7 @@ How to create a developer workspace for Kitodo.Production with Eclipse on Window
 
 Prerequisites:
 --------------
-* Make sure you have [Java SE Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html) in at least version 8 installed
+* Make sure you have [Java SE Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html) in at least version 11 installed
 * Make sure you have [Git](https://git-scm.com/downloads) installed
 * Make sure you have [Maven](https://maven.apache.org/download.cgi) installed
 * Make sure you have [Eclipse IDE for Java EE Developers](https://www.eclipse.org/downloads/) installed

--- a/docs/developer/gettingstarted/virtualbox.md
+++ b/docs/developer/gettingstarted/virtualbox.md
@@ -55,6 +55,8 @@ su -c 'echo "deb http://ftp.debian.org/debian stretch-backports main contrib" > 
 
 Follow the installation instructions in <https://github.com/kitodo/kitodo-production/wiki/Installationsanleitung-f%C3%BCr-Kitodo.Production-3.x>
 
+Make sure to install Java 11 when using Kitodo.Production v3.4 and above, see [instructions](./development-version.md#install-openjdk-11).
+
 ## Create shortcuts
 
 * Website link


### PR DESCRIPTION
- Indicating change to Java v11 in getting-started docs. 
- Added instructions to install openjdk-11 on Debian 9.

See previous pull request on Upgrade to Java v11: #4547 