### PR TITLE
Add filter to show current tasks of selected projects

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -918,6 +918,7 @@ showDataForProcess=Zeige Daten des Vorgangs
 showInSelectList=In Auswahlliste anzeigen
 showInactiveProjects=Deaktivierte Projekte zeigen
 showProjectProcesses=Vorg\u00E4nge dieses Projektes anzeigen
+showProjectTasks=Aktuelle Aufgaben dieses Projektes anzeigen
 signIn=Anmelden
 # shouldContentBeRemoved is used in onclick
 shouldContentBeRemoved=Soll der Inhalt wirklich gel\u00F6scht werden?

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -933,6 +933,7 @@ showDataForProcess=show process data
 showInSelectList=Show in selection list
 showInactiveProjects=show deactivated projects
 showProjectProcesses=Show processes of this project
+showProjectTasks=Show current tasks of this project
 signIn=Sign in
 # shouldContentBeRemoved is used in onclick
 shouldContentBeRemoved=Do you really want to delete the content?

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
@@ -50,6 +50,13 @@
                     <h:outputText><i class="fa fa-pencil-square-o fa-lg"/></h:outputText>
                 </h:link>
                 <h:link styleClass="action"
+                        rendered="#{SecurityAccessController.hasAuthorityToViewTaskList()}"
+                        outcome="tasks?tabIndex=0"
+                        title="#{msgs.showProjectTasks}">
+                    <f:param name="projecttitle" value="#{project.title}"/>
+                    <h:outputText><i class="fa fa-paperclip fa-lg"/></h:outputText>
+                </h:link>
+                <h:link styleClass="action"
                         rendered="#{SecurityAccessController.hasAuthorityToViewProcessList()}"
                         outcome="processes?tabIndex=0"
                         title="#{msgs.showProjectProcesses}">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -99,6 +99,14 @@
                 </h:link>
 
                 <h:link styleClass="action"
+                        rendered="#{SecurityAccessController.hasAuthorityToViewTaskList()}"
+                        outcome="tasks?tabIndex=0"
+                        title="#{msgs.showProjectTasks}">
+                    <f:param name="projecttitle" value="#{item.title}"/>
+                    <h:outputText><i class="fa fa-paperclip fa-lg"/></h:outputText>
+                </h:link>
+
+                <h:link styleClass="action"
                         rendered="#{SecurityAccessController.hasAuthorityToViewProcessList()}"
                         outcome="processes?tabIndex=0"
                         title="#{msgs.showProjectProcesses}">

--- a/Kitodo/src/main/webapp/pages/tasks.xhtml
+++ b/Kitodo/src/main/webapp/pages/tasks.xhtml
@@ -16,11 +16,15 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:f="http://xmlns.jcp.org/jsf/core"
-        xmlns:p="http://primefaces.org/ui">
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:o="http://omnifaces.org/ui">
     <f:metadata>
         <!--@elvariable id="keepPagination" type="java.lang.Boolean"-->
         <f:viewParam name="keepPagination"/>
         <f:viewAction action="#{CurrentTaskForm.resetPaginator(keepPagination)}"/>
+        <!--@elvariable id="projecttitle" type="java.lang.String"-->
+        <f:viewParam name="projecttitle"/>
+        <o:viewAction action="#{CurrentTaskForm.setFilter('project:' += projecttitle)}" if="#{not empty projecttitle}"/>
     </f:metadata>
 
     <ui:define name="contentHeader">


### PR DESCRIPTION
Adds another shortcut to the project desktop widget and project list page to show the task list filtered by a specific project (similar to #4647)
![Bildschirmfoto 2021-11-08 um 21 32 01](https://user-images.githubusercontent.com/19183925/140813787-9e2f73f7-4960-4deb-abea-052e8a27713e.png)


