### PR TITLE
Show id and title of linked processes in metadata editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -147,7 +147,7 @@ public class StructurePanel implements Serializable {
     }
 
     void deleteSelectedStructure() {
-        if (!getSelectedStructure().isPresent()) {
+        if (getSelectedStructure().isEmpty()) {
             /*
              * No element is selected or the selected element is not a structure
              * but, for example, a physical division.
@@ -612,24 +612,20 @@ public class StructurePanel implements Serializable {
      * Adds a tree node to the given parent node. The tree node is set to
      * ‘expanded’.
      *
+     * @param parentProcess
+     *            parent process of current process
      * @param type
      *            the internal name of the type of node, to be resolved through
      *            the rule set
-     * @param linked
-     *            whether the node is a link. If so, it will be marked with a
-     *            link symbol.
-     * @param dataObject
-     *            the internal object represented by the node
      * @param parent
      *            parent node to which the new node is to be added
      * @return the generated node so that you can add children to it
      */
-    private DefaultTreeNode addTreeNode(Process parentProcess, String type, boolean linked, Object dataObject,
-                                        DefaultTreeNode parent) {
+    private DefaultTreeNode addTreeNode(Process parentProcess, String type, DefaultTreeNode parent) {
         StructuralElementViewInterface structuralElementView = dataEditor.getRulesetManagement().getStructuralElementView(type,
             dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
         return addTreeNode("[" + parentProcess.getId() + "] " + structuralElementView.getLabel() + " - "
-                        + parentProcess.getTitle(), structuralElementView.isUndefined(), linked, dataObject, parent);
+                        + parentProcess.getTitle(), structuralElementView.isUndefined(), true, null, parent);
     }
 
     /**
@@ -706,7 +702,7 @@ public class StructurePanel implements Serializable {
                     if (Objects.isNull(logicalDivision.getType())) {
                         break;
                     } else {
-                        parentNode = addTreeNode(parent, logicalDivision.getType(), true, null, parentNode);
+                        parentNode = addTreeNode(parent, logicalDivision.getType(), parentNode);
                         parentNode.setExpanded(true);
                     }
                 }
@@ -1256,7 +1252,7 @@ public class StructurePanel implements Serializable {
         }
     }
 
-    private void checkLogicalDragDrop(StructureTreeNode dragNode, StructureTreeNode dropNode) throws Exception {
+    private void checkLogicalDragDrop(StructureTreeNode dragNode, StructureTreeNode dropNode) {
 
         LogicalDivision dragStructure = (LogicalDivision) dragNode.getDataObject();
         LogicalDivision dropStructure = (LogicalDivision) dropNode.getDataObject();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -508,7 +508,8 @@ public class StructurePanel implements Serializable {
                             .processIdFromUri(structure.getLink().getUri())) {
                         StructuralElementViewInterface view = dataEditor.getRulesetManagement().getStructuralElementView(
                             type, dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
-                        node = new StructureTreeNode(view.getLabel(), view.isUndefined(), true, structure);
+                        node = new StructureTreeNode("[" + child.getId() + "] " + view.getLabel() + " - "
+                                + child.getTitle(), view.isUndefined(), true, structure);
                     }
                 } catch (DataException e) {
                     Helper.setErrorMessage("metadataReadError", e.getMessage(), logger, e);
@@ -623,11 +624,12 @@ public class StructurePanel implements Serializable {
      *            parent node to which the new node is to be added
      * @return the generated node so that you can add children to it
      */
-    private DefaultTreeNode addTreeNode(String type, boolean linked, Object dataObject, DefaultTreeNode parent) {
+    private DefaultTreeNode addTreeNode(Process parentProcess, String type, boolean linked, Object dataObject,
+                                        DefaultTreeNode parent) {
         StructuralElementViewInterface structuralElementView = dataEditor.getRulesetManagement().getStructuralElementView(type,
             dataEditor.getAcquisitionStage(), dataEditor.getPriorityList());
-        return addTreeNode(structuralElementView.getLabel(), structuralElementView.isUndefined(), linked, dataObject,
-            parent);
+        return addTreeNode("[" + parentProcess.getId() + "] " + structuralElementView.getLabel() + " - "
+                        + parentProcess.getTitle(), structuralElementView.isUndefined(), linked, dataObject, parent);
     }
 
     /**
@@ -704,7 +706,7 @@ public class StructurePanel implements Serializable {
                     if (Objects.isNull(logicalDivision.getType())) {
                         break;
                     } else {
-                        parentNode = addTreeNode(logicalDivision.getType(), true, null, parentNode);
+                        parentNode = addTreeNode(parent, logicalDivision.getType(), true, null, parentNode);
                         parentNode.setExpanded(true);
                     }
                 }


### PR DESCRIPTION
Currently only the document type of linked processes is displayed in the metadata editor. That can become quite confusing and does not help a lot when multiple child processes of the same type are linked to one parent process, because it is not obvious which child node in the structure tree represents which child process, and thus, the order of those child processes (and potential pages in the parent process) cannot be validated/checked:

<img width="534" alt="Bildschirmfoto 2022-01-18 um 13 12 21" src="https://user-images.githubusercontent.com/19183925/149937397-56f28991-8f2b-472e-a544-74ab88637b85.png">

The change in this pull request displays additional information about the linked processes, namely it's ID and process title, similar to what is displayed in when linking title records during metadata import. 
This helps identifying specific child processes and structuring linked processes and pages within a parent process:

<img width="569" alt="Bildschirmfoto 2022-01-18 um 13 06 53" src="https://user-images.githubusercontent.com/19183925/149937854-7b00e6c8-2128-4b9c-b9d5-01099e9dd80e.png">


