### PR TITLE
Add new images to actual logical root

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1184,6 +1184,11 @@ public class FileService {
     private void addNewMediaToWorkpiece(List<String> canonicals, Map<String, Map<Subfolder, URI>> mediaToAdd,
             Workpiece workpiece) {
 
+        LogicalDivision actualLogicalRoot = workpiece.getLogicalStructure();
+        while (Objects.isNull(actualLogicalRoot.getType()) && actualLogicalRoot.getChildren().size() == 1) {
+            actualLogicalRoot = actualLogicalRoot.getChildren().get(0);
+        }
+
         for (Entry<String, Map<Subfolder, URI>> entry : mediaToAdd.entrySet()) {
             int insertionPoint = 0;
             for (String canonical : canonicals) {
@@ -1197,8 +1202,8 @@ public class FileService {
             workpiece.getPhysicalStructure().getChildren().add(insertionPoint, physicalDivision);
             View view = new View();
             view.setPhysicalDivision(physicalDivision);
-            workpiece.getLogicalStructure().getViews().add(view);
-            view.getPhysicalDivision().getLogicalDivisions().add(workpiece.getLogicalStructure());
+            actualLogicalRoot.getViews().add(view);
+            view.getPhysicalDivision().getLogicalDivisions().add(actualLogicalRoot);
             canonicals.add(insertionPoint, entry.getKey());
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1188,6 +1188,11 @@ public class FileService {
         while (Objects.isNull(actualLogicalRoot.getType()) && actualLogicalRoot.getChildren().size() == 1) {
             actualLogicalRoot = actualLogicalRoot.getChildren().get(0);
         }
+        // If the newspaper has multiple issues in the process, then everything
+        // stays as it was
+        if (Objects.isNull(actualLogicalRoot.getType()) && actualLogicalRoot.getChildren().size() != 1) {
+            actualLogicalRoot = workpiece.getLogicalStructure();
+        }
 
         for (Entry<String, Map<Subfolder, URI>> entry : mediaToAdd.entrySet()) {
             int insertionPoint = 0;


### PR DESCRIPTION
When there are nameless containers on top of the logical structure, skip them. Fixes #3434