### PR TITLE
Update log4j2 to close CVE-2021-45105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <poi.version>3.17</poi.version>
         <primefaces.version>7.0.2</primefaces.version>
         <saxon.version>9.9.1-5</saxon.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <junit.version>5.5.2</junit.version>
         <elasticsearch.version>7.10.2</elasticsearch.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>


### PR DESCRIPTION
See: 
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
* https://logging.apache.org/log4j/2.x/security.html