### PR TITLE
Not complain for a too short password when password input is disabled

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -16,6 +16,7 @@ import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -215,6 +216,9 @@ public class UserForm extends BaseForm {
     }
 
     private Set<ConstraintViolation<KitodoPassword>> getPasswordViolations() {
+        if (isLdapServerReadOnly()) {
+            return Collections.emptySet();
+        }
         KitodoPassword validPassword = new KitodoPassword(passwordToEncrypt);
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         Validator validator = factory.getValidator();


### PR DESCRIPTION
When a user is created with an LDAP group whose LDAP server is read-only, then the password field is inactive. In this case, do not check the password for validity, or saving the user is not possible.

Resolves #4934.