### PR TITLE
Upgrade to Tomcat v9

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -32,7 +32,7 @@
         <parent.basedir>${basedir}/../</parent.basedir>
         <maxAllowedViolations>15</maxAllowedViolations>
         <selenium.version>3.141.59</selenium.version>
-        <cargo.plugin.version>1.7.7</cargo.plugin.version>
+        <cargo.plugin.version>1.9.7</cargo.plugin.version>
     </properties>
 
     <dependencies>
@@ -302,7 +302,7 @@
             <artifactId>poi-ooxml</artifactId>
             <version>${poi.version}</version>
             <exclusions>
-                <!-- exlcude stax-api which provides javax.xml.namespace package 
+                <!-- exlcude stax-api which provides javax.xml.namespace package
                      already included in system modules of Java 11+ -->
             	<exclusion>
                     <groupId>stax</groupId>
@@ -332,7 +332,7 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
-                <!-- exlcude xml-apis which provides javax.xml.transform package 
+                <!-- exlcude xml-apis which provides javax.xml.transform package
                      already included in system modules of Java 11+ -->
                 <exclusion>
                     <groupId>xml-apis</groupId>
@@ -618,7 +618,7 @@
 
                     <plugin>
                         <groupId>org.codehaus.cargo</groupId>
-                        <artifactId>cargo-maven2-plugin</artifactId>
+                        <artifactId>cargo-maven3-plugin</artifactId>
                         <version>${cargo.plugin.version}</version>
 
                         <configuration>
@@ -734,7 +734,7 @@
 
                     <plugin>
                         <groupId>org.codehaus.cargo</groupId>
-                        <artifactId>cargo-maven2-plugin</artifactId>
+                        <artifactId>cargo-maven3-plugin</artifactId>
                         <version>${cargo.plugin.version}</version>
 
                         <configuration>

--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -11,9 +11,9 @@
  * GPL3-License.txt file that was distributed with this source code.
  *
 -->
-<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app version="4.0" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
 
     <display-name>Kitodo</display-name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <maven.compiler.debug>true</maven.compiler.debug>
         <maven.compiler.debuglevel>lines,vars,source</maven.compiler.debuglevel>
         <maxAllowedViolations>1</maxAllowedViolations>
-        <tomcat.baseversion>8</tomcat.baseversion>
-        <tomcat.version>8.5.69</tomcat.version>
+        <tomcat.baseversion>9</tomcat.baseversion>
+        <tomcat.version>9.0.52</tomcat.version>
         <awaitility.version>4.0.1</awaitility.version>
         <com.h2database.h2.version>1.4.199</com.h2database.h2.version>
         <commons-codec.version>1.13</commons-codec.version>


### PR DESCRIPTION
In reference to the recent update to Tomcat 8.5, see #2929, we could also update to Tomcat 9.

Advantages: 
- Potentially longer maintenance window (end-of-life dates for 8.5 and 9 not announced yet)
- New installations of Kitodo might be based on current LTS releases of Ubuntu and Debian,  
  which only provide packages for Tomcat 9
  - Ubuntu 18.04 (eol April 2023) provides packages for both Tomcat 8 and 9 called `tomcat8` and `tomcat9`
  - Ubuntu 20.04 (eol  April 2025) provides only packages for Tomcat 9 called `tomcat9`
  - Debian 9 (eol August 2022) provides only packages for Tomcat 8 called `tomcat8`,  
     Tomcat 9 can only be installed via backports or manually
  - Debian 10 (eol ~2024) provides only packages for Tomcat 9 called `tomcat9`