### PR TITLE
Catch exceptions on corrupt data during indexing

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexAllThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexAllThread.java
@@ -35,7 +35,7 @@ public class IndexAllThread extends Thread {
         for (ObjectType objectType : ObjectType.getIndexableObjectTypes()) {
             try {
                 indexingService.startIndexing(objectType, context);
-            } catch (DataException | CustomResponseException e) {
+            } catch (DataException | CustomResponseException | RuntimeException e) {
                 Helper.setErrorMessage(e.getLocalizedMessage(), IndexingService.getLogger(), e);
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
In the case of corrupt data, e.g. damaged METS files, `RuntimeException` can be thrown out of the APIs used. If these are not logged, you will look in vain for the problem, the indexing just _gets stuck_.

![Screenshot](https://user-images.githubusercontent.com/3040657/136555773-5f250184-06f8-4980-a21a-3f41fa9f0e09.png)

In this case, as an exception of the general rule, `RuntimeException` should be intercepted so that it is visible in the log file, so that the cause can be debugged. This is especially important when re-indexing, if otherwise nothing will go on.