### PR TITLE
Document parameter UserForImageReading

### DIFF
--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -168,6 +168,12 @@ script_createDirMeta=/usr/local/kitodo/scripts/script_createDirMeta(.sh|.bat)
 # permissions for the user
 script_createSymLink=/usr/local/kitodo/scripts/script_createSymLink(.sh|.bat)
 
+# User name that is passed to the script for creating the symbolic link if the
+# workflow step only has the "Read images" permission. Defaults to: root. The
+# idea is: If the user is logged in with his username via Samba, and the media
+# files belong to root, he may view them, but not change or delete them.
+UserForImageReading=root
+
 # Script to remove the symbolic link from the user home directory
 script_deleteSymLink=/usr/local/kitodo/scripts/script_deleteSymLink(.sh|.bat)
 


### PR DESCRIPTION
Document parameter `UserForImageReading` ([File Management](/kitodo/kitodo-production/blob/master/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java#L497)).