### PR TITLE
Update log4j2 to fix CVE-2021-44228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <poi.version>3.17</poi.version>
         <primefaces.version>7.0.2</primefaces.version>
         <saxon.version>9.9.1-5</saxon.version>
-        <log4j.version>2.13.2</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
         <junit.version>5.5.2</junit.version>
         <elasticsearch.version>7.10.2</elasticsearch.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>


### PR DESCRIPTION
More information about CVE-2021-44228:
- https://www.lunasec.io/docs/blog/log4j-zero-day/
- https://github.com/jas502n/Log4j2-CVE-2021-44228