### PR TITLE
Do not crash showing processes list if ruleset file not found

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -102,7 +102,6 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Property;
 import org.kitodo.data.database.beans.Role;
-import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.enums.CommentType;
@@ -2634,9 +2633,8 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         if (RULESET_CACHE_FOR_CREATE_FROM_CALENDAR.containsKey(rulesetId)) {
             functionalDivisions = RULESET_CACHE_FOR_CREATE_FROM_CALENDAR.get(rulesetId);
         } else {
-            Ruleset ruleset = ServiceManager.getRulesetService().getById(rulesetId);
-            functionalDivisions = ServiceManager.getRulesetService().openRuleset(ruleset)
-                    .getFunctionalDivisions(FunctionalDivision.CREATE_CHILDREN_WITH_CALENDAR);
+            functionalDivisions = ServiceManager.getRulesetService()
+                    .getFunctionalDivisions(rulesetId, FunctionalDivision.CREATE_CHILDREN_WITH_CALENDAR);
             RULESET_CACHE_FOR_CREATE_FROM_CALENDAR.put(rulesetId, functionalDivisions);
         }
         return functionalDivisions.contains(processDTO.getBaseType());
@@ -2660,9 +2658,8 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         if (RULESET_CACHE_FOR_CREATE_CHILD_FROM_PARENT.containsKey(rulesetId)) {
             functionalDivisions = RULESET_CACHE_FOR_CREATE_CHILD_FROM_PARENT.get(rulesetId);
         } else {
-            Ruleset ruleset = ServiceManager.getRulesetService().getById(rulesetId);
-            functionalDivisions = ServiceManager.getRulesetService().openRuleset(ruleset)
-                    .getFunctionalDivisions(FunctionalDivision.CREATE_CHILDREN_FROM_PARENT);
+            functionalDivisions = ServiceManager.getRulesetService()
+                    .getFunctionalDivisions(rulesetId, FunctionalDivision.CREATE_CHILDREN_FROM_PARENT);
             RULESET_CACHE_FOR_CREATE_CHILD_FROM_PARENT.put(rulesetId, functionalDivisions);
         }
         return functionalDivisions.contains(processDTO.getBaseType());


### PR DESCRIPTION
The UI crashes when listing all processes, but a ruleset file is missing. The exception is not informative:

![Screenshot](https://user-images.githubusercontent.com/3040657/146151212-46d79b50-e409-4cf7-807b-fbdbd0fc6066.png)

This will disable impossible buttons and instead, shows an error message.