### PR TITLE
Fix messages_en.properties

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -603,7 +603,7 @@ metadataDuplicate=Duplicate metadata
 metadataEdit=Edit metadata
 metadataForDMSExport=Export metadata for DMS
 metadataGroups=Metadata groups
-metadataHideImage==Hide image
+metadataHideImage=Hide image
 metadataImport=Import metadata
 metadataLanguage=Language for metadata
 metadataPaste=Paste metadata
@@ -703,7 +703,7 @@ noLdapGroupAssignedToUser=No LDAP group is assigned to user
 noLdapServerAssignedToLdapGroup=No LDAP server is assigned to LDAP group
 noMedia=No media
 none=None
-normDataRecord=URI\
+normDataRecord=URI
 noImageFolderConfiguredInProject=No target folder for imagegeneration configured in project.
 noSourceFolderConfiguredInProject=No source folder for imagegeneration configured in project.
 noProjectsConfigured=This template is not used by any project!


### PR DESCRIPTION
Trailing backslash comments out newline, which caused `normDataRecord `→ _URInoImageFolderConfiguredInProject=No target folder for imagegeneration configured in project._ and key `noImageFolderConfiguredInProject` is not found.