### PR TITLE
Update commons-io to 2.11.0 (security fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <commons-codec.version>1.13</commons-codec.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
-        <commons-io.version>2.6</commons-io.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-net.version>3.8.0</commons-net.version>
         <org.apache.xmlgraphics.version>2.3</org.apache.xmlgraphics.version>


### PR DESCRIPTION
- Fix vulnerability [CVE-2021-29425](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425) and in its dependencies.
- Recommend update from Snyk.