### PR TITLE
Remove existing created content when generating all images

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/enums/ImageGeneratorStep.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/ImageGeneratorStep.java
@@ -36,6 +36,9 @@ public enum ImageGeneratorStep implements Consumer<ImageGenerator> {
             imageGenerator.letTheSupervisorDo(
                 emptyTask -> emptyTask.setWorkDetail(Helper.getTranslation("listSourceFolder")));
             imageGenerator.determineSources();
+            if (imageGenerator.getMode().equals(GenerationMode.ALL)) {
+            	imageGenerator.removeGeneratedContent();
+            }
             imageGenerator.setState(DETERMINE_WHICH_IMAGES_NEED_TO_BE_GENERATED);
             imageGenerator.setPosition(-1);
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/image/ImageGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/image/ImageGenerator.java
@@ -113,17 +113,16 @@ public class ImageGenerator implements Runnable {
         this.sourceFolder = sourceFolder;
         this.mode = mode;
         this.outputs = outputs;
-        // cleanup target folders if _all_ output is generated
-        if (mode.equals(GenerationMode.ALL)) {
-            removeGeneratedContent((List<Subfolder>) outputs);
-        }
         this.state = ImageGeneratorStep.LIST_SOURCE_FOLDER;
         this.sources = Collections.emptyList();
         this.contentToBeGenerated = new LinkedList<>();
     }
 
-    private void removeGeneratedContent(List<Subfolder> contentFolders) {
-        for (Subfolder subfolder : contentFolders) {
+    /**
+     * Cleanup target folders if <i>all</i> output is generated.
+     */
+    public void removeGeneratedContent() {
+        for (Subfolder subfolder : outputs) {
             for (URI uri : subfolder.listContents(true).values()) {
                 try {
                     ServiceManager.getFileService().delete(uri);


### PR DESCRIPTION
If fewer scans are present during a second run of "Generate all images", existing png derivates - for the metadata editor and export - for scans that have been removed are not cleaned up, resulting in a mismatch between generator source and generated content.

This pull request covers manual and automatic generation of all images (via automatic tasks) and cleans up all existing generated content before generating all images to prevent the described problem.