### PR TITLE
Deactivate ruleset selection during process creation

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -681,6 +681,7 @@ newProcess.catalogueSearch.parentIDMetadataMissing=Es wurde kein Metadatum zum S
 newProcess.catalogueSearch.parentIDParameterMissing=Es wurde kein Parameter zum Suchen von Kindelementen eines bestimmten Elterndokuments f\u00fcr den ausgew\u00E4hlten Katalog in der kitodo_opac.xml konfiguriert (fehlender Konfigurationsparameter "parentElement")!
 newProcess.catalogueSearch.savingSecondaryProcesses=Speichern von untergeordneten Einheiten
 newProcess.fileUpload.heading=Dateiupload
+newProcess.rulesetSelection.deactivated=Der Regelsatz wird durch die verwendete Produktionsvorlage vorgegeben und kann w\u00E4hrend der Vorgangserstellung nicht ge\u00E4ndert werden
 newProcess.titleGeneration.creationRuleNotFound=Es konnte keine Regel zur Titelgenerierung f\u00fcr Vorg\u00E4nge vom Typ \u201E{0}\u201C im Regelsatz \u201E{1}\u201C gefunden werden!
 newProject=Neues Projekt
 newRole=Neue Rolle

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -693,6 +693,7 @@ newProcess.catalogueSearch.parentIDMetadataMissing=No parent ID metadata ("highe
 newProcess.catalogueSearch.parentIDParameterMissing=Parameter for retrieving child documents of a specific parent document not configured in kitodo_opac.xml for selected catalog (missing element "parentElement")!
 newProcess.catalogueSearch.savingSecondaryProcesses=Saving secondary processes
 newProcess.fileUpload.heading=Fileupload
+newProcess.rulesetSelection.deactivated=Ruleset is predetermined by given template and cannot be changed during process creation
 newProcess.titleGeneration.creationRuleNotFound=No title creation rules found for docType \u201E{0}\u201C in ruleset \u201E{1}\u201C!
 newProject=New project
 newRole=New role

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
@@ -49,25 +49,15 @@
                 </p:selectOneMenu>
             </div>
 
-            <div>
-                <!-- Preferences -->
+            <h:panelGroup layout="block"
+                          title="#{msgs['newProcess.rulesetSelection.deactivated']}">
                 <p:outputLabel for="ruleset"
                                value="#{msgs.ruleset}"/>
-                <h:panelGroup>
-                    <p:selectOneMenu id="ruleset"
-                                     value="#{CreateProcessForm.mainProcess.ruleset}"
-                                     converter="#{rulesetConverter}"
-                                     required="true">
-                        <f:selectItems value="#{ProcessForm.rulesets}"
-                                       var="ruleset"
-                                       itemValue="#{ruleset}"
-                                       itemLabel="#{ruleset.title}"/>
-                        <p:ajax event="change"
-                                listener="#{CreateProcessForm.updateRulesetAndDocType(CreateProcessForm.mainProcess.ruleset)}"
-                                update="editForm:processFromTemplateTabView:docType,editForm:processFromTemplateTabView:metadataTable"/>
-                    </p:selectOneMenu>
-                </h:panelGroup>
-            </div>
+                <p:inputText id="ruleset"
+                             styleClass="input"
+                             disabled="#{true}"
+                             value="#{CreateProcessForm.mainProcess.ruleset.title}"/>
+            </h:panelGroup>
 
             <div>
                 <p:outputLabel for="usingTemplates"


### PR DESCRIPTION
Fixes #4717 

I opted for deactivating the ruleset field instead of removing it because I think the information about which ruleset is used is still relevant to the user.