### PR TITLE
Allow integer metadata with leading zeros

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
@@ -75,6 +75,13 @@ public interface SimpleMetadataViewInterface extends MetadataViewInterface {
      * @return how the input item should be displayed
      */
     InputType getInputType();
+    
+    /**
+     * Returns the minimum number of digits for integer types.
+     *
+     * @return the minimum number of digits
+     */
+    int getMinDigits();
 
     /**
      * Returns the possible values if the metadata key is a list of values. For

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyDeclaration.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyDeclaration.java
@@ -157,6 +157,10 @@ class KeyDeclaration extends Labeled {
         }
     }
 
+    int getMinDigits() {
+        return optionalKey.isPresent() ? optionalKey.get().getMinDigits() : 1;
+    }
+
     /**
      * Returns the namespace of the key, if there is one. This is needed for
      * validation.

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
@@ -135,6 +135,11 @@ class KeyView extends AbstractKeyView<KeyDeclaration> implements DatesSimpleMeta
     }
 
     @Override
+    public int getMinDigits() {
+        return declaration.getMinDigits();
+    }
+    
+    @Override
     public Map<String, String> getSelectItems(List<Map<MetadataEntry, Boolean>> metadata) {
         return rule.getSelectItems(declaration.getSelectItems(priorityList), metadata);
     }

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/CodomainElement.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/CodomainElement.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.dataeditor.ruleset.xml;
 
+import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlAttribute;
 
 /**
@@ -25,11 +27,27 @@ class CodomainElement {
     private Type type;
 
     /**
+     * Minimum number of digits with type {@code integer}. Must be a
+     * positive integer.
+     */
+    @XmlAttribute
+    private Integer minDigits;
+
+    /**
      * The name space for URIs.
      */
     @XmlAttribute
     private String namespace;
 
+    /**
+     * Returns the minimum number of digits for integer values.
+     *
+     * @return the minimum number of digits
+     */
+    int getMinDigits() {
+        return Objects.isNull(minDigits) ? 1 : minDigits;
+    }
+    
     /**
      * Returns the name space for URIs.
      *

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Key.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Key.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -141,9 +142,18 @@ public class Key {
     }
 
     /**
+     * Returns the minimum number of digits for integer values.
+     *
+     * @return the minimum number of digits
+     */
+    public int getMinDigits() {
+        return Objects.isNull(codomain) ? 1 : codomain.getMinDigits();
+    }    
+    
+    /**
      * Returns the namespace, if one has been set.
      *
-     * @return the namespace, if annie
+     * @return the namespace, if any
      */
     public Optional<String> getNamespace() {
         if (codomain == null) {

--- a/Kitodo/rulesets/ruleset.xsd
+++ b/Kitodo/rulesets/ruleset.xsd
@@ -49,9 +49,13 @@
                 URI; if the type is specified, this applies. If a namespace has been specified, Production looks for an
                 XML file in the same directory whose file name is the same as the last segment of the namespace URI
                 and, if it finds it, makes the namespace elements available as a selection list.
+                
+                The attribute "minDigits" can be used with type="integer" to define a minimum number of digits, which
+                will save the value with leading zeroes, if it has less digits.
             </xs:documentation>
         </xs:annotation>
         <xs:attribute type="ruleset:Type" name="type"/>
+        <xs:attribute type="xs:positiveInteger" name="minDigits" default="1"/>
         <xs:attribute type="xs:anyURI" name="namespace"/>
     </xs:complexType>
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -36,12 +36,22 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
 
     ProcessTextMetadata(ProcessFieldedMetadata container, SimpleMetadataViewInterface settings, MetadataEntry value) {
         super(container, settings, Objects.isNull(settings) ? value.getKey() : settings.getLabel());
-        this.value = Objects.isNull(value) ? settings.getDefaultValue() : value.getValue();
+        this.value = addLeadingZeros(Objects.isNull(value) ? settings.getDefaultValue() : value.getValue());
     }
 
     ProcessTextMetadata(ProcessTextMetadata template) {
         super(template.container, template.settings, template.label);
         this.value = template.value;
+    }
+
+    private final String addLeadingZeros(String value) {
+        if (Objects.equals(super.settings.getInputType(), InputType.INTEGER)) {
+            int valueLength = value.length();
+            int minDigits = super.settings.getMinDigits();
+            return valueLength >= minDigits ? value : "0".repeat(minDigits - valueLength).concat(value);
+        } else {
+            return value;
+        }
     }
 
     @Override
@@ -136,6 +146,6 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
      *            value to be set
      */
     public void setValue(String value) {
-        this.value = value;
+        this.value = addLeadingZeros(value);
     }
 }


### PR DESCRIPTION
The leading zeroes are not visible in the spinner (the PrimeFaces component doesn’t support that, I tried it), but they are stored in the data.

Resolves #4992.