### PR TITLE
Fixes #4666

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -639,12 +639,14 @@ public class UserForm extends BaseForm {
             Helper.setErrorMessage("passwordsDontMatchOld");
         }
         try {
-            if (DynamicAuthenticationProvider.getInstance().isLdapAuthentication()) {
-                ServiceManager.getLdapServerService().changeUserPassword(userObject, this.passwordToEncrypt);
-            }
             Set<ConstraintViolation<KitodoPassword>> passwordViolations = getPasswordViolations();
             if (passwordViolations.isEmpty()) {
-                userService.changeUserPassword(userObject, this.passwordToEncrypt);
+                if (DynamicAuthenticationProvider.getInstance().isLdapAuthentication()
+                        && Objects.nonNull(userObject.getLdapGroup())) {
+                    ServiceManager.getLdapServerService().changeUserPassword(userObject, passwordToEncrypt);
+                } else {
+                    userService.changeUserPassword(userObject, this.passwordToEncrypt);
+                }
                 Helper.setMessage("passwordChanged");
                 PrimeFaces.current().executeScript("PF('resetPasswordDialog').hide();");
             } else {


### PR DESCRIPTION
- Treats a user without an LDAP group as a database user
- Order of instructions changed: If the password is not allowed, it will not be changed in the LDAP.