### PR TITLE
Prevent NPE on accessing not full initialised dataeditorform class

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1376,9 +1376,12 @@ public class StructurePanel implements Serializable {
      *          whether metadata structure should be displayed in separate structure trees or not
      */
     public boolean isSeparateMedia() {
-        Template template = dataEditor.getProcess().getTemplate();
-        if ( Objects.nonNull(template) ) {
-            return template.getWorkflow().isSeparateStructure();
+        Process process = dataEditor.getProcess();
+        if (Objects.nonNull(process)) {
+            Template template = process.getTemplate();
+            if ( Objects.nonNull(template) ) {
+                return template.getWorkflow().isSeparateStructure();
+            }
         }
         return false;
     }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/dataeditor/StructurePanelTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/dataeditor/StructurePanelTest.java
@@ -54,4 +54,11 @@ public class StructurePanelTest {
 
         Assert.assertTrue(((StructureTreeNode) result.getChildren().get(0).getData()).isLinked());
     }
+
+    @Test
+    public void preventNullPointerExceptionInIsSeparateMediaOnNotFullInitializedDataEditorForm() {
+        DataEditorForm dummyDataEditorForm = new DataEditorForm();
+        final StructurePanel underTest = new StructurePanel(dummyDataEditorForm);
+        Assert.assertFalse(underTest.isSeparateMedia());
+    }
 }


### PR DESCRIPTION
Possible fix for #5065.