### PR TITLE
Check newspaper process title duplicates

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
@@ -22,12 +22,10 @@ import java.time.MonthDay;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -37,7 +35,6 @@ import java.util.regex.Pattern;
 import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
-import javax.naming.ConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -45,17 +42,11 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
-import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
-import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
-import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.config.ConfigCore;
-import org.kitodo.config.ConfigProject;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.exceptions.DoctypeMissingException;
-import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.XMLUtils;
 import org.kitodo.production.helper.tasks.GeneratesNewspaperProcessesThread;
@@ -67,11 +58,8 @@ import org.kitodo.production.model.bibliography.course.Granularity;
 import org.kitodo.production.model.bibliography.course.IndividualIssue;
 import org.kitodo.production.model.bibliography.course.Issue;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;
-import org.kitodo.production.process.NewspaperProcessesGenerator;
-import org.kitodo.production.process.TitleGenerator;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.calendar.CalendarService;
-import org.kitodo.production.services.data.RulesetService;
 import org.primefaces.PrimeFaces;
 import org.primefaces.model.DefaultStreamedContent;
 import org.primefaces.model.StreamedContent;
@@ -673,7 +661,6 @@ public class CalendarForm implements Serializable {
      */
     public String createProcesses() throws DAOException {
         Process process = ServiceManager.getProcessService().getById(parentId);
-
         TaskManager.addTask(new GeneratesNewspaperProcessesThread(process, course));
         if (ServiceManager.getSecurityAccessService().hasAuthorityToViewTaskManagerPage()) {
             return TASK_MANAGER_REFERER;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
@@ -21,7 +21,6 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.DoctypeMissingException;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.production.helper.Helper;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.process.NewspaperProcessesGenerator;
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
@@ -21,6 +21,7 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.DoctypeMissingException;
 import org.kitodo.exceptions.ProcessGenerationException;
+import org.kitodo.production.helper.Helper;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.process.NewspaperProcessesGenerator;
 
@@ -74,6 +75,10 @@ public class GeneratesNewspaperProcessesThread extends EmptyTask {
      */
     @Override
     public void run() {
+        if(generator.isDuplicatedTitles()) {
+            Helper.setErrorMessage("duplicatedTitles");
+            return;
+        }
         try {
             while (generator.getProgress() < generator.getNumberOfSteps()) {
                 generator.nextStep();

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
@@ -75,13 +75,11 @@ public class GeneratesNewspaperProcessesThread extends EmptyTask {
      */
     @Override
     public void run() {
-        if(generator.isDuplicatedTitles()) {
-            Helper.setErrorMessage("duplicatedTitles");
-            return;
-        }
         try {
             while (generator.getProgress() < generator.getNumberOfSteps()) {
-                generator.nextStep();
+                if(!generator.nextStep()) {
+                    return;
+                }
                 super.setProgress(generator.getProgress() / generator.getNumberOfSteps());
                 if (Thread.currentThread().isInterrupted()) {
                     return;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/GeneratesNewspaperProcessesThread.java
@@ -76,7 +76,7 @@ public class GeneratesNewspaperProcessesThread extends EmptyTask {
     public void run() {
         try {
             while (generator.getProgress() < generator.getNumberOfSteps()) {
-                if(!generator.nextStep()) {
+                if (!generator.nextStep()) {
                     return;
                 }
                 super.setProgress(generator.getProgress() / generator.getNumberOfSteps());

--- a/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
@@ -406,7 +406,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
      *            allowed Metadata views
      * @return the initialized title generator
      */
-    public static TitleGenerator initializeTitleGenerator(ConfigProject configProject, Workpiece workpiece,
+    private static TitleGenerator initializeTitleGenerator(ConfigProject configProject, Workpiece workpiece,
             Collection<MetadataViewInterface> allowedMetadata)
             throws DoctypeMissingException {
 
@@ -801,7 +801,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         }
     }
 
-    public boolean isDuplicatedTitles() throws ProcessGenerationException, DataException {
+    private boolean isDuplicatedTitles() throws ProcessGenerationException, DataException {
         List<List<IndividualIssue>> processes = course.getProcesses();
         List<String> issueTitles = new ArrayList<>();
         for (List<IndividualIssue> individualProcess : processes) {
@@ -810,7 +810,6 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
                 String title = makeTitle(issueDivisionView.getProcessTitle().orElse("+'_'+#YEAR+#MONTH+#DAY+#ISSU"),
                     genericFields);
                 if (!ServiceManager.getProcessService().findByTitle(title).isEmpty() || issueTitles.contains(title)) {
-                    System.out.println(title);
                     return true;
                 }
                 issueTitles.add(title);

--- a/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
@@ -56,6 +56,7 @@ import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.DoctypeMissingException;
 import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.production.forms.createprocess.ProcessFieldedMetadata;
+import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.model.bibliography.course.IndividualIssue;
@@ -400,7 +401,7 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
      *            allowed Metadata views
      * @return the initialized title generator
      */
-    private static TitleGenerator initializeTitleGenerator(ConfigProject configProject, Workpiece workpiece,
+    public static TitleGenerator initializeTitleGenerator(ConfigProject configProject, Workpiece workpiece,
             Collection<MetadataViewInterface> allowedMetadata)
             throws DoctypeMissingException {
 
@@ -793,5 +794,22 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         if (logger.isTraceEnabled()) {
             logger.trace("Finish took {} ms", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - begin));
         }
+    }
+
+    public boolean isDuplicatedTitles() throws ProcessGenerationException {
+        List<List<IndividualIssue>> processes = course.getProcesses();
+        List<String> issueTitles = new ArrayList<>();
+        for (List<IndividualIssue> individualProcess : processes) {
+            for (IndividualIssue individualIssue : individualProcess) {
+                Map<String, String> genericFields = individualIssue.getGenericFields();
+                String title = makeTitle(issueDivisionView.getProcessTitle().orElse("+'_'+#YEAR+#MONTH+#DAY+#ISSU"),
+                    genericFields);
+                if (issueTitles.contains(title)) {
+                    return true;
+                }
+                issueTitles.add(title);
+            }
+        }
+        return false;
     }
 }

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -39,6 +39,7 @@ docketMissing=Die Konfigurationsdatei zur Laufzettelgenerierung existiert nicht
 docketNotFound=Die angegebene Datei konnte nicht gefunden werden.
 docketTitleDuplicated=Der Laufzettel mit den gleichen Titel existiert schon.
 docTypeNotFound=docType ''{0}'' wurde nicht im selektierten Regelsatz gefunden
+duplicatedTitles=Es wurden duplizierte Titel gefunden
 emptySourceFolder=Der Quellordner zur Bildgenerierung ist leer
 errorDataIncomplete=Unvollst\u00E4ndige Daten\:
 errorDatabaseReading=Fehler beim Datenbanklesen von ''{0}'' with ID {1}.

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -40,6 +40,7 @@ docketMissing=the configuration file for docket creation is missing
 docketNotFound=The specified file could not be found.
 docketTitleDuplicated=The docket with the same title exists already.
 docTypeNotFound=docType ''{0}'' could not be found in selected ruleset
+duplicatedTitles=Duplicated titles found
 emptySourceFolder=The source folder is empty
 errorDataIncomplete=Incomplete data\:
 errorDatabaseReading=Error on reading database for ''{0}'' with ID {1}.

--- a/Kitodo/src/test/java/org/kitodo/NewspaperCourse.java
+++ b/Kitodo/src/test/java/org/kitodo/NewspaperCourse.java
@@ -20,6 +20,7 @@ import org.kitodo.production.model.bibliography.course.Issue;
 
 public class NewspaperCourse {
     private static Course course;
+    private static Course duplicatedCourse;
 
     /**
      * Returns a course of appearance.
@@ -33,10 +34,28 @@ public class NewspaperCourse {
         return course;
     }
 
+    /**
+     * Returns a course of appearance with duplicated Entries.
+     *
+     * @return a course of appearance
+     */
+    public static Course getDuplicatedCourse() {
+        if (Objects.isNull(duplicatedCourse)) {
+            duplicatedCourse = createDuplicatedCourse();
+        }
+        return duplicatedCourse;
+    }
+
     private static Course createCourse() {
         Course course = new Course();
         addFirstBlock(course);
         addSecondBlock(course);
+        return course;
+    }
+
+    private static Course createDuplicatedCourse() {
+        Course course = new Course();
+        addFirstBlockDuplicate(course);
         return course;
     }
 
@@ -53,6 +72,25 @@ public class NewspaperCourse {
         issue.addAddition(LocalDate.of(1703, 8, 31));
         issue.addAddition(LocalDate.of(1703, 9, 6));
         block.addIssue(issue);
+        course.add(block);
+    }
+
+    private static void addFirstBlockDuplicate(Course course) {
+        Block block = new Block(course);
+        block.setPublicationPeriod(LocalDate.of(1703, 8, 8), LocalDate.of(1703, 9, 30));
+        Issue issue = new Issue(course);
+        issue.setMonday(true);
+        issue.addAddition(LocalDate.of(1703, 8, 8));
+        issue.addExclusion(LocalDate.of(1703, 8, 9));
+        issue.addExclusion(LocalDate.of(1703, 8, 16));
+        issue.addAddition(LocalDate.of(1703, 8, 17));
+        issue.addExclusion(LocalDate.of(1703, 8, 30));
+        issue.addAddition(LocalDate.of(1703, 8, 31));
+        issue.addAddition(LocalDate.of(1703, 9, 6));
+        block.addIssue(issue);
+        Issue secondIssue = new Issue(course);
+        secondIssue.setMonday(true);
+        block.addIssue(secondIssue);
         course.add(block);
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -222,7 +222,7 @@ public class NewspaperProcessesGeneratorIT {
 
         ProcessDTO byId = ServiceManager.getProcessService().findById(11);
         Assert.assertNull("Process should not have been created", byId.getTitle());
-        
+
     }
 
     private void dayChecksOfShouldGenerateSeasonProcesses(Process seasonProcess, Workpiece seasonYearWorkpiece) {

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -48,6 +48,9 @@ import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.production.helper.tasks.GeneratesNewspaperProcessesThread;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.model.bibliography.course.Granularity;
 import org.kitodo.production.services.ServiceManager;
@@ -210,8 +213,16 @@ public class NewspaperProcessesGeneratorIT {
     }
 
     @Test
-    private void shouldNotGenerateDuplicateProcessTitle() {
+    public void shouldNotGenerateDuplicateProcessTitle() throws DAOException, DataException {
+        Process completeEdition = ServiceManager.getProcessService().getById(10);
+        Course course = NewspaperCourse.getDuplicatedCourse();
+        course.splitInto(Granularity.DAYS);
+        GeneratesNewspaperProcessesThread generatesNewspaperProcessesThread = new GeneratesNewspaperProcessesThread(completeEdition, course);
+        generatesNewspaperProcessesThread.run();
 
+        ProcessDTO byId = ServiceManager.getProcessService().findById(11);
+        Assert.assertNull("Process should not have been created", byId.getTitle());
+        
     }
 
     private void dayChecksOfShouldGenerateSeasonProcesses(Process seasonProcess, Workpiece seasonYearWorkpiece) {

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -209,6 +209,11 @@ public class NewspaperProcessesGeneratorIT {
         cleanUp();
     }
 
+    @Test
+    private void shouldNotGenerateDuplicateProcessTitle() {
+
+    }
+
     private void dayChecksOfShouldGenerateSeasonProcesses(Process seasonProcess, Workpiece seasonYearWorkpiece) {
         // all days must be inside their month
         for (LogicalDivision monthLogicalDivision : seasonYearWorkpiece.getLogicalStructure()


### PR DESCRIPTION
this fixes #4712 
It's an easy and pragmatic solution wihtout a lot of changes in the code. The duplicates are identified when starting the thread. if there will be duplicates the thread finishes (without creating any processes).
This is not the solution suggested in the ticket, but it prevents the creation of duplicated titles, and it also doesn't create half of the processes until a duplicate is found (which would lead to incomplete editions).

Disadvantage: the duplicates are not identified in the CalendarForm, so if the user makes a mistake, he has to configure the whole newspaper again.