### PR TITLE
Remove existing created content when (re-)generating all images

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -343,9 +343,24 @@ public class CurrentTaskForm extends BaseForm {
             Helper.setErrorMessage("emptySourceFolder");
         } else {
             List<Subfolder> outputs = SubfolderFactoryService.createAll(myProcess, contentFolders);
+            if (mode.equals(GenerationMode.ALL)) {
+                removeGeneratedContent(outputs);
+            }
             ImageGenerator imageGenerator = new ImageGenerator(sourceFolder, mode, outputs);
             TaskManager.addTask(new TaskImageGeneratorThread(myProcess.getTitle(), imageGenerator));
             Helper.setMessage(messageKey);
+        }
+    }
+
+    private void removeGeneratedContent(List<Subfolder> contentFolders) {
+        for (Subfolder subfolder : contentFolders) {
+            for (URI uri : subfolder.listContents(true).values()) {
+                try {
+                    ServiceManager.getFileService().delete(uri);
+                } catch (IOException e) {
+                    Helper.setErrorMessage(e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
If fewer scans are present during a second run of "Generate all images", existing png derivates for the metadata editor and export for scans that have been removed are not cleaned up, resulting in a mismatch between generator source and generated content.

This pull request cleans up all existing generated content before generating all images to prevent the described problem.