### PR TITLE
Update flyway

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
       - name: start mysql
         run:
             sudo service mysql start
+      - name: check MySQL version
+        run:
+            mysql --version
       - name: create database
         run:
             mysql -u root -proot -e 'CREATE DATABASE kitodo;'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
-    services:
-      mysql:
-        image: mysql:8.0
+    runs-on: ubuntu-20.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -255,6 +255,12 @@
                                 <version>${mariadb-java-client.version}</version>
                                 <scope>runtime</scope>
                             </dependency>
+                            <dependency>
+                                <groupId>org.flywaydb</groupId>
+                                <artifactId>flyway-mysql</artifactId>
+                                <version>${flyway-maven-plugin.version}</version>
+                                <scope>runtime</scope>
+                            </dependency>
                         </dependencies>
                         <executions>
                             <execution>

--- a/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.actions
+++ b/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.actions
@@ -1,4 +1,4 @@
 flyway.user=kitodo
 flyway.password=kitodo
-flyway.url=jdbc:mysql://localhost/kitodo?useSSL=false
+flyway.url=jdbc:mysql://localhost/kitodo
 flyway.locations=filesystem:Kitodo-DataManagement/src/main/resources/db/migration

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <mockito.version>2.0.2-beta</mockito.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <spring.security.version>4.2.13.RELEASE</spring.security.version>
-        <flyway-maven-plugin.version>7.15.0</flyway-maven-plugin.version>
+        <flyway-maven-plugin.version>8.4.4</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.3.0</spotbugs-maven-plugin.version>
         <pitest.version>1.4.10</pitest.version>
         <mariadb-java-client.version>2.4.4</mariadb-java-client.version>


### PR DESCRIPTION
Update Flyway to version 8.4.4 including necessary dependency for MySQL based databases (like Oracle MySQL or MariaDB). FlyWay did not support old MySQL version like in Ubuntu 18.04 so a update to Ubuntu 20.04 is necessary before.