### PR TITLE
Prestructured import

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -67,8 +67,21 @@ public class OPACConfig {
     }
 
     /**
+     * Retrieve and return the value of the "prestructured" flag of a specific catalog,
+     * controlling whether the import of a process' structure is completely handled by the
+     * import XSLT file or not.
+     *
+     * @param catalogName String identifying the catalog by its title
+     * @return whether the "prestructured" value is set for the given catalog or not
+     */
+    public static boolean isPrestructuredImport(String catalogName) {
+        return getCatalog(catalogName).containsKey("prestructured")
+                && getCatalog(catalogName).getBoolean("prestructured");
+    }
+
+    /**
      * Retrieve the "interfaceType" of the catalog identified by it title.
-     * @param catalogName String String identifying the catalog by its title
+     * @param catalogName String identifying the catalog by its title
      * @return String name of interfaceType
      */
     public static SearchInterfaceType getInterfaceType(String catalogName) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.faces.context.FacesContext;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.lang.StringUtils;
@@ -182,7 +183,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                 showRecord();
             } catch (IOException | ProcessGenerationException | XPathExpressionException | URISyntaxException
                     | ParserConfigurationException | UnsupportedFormatException | SAXException | NoRecordFoundException
-                    | DAOException | ConfigException e) {
+                    | DAOException | ConfigException | TransformerException e) {
                 Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.io.IOUtils;
@@ -66,7 +67,7 @@ public class FileUploadDialog extends MetadataImportDialog {
             Document internalDocument = importService.convertDataRecordToInternal(
                 createRecordFromXMLElement(IOUtils.toString(uploadedFile.getInputstream(), Charset.defaultCharset())),
                 selectedCatalog, false);
-            TempProcess tempProcess = importService.createTempProcessFromDocument(internalDocument,
+            TempProcess tempProcess = importService.createTempProcessFromDocument(selectedCatalog, internalDocument,
                 createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
 
             LinkedList<TempProcess> processes = new LinkedList<>();
@@ -79,14 +80,15 @@ public class FileUploadDialog extends MetadataImportDialog {
             fillCreateProcessForm(processes);
             showRecord();
         } catch (IOException | ProcessGenerationException | URISyntaxException | ParserConfigurationException
-                | UnsupportedFormatException | SAXException | ConfigException | XPathExpressionException e) {
+                | UnsupportedFormatException | SAXException | ConfigException | XPathExpressionException
+                | TransformerException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
     }
 
     private TempProcess extractParentRecordFromFile(UploadedFile uploadedFile, Document internalDocument)
             throws XPathExpressionException, UnsupportedFormatException, URISyntaxException, IOException,
-            ParserConfigurationException, SAXException, ProcessGenerationException {
+            ParserConfigurationException, SAXException, ProcessGenerationException, TransformerException {
         Collection<String> higherLevelIdentifier = this.createProcessForm.getRulesetManagement()
                 .getFunctionalKeys(FunctionalMetadata.HIGHERLEVEL_IDENTIFIER);
 
@@ -97,7 +99,7 @@ public class FileUploadDialog extends MetadataImportDialog {
                 Document internalParentDocument = importService.convertDataRecordToInternal(
                         createRecordFromXMLElement(IOUtils.toString(uploadedFile.getInputstream(), Charset.defaultCharset())),
                         selectedCatalog, true);
-                return importService.createTempProcessFromDocument(internalParentDocument,
+                return importService.createTempProcessFromDocument(selectedCatalog, internalParentDocument,
                         createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -15,14 +15,11 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.Metadata;
-import org.kitodo.api.MetadataEntry;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.TempProcess;
 import org.kitodo.production.services.ServiceManager;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -15,11 +15,14 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.TempProcess;
 import org.kitodo.production.services.ServiceManager;
@@ -104,13 +107,21 @@ public abstract class MetadataImportDialog {
      */
     void fillCreateProcessForm(LinkedList<TempProcess> processes) {
         this.createProcessForm.setProcesses(processes);
-        if (!processes.isEmpty() && processes.getFirst().getMetadataNodes().getLength() > 0) {
+        if (!processes.isEmpty() && Objects.nonNull(processes.getFirst())) {
             TempProcess firstProcess = processes.getFirst();
-            this.createProcessForm.getProcessDataTab()
-                    .setDocType(firstProcess.getWorkpiece().getLogicalStructure().getType());
-            Collection<Metadata> metadata = ImportService.importMetadata(firstProcess.getMetadataNodes(),
-                    MdSec.DMD_SEC);
-            createProcessForm.getProcessMetadataTab().getProcessDetails().setMetadata(metadata);
+            if (Objects.nonNull(firstProcess.getWorkpiece())
+                    && Objects.nonNull(firstProcess.getWorkpiece().getLogicalStructure())
+                    && Objects.nonNull(firstProcess.getWorkpiece().getLogicalStructure().getType())) {
+                firstProcess.verifyDocType();
+                this.createProcessForm.getProcessDataTab()
+                        .setDocType(firstProcess.getWorkpiece().getLogicalStructure().getType());
+            }
+            if (Objects.nonNull(firstProcess.getMetadataNodes())
+                    && firstProcess.getMetadataNodes().getLength() > 0) {
+                Collection<Metadata> metadata = ImportService.importMetadata(firstProcess.getMetadataNodes(),
+                        MdSec.DMD_SEC);
+                createProcessForm.getProcessMetadataTab().getProcessDetails().setMetadata(metadata);
+            }
         }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
@@ -114,14 +114,14 @@ public class TempProcess {
      * This function is currently only used for the import of prestructured processes.
      */
     public void verifyDocType() {
-        if (Objects.nonNull(this.getWorkpiece().getRootElement().getMetadata())) {
-            Optional<Metadata> docTypeMetadata = this.getWorkpiece().getRootElement().getMetadata()
+        if (Objects.nonNull(this.getWorkpiece().getLogicalStructure().getMetadata())) {
+            Optional<Metadata> docTypeMetadata = this.getWorkpiece().getLogicalStructure().getMetadata()
                     .stream().filter(m -> m.getKey().equals(DOC_TYPE)).findFirst();
             if (docTypeMetadata.isPresent() && docTypeMetadata.get() instanceof MetadataEntry) {
                 String docType = ((MetadataEntry)docTypeMetadata.get()).getValue();
                 if (StringUtils.isNotBlank(docType)
-                        && !this.getWorkpiece().getRootElement().getType().equals(docType)) {
-                    this.getWorkpiece().getRootElement().setType(docType);
+                        && !this.getWorkpiece().getLogicalStructure().getType().equals(docType)) {
+                    this.getWorkpiece().getLogicalStructure().setType(docType);
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
@@ -11,6 +11,12 @@
 
 package org.kitodo.production.helper;
 
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
 import org.w3c.dom.NodeList;
@@ -19,6 +25,8 @@ import org.w3c.dom.NodeList;
  * This class is used during import.
  */
 public class TempProcess {
+
+    private static final String DOC_TYPE = "docType";
 
     private Workpiece workpiece;
 
@@ -96,5 +104,26 @@ public class TempProcess {
      */
     public NodeList getMetadataNodes() {
         return metadataNodes;
+    }
+
+    /**
+     * Verify the doc type of the process. This Method checks whether the process has a metadata
+     * of type "docType" and if its value equals the type of the logical root element. If not, the
+     * logical root is set to the value of the "docType" metadata.
+     *
+     * This function is currently only used for the import of prestructured processes.
+     */
+    public void verifyDocType() {
+        if (Objects.nonNull(this.getWorkpiece().getRootElement().getMetadata())) {
+            Optional<Metadata> docTypeMetadata = this.getWorkpiece().getRootElement().getMetadata()
+                    .stream().filter(m -> m.getKey().equals(DOC_TYPE)).findFirst();
+            if (docTypeMetadata.isPresent() && docTypeMetadata.get() instanceof MetadataEntry) {
+                String docType = ((MetadataEntry)docTypeMetadata.get()).getValue();
+                if (StringUtils.isNotBlank(docType)
+                        && !this.getWorkpiece().getRootElement().getType().equals(docType)) {
+                    this.getWorkpiece().getRootElement().setType(docType);
+                }
+            }
+        }
     }
 }

--- a/Kitodo/src/main/resources/kitodo_opac.xml
+++ b/Kitodo/src/main/resources/kitodo_opac.xml
@@ -20,6 +20,8 @@
         <interfaceType>sru</interfaceType>
         <returnFormat>xml</returnFormat>
         <metadataFormat>MARC</metadataFormat>
+        <!-- Use the following element to activate prestructured import, e.g. delegate creating the METS structure to configured XSLT mapping file -->
+        <!-- <prestructured>true</prestructured> -->
         <fileUpload>false</fileUpload>
         <parentElement trimMode="parenthesis"/>
         <exemplarField xpath=".//*[local-name()='datafield'][@tag='954']"

--- a/Kitodo/src/main/resources/xslt/mods2dfgviewer_prestructured.xsl
+++ b/Kitodo/src/main/resources/xslt/mods2dfgviewer_prestructured.xsl
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:mets="http://www.loc.gov/METS/"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:kitodo="http://meta.kitodo.org/v1/">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="mets:mets">
+        <mets:mets>
+            <xsl:apply-templates select="@* | node()"/>
+        </mets:mets>
+    </xsl:template>
+
+    <!-- Copy existing METS structure! -->
+    <!-- ### METS header -->
+    <xsl:template match="mets:metsHdr">
+        <mets:metsHdr>
+            <xsl:copy-of select="@*"/>
+            <xsl:copy-of select="node()"/>
+        </mets:metsHdr>
+    </xsl:template>
+
+    <!-- ### METS fileSec -->
+    <xsl:template match="mets:fileSec">
+        <mets:fileSec>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="mets:fileGrp"/>
+        </mets:fileSec>
+    </xsl:template>
+
+    <!-- ### METS fileGrp -->
+    <xsl:template match="mets:fileGrp">
+        <mets:fileGrp>
+            <xsl:copy-of select="@*"/>
+            <xsl:copy-of select="node()"/>
+        </mets:fileGrp>
+    </xsl:template>
+
+    <!-- ### METS structMaps -->
+    <xsl:template match="mets:structMap">
+        <mets:structMap>
+            <xsl:copy-of select="@*"/>
+            <xsl:copy-of select="node()"/>
+        </mets:structMap>
+    </xsl:template>
+
+    <!-- ### METS structLink -->
+    <xsl:template match="mets:structLink">
+        <mets:structLink>
+            <xsl:copy-of select="@*"/>
+            <xsl:copy-of select="node()"/>
+        </mets:structLink>
+    </xsl:template>
+
+    <!-- ### METS dmdSec -->
+    <xsl:template match="mets:dmdSec">
+        <mets:dmdSec>
+            <!-- copy original ID of DMDSection! -->
+            <xsl:copy-of select="@*"/>
+            <!-- create required METS nodes -->
+            <mets:mdWrap>
+                <mets:xmlData>
+                    <!-- map existing MODS metadata to internal format -->
+                    <xsl:apply-templates select="mets:mdWrap/mets:xmlData/mods:mods"/>
+                </mets:xmlData>
+            </mets:mdWrap>
+        </mets:dmdSec>
+    </xsl:template>
+
+    <!-- ### map MODS metadata to Kitodo metadata -->
+    <xsl:template match="mods:mods">
+        <kitodo:kitodo>
+            <xsl:apply-templates select="@*|node()"/>
+            <!-- ### DocType ### -->
+            <kitodo:metadata name="docType">
+                <xsl:variable name="genre" select="mods:genre[@authority='gnd-content']"/>
+                <xsl:choose>
+                    <xsl:when test="(mods:originInfo/mods:issuance[.='continuing'])
+                                or  (mods:originInfo/mods:issuance[.='serial'])">
+                        <xsl:choose>
+                            <xsl:when test="$genre = 'Zeitschrift'">
+                                <xsl:text>periodical</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="$genre = 'Zeitung'">
+                                <xsl:text>newspaper</xsl:text>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>periodical</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:when
+                            test="((mods:relatedItem/mods:identifier[@type='localparentid']) or (mods:relatedItem[@type='host']))">
+                        <xsl:choose>
+                            <xsl:when test="((mods:originInfo/mods:issuance[.='monographic'])
+                                          or (mods:originInfo/mods:issuance[.='integrating resource'])
+                                          or (mods:originInfo/mods:issuance[.='single unit'])
+                                          or (mods:typeOfResource[@manuscript='yes'][.='text']))">
+                                <xsl:text>volume</xsl:text>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>multivolume_work</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:choose>
+                            <xsl:when
+                                    test="(mods:originInfo/mods:issuance[.='monographic']) and (mods:genre[@authoriy='gnd-content'][.='Altkarte'])">
+                                <xsl:text>map</xsl:text>
+                            </xsl:when>
+                            <xsl:when
+                                    test="(mods:originInfo/mods:issuance[.='monographic']) or (mods:originInfo/mods:issuance[.='integrating resource'])">
+                                <xsl:text>monograph</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="mods:originInfo/mods:issuance[.='single unit']">
+                                <xsl:text>volume</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="(mods:originInfo/mods:issuance[.='multipart monograph'])">
+                                <xsl:text>multivolume_work</xsl:text>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>monograph</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </kitodo:metadata>
+        </kitodo:kitodo>
+    </xsl:template>
+
+    <!-- ### Map MODS fields to Kitodo metadata with MODS node name without MODS prefix ### -->
+
+    <!-- Create "kitodo:metadata" elements for MODS leaves without attributes or attributes of MODS leaf nodes -->
+    <!-- MODS leaf nodes without attributes -->
+    <xsl:template match="//mods:mods//*[not(*) and not(@*) and not(local-name(.)='topic'
+                                      or local-name(.)='note'
+                                      or local-name(.)='part'
+                                      or local-name(.)='name'
+                                      or local-name(.)='namePart'
+                                      or local-name(.)='dateCreated'
+                                      or local-name(.)='dateIssued'
+                                      or local-name(.)='placeTerm'
+                                      or local-name(.)='scriptTerm'
+                                      or local-name(.)='roleTerm'
+                                      or local-name(.)='relatedItem'
+                                      or local-name(.)='geographic'
+                                      or local-name(.)='temporal'
+                                      or local-name(.)='titleInfo'
+                                      or local-name(.)='classification'
+                                      or local-name(.)='recordIdentifier'
+                                      or local-name(.)='identifier'
+                                      or local-name(.)='physicalLocation'
+                                      or local-name(.)='languageTerm'
+                                      or local-name(.)='accessCondition'
+                                      or local-name(.)='url')]">
+        <kitodo:metadata name="{local-name(.)}">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- attributes of MODS leaf nodes -->
+    <xsl:template match="//mods:mods//@*[not(*) and local-name(.)!='schemaLocation']">
+        <kitodo:metadata name="{local-name(.)}">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- Create "kitodo:metadataGroup" elements for MODS non-leaf nodes or leaf nodes with attributes -->
+    <!-- MODS non-leaf nodes-->
+    <xsl:template match="//mods:mods//*[child::* and not(local-name()='recordInfo')]">
+        <kitodo:metadataGroup name="{local-name(.)}">
+            <xsl:apply-templates/>
+        </kitodo:metadataGroup>
+    </xsl:template>
+
+    <!-- MODS nodes with attributes (leaves and non-leaves)-->
+    <xsl:template match="//mods:mods//*[(local-name(.)='topic'
+                                      or local-name(.)='note'
+                                      or local-name(.)='part'
+                                      or local-name(.)='name'
+                                      or local-name(.)='namePart'
+                                      or local-name(.)='dateCreated'
+                                      or local-name(.)='dateIssued'
+                                      or local-name(.)='placeTerm'
+                                      or local-name(.)='scriptTerm'
+                                      or local-name(.)='roleTerm'
+                                      or local-name(.)='relatedItem'
+                                      or local-name(.)='geographic'
+                                      or local-name(.)='temporal'
+                                      or local-name(.)='titleInfo'
+                                      or local-name(.)='classification'
+                                      or local-name(.)='identifier'
+                                      or local-name(.)='physicalLocation'
+                                      or local-name(.)='languageTerm'
+                                      or local-name(.)='accessCondition'
+                                      or local-name(.)='url')
+                                      or (not(*) and(@*))]">
+
+        <kitodo:metadataGroup name="{local-name(.)}">
+            <xsl:if test="(local-name(.)='topic'
+                                      or local-name(.)='note'
+                                      or local-name(.)='part'
+                                      or local-name(.)='name'
+                                      or local-name(.)='namePart'
+                                      or local-name(.)='dateCreated'
+                                      or local-name(.)='dateIssued'
+                                      or local-name(.)='placeTerm'
+                                      or local-name(.)='scriptTerm'
+                                      or local-name(.)='roleTerm'
+                                      or local-name(.)='relatedItem'
+                                      or local-name(.)='geographic'
+                                      or local-name(.)='temporal'
+                                      or local-name(.)='titleInfo'
+                                      or local-name(.)='classification'
+                                      or local-name(.)='identifier'
+                                      or local-name(.)='physicalLocation'
+                                      or local-name(.)='languageTerm'
+                                      or local-name(.)='accessCondition'
+                                      or local-name(.)='url')">
+                <xsl:if test="normalize-space(./text()) != ''">
+                    <kitodo:metadata name="value"><xsl:value-of select="normalize-space(./text())"/></kitodo:metadata>
+                </xsl:if>
+                <xsl:apply-templates select="@*"/>
+                <xsl:apply-templates />
+            </xsl:if>
+            <xsl:if test="not(local-name(.)='topic'
+                                      or local-name(.)='note'
+                                      or local-name(.)='part'
+                                      or local-name(.)='name'
+                                      or local-name(.)='namePart'
+                                      or local-name(.)='dateCreated'
+                                      or local-name(.)='dateIssued'
+                                      or local-name(.)='placeTerm'
+                                      or local-name(.)='scriptTerm'
+                                      or local-name(.)='roleTerm'
+                                      or local-name(.)='relatedItem'
+                                      or local-name(.)='geographic'
+                                      or local-name(.)='temporal'
+                                      or local-name(.)='titleInfo'
+                                      or local-name(.)='classification'
+                                      or local-name(.)='identifier'
+                                      or local-name(.)='physicalLocation'
+                                      or local-name(.)='accessCondition'
+                                      or local-name(.)='languageTerm'
+                                      or local-name(.)='url')">
+                <xsl:apply-templates select="@*"/>
+                <xsl:apply-templates />
+            </xsl:if>
+        </kitodo:metadataGroup>
+    </xsl:template>
+
+    <!-- ### Allegro ID used for import (equals the searched ID) - SRU-MODS -->
+    <xsl:template match="//mods:mods//mods:recordIdentifier[@source='allegro']">
+        <kitodo:metadata name="allegroId">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### MODS Access Condition mapped to Kitodo Access Restriction -->
+    <xsl:template match="//mods:mods//mods:accessCondition[@type='restriction on access']">
+        <xsl:if test="normalize-space(./text())='Metadata Only Access'">
+          <kitodo:metadata name="accessRestriction">restricted</kitodo:metadata>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ### Ignore unmapped text ### -->
+    <xsl:template match="text()"/>
+
+    <!-- ### Ignore MODS schema location (as it is not required in the internal format) ### -->
+    <xsl:template match="@xsi:schemaLocation"/>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This pull request enables "prestructured import" of structure and metadata. 

That means the import service delegates the creation of the whole process METS structure required to the referenced XSLT mapping file (see provided example XSLT mapping file `mods2dfgviewer_prestructured.xsl` for details). The XSLT mapping is responsible for creating the METS structure (in contrast to just mapping the contained metadata in MODS/MARC/whatever to Kitodo internal format) by either copying the existing or creating new METS elements.

This feature can be activated by adding the line `<prestructured>true</prestructured>` to the corresponding OPAC configuration in `kitodo_opac.xml`.

**Note:** the provided file `mods2dfgviewer_prestructured.xsl` is just a template and should be adapted for individual use cases. Especially the mapping of METS filegroups and including files with `href` attributes without changes will not be applicable in most cases, because it means remote image files on other system will be referenced within the resulting METS file.