### PR TITLE
Enable first step as automatic task

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -299,7 +299,7 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
         }
         try {
             createProcessHierarchy();
-            checkForAutomaticTask();
+            runAutomaticTasks();
             if (Objects.nonNull(PrimeFaces.current()) && Objects.nonNull(FacesContext.getCurrentInstance())) {
                 PrimeFaces.current().executeScript("PF('sticky-notifications').renderMessage({'summary':'"
                         + Helper.getTranslation("processSaving") + "','detail':'"
@@ -321,15 +321,13 @@ public class CreateProcessForm extends BaseForm implements RulesetSetupInterface
         return this.stayOnCurrentPage;
     }
 
-    private void checkForAutomaticTask() {
+    private void runAutomaticTasks() {
         Task currentTask = ServiceManager.getProcessService().getCurrentTask(getMainProcess());
-        if (Objects.nonNull(currentTask)) {
-            if (currentTask.isTypeAutomatic()) {
-                currentTask.setProcessingStatus(TaskStatus.INWORK);
-                currentTask.setProcessingBegin(new Date());
-                TaskScriptThread thread = new TaskScriptThread(currentTask);
-                TaskManager.addTask(thread);
-            }   
+        if (Objects.nonNull(currentTask) && currentTask.isTypeAutomatic()) {
+            currentTask.setProcessingStatus(TaskStatus.INWORK);
+            currentTask.setProcessingBegin(new Date());
+            TaskScriptThread thread = new TaskScriptThread(currentTask);
+            TaskManager.addTask(thread);       
         }
     }
     


### PR DESCRIPTION
Hello,
Right now it is not possible to define the first task in the workflow as an automatic task since the necessary checks seem only to be performed after another task is closed.

https://github.com/kitodo/kitodo-production/blob/51fbdd742fc272a8244964e8a8e4d06acb277bbd/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java#L439-L443

In order to enable an _automatic_ first task i added a check after the process is created and defined the necessary logic to start the automatic task. The solution works in my environment but please check if i am missing something.

Fixes https://github.com/kitodo/kitodo-production/issues/4276 and https://github.com/kitodo/kitodo-production/issues/3672