### PR TITLE
Update ubuntu base

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
       - name: start mysql
         run:
             sudo service mysql start
+      - name: check MySQL version
+        run:
+            mysql --version
       - name: create database
         run:
             mysql -u root -proot -e 'CREATE DATABASE kitodo;'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
-    services:
-      mysql:
-        image: mysql:8.0
+    runs-on: ubuntu-20.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.actions
+++ b/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.actions
@@ -1,4 +1,4 @@
 flyway.user=kitodo
 flyway.password=kitodo
-flyway.url=jdbc:mysql://localhost/kitodo?useSSL=false
+flyway.url=jdbc:mysql://localhost/kitodo
 flyway.locations=filesystem:Kitodo-DataManagement/src/main/resources/db/migration


### PR DESCRIPTION
Update current CI environment from Ubuntu 18.04 to 20.04. Ubuntu 20.04 is shipping Oracle MySQL 8.0 by default and an additional image is not needed any more. The declared MySQL 8.0 image in previous version was not used in any way. I discovered this while my work for updating FlyWay to a new version.