### PR TITLE
add resource expiration in development environment

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -821,8 +821,8 @@
             </activation>
             <properties>
                 <jsf.projectStage>Development</jsf.projectStage>
-                <!-- resource expiration after two minutes -->
-                <myfaces.resourceMaxTimeExpires>120000</myfaces.resourceMaxTimeExpires>
+                <!-- resource expiration after four minutes -->
+                <myfaces.resourceMaxTimeExpires>240000</myfaces.resourceMaxTimeExpires>
             </properties>
         </profile>
     </profiles>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -34,6 +34,7 @@
         <selenium.version>3.141.59</selenium.version>
         <cargo.plugin.version>1.9.7</cargo.plugin.version>
         <jsf.projectStage>Production</jsf.projectStage>
+        <myfaces.resourceMaxTimeExpires>604800000</myfaces.resourceMaxTimeExpires>
     </properties>
 
     <dependencies>
@@ -820,6 +821,8 @@
             </activation>
             <properties>
                 <jsf.projectStage>Development</jsf.projectStage>
+                <!-- resource expiration after two minutes -->
+                <myfaces.resourceMaxTimeExpires>120000</myfaces.resourceMaxTimeExpires>
             </properties>
         </profile>
     </profiles>

--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -48,6 +48,11 @@
     </context-param>
 
     <context-param>
+        <param-name>org.apache.myfaces.RESOURCE_MAX_TIME_EXPIRES</param-name>
+        <param-value>${myfaces.resourceMaxTimeExpires}</param-value>
+    </context-param>
+
+    <context-param>
         <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
         <param-value>true</param-value>
     </context-param>


### PR DESCRIPTION
When changes are made to css or javascript, for example, they are not reloaded even though the browser cache is disabled. Only an explicit refresh of the resource url can fix this. 