### PR TITLE
Use typed converter classes

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/converter/AuthorityConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/AuthorityConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Authority;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class AuthorityConverter extends BeanConverter implements Converter {
+public class AuthorityConverter extends BeanConverter implements Converter<Authority> {
 
     @Override
-    public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
-        return getAsObject(ServiceManager.getAuthorityService(), value);
+    public Authority getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
+        return (Authority) getAsObject(ServiceManager.getAuthorityService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
+    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Authority value) {
         return getAsString(value, "authority");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/BatchConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/BatchConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Batch;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class BatchConverter extends BeanConverter implements Converter {
+public class BatchConverter extends BeanConverter implements Converter<Batch> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getBatchService(), value);
+    public Batch getAsObject(FacesContext context, UIComponent component, String value) {
+        return (Batch) getAsObject(ServiceManager.getBatchService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, Batch value) {
         return getAsString(value, "batch");
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ClientConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ClientConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Client;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ClientConverter extends BeanConverter implements Converter {
+public class ClientConverter extends BeanConverter implements Converter<Client> {
 
     @Override
-    public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
-        return getAsObject(ServiceManager.getClientService(), value);
+    public Client getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
+        return (Client) getAsObject(ServiceManager.getClientService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
+    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Client value) {
         return getAsString(value, "client");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/DocketConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/DocketConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Docket;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class DocketConverter extends BeanConverter implements Converter {
+public class DocketConverter extends BeanConverter implements Converter<Docket> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getDocketService(), value);
+    public Docket getAsObject(FacesContext context, UIComponent component, String value) {
+        return (Docket) getAsObject(ServiceManager.getDocketService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, Docket value) {
         return getAsString(value, "docket");
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
@@ -26,10 +26,10 @@ import org.kitodo.production.helper.Helper;
 
 
 @Named("IllustratedSelectItemConverter")
-public class IllustratedSelectItemConverter implements Converter, Serializable {
+public class IllustratedSelectItemConverter implements Converter<IllustratedSelectItem>, Serializable {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
+    public IllustratedSelectItem getAsObject(FacesContext context, UIComponent component, String value) {
         if (StringUtils.isNotEmpty(value)) {
             List<IllustratedSelectItem> illustratedSelectItems = (List<IllustratedSelectItem>) component.getAttributes()
                     .get("illustratedSelectItems");
@@ -43,10 +43,9 @@ public class IllustratedSelectItemConverter implements Converter, Serializable {
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object object) {
+    public String getAsString(FacesContext context, UIComponent component, IllustratedSelectItem object) {
         if (Objects.nonNull(object)) {
-            IllustratedSelectItem selectItem = (IllustratedSelectItem) object;
-            return selectItem.getLabel();
+            return object.getLabel();
         }
         return null;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/LdapGroupConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/LdapGroupConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.LdapGroup;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class LdapGroupConverter extends BeanConverter implements Converter {
+public class LdapGroupConverter extends BeanConverter implements Converter<LdapGroup> {
 
     @Override
-    public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
-        return getAsObject(ServiceManager.getLdapGroupService(), value);
+    public LdapGroup getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
+        return (LdapGroup) getAsObject(ServiceManager.getLdapGroupService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
+    public String getAsString(FacesContext facesContext, UIComponent uiComponent, LdapGroup value) {
         return getAsString(value, "ldapGroup");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/LdapServerConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/LdapServerConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.LdapServer;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class LdapServerConverter extends BeanConverter implements Converter {
+public class LdapServerConverter extends BeanConverter implements Converter<LdapServer> {
 
     @Override
-    public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
-        return getAsObject(ServiceManager.getLdapServerService(), value);
+    public LdapServer getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
+        return (LdapServer) getAsObject(ServiceManager.getLdapServerService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
+    public String getAsString(FacesContext facesContext, UIComponent uiComponent, LdapServer value) {
         return getAsString(value, "ldapServer");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ListColumnConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ListColumnConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.ListColumn;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ListColumnConverter extends BeanConverter implements Converter {
+public class ListColumnConverter extends BeanConverter implements Converter<ListColumn> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getListColumnService(), value);
+    public ListColumn getAsObject(FacesContext context, UIComponent component, String value) {
+        return (ListColumn) getAsObject(ServiceManager.getListColumnService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, ListColumn value) {
         return getAsString(value, "listColumn");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ProcessConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ProcessConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Process;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ProcessConverter extends BeanConverter implements Converter {
+public class ProcessConverter extends BeanConverter implements Converter<Process> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getProcessService(), value);
+    public Process getAsObject(FacesContext context, UIComponent component, String value) {
+        return (Process) getAsObject(ServiceManager.getProcessService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, Process value) {
         return getAsString(value, "process");
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/converter/ProjectConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/ProjectConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Project;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class ProjectConverter extends BeanConverter implements Converter {
+public class ProjectConverter extends BeanConverter implements Converter<Project> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getProjectService(), value);
+    public Project getAsObject(FacesContext context, UIComponent component, String value) {
+        return (Project) getAsObject(ServiceManager.getProjectService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, Project value) {
         return getAsString(value, "project");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/RulesetConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/RulesetConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class RulesetConverter extends BeanConverter implements Converter {
+public class RulesetConverter extends BeanConverter implements Converter<Ruleset> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getRulesetService(), value);
+    public Ruleset getAsObject(FacesContext context, UIComponent component, String value) {
+        return (Ruleset) getAsObject(ServiceManager.getRulesetService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, Ruleset value) {
         return getAsString(value, "ruleset");
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/TaskConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/TaskConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Task;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class TaskConverter extends BeanConverter implements Converter {
+public class TaskConverter extends BeanConverter implements Converter<Task> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getTaskService(), value);
+    public Task getAsObject(FacesContext context, UIComponent component, String value) {
+        return (Task) getAsObject(ServiceManager.getTaskService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, Task value) {
         return getAsString(value, "task");
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/converter/URIConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/URIConverter.java
@@ -24,11 +24,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 @Named("URIConverter")
-public class URIConverter implements Converter {
+public class URIConverter implements Converter<URI> {
     private static final Logger logger = LogManager.getLogger(URIConverter.class);
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
+    public URI getAsObject(FacesContext context, UIComponent component, String value) {
         if (Objects.isNull(value) || value.isEmpty()) {
             return null;
         } else {
@@ -42,9 +42,9 @@ public class URIConverter implements Converter {
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object object) {
+    public String getAsString(FacesContext context, UIComponent component, URI object) {
         if (Objects.nonNull(object)) {
-            return String.valueOf(((URI) object).getPath());
+            return String.valueOf(object.getPath());
         } else {
             return null;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/converter/WorkflowConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/WorkflowConverter.java
@@ -16,18 +16,19 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
+import org.kitodo.data.database.beans.Workflow;
 import org.kitodo.production.services.ServiceManager;
 
 @Named
-public class WorkflowConverter extends BeanConverter implements Converter {
+public class WorkflowConverter extends BeanConverter implements Converter<Workflow> {
 
     @Override
-    public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        return getAsObject(ServiceManager.getWorkflowService(), value);
+    public Workflow getAsObject(FacesContext context, UIComponent component, String value) {
+        return (Workflow) getAsObject(ServiceManager.getWorkflowService(), value);
     }
 
     @Override
-    public String getAsString(FacesContext context, UIComponent component, Object value) {
+    public String getAsString(FacesContext context, UIComponent component, Workflow value) {
         return getAsString(value, "workflow");
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/converter/AuthorityConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/AuthorityConverterIT.java
@@ -19,6 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.Authority;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.services.ServiceManager;
 
 public class AuthorityConverterIT {
 
@@ -39,22 +41,22 @@ public class AuthorityConverterIT {
     @Test
     public void shouldGetAsObject() {
         AuthorityConverter authorityConverter = new AuthorityConverter();
-        Authority authority = (Authority) authorityConverter.getAsObject(null, null, "20");
+        Authority authority = authorityConverter.getAsObject(null, null, "20");
         assertEquals(MESSAGE, 20, authority.getId().intValue());
     }
 
     @Test
     public void shouldGetAsObjectIncorrectString() {
         AuthorityConverter authorityConverter = new AuthorityConverter();
-        String authority = (String) authorityConverter.getAsObject(null, null, "in");
-        assertEquals(MESSAGE, "0", authority);
+        Authority authority = authorityConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", String.valueOf(authority.getId()));
     }
 
     @Test
     public void shouldGetAsObjectIncorrectId() {
         AuthorityConverter authorityConverter = new AuthorityConverter();
-        String authority = (String) authorityConverter.getAsObject(null, null, "1000");
-        assertEquals(MESSAGE, "0", authority);
+        Authority authority = authorityConverter.getAsObject(null, null, "1000");
+        assertEquals(MESSAGE, "0", String.valueOf(authority.getId()));
     }
 
     @Test
@@ -82,10 +84,11 @@ public class AuthorityConverterIT {
     }
 
     @Test
-    public void shouldGetAsStringWithString() {
+    public void shouldGetAsStringWithAuthority() throws DAOException {
         AuthorityConverter authorityConverter = new AuthorityConverter();
-        String authority = authorityConverter.getAsString(null, null, "20");
-        assertEquals(MESSAGE, "20", authority);
+        Authority authority = ServiceManager.getAuthorityService().getById(20);
+        String authorityId = authorityConverter.getAsString(null, null, authority);
+        assertEquals(MESSAGE, "20", authorityId);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/converter/ClientConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/ClientConverterIT.java
@@ -19,6 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.Client;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.services.ServiceManager;
 
 public class ClientConverterIT {
 
@@ -39,21 +41,21 @@ public class ClientConverterIT {
     @Test
     public void shouldGetAsObject() {
         ClientConverter clientConverter = new ClientConverter();
-        Client client = (Client) clientConverter.getAsObject(null, null, "2");
+        Client client = clientConverter.getAsObject(null, null, "2");
         assertEquals(MESSAGE, 2, client.getId().intValue());
     }
 
     @Test
     public void shouldGetAsObjectIncorrectString() {
         ClientConverter clientConverter = new ClientConverter();
-        String client = (String) clientConverter.getAsObject(null, null, "in");
-        assertEquals(MESSAGE, "0", client);
+        Client client = clientConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", String.valueOf(client.getId()));
     }
 
     @Test
     public void shouldGetAsObjectIncorrectId() {
         ClientConverter clientConverter = new ClientConverter();
-        String client = (String) clientConverter.getAsObject(null, null, "10");
+        String client = String.valueOf(clientConverter.getAsObject(null, null, "10"));
         assertEquals(MESSAGE, "0", client);
     }
 
@@ -82,10 +84,11 @@ public class ClientConverterIT {
     }
 
     @Test
-    public void shouldGetAsStringWithString() {
+    public void shouldGetByIdAsString() throws DAOException {
         ClientConverter clientConverter = new ClientConverter();
-        String client = clientConverter.getAsString(null, null, "20");
-        assertEquals(MESSAGE, "20", client);
+        Client client = ServiceManager.getClientService().getById(20);
+        String clientId = clientConverter.getAsString(null, null, client);
+        assertEquals(MESSAGE, "20", clientId);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/converter/DocketConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/DocketConverterIT.java
@@ -19,6 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.Docket;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.services.ServiceManager;
 
 public class DocketConverterIT {
 
@@ -40,22 +42,22 @@ public class DocketConverterIT {
     @Test
     public void shouldGetAsObject() {
         DocketConverter docketConverter = new DocketConverter();
-        Docket docket = (Docket) docketConverter.getAsObject(null, null, "2");
+        Docket docket = docketConverter.getAsObject(null, null, "2");
         assertEquals(MESSAGE, 2, docket.getId().intValue());
     }
 
     @Test
     public void shouldGetAsObjectIncorrectString() {
         DocketConverter docketConverter = new DocketConverter();
-        String docket = (String) docketConverter.getAsObject(null, null, "in");
-        assertEquals(MESSAGE, "0", docket);
+        Docket docket = docketConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", String.valueOf(docket.getId()));
     }
 
     @Test
     public void shouldGetAsObjectIncorrectId() {
         DocketConverter docketConverter = new DocketConverter();
-        String docket = (String) docketConverter.getAsObject(null, null, "10");
-        assertEquals(MESSAGE, "0", docket);
+        Docket docket = docketConverter.getAsObject(null, null, "10");
+        assertEquals(MESSAGE, "0", String.valueOf(docket.getId()));
     }
 
     @Test
@@ -83,10 +85,11 @@ public class DocketConverterIT {
     }
 
     @Test
-    public void shouldGetAsStringWithString() {
+    public void shouldGetAsStringWithDocket() throws DAOException {
         DocketConverter docketConverter = new DocketConverter();
-        String docket = docketConverter.getAsString(null, null, "20");
-        assertEquals(MESSAGE, "20", docket);
+        Docket docket = ServiceManager.getDocketService().getById(20);
+        String docketId = docketConverter.getAsString(null, null, docket);
+        assertEquals(MESSAGE, "20", docketId);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/converter/RulesetConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/RulesetConverterIT.java
@@ -19,6 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.Ruleset;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.services.ServiceManager;
 
 public class RulesetConverterIT {
 
@@ -40,22 +42,22 @@ public class RulesetConverterIT {
     @Test
     public void shouldGetAsObject() {
         RulesetConverter rulesetConverter = new RulesetConverter();
-        Ruleset ruleset = (Ruleset) rulesetConverter.getAsObject(null, null, "2");
+        Ruleset ruleset = rulesetConverter.getAsObject(null, null, "2");
         assertEquals(MESSAGE, 2, ruleset.getId().intValue());
     }
 
     @Test
     public void shouldGetAsObjectIncorrectString() {
         RulesetConverter rulesetConverter = new RulesetConverter();
-        String ruleset = (String) rulesetConverter.getAsObject(null, null, "in");
-        assertEquals(MESSAGE, "0", ruleset);
+        Ruleset ruleset = rulesetConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", String.valueOf(ruleset.getId()));
     }
 
     @Test
     public void shouldGetAsObjectIncorrectId() {
         RulesetConverter rulesetConverter = new RulesetConverter();
-        String ruleset = (String) rulesetConverter.getAsObject(null, null, "10");
-        assertEquals(MESSAGE, "0", ruleset);
+        Ruleset ruleset = rulesetConverter.getAsObject(null, null, "10");
+        assertEquals(MESSAGE, "0", String.valueOf(ruleset.getId()));
     }
 
     @Test
@@ -83,10 +85,11 @@ public class RulesetConverterIT {
     }
 
     @Test
-    public void shouldGetAsStringWithString() {
+    public void shouldGetAsStringWithRuleset() throws DAOException {
         RulesetConverter rulesetConverter = new RulesetConverter();
-        String ruleset = rulesetConverter.getAsString(null, null, "20");
-        assertEquals(MESSAGE, "20", ruleset);
+        Ruleset ruleset = ServiceManager.getRulesetService().getById(20);
+        String rulesetId = rulesetConverter.getAsString(null, null, ruleset);
+        assertEquals(MESSAGE, "20", rulesetId);
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/converter/WorkflowConverterIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/converter/WorkflowConverterIT.java
@@ -19,6 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.Workflow;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.services.ServiceManager;
 
 public class WorkflowConverterIT {
 
@@ -39,22 +41,22 @@ public class WorkflowConverterIT {
     @Test
     public void shouldGetAsObject() {
         WorkflowConverter workflowConverter = new WorkflowConverter();
-        Workflow workflow = (Workflow) workflowConverter.getAsObject(null, null, "2");
+        Workflow workflow = workflowConverter.getAsObject(null, null, "2");
         assertEquals(MESSAGE, 2, workflow.getId().intValue());
     }
 
     @Test
     public void shouldGetAsObjectIncorrectString() {
         WorkflowConverter workflowConverter = new WorkflowConverter();
-        String workflow = (String) workflowConverter.getAsObject(null, null, "in");
-        assertEquals(MESSAGE, "0", workflow);
+        Workflow workflow = workflowConverter.getAsObject(null, null, "in");
+        assertEquals(MESSAGE, "0", String.valueOf(workflow));
     }
 
     @Test
     public void shouldGetAsObjectIncorrectId() {
         WorkflowConverter workflowConverter = new WorkflowConverter();
-        String workflow = (String) workflowConverter.getAsObject(null, null, "10");
-        assertEquals(MESSAGE, "0", workflow);
+        Workflow workflow = workflowConverter.getAsObject(null, null, "10");
+        assertEquals(MESSAGE, "0", String.valueOf(workflow.getId()));
     }
 
     @Test
@@ -82,10 +84,11 @@ public class WorkflowConverterIT {
     }
 
     @Test
-    public void shouldGetAsStringWithString() {
+    public void shouldGetAsStringWithWorkflow() throws DAOException {
         WorkflowConverter workflowConverter = new WorkflowConverter();
-        String workflow = workflowConverter.getAsString(null, null, "20");
-        assertEquals(MESSAGE, "20", workflow);
+        Workflow workflow = ServiceManager.getWorkflowService().getById(20);
+        String workflowId = workflowConverter.getAsString(null, null, workflow);
+        assertEquals(MESSAGE, "20", workflowId);
     }
 
     @Test


### PR DESCRIPTION
Prevent untyped converter classes to improve type safety.

"Raw types bypass generic type checks, deferring the catch of unsafe code to runtime. Therefore, you should avoid using raw types."
(https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html)