### PR TITLE
skip related to speed up excel

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -137,7 +137,7 @@ public class SearchResultGeneration {
                     BoolQueryBuilder queryForFilter = getQueryForFilter(ObjectType.PROCESS);
                     queryForFilter.should(rangeQueryBuilder);
                     processDTOS = ServiceManager.getProcessService().findByQuery(queryForFilter,
-                        ServiceManager.getProcessService().sortByTitle(SortOrder.ASC), false);
+                        ServiceManager.getProcessService().sortByTitle(SortOrder.ASC), true);
                     queriedIds += elasticsearchLimit;
                     for (ProcessDTO processDTO : processDTOS) {
                         prepareRow(rowCounter, sheet, processDTO);


### PR DESCRIPTION
This is a hotfix for #4331 as changing the filterquery to database is not a trivial task. 
The hotfix is: When result count is larger then 10'000 (the given limit from elasticsearch) then no task status is shown in the excel because loading related items (tasks and there status) takes forever.