### PR TITLE
Rename hasParent() to match EL property rules

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
@@ -32,7 +32,7 @@ public class ProcessDTO extends BaseTemplateDTO {
     private String processBaseUri;
     private String batchID;
     private Integer parentID;
-    private boolean hasChildren;
+    private boolean parenthood;
     private Integer sortHelperArticles;
     private Integer sortHelperDocstructs;
     private Integer sortHelperImages;
@@ -270,21 +270,23 @@ public class ProcessDTO extends BaseTemplateDTO {
     }
 
     /**
-     * Get hasChildren.
+     * Returns whether the process is a parent.
      *
-     * @return value of hasChildren
+     * @return whether the process is a parent
      */
-    public boolean hasChildren() {
-        return hasChildren;
+    public boolean isParenthood() {
+        return parenthood;
     }
 
     /**
-     * Set hasChildren.
+     * Set whether the process is a parent. A Parenthood exists when the process
+     * has children.
      *
-     * @param hasChildren as boolean
+     * @param parenthood
+     *            whether the process is a parent
      */
-    public void setHasChildren(boolean hasChildren) {
-        this.hasChildren = hasChildren;
+    public void setParenthood(boolean parenthood) {
+        this.parenthood = parenthood;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -869,7 +869,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             processDTO.setSortHelperImages(ProcessTypeField.SORT_HELPER_IMAGES.getIntValue(jsonObject));
             processDTO.setSortHelperMetadata(ProcessTypeField.SORT_HELPER_METADATA.getIntValue(jsonObject));
             processDTO.setProcessBaseUri(ProcessTypeField.PROCESS_BASE_URI.getStringValue(jsonObject));
-            processDTO.setHasChildren(ProcessTypeField.HAS_CHILDREN.getBooleanValue(jsonObject));
+            processDTO.setParenthood(ProcessTypeField.HAS_CHILDREN.getBooleanValue(jsonObject));
             processDTO.setParentID(ProcessTypeField.PARENT_ID.getIntValue(jsonObject));
             processDTO.setBaseType(ProcessTypeField.BASE_TYPE.getStringValue(jsonObject));
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
@@ -87,12 +87,12 @@
                     <h:outputText><i class="fa fa-file-code-o"/></h:outputText>
                 </p:commandLink>
                 <h:panelGroup styleClass="action"
-                              title="#{process.hasChildren() ? msgs.processNotDeletableWithChildren : msgs.delete}">
+                              title="#{process.parenthood ? msgs.processNotDeletableWithChildren : msgs.delete}">
                     <p:commandLink id="deleteProcess"
                                    action="#{DesktopForm.deleteProcess(process.id)}"
-                                   title="#{ process.hasChildren() ? msgs.processNotDeletableWithChildren : msgs.delete}"
+                                   title="#{ process.parenthood ? msgs.processNotDeletableWithChildren : msgs.delete}"
                                    rendered="#{SecurityAccessController.hasAuthorityToDeleteProcess()}"
-                                   disabled="#{process.hasChildren()}"
+                                   disabled="#{process.parenthood}"
                                    update="processTable">
                         <h:outputText><i class="fa fa-trash-o"/></h:outputText>
                         <p:confirm header="#{msgs.confirmDelete}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processActionsColumn.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processActionsColumn.xhtml
@@ -134,12 +134,12 @@
                 <h:outputText><i class="fa fa-file-archive-o fa-lg"/></h:outputText>
             </h:commandLink>
             <h:panelGroup styleClass="action"
-                          title="#{process.hasChildren() ? msgs.processNotDeletableWithChildren : msgs.delete}">
+                          title="#{process.parenthood ? msgs.processNotDeletableWithChildren : msgs.delete}">
                 <p:commandLink id="deleteProcess"
                                action="#{ProcessListView.delete(process)}"
                                title="#{msgs.delete}"
                                rendered="#{SecurityAccessController.hasAuthorityToDeleteProcess()}"
-                               disabled="#{process.hasChildren()}"
+                               disabled="#{process.parenthood}"
                                update="@form">
                     <h:outputText><i class="fa fa-trash-o"/></h:outputText>
                     <p:confirm header="#{msgs.confirmDelete}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -46,10 +46,10 @@
             <p:column styleClass="checkboxListColumn" selectionMode="multiple" resizable="false"/>
 
             <p:column styleClass="hierarchy-info">
-                <p:rowToggler rendered="#{process.getParentID() ne 0 or process.hasChildren() or ProcessForm.getCurrentTasksForUser(process).size() gt 0}"/>
-                <h:outputText rendered="#{process.getParentID() ne 0 and not process.hasChildren()}"><i class="fa fa-long-arrow-left" title="#{msgs.hierarchicalParents}"/></h:outputText>
-                <h:outputText rendered="#{process.getParentID() eq 0 and process.hasChildren()}"><i class="fa fa-long-arrow-right" title="#{msgs.hierarchicalChildren}"/></h:outputText>
-                <h:outputText rendered="#{process.getParentID() ne 0 and process.hasChildren()}"><i class="fa fa-exchange fa-rotate-90" title="#{msgs.hierarchicalBoth}"/></h:outputText>
+                <p:rowToggler rendered="#{process.getParentID() ne 0 or process.parenthood or ProcessForm.getCurrentTasksForUser(process).size() gt 0}"/>
+                <h:outputText rendered="#{process.getParentID() ne 0 and not process.parenthood}"><i class="fa fa-long-arrow-left" title="#{msgs.hierarchicalParents}"/></h:outputText>
+                <h:outputText rendered="#{process.getParentID() eq 0 and process.parenthood}"><i class="fa fa-long-arrow-right" title="#{msgs.hierarchicalChildren}"/></h:outputText>
+                <h:outputText rendered="#{process.getParentID() ne 0 and process.parenthood}"><i class="fa fa-exchange fa-rotate-90" title="#{msgs.hierarchicalBoth}"/></h:outputText>
             </p:column>
             <p:column id="idColumn"
                       width="50"
@@ -176,11 +176,11 @@
                                      columnClasses="label, value">
                             <h:outputText value="#{msgs.hierarchicalChildren}:"/>
                             <h:panelGroup>
-                                <h:outputText value="#{ProcessForm.getNumberOfChildProcesses(process.getId())} " rendered="#{process.hasChildren()}"/>
+                                <h:outputText value="#{ProcessForm.getNumberOfChildProcesses(process.getId())} " rendered="#{process.parenthood}"/>
                                 <p:commandLink value="#{msgs.show}"
                                                action="#{ProcessForm.changeFilter('parentprocessid:'.concat(process.getId()))}"
-                                               rendered="#{process.hasChildren()}"/>
-                                <h:outputText value=" #{msgs.none}" rendered="#{not process.hasChildren()}"/>
+                                               rendered="#{process.parenthood}"/>
+                                <h:outputText value=" #{msgs.none}" rendered="#{not process.parenthood}"/>
                             </h:panelGroup>
                         </p:panelGrid>
                     </p:panelGrid>

--- a/Kitodo/src/main/webapp/pages/searchResult.xhtml
+++ b/Kitodo/src/main/webapp/pages/searchResult.xhtml
@@ -51,10 +51,10 @@
                                   resizable="false"/>
 
                         <p:column styleClass="hierarchy-info">
-                            <p:rowToggler rendered="#{process.getParentID() ne 0 or process.hasChildren()}"/>
-                            <h:outputText rendered="#{process.getParentID() ne 0 and not process.hasChildren()}"><i class="fa fa-long-arrow-left" title="#{msgs.hierarchicalParents}"/></h:outputText>
-                            <h:outputText rendered="#{process.getParentID() eq 0 and process.hasChildren()}"><i class="fa fa-long-arrow-right" title="#{msgs.hierarchicalChildren}"/></h:outputText>
-                            <h:outputText rendered="#{process.getParentID() ne 0 and process.hasChildren()}"><i class="fa fa-exchange fa-rotate-90" title="#{msgs.hierarchicalBoth}"/></h:outputText>
+                            <p:rowToggler rendered="#{process.getParentID() ne 0 or process.parenthood}"/>
+                            <h:outputText rendered="#{process.getParentID() ne 0 and not process.parenthood}"><i class="fa fa-long-arrow-left" title="#{msgs.hierarchicalParents}"/></h:outputText>
+                            <h:outputText rendered="#{process.getParentID() eq 0 and process.parenthood}"><i class="fa fa-long-arrow-right" title="#{msgs.hierarchicalChildren}"/></h:outputText>
+                            <h:outputText rendered="#{process.getParentID() ne 0 and process.parenthood}"><i class="fa fa-exchange fa-rotate-90" title="#{msgs.hierarchicalBoth}"/></h:outputText>
                         </p:column>
 
                         <p:column id="idColumn"
@@ -140,12 +140,12 @@
                                         <h:outputText value="#{msgs.hierarchicalChildren}:"/>
                                         <h:panelGroup>
                                             <h:outputText value="#{ProcessForm.getNumberOfChildProcesses(process.getId())} "
-                                                          rendered="#{process.hasChildren()}"/>
+                                                          rendered="#{process.parenthood}"/>
                                             <p:commandLink value="#{msgs.show}"
                                                            action="#{ProcessForm.changeFilter('parentprocessid:'.concat(process.getId()))}"
-                                                           rendered="#{process.hasChildren()}"/>
+                                                           rendered="#{process.parenthood}"/>
                                             <h:outputText value=" #{msgs.none}"
-                                                          rendered="#{not process.hasChildren()}"/>
+                                                          rendered="#{not process.parenthood}"/>
                                         </h:panelGroup>
                                     </p:panelGrid>
                                 </p:panelGrid>


### PR DESCRIPTION
Access to object properties in JSP should be done via El expressions for properties, and that defines that an _is_ property is to be used for `boolean`, not a _has_ property. With the renaming, that will be clarified.