### PR TITLE
Fix styling of disabled project list on template details page

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -633,11 +633,13 @@ section#content-section {
 }
 
 #editForm table.ui-selectmanycheckbox {
-    border: solid var(--default-border-width) var(--blue);
     border-radius: var(--default-border-radius);
-    box-sizing: border-box;
     padding: .5em;
     width: 100%;
+}
+
+.ui-widget-content label.ui-state-disabled {
+    opacity: 1;
 }
 
 #editForm table.ui-selectmanycheckbox tbody {

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -519,6 +519,7 @@ button.ui-datepicker-trigger.ui-button-icon-only::before {
 .ui-selectcheckboxmenu-multiple-container.ui-inputfield,
 .ui-picklist-list-wrapper,
 .ui-selectoneradio,
+.ui-selectmanycheckbox,
 .ui-widget-content .ui-inputfield {
     border: solid var(--default-border-width) var(--blue);
     box-shadow: 0 0 0 transparent;
@@ -836,6 +837,7 @@ button.ui-datepicker-trigger.ui-button-icon-only::before {
 .ui-selectonemenu.ui-state-disabled .ui-selectonemenu-trigger,
 .ui-spinner.ui-state-disabled .ui-spinner-input,
 .ui-spinner.ui-state-disabled .ui-spinner-button::after,
+.ui-selectmanycheckbox.disabled,
 .ui-selectoneradio.disabled {
     color: var(--medium-gray);
     border-color: var(--medium-gray);

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/details.xhtml
@@ -22,6 +22,7 @@
                 <p:outputLabel for="title" value="#{msgs.templateTitle}"/>
                 <p:inputText id="title" placeholder="#{msgs.templateTitle}"
                              value="#{TemplateForm.template.title}"
+                             title="#{TemplateForm.template.title}"
                              class="input" disabled="#{isViewMode}"
                              required="#{not empty param['editForm:save']}">
                     <p:ajax event="blur"/>
@@ -30,8 +31,9 @@
 
             <div>
                 <p:outputLabel for="project" value="#{msgs.projects}"/>
-                <p:selectManyCheckbox  id="project" value="#{TemplateForm.assignedProjects}" layout="grid" columns="1" converter="#{projectConverter}"
-                                 required="#{not empty param['editForm:save']}" disabled="#{isViewMode}">
+                <p:selectManyCheckbox  id="project" value="#{TemplateForm.assignedProjects}" layout="grid" columns="1"
+                                       converter="#{projectConverter}" required="#{not empty param['editForm:save']}"
+                                       styleClass="input #{isViewMode ? 'disabled' : ''}" disabled="#{isViewMode}">
                     <f:selectItems value="#{TemplateForm.projects}"
                                    var="project"
                                    itemLabel="#{project.title}"
@@ -44,6 +46,7 @@
             <div>
                 <p:outputLabel for="active" value="#{msgs.active}"/>
                 <p:selectBooleanCheckbox id="active" styleClass="switch input" value="#{TemplateForm.template.active}"
+                                         title="#{TemplateForm.template.active}"
                                          disabled="#{isViewMode}">
                     <p:ajax event="change" oncomplete="toggleSave()"/>
                 </p:selectBooleanCheckbox>
@@ -54,7 +57,8 @@
         <p:row>
             <div>
                 <p:outputLabel for="ruleset" value="#{msgs.ruleset}"/>
-                <p:selectOneMenu id="ruleset" value="#{TemplateForm.template.ruleset}" converter="#{rulesetConverter}"
+                <p:selectOneMenu id="ruleset" value="#{TemplateForm.template.ruleset}"
+                                 title="#{TemplateForm.template.ruleset}" converter="#{rulesetConverter}"
                                  required="#{not empty param['editForm:save']}" disabled="#{isViewMode}">
                     <f:selectItems value="#{TemplateForm.rulesets}"
                                    var="ruleset"
@@ -66,7 +70,8 @@
 
             <div>
                 <p:outputLabel for="docket" value="#{msgs.docket}"/>
-                <p:selectOneMenu id="docket" value="#{TemplateForm.template.docket}" converter="#{docketConverter}"
+                <p:selectOneMenu id="docket" value="#{TemplateForm.template.docket}"
+                                 title="#{TemplateForm.template.docket}" converter="#{docketConverter}"
                                  required="#{not empty param['editForm:save']}" disabled="#{isViewMode}">
                     <f:selectItems value="#{TemplateForm.dockets}"
                                    var="docket"
@@ -78,7 +83,8 @@
 
             <div>
                 <p:outputLabel for="workflow" value="#{msgs.workflow}"/>
-                <p:selectOneMenu id="workflow" value="#{TemplateForm.template.workflow}" disabled="#{isViewMode}"
+                <p:selectOneMenu id="workflow" value="#{TemplateForm.template.workflow}"
+                                 title="#{TemplateForm.template.workflow}" disabled="#{isViewMode}"
                                  converter="#{workflowConverter}"
                                  required="#{not empty param['editForm:save']}">
                     <f:selectItems value="#{TemplateForm.workflows}"


### PR DESCRIPTION
Fix styling of project list on template details page if page is in `viewMode`, e.g. input fields are disabled.

**_before:_**
<img width="1388" alt="Bildschirmfoto 2021-10-26 um 20 25 25" src="https://user-images.githubusercontent.com/19183925/138938823-d2fe33a2-5389-4839-b31b-38676de315f6.png">

**_after:_**
<img width="1390" alt="Bildschirmfoto 2021-10-26 um 20 23 06" src="https://user-images.githubusercontent.com/19183925/138938802-1e2c6d9e-0d54-4240-a9f4-4f1a61c0082f.png">


