### PR TITLE
Fix process creation performance

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
@@ -65,6 +65,7 @@ public class ProcessType extends BaseType<Process> {
         jsonObject.put(ProcessTypeField.METADATA.getKey(), process.getMetadata());
         jsonObject.put(ProcessTypeField.PROPERTIES.getKey(), getProperties(process));
         jsonObject.put(ProcessTypeField.BASE_TYPE.getKey(), process.getBaseType());
+        jsonObject.put(ProcessTypeField.IN_CHOICE_LIST_SHOWN.getKey(), process.getInChoiceListShown());
         return jsonObject;
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/ProcessTypeField.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/ProcessTypeField.java
@@ -41,7 +41,8 @@ public enum ProcessTypeField implements TypeInterface {
     TEMPLATES("templates"),
     WORKPIECES("workpieces"),
     METADATA("meta"),
-    BASE_TYPE("baseType");
+    BASE_TYPE("baseType"),
+    IN_CHOICE_LIST_SHOWN("inChoiceListShown");
 
     private String name;
 

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/ProcessTypeTest.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/ProcessTypeTest.java
@@ -284,7 +284,7 @@ public class ProcessTypeTest {
         Process process = prepareData().get(0);
         Map<String, Object> actual = processType.createDocument(process);
 
-        assertEquals("Amount of keys is incorrect!", 27, actual.keySet().size());
+        assertEquals("Amount of keys is incorrect!", 28, actual.keySet().size());
 
         List<Map<String, Object>> batches = ProcessTypeField.BATCHES.getJsonArray(actual);
         Map<String, Object> batch = batches.get(0);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SearchTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SearchTab.java
@@ -11,22 +11,28 @@
 
 package org.kitodo.production.forms.createprocess;
 
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.elasticsearch.index.type.enums.ProcessTypeField;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
@@ -64,17 +70,12 @@ public class SearchTab {
      *
      * @return list of SelectItem objects
      */
-    public List<Process> getProcessesForChoiceList() {
+    public List<Process> getProcessesForChoiceList() throws DataException, DAOException {
         List<Process> processes = new ArrayList<>();
-        User currentUser = ServiceManager.getUserService().getCurrentUser();
-        for (Project project : currentUser.getProjects()) {
-            try {
-                processes.addAll(ServiceManager.getProjectService().getById(project.getId()).getProcesses());
-            } catch (DAOException e) {
-                Helper.setErrorMessage(e);
-            }
+        List<ProcessDTO> byInChoiceListShown = ServiceManager.getProcessService().findByInChoiceListShown(true, true);
+        for (ProcessDTO processDTO : byInChoiceListShown) {
+            processes.add(ServiceManager.getProcessService().getById(processDTO.getId()));
         }
-        processes = processes.stream().filter(Process::getInChoiceListShown).collect(Collectors.toList());
         return processes;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SearchTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SearchTab.java
@@ -22,17 +22,13 @@ import java.util.Objects;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
-import org.kitodo.data.database.beans.Project;
-import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.data.elasticsearch.index.type.enums.ProcessTypeField;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
@@ -70,12 +66,19 @@ public class SearchTab {
      *
      * @return list of SelectItem objects
      */
-    public List<Process> getProcessesForChoiceList() throws DataException, DAOException {
+    public List<Process> getProcessesForChoiceList() {
         List<Process> processes = new ArrayList<>();
-        List<ProcessDTO> byInChoiceListShown = ServiceManager.getProcessService().findByInChoiceListShown(true, true);
-        for (ProcessDTO processDTO : byInChoiceListShown) {
-            processes.add(ServiceManager.getProcessService().getById(processDTO.getId()));
+        List<ProcessDTO> byInChoiceListShown;
+        try {
+            byInChoiceListShown = ServiceManager.getProcessService().findByInChoiceListShown(true, true);
+            for (ProcessDTO processDTO : byInChoiceListShown) {
+                processes.add(ServiceManager.getProcessService().getById(processDTO.getId()));
+            }
+        } catch (DataException | DAOException e) {
+            Helper.setErrorMessage(CreateProcessForm.ERROR_READING, new Object[] {ObjectType.PROCESS.getTranslationSingular()},
+                    logger, e);
         }
+
         return processes;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -2778,4 +2778,17 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         }
         return FileService.hasImages(process, generatorSource);
     }
+
+    /**
+     * find processes by inChoiceListShown attribute.
+     * @param inChoiceListShown the needed value of the attribute
+     * @param related if the process is related
+     * @return a list of found processes
+     */
+    public List<ProcessDTO> findByInChoiceListShown(boolean inChoiceListShown, boolean related) throws DataException {
+        BoolQueryBuilder inChoiceListShownQuery = new BoolQueryBuilder();
+        MatchQueryBuilder matchQuery = matchQuery(ProcessTypeField.IN_CHOICE_LIST_SHOWN.getKey(), true);
+        inChoiceListShownQuery.must(matchQuery);
+        return ServiceManager.getProcessService().findByQuery(matchQuery, related);
+    }
 }

--- a/Kitodo/src/main/resources/elasticsearch_mappings/process.json
+++ b/Kitodo/src/main/resources/elasticsearch_mappings/process.json
@@ -50,6 +50,9 @@
       "hasChildren": {
         "type": "boolean"
       },
+      "inChoiceListShown": {
+        "type": "boolean"
+      },
       "baseType": {
         "type": "text",
         "fields": {

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -123,6 +123,12 @@ public class ProcessServiceIT {
     }
 
     @Test
+    public void shouldFindByInChoiceListShown() throws DataException, DAOException {
+        List<ProcessDTO> byInChoiceListShown = ServiceManager.getProcessService().findByInChoiceListShown(true, true);
+        Assert.assertEquals("wrong amount of processes found", 1, byInChoiceListShown.size());
+    }
+
+    @Test
     public void shouldSaveProcess() throws Exception {
         Process parent = new Process();
         parent.setTitle("Parent");


### PR DESCRIPTION
Requesting all processes and filtering them with streaming took a long time, when user is assigned to a lot of projects (with a lot of processes)
Speed up page loading by indexseraching.