### PR TITLE
Set refresh interval of test ES index to 1ms

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/KitodoRestClient.java
@@ -13,6 +13,7 @@ package org.kitodo.data.elasticsearch;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.ws.rs.HttpMethod;
@@ -31,6 +32,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Requests;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -232,6 +234,16 @@ public abstract class KitodoRestClient implements RestClientInterface {
      */
     public String getIndexBase() {
         return indexBase;
+    }
+
+    /**
+     * Update refresh interval of search indices to 1 ms.
+     *
+     * @throws IOException when index cannot be reached
+     */
+    public void setRefreshInterval() throws IOException {
+        this.highLevelClient.indices().putSettings(Requests.updateSettingsRequest()
+                .settings(Collections.singletonMap("refresh_interval", "1ms")), RequestOptions.DEFAULT);
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -125,6 +125,7 @@ public class MockDatabase {
         for (String mappingType : KitodoRestClient.MAPPING_TYPES) {
             indexRestClient.createIndex(readMapping(mappingType), mappingType);
         }
+        indexRestClient.setRefreshInterval();
     }
 
     public static void startNodeWithoutMapping() throws Exception {


### PR DESCRIPTION
Hopefully fixes #4715 

This changes the `index.refresh_interval` from its default 1 second to 1 millisecond. 

The `refresh_interval` describes the time needed for indexed elements to become available for search requests (see https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-refresh-interval-setting for details), which could be less than one second in some Kitodo test cases.