### PR TITLE
Ensure that subsequent children are linked to their parent

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -336,10 +336,12 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
             return this.stayOnCurrentPage;
         }
         createNewProcess();
+        Process parentProcess = titleRecordLinkTab.getTitleRecordProcess();
         return FacesContext.getCurrentInstance().getExternalContext().getRequestServletPath()
                 + "?referrer=" + referringView
                 + "&templateId=" + template.getId()
                 + "&projectId=" + project.getId()
+                + (Objects.nonNull(parentProcess) ? "&parentId=" + parentProcess.getId() : "")
                 + "&faces-redirect=true";
     }
 


### PR DESCRIPTION
If a process is created as a child of a parent, using the plus button on the parent process, and the child is created with "Save and New", for the next child, the parent process is again set, which is the user expectation.

Fixes #5072