### PR TITLE
mark the index status of base beans within a transaction as done with…

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
@@ -26,6 +26,8 @@ import org.hibernate.Transaction;
 import org.hibernate.exception.SQLGrammarException;
 import org.hibernate.query.Query;
 import org.kitodo.data.database.beans.BaseBean;
+import org.kitodo.data.database.beans.BaseIndexedBean;
+import org.kitodo.data.database.enums.IndexAction;
 import org.kitodo.data.database.exceptions.DAOException;
 
 /**
@@ -86,6 +88,19 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
      */
     public void save(T baseBean) throws DAOException {
         storeObject(baseBean);
+    }
+
+    /**
+     * Saves base bean objects as indexed.
+     *
+     * @param baseBeans
+     *            list of base beans
+     * @throws DAOException
+     *             if the current session can't be retrieved or an exception is
+     *             thrown while performing the rollback
+     */
+    public void saveAsIndexed(List<T> baseBeans) throws DAOException {
+        storeAsIndexed(baseBeans);
     }
 
     /**
@@ -351,6 +366,22 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
             session.flush();
             transaction.commit();
         } catch (PersistenceException e) {
+            throw new DAOException(e);
+        }
+    }
+
+    void storeAsIndexed(List<T> baseBeans) throws DAOException {
+        try (Session session = HibernateUtil.getSession()) {
+            Transaction transaction = session.beginTransaction();
+            for (BaseBean baseBean : baseBeans) {
+                BaseIndexedBean entity = (BaseIndexedBean) getById(baseBean.getId());
+                entity.setIndexAction(IndexAction.DONE);
+                session.saveOrUpdate(entity);
+                session.flush();
+            }
+            transaction.commit();
+            session.close();
+        } catch (RuntimeException e) {
             throw new DAOException(e);
         }
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
@@ -371,18 +371,10 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
     }
 
     void storeAsIndexed(List<T> baseBeans) throws DAOException {
-        try (Session session = HibernateUtil.getSession()) {
-            Transaction transaction = session.beginTransaction();
-            for (BaseBean baseBean : baseBeans) {
-                BaseIndexedBean entity = (BaseIndexedBean) getById(baseBean.getId());
-                entity.setIndexAction(IndexAction.DONE);
-                session.saveOrUpdate(entity);
-                session.flush();
-            }
-            transaction.commit();
-            session.close();
-        } catch (RuntimeException e) {
-            throw new DAOException(e);
+        for (BaseBean baseBean : baseBeans) {
+            BaseIndexedBean entity = (BaseIndexedBean) getById(baseBean.getId());
+            entity.setIndexAction(IndexAction.DONE);
+            storeObject((T) entity);
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchDatabaseService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchDatabaseService.java
@@ -65,6 +65,16 @@ public abstract class SearchDatabaseService<T extends BaseBean, S extends BaseDA
     }
 
     /**
+     * Method saves objects to database.
+     *
+     * @param baseIndexedBeans
+     *            beans object to store as indexed
+     */
+    public void saveAsIndexed(List<T> baseIndexedBeans) throws DAOException {
+        dao.saveAsIndexed(baseIndexedBeans);
+    }
+
+    /**
      * Method removes object from database.
      *
      * @param baseIndexedBean

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -208,8 +208,8 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
         indexer.setMethod(HttpMethod.PUT);
         if (!baseIndexedBeans.isEmpty()) {
             indexer.performMultipleRequests(baseIndexedBeans, type, true);
+            saveAsIndexed(baseIndexedBeans);
         }
-        saveAsIndexed(baseIndexedBeans);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -209,14 +209,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
         if (!baseIndexedBeans.isEmpty()) {
             indexer.performMultipleRequests(baseIndexedBeans, type, true);
         }
-        setIndexColumToIndexed(baseIndexedBeans);
-    }
-
-    private void setIndexColumToIndexed(List<T> baseIndexedBeans) throws DAOException {
-        for (T baseIndexedBean : baseIndexedBeans) {
-            baseIndexedBean.setIndexAction(IndexAction.DONE);
-            saveToDatabase(baseIndexedBean);
-        }
+        saveAsIndexed(baseIndexedBeans);
     }
 
     /**


### PR DESCRIPTION
…out using the base type derivation

Fixes that the indexing hangs when the entity is marked as indexed.