### PR TITLE
Remove limit on push events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,8 @@ name: CI
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push and pull request events but only for pull_requests on the master branch
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
This pull request open the possibility to automatically  run the changes in the CI environment on your on branches on your fork. Without this change you must trigger the CI execution in a manual way which is time consuming and in most cases you did not run your changes in the CI.