### PR TITLE
Add action to show processes of specific project

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -909,6 +909,7 @@ showInactiveProjects=Deaktivierte Projekte zeigen
 showOnlyOwnTasks=Nur eigene Aufgaben anzeigen
 showOnlyOpenTasks=Offene Aufgaben
 showOnlyTasksInWork=Aufgaben in Bearbeitung
+showProjectProcesses=Vorg\u00E4nge dieses Projektes anzeigen
 signIn=Anmelden
 # shouldContentBeRemoved is used in onclick
 shouldContentBeRemoved=Soll der Inhalt wirklich gel\u00F6scht werden?

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -924,6 +924,7 @@ showInactiveProjects=show deactivated projects
 showOnlyOwnTasks=Show only my tasks
 showOnlyOpenTasks=Open tasks
 showOnlyTasksInWork=Tasks in work
+showProjectProcesses=Show processes of this project
 signIn=Sign in
 # shouldContentBeRemoved is used in onclick
 shouldContentBeRemoved=Do you really want to delete the content?

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
@@ -50,6 +50,13 @@
                     <h:outputText><i class="fa fa-pencil-square-o fa-lg"/></h:outputText>
                 </h:link>
                 <h:link styleClass="action"
+                        rendered="#{SecurityAccessController.hasAuthorityToViewProcessList()}"
+                        outcome="processes?tabIndex=0"
+                        title="#{msgs.showProjectProcesses}">
+                    <f:param name="projecttitle" value="#{project.title}"/>
+                    <h:outputText><i class="fa fa-clipboard fa-lg"/></h:outputText>
+                </h:link>
+                <h:link styleClass="action"
                         rendered="#{SecurityAccessController.hasAuthorityToViewDatabaseStatistics()}">
                     <h:outputText><i class="fa fa-bar-chart fa-lg"/></h:outputText>
                 </h:link>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -99,6 +99,14 @@
                 </h:link>
 
                 <h:link styleClass="action"
+                        rendered="#{SecurityAccessController.hasAuthorityToViewProcessList()}"
+                        outcome="processes?tabIndex=0"
+                        title="#{msgs.showProjectProcesses}">
+                    <f:param name="projecttitle" value="#{item.title}"/>
+                    <h:outputText><i class="fa fa-clipboard fa-lg"/></h:outputText>
+                </h:link>
+
+                <h:link styleClass="action"
                         id="editProject"
                         rendered="#{SecurityAccessController.hasAuthorityToEditProject()}"
                         outcome="projectEdit"

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -16,7 +16,8 @@
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:f="http://xmlns.jcp.org/jsf/core"
-        xmlns:p="http://primefaces.org/ui">
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:o="http://omnifaces.org/ui">
     <f:metadata>
         <f:viewParam name="tabIndex"/>
         <!--@elvariable id="tabIndex" type="java.lang.Integer"-->
@@ -24,6 +25,9 @@
         <!--@elvariable id="keepPagination" type="java.lang.String"-->
         <f:viewParam name="keepPagination"/>
         <f:viewAction action="#{ProcessForm.resetPaginator(keepPagination)}"/>
+        <!--@elvariable id="projecttitle" type="java.lang.String"-->
+        <f:viewParam name="projecttitle"/>
+        <o:viewAction action="#{ProcessForm.setFilter('project:' += projecttitle)}" if="#{not empty projecttitle}"/>
     </f:metadata>
 
     <ui:define name="contentHeader">


### PR DESCRIPTION
This pull request adds a new action icon to the project widget and project list that leads to the list of processes belonging to the selected project (the action sets the process list filter to the name of the selected project).

<img width="224" alt="Bildschirmfoto 2021-09-07 um 15 26 19" src="https://user-images.githubusercontent.com/19183925/132352702-cd37252d-ae18-4d12-8cfd-29ce871b2370.png">




