### PR TITLE
Performance MetaDataEditor Gallery Drag-&-Drop via jQuery-UI

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -506,16 +506,12 @@ public class GalleryPanel {
      * @return GalleryStripe representing the logical structure element to which the Media is assigned
      */
     GalleryStripe getLogicalStructureOfMedia(GalleryMediaContent galleryMediaContent) {
-        if (Objects.nonNull(galleryMediaContent.getId())) {
-            for (GalleryStripe galleryStripe : stripes) {
-                for (GalleryMediaContent mediaContent : galleryStripe.getMedias()) {
-                    if (galleryMediaContent.getId().equals(mediaContent.getId())) {
-                        return galleryStripe;
-                    }
+        for (GalleryStripe galleryStripe : stripes) {
+            for (GalleryMediaContent mediaContent : galleryStripe.getMedias()) {
+                if (galleryMediaContent.getId().equals(mediaContent.getId())) {
+                    return galleryStripe;
                 }
             }
-        } else {
-            logger.error("galleryMediaContent has id of null, weird!");
         }
         return null;
     }
@@ -741,12 +737,7 @@ public class GalleryPanel {
                 if (Objects.nonNull(galleryStripe)) {
                     return dataEditor.isSelected(physicalDivision, galleryStripe.getStructure());
                 } else {
-                    GalleryStripe stripe = getLogicalStructureOfMedia(galleryMediaContent);
-                    if (Objects.nonNull(stripe)) {
-                        return dataEditor.isSelected(physicalDivision, stripe.getStructure());
-                    } else {
-                        logger.error("could not find GalleryStripe for galleryMediaContent:" + galleryMediaContent);
-                    }
+                    return dataEditor.isSelected(physicalDivision, getLogicalStructureOfMedia(galleryMediaContent).getStructure());
                 }
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -51,7 +51,6 @@ import org.kitodo.production.model.Subfolder;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.file.FileService;
 import org.primefaces.PrimeFaces;
-import org.primefaces.event.DragDropEvent;
 import org.primefaces.model.DefaultStreamedContent;
 import org.primefaces.model.StreamedContent;
 
@@ -211,15 +210,12 @@ public class GalleryPanel {
      *            JSF drag'n'drop event description object
      */
     public void onPageDrop() {
-
         FacesContext context = FacesContext.getCurrentInstance();
         Map<String,String> params = context.getExternalContext().getRequestParameterMap();
         String dragId = params.get("dragId");
         String dropId = params.get("dropId");
         
-        logger.debug("onPageDrop event drag " + dragId + " to drop " + dropId);
         int toStripeIndex = getDropStripeIndex(dropId);
-
         if (toStripeIndex == -1 || !dragStripeIndexMatches(dragId)) {
             logger.error("Unsupported drag'n'drop event from {} to {}", dragId, dropId);
             return;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -210,11 +210,18 @@ public class GalleryPanel {
      * @param event
      *            JSF drag'n'drop event description object
      */
-    public void onPageDrop(DragDropEvent event) {
-        int toStripeIndex = getDropStripeIndex(event);
+    public void onPageDrop() {
 
-        if (toStripeIndex == -1 || !dragStripeIndexMatches(event)) {
-            logger.error("Unsupported drag'n'drop event from {} to {}", event.getDragId(), event.getDropId());
+        FacesContext context = FacesContext.getCurrentInstance();
+        Map<String,String> params = context.getExternalContext().getRequestParameterMap();
+        String dragId = params.get("dragId");
+        String dropId = params.get("dropId");
+        
+        logger.debug("onPageDrop event drag " + dragId + " to drop " + dropId);
+        int toStripeIndex = getDropStripeIndex(dropId);
+
+        if (toStripeIndex == -1 || !dragStripeIndexMatches(dragId)) {
+            logger.error("Unsupported drag'n'drop event from {} to {}", dragId, dropId);
             return;
         }
 
@@ -232,7 +239,7 @@ public class GalleryPanel {
 
         viewsToBeMoved.sort(IMAGE_ORDER_COMPARATOR);
 
-        int toMediaIndex = getMediaIndex(event);
+        int toMediaIndex = getMediaIndex(dropId);
         try {
             updateData(toStripe, viewsToBeMoved, toMediaIndex);
         } catch (Exception e) {
@@ -244,25 +251,25 @@ public class GalleryPanel {
         updateAffectedStripes(toStripe, viewsToBeMoved);
     }
 
-    private boolean dragStripeIndexMatches(DragDropEvent event) {
-        Matcher dragStripeImageMatcher = DRAG_STRIPE_IMAGE.matcher(event.getDragId());
-        Matcher dragUnstructuredMediaMatcher = DRAG_UNSTRUCTURED_MEDIA.matcher(event.getDragId());
+    private boolean dragStripeIndexMatches(String dragId) {
+        Matcher dragStripeImageMatcher = DRAG_STRIPE_IMAGE.matcher(dragId);
+        Matcher dragUnstructuredMediaMatcher = DRAG_UNSTRUCTURED_MEDIA.matcher(dragId);
         return dragUnstructuredMediaMatcher.matches() || dragStripeImageMatcher.matches();
     }
 
-    private int getDropStripeIndex(DragDropEvent event) {
+    private int getDropStripeIndex(String dropId) {
         // empty stripe of structure element
-        Matcher dropStripeMatcher = DROP_STRIPE.matcher(event.getDropId());
+        Matcher dropStripeMatcher = DROP_STRIPE.matcher(dropId);
         // between two pages of structure element
-        Matcher dropMediaAreaMatcher = DROP_MEDIA_AREA.matcher(event.getDropId());
+        Matcher dropMediaAreaMatcher = DROP_MEDIA_AREA.matcher(dropId);
         // after last page of structure element
-        Matcher dropMediaLastAreaMatcher = DROP_MEDIA_LAST_AREA.matcher(event.getDropId());
+        Matcher dropMediaLastAreaMatcher = DROP_MEDIA_LAST_AREA.matcher(dropId);
         // empty unstructured media stripe
-        Matcher dropUnstructuredMediaStripeMatcher = DROP_UNSTRUCTURED_STRIPE.matcher(event.getDropId());
+        Matcher dropUnstructuredMediaStripeMatcher = DROP_UNSTRUCTURED_STRIPE.matcher(dropId);
         // between two pages of unstructured media stripe
-        Matcher dropUnstructuredMediaAreaMatcher = DROP_UNSTRUCTURED_MEDIA_AREA.matcher(event.getDropId());
+        Matcher dropUnstructuredMediaAreaMatcher = DROP_UNSTRUCTURED_MEDIA_AREA.matcher(dropId);
         // after last page of unstructured media stripe
-        Matcher dropUnstructuredMediaLastAreaMatcher = DROP_UNSTRUCTURED_MEDIA_LAST_AREA.matcher(event.getDropId());
+        Matcher dropUnstructuredMediaLastAreaMatcher = DROP_UNSTRUCTURED_MEDIA_LAST_AREA.matcher(dropId);
         if (dropStripeMatcher.matches()) {
             return Integer.parseInt(dropStripeMatcher.group(1));
         } else if (dropMediaAreaMatcher.matches()) {
@@ -279,11 +286,11 @@ public class GalleryPanel {
         }
     }
 
-    private int getMediaIndex(DragDropEvent event) {
-        Matcher dropMediaAreaMatcher = DROP_MEDIA_AREA.matcher(event.getDropId());
-        Matcher dropMediaLastAreaMatcher = DROP_MEDIA_LAST_AREA.matcher(event.getDropId());
-        Matcher dropUnstructuredMediaAreaMatcher = DROP_UNSTRUCTURED_MEDIA_AREA.matcher(event.getDropId());
-        Matcher dropUnstructuredMediaLastAreaMatcher = DROP_UNSTRUCTURED_MEDIA_LAST_AREA.matcher(event.getDropId());
+    private int getMediaIndex(String dropId) {
+        Matcher dropMediaAreaMatcher = DROP_MEDIA_AREA.matcher(dropId);
+        Matcher dropMediaLastAreaMatcher = DROP_MEDIA_LAST_AREA.matcher(dropId);
+        Matcher dropUnstructuredMediaAreaMatcher = DROP_UNSTRUCTURED_MEDIA_AREA.matcher(dropId);
+        Matcher dropUnstructuredMediaLastAreaMatcher = DROP_UNSTRUCTURED_MEDIA_LAST_AREA.matcher(dropId);
         if (dropMediaAreaMatcher.matches()) {
             return Integer.parseInt(dropMediaAreaMatcher.group(2));
         } else if (dropMediaLastAreaMatcher.matches()) {
@@ -503,12 +510,16 @@ public class GalleryPanel {
      * @return GalleryStripe representing the logical structure element to which the Media is assigned
      */
     GalleryStripe getLogicalStructureOfMedia(GalleryMediaContent galleryMediaContent) {
-        for (GalleryStripe galleryStripe : stripes) {
-            for (GalleryMediaContent mediaContent : galleryStripe.getMedias()) {
-                if (galleryMediaContent.getId().equals(mediaContent.getId())) {
-                    return galleryStripe;
+        if (Objects.nonNull(galleryMediaContent.getId())) {
+            for (GalleryStripe galleryStripe : stripes) {
+                for (GalleryMediaContent mediaContent : galleryStripe.getMedias()) {
+                    if (galleryMediaContent.getId().equals(mediaContent.getId())) {
+                        return galleryStripe;
+                    }
                 }
             }
+        } else {
+            logger.error("galleryMediaContent has id of null, weird!");
         }
         return null;
     }
@@ -734,7 +745,12 @@ public class GalleryPanel {
                 if (Objects.nonNull(galleryStripe)) {
                     return dataEditor.isSelected(physicalDivision, galleryStripe.getStructure());
                 } else {
-                    return dataEditor.isSelected(physicalDivision, getLogicalStructureOfMedia(galleryMediaContent).getStructure());
+                    GalleryStripe stripe = getLogicalStructureOfMedia(galleryMediaContent);
+                    if (Objects.nonNull(stripe)) {
+                        return dataEditor.isSelected(physicalDivision, stripe.getStructure());
+                    } else {
+                        logger.error("could not find GalleryStripe for galleryMediaContent:" + galleryMediaContent);
+                    }
                 }
             }
         }

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
@@ -9,18 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-// This file requires the following globals
-
-// provided by <p:remoteCommand /> in gallery.xhtml
-if (typeof triggerOnPageDrop === "undefined") {
-    var triggerOnPageDrop = function() {};
-}
-
-// provided by PrimeFaces
-if (typeof PrimeFaces === "undefined") {
-    var PrimeFaces = {};
-}
-
+/* global triggerOnPageDrop, PrimeFaces */
 
 /**
  * Registers event handler that makes relevant components of gallery 

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
@@ -9,6 +9,14 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
+// This file requires the following globals
+
+// provided by <p:remoteCommand /> in gallery.xhtml
+var triggerOnPageDrop = triggerOnPageDrop || function() {};
+
+// provided by PrimeFaces
+var PrimeFaces = PrimeFaces || {};
+
 /**
  * Registers event handler that makes relevant components of gallery 
  * draggable and droppable via jquery-ui. 
@@ -28,7 +36,7 @@ function registerMakeDragAndDroppable() {
         return function () {
             clearTimeout(timer);
             timer = setTimeout(func, timeout);
-        }
+        };
     }
 
     function onDrop(event, ui) {
@@ -40,6 +48,7 @@ function registerMakeDragAndDroppable() {
 
     // apply jquery draggable and droppable to the relevant dom elements
     let makeDragAndDroppable = makeDebounced(function () {
+        console.log("mageDragAndDroppable");
         // make individual pages draggable
         $("#imagePreviewForm\\:structuredPages .draggableStructurePagePanel").draggable({
             scope: "assignedPagesDroppable",

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
@@ -31,7 +31,7 @@ function registerMakeDragAndDroppable() {
 
     // define debouce function that will allow to make components draggable in one go
     // after all of them have been updated via Primefaces when reloading the gallery
-    function makeDebounced(func, timeout = 250) {
+    function makeDebounced(func, timeout = 100) {
         let timer = null;
         return function () {
             clearTimeout(timer);

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
@@ -12,10 +12,15 @@
 // This file requires the following globals
 
 // provided by <p:remoteCommand /> in gallery.xhtml
-var triggerOnPageDrop = triggerOnPageDrop || function() {};
+if (typeof triggerOnPageDrop === "undefined") {
+    var triggerOnPageDrop = function() {};
+}
 
 // provided by PrimeFaces
-var PrimeFaces = PrimeFaces || {};
+if (typeof PrimeFaces === "undefined") {
+    var PrimeFaces = {};
+}
+
 
 /**
  * Registers event handler that makes relevant components of gallery 
@@ -48,7 +53,6 @@ function registerMakeDragAndDroppable() {
 
     // apply jquery draggable and droppable to the relevant dom elements
     let makeDragAndDroppable = makeDebounced(function () {
-        console.log("mageDragAndDroppable");
         // make individual pages draggable
         $("#imagePreviewForm\\:structuredPages .draggableStructurePagePanel").draggable({
             scope: "assignedPagesDroppable",

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
@@ -40,8 +40,6 @@ function registerMakeDragAndDroppable() {
 
     // apply jquery draggable and droppable to the relevant dom elements
     let makeDragAndDroppable = makeDebounced(function () {
-        const startTime = Date.now();
-
         // make individual pages draggable
         $("#imagePreviewForm\\:structuredPages .draggableStructurePagePanel").draggable({
             scope: "assignedPagesDroppable",
@@ -77,7 +75,6 @@ function registerMakeDragAndDroppable() {
             activeClass: "media-stripe-active",
             drop: onDrop,
         });
-        console.log("makeDragAndDroppable in " + (Date.now() - startTime) + "ms");
     });
 
     // update components after they have been updated via PrimeFaces

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
@@ -1,0 +1,96 @@
+/**
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+/**
+ * Registers event handler that makes relevant components of gallery 
+ * draggable and droppable via jquery-ui. 
+ * 
+ * This is much faster than adding individual <p:draggable/> and 
+ * <p:droppable/> primefaces components, which would initialize drag and 
+ * drop capabilities individually for each component.
+ * Additionally, this reduces the form complexity of the gallery view, which 
+ * results in faster form updates for very large galleries.
+ */
+function registerMakeDragAndDroppable() {
+
+    // define debouce function that will allow to make components draggable in one go
+    // after all of them have been updated via Primefaces when reloading the gallery
+    function makeDebounced(func, timeout = 250) {
+        let timer = null;
+        return function () {
+            clearTimeout(timer);
+            timer = setTimeout(func, timeout);
+        }
+    }
+
+    function onDrop(event, ui) {
+        let dragId = ui.draggable.attr('id');
+        let dropId = $(event.target).attr('id');     
+        // trigger remote command, see gallery.xhtml and GalleryPanel.onPageDrop
+        triggerOnPageDrop([{"name": "dragId", "value": dragId}, {"name": "dropId", "value": dropId}]);
+    }
+
+    // apply jquery draggable and droppable to the relevant dom elements
+    let makeDragAndDroppable = makeDebounced(function () {
+        const startTime = Date.now();
+
+        // make individual pages draggable
+        $("#imagePreviewForm\\:structuredPages .draggableStructurePagePanel").draggable({
+            scope: "assignedPagesDroppable",
+            stack: ".ui-panel",
+            revert: true,
+        });
+        $("#imagePreviewForm\\:unstructuredMediaList .draggableUnstructuredMediaPanel").draggable({
+            scope: "assignedPagesDroppable",
+            stack: ".ui-panel",
+            revert: true,
+        });
+
+        // make droppable containers before and after each page
+        $("#imagePreviewForm\\:structuredPages .page-drop-area").droppable({
+            scope: "assignedPagesDroppable",
+            activeClass: "media-stripe-index-active",
+            drop: onDrop,
+        });
+        $("#imagePreviewForm\\:unstructuredMediaList .page-drop-area").droppable({
+            scope: "assignedPagesDroppable",
+            activeClass: "media-stripe-index-active",
+            drop: onDrop,
+        });
+
+        // make droppable container for empty stripes
+        $("#imagePreviewForm\\:structuredPages .structureElementDataList").has(".ui-datalist-empty-message").droppable({
+            scope: "assignedPagesDroppable",
+            activeClass: "media-stripe-active",
+            drop: onDrop,
+        });
+        $("#imagePreviewForm\\:unstructuredMediaList").has(".ui-datalist-empty-message").droppable({
+            scope: "assignedPagesDroppable",
+            activeClass: "media-stripe-active",
+            drop: onDrop,
+        });
+        console.log("makeDragAndDroppable in " + (Date.now() - startTime) + "ms");
+    });
+
+    // update components after they have been updated via PrimeFaces
+    let backupFunc = PrimeFaces.ajax.Utils.updateElement;
+    PrimeFaces.ajax.Utils.updateElement = function() {
+        backupFunc.apply(this, arguments);
+        makeDragAndDroppable();
+    };
+
+    // make components draggable the very first time the gallery loads
+    makeDragAndDroppable();
+}
+
+$(function() {
+    registerMakeDragAndDroppable();
+});

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -24,36 +24,6 @@
         <!--@elvariable id="editImages" type="boolean"-->
         <ui:param name="editImages" value="#{SecurityAccessController.hasAuthorityToEditProcessImages()}"/>
 
-        <script>                
-            function makeDragAndDroppable() {
-                const startTime = Date.now();
-                $("#imagePreviewForm\\:structuredPages .draggableStructurePagePanel").draggable({
-                    scope: "assignedPagesDroppable",
-                    stack: ".ui-panel",
-                    revert: true,                   
-                });
-
-                $("#imagePreviewForm\\:structuredPages .page-drop-area").droppable({
-                    scope: "assignedPagesDroppable",
-                    activeClass: "media-stripe-index-active",        
-                    drop: function(event, ui) {
-                        let dragId = ui.draggable.attr('id');
-                        let dropId = $(event.target).attr('id');                       
-                        triggerOnPageDrop([{"name": "dragId", "value": dragId}, {"name": "dropId", "value": dropId}]);
-                    }         
-                });
-                console.log("makeDragAndDroppable in " + (Date.now() - startTime) + "ms");
-            }
-
-            var makeDragAndDroppableTimer = null;
-            var originalPrimeFacesAjaxUtilsUpdateElement = PrimeFaces.ajax.Utils.updateElement;
-            PrimeFaces.ajax.Utils.updateElement = function(id, content, xhr) {
-                originalPrimeFacesAjaxUtilsUpdateElement.apply(this, arguments);
-                clearTimeout(makeDragAndDroppableTimer);
-                makeDragAndDroppableTimer = setTimeout(makeDragAndDroppable, 250);
-            };
-        </script>
-
         <h:form id="imagePreviewForm" style="height: 100%;" styleClass="focusable">
 
             <p:remoteCommand 
@@ -175,40 +145,12 @@
                                         </p:outputPanel>
                                     </p:outputPanel>
                                 </p:panel>
-                                <!--<ui:fragment rendered="#{editImages}">
-                                    <p:draggable id="structuredPagesDraggable"
-                                                 scope="assignedPagesDroppable"
-                                                 for="imagePreviewForm:structuredPages:#{currentElement.rowIndex}:structureElementDataList:#{structuredThumbnail.rowIndex}:structuredPagePanel"
-                                                 revert="true"
-                                                 stack=".ui-panel"/>
-                                    <p:droppable for="imagePreviewForm:structuredPages:#{currentElement.rowIndex}:structureElementDataList:#{structuredThumbnail.rowIndex}:structuredPageDropArea"
-                                                 scope="assignedPagesDroppable"
-                                                 activeStyleClass="media-stripe-index-active">
-                                        <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                update="@(.pageList)"/>
-                                    </p:droppable>
-                                </ui:fragment>-->
                                 <!-- add one last drop area after the last page in a stripe -->
-                                <!--<ui:fragment rendered="#{editImages and stripe.medias.size() ne 0 and  stripe.medias.size() - 1 eq structuredThumbnail.rowIndex}">
+                                <ui:fragment rendered="#{editImages and stripe.medias.size() ne 0 and  stripe.medias.size() - 1 eq structuredThumbnail.rowIndex}">
                                     <p:panel id="structuredPageLastDropArea"
                                              styleClass="page-drop-area"/>
-                                    <p:droppable for="imagePreviewForm:structuredPages:#{currentElement.rowIndex}:structureElementDataList:#{structuredThumbnail.rowIndex}:structuredPageLastDropArea"
-                                                 scope="assignedPagesDroppable"
-                                                 activeStyleClass="media-stripe-index-active">
-                                        <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                update="@(.pageList)"/>
-                                    </p:droppable>
-                                </ui:fragment>-->
+                                </ui:fragment>
                             </p:dataList>
-                            <!--<ui:fragment rendered="#{editImages and stripe.medias.size() eq 0}">
-                                <p:droppable id="structuredPagesDroppable"
-                                             scope="assignedPagesDroppable"
-                                             for="imagePreviewForm:structuredPages:#{currentElement.rowIndex}:structureElementDataList"
-                                             activeStyleClass="media-stripe-active">
-                                    <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                            update="@(.pageList)"/>
-                                </p:droppable>
-                            </ui:fragment>-->
                         </p:outputPanel>
                     </p:dataList>
 
@@ -232,7 +174,7 @@
                                     <p:panel id="unstructuredPageDropArea"
                                              rendered="#{editImages}"
                                              styleClass="page-drop-area"/>
-                                    <p:panel id="unstructuredMediaPanel">
+                                    <p:panel id="unstructuredMediaPanel" styleClass="draggableUnstructuredMediaPanel">
                                         <h:panelGroup id="updateSelectedUnstructuredMediaLink" styleClass="thumbnail-parent">
                                             <p:outputPanel styleClass="thumbnail #{DataEditorForm.consecutivePagesSelected() ? '' : 'discontinuous'} #{DataEditorForm.galleryPanel.isSelected(media, DataEditorForm.galleryPanel.stripes.get(0)) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, DataEditorForm.galleryPanel.stripes.get(0)) ? 'last-selection' : ''}"/>
                                             <p:outputPanel styleClass="thumbnail-container"
@@ -254,40 +196,12 @@
                                             </p:outputPanel>
                                         </h:panelGroup>
                                     </p:panel>
-                                    <!--<ui:fragment rendered="#{editImages}">
-                                        <p:draggable id="unstructuredMediaDraggable"
-                                                     for="imagePreviewForm:unstructuredMediaList:#{currentMedia.rowIndex}:unstructuredMediaPanel"
-                                                     revert="true"
-                                                     scope="assignedPagesDroppable"
-                                                     stack=".ui-panel"/>
-                                        <p:droppable for="imagePreviewForm:unstructuredMediaList:#{currentMedia.rowIndex}:unstructuredPageDropArea"
-                                                     scope="assignedPagesDroppable"
-                                                     activeStyleClass="media-stripe-index-active">
-                                            <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                    update="@(.pageList)"/>
-                                        </p:droppable>
-                                    </ui:fragment>-->
                                     <!-- add one last drop area after the last page in a stripe -->
-                                    <!--<ui:fragment rendered="#{editImages and DataEditorForm.galleryPanel.stripes.get(0).medias.size() ne 0 and DataEditorForm.galleryPanel.stripes.get(0).medias.size() - 1 eq currentMedia.rowIndex}">
+                                    <ui:fragment rendered="#{editImages and DataEditorForm.galleryPanel.stripes.get(0).medias.size() ne 0 and DataEditorForm.galleryPanel.stripes.get(0).medias.size() - 1 eq currentMedia.rowIndex}">
                                         <p:panel id="unstructuredPageLastDropArea"
                                                  styleClass="page-drop-area"/>
-                                        <p:droppable for="imagePreviewForm:unstructuredMediaList:#{currentMedia.rowIndex}:unstructuredPageLastDropArea"
-                                                     scope="assignedPagesDroppable"
-                                                     activeStyleClass="media-stripe-index-active">
-                                            <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                    update="@(.pageList)"/>
-                                        </p:droppable>
-                                    </ui:fragment>-->
+                                    </ui:fragment>
                                 </p:dataList>
-                                <!--<ui:fragment rendered="#{editImages and DataEditorForm.galleryPanel.stripes.get(0).medias.size() eq 0}">
-                                    <p:droppable id="unstructuredPagesDroppable"
-                                                 scope="assignedPagesDroppable"
-                                                 for="imagePreviewForm:unstructuredMediaList"
-                                                 activeStyleClass="media-stripe-active">
-                                        <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                update="@(.pageList)"/>
-                                    </p:droppable>
-                                </ui:fragment>-->
                             </p:outputPanel>
                         </h:panelGroup>
                     </p:outputPanel>
@@ -480,5 +394,6 @@
         <h:outputStylesheet name="webjars/openlayers/5.2.0/ol.css"/>
         <h:outputScript library="webjars" name="openlayers/5.2.0/ol.js" />
         <h:outputScript name="js/ol_custom.js"/>
+        <h:outputScript name="js/metadataeditor_gallery_drag_drop.js" rendered="#{editImages}" />
     </p:panel>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -24,7 +24,45 @@
         <!--@elvariable id="editImages" type="boolean"-->
         <ui:param name="editImages" value="#{SecurityAccessController.hasAuthorityToEditProcessImages()}"/>
 
+        <script>                
+            function makeDragAndDroppable() {
+                const startTime = Date.now();
+                $("#imagePreviewForm\\:structuredPages .draggableStructurePagePanel").draggable({
+                    scope: "assignedPagesDroppable",
+                    stack: ".ui-panel",
+                    revert: true,                   
+                });
+
+                $("#imagePreviewForm\\:structuredPages .page-drop-area").droppable({
+                    scope: "assignedPagesDroppable",
+                    activeClass: "media-stripe-index-active",        
+                    drop: function(event, ui) {
+                        let dragId = ui.draggable.attr('id');
+                        let dropId = $(event.target).attr('id');                       
+                        triggerOnPageDrop([{"name": "dragId", "value": dragId}, {"name": "dropId", "value": dropId}]);
+                    }         
+                });
+                console.log("makeDragAndDroppable in " + (Date.now() - startTime) + "ms");
+            }
+
+            var makeDragAndDroppableTimer = null;
+            var originalPrimeFacesAjaxUtilsUpdateElement = PrimeFaces.ajax.Utils.updateElement;
+            PrimeFaces.ajax.Utils.updateElement = function(id, content, xhr) {
+                originalPrimeFacesAjaxUtilsUpdateElement.apply(this, arguments);
+                clearTimeout(makeDragAndDroppableTimer);
+                makeDragAndDroppableTimer = setTimeout(makeDragAndDroppable, 250);
+            };
+        </script>
+
         <h:form id="imagePreviewForm" style="height: 100%;" styleClass="focusable">
+
+            <p:remoteCommand 
+                name="triggerOnPageDrop" 
+                actionListener="#{DataEditorForm.galleryPanel.onPageDrop}" 
+                update="@(.pageList)
+                        logicalTree
+                        paginationForm:paginationWrapperPanel"/>
+            
             <p:graphicImage id="mediaViewData" value="#{DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).mediaViewData}" style="display: none;"/>
 
             <p:remoteCommand name="select"
@@ -113,31 +151,31 @@
                                 <p:panel id="structuredPageDropArea"
                                          rendered="#{editImages}"
                                          styleClass="page-drop-area"/>
-                                <p:panel id="structuredPagePanel">
+                                <p:panel id="structuredPagePanel" styleClass="draggableStructurePagePanel">
                                     <p:outputPanel styleClass="thumbnail-parent">
                                         <p:outputPanel styleClass="thumbnail #{DataEditorForm.consecutivePagesSelected() ? '' : 'discontinuous'} #{DataEditorForm.galleryPanel.isSelected(media, stripe) ? 'selected' : ''} #{DataEditorForm.galleryPanel.isLastSelection(media, stripe) ? 'last-selection' : ''}"/>
                                         <p:outputPanel styleClass="thumbnail-container"
-                                                       a:data-order="#{media.order}"
-                                                       a:data-stripe="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe)}">
+                                                    a:data-order="#{media.order}"
+                                                    a:data-stripe="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe)}">
                                             <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
                                                             rendered="#{media.showingInPreview}">
                                                 <f:param name="mediaId"
-                                                         value="#{media.id}" />
+                                                        value="#{media.id}" />
                                                 <f:param name="process"
-                                                         value="#{DataEditorForm.process.id}"/>
+                                                        value="#{DataEditorForm.process.id}"/>
                                                 <f:param name="sessionId"
-                                                         value="#{DataEditorForm.galleryPanel.cachingUUID}"/>
+                                                        value="#{DataEditorForm.galleryPanel.cachingUUID}"/>
                                             </p:graphicImage>
                                             <h:outputText value="#{DataEditorForm.galleryPanel.getSeveralAssignmentsIndex(media) + 1}"
-                                                          rendered="#{media.assignedSeveralTimes}"
-                                                          styleClass="assigned-several-times"/>
+                                                        rendered="#{media.assignedSeveralTimes}"
+                                                        styleClass="assigned-several-times"/>
                                             <h:panelGroup class="thumbnail-overlay">
                                                 #{msgs.image} #{media.order}, #{msgs.page} #{media.orderlabel}
                                             </h:panelGroup>
                                         </p:outputPanel>
                                     </p:outputPanel>
                                 </p:panel>
-                                <ui:fragment rendered="#{editImages}">
+                                <!--<ui:fragment rendered="#{editImages}">
                                     <p:draggable id="structuredPagesDraggable"
                                                  scope="assignedPagesDroppable"
                                                  for="imagePreviewForm:structuredPages:#{currentElement.rowIndex}:structureElementDataList:#{structuredThumbnail.rowIndex}:structuredPagePanel"
@@ -147,36 +185,30 @@
                                                  scope="assignedPagesDroppable"
                                                  activeStyleClass="media-stripe-index-active">
                                         <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                update="@(.pageList)
-                                                        logicalTree
-                                                        paginationForm:paginationWrapperPanel"/>
+                                                update="@(.pageList)"/>
                                     </p:droppable>
-                                </ui:fragment>
+                                </ui:fragment>-->
                                 <!-- add one last drop area after the last page in a stripe -->
-                                <ui:fragment rendered="#{editImages and stripe.medias.size() ne 0 and  stripe.medias.size() - 1 eq structuredThumbnail.rowIndex}">
+                                <!--<ui:fragment rendered="#{editImages and stripe.medias.size() ne 0 and  stripe.medias.size() - 1 eq structuredThumbnail.rowIndex}">
                                     <p:panel id="structuredPageLastDropArea"
                                              styleClass="page-drop-area"/>
                                     <p:droppable for="imagePreviewForm:structuredPages:#{currentElement.rowIndex}:structureElementDataList:#{structuredThumbnail.rowIndex}:structuredPageLastDropArea"
                                                  scope="assignedPagesDroppable"
                                                  activeStyleClass="media-stripe-index-active">
                                         <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                update="@(.pageList)
-                                                        logicalTree
-                                                        paginationForm:paginationWrapperPanel"/>
+                                                update="@(.pageList)"/>
                                     </p:droppable>
-                                </ui:fragment>
+                                </ui:fragment>-->
                             </p:dataList>
-                            <ui:fragment rendered="#{editImages and stripe.medias.size() eq 0}">
+                            <!--<ui:fragment rendered="#{editImages and stripe.medias.size() eq 0}">
                                 <p:droppable id="structuredPagesDroppable"
                                              scope="assignedPagesDroppable"
                                              for="imagePreviewForm:structuredPages:#{currentElement.rowIndex}:structureElementDataList"
                                              activeStyleClass="media-stripe-active">
                                     <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                            update="@(.pageList)
-                                                    logicalTree
-                                                    paginationForm:paginationWrapperPanel"/>
+                                            update="@(.pageList)"/>
                                 </p:droppable>
-                            </ui:fragment>
+                            </ui:fragment>-->
                         </p:outputPanel>
                     </p:dataList>
 
@@ -222,7 +254,7 @@
                                             </p:outputPanel>
                                         </h:panelGroup>
                                     </p:panel>
-                                    <ui:fragment rendered="#{editImages}">
+                                    <!--<ui:fragment rendered="#{editImages}">
                                         <p:draggable id="unstructuredMediaDraggable"
                                                      for="imagePreviewForm:unstructuredMediaList:#{currentMedia.rowIndex}:unstructuredMediaPanel"
                                                      revert="true"
@@ -232,36 +264,30 @@
                                                      scope="assignedPagesDroppable"
                                                      activeStyleClass="media-stripe-index-active">
                                             <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                    update="@(.pageList)
-                                                            logicalTree
-                                                            paginationForm:paginationWrapperPanel"/>
+                                                    update="@(.pageList)"/>
                                         </p:droppable>
-                                    </ui:fragment>
+                                    </ui:fragment>-->
                                     <!-- add one last drop area after the last page in a stripe -->
-                                    <ui:fragment rendered="#{editImages and DataEditorForm.galleryPanel.stripes.get(0).medias.size() ne 0 and DataEditorForm.galleryPanel.stripes.get(0).medias.size() - 1 eq currentMedia.rowIndex}">
+                                    <!--<ui:fragment rendered="#{editImages and DataEditorForm.galleryPanel.stripes.get(0).medias.size() ne 0 and DataEditorForm.galleryPanel.stripes.get(0).medias.size() - 1 eq currentMedia.rowIndex}">
                                         <p:panel id="unstructuredPageLastDropArea"
                                                  styleClass="page-drop-area"/>
                                         <p:droppable for="imagePreviewForm:unstructuredMediaList:#{currentMedia.rowIndex}:unstructuredPageLastDropArea"
                                                      scope="assignedPagesDroppable"
                                                      activeStyleClass="media-stripe-index-active">
                                             <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                    update="@(.pageList)
-                                                            logicalTree
-                                                            paginationForm:paginationWrapperPanel"/>
+                                                    update="@(.pageList)"/>
                                         </p:droppable>
-                                    </ui:fragment>
+                                    </ui:fragment>-->
                                 </p:dataList>
-                                <ui:fragment rendered="#{editImages and DataEditorForm.galleryPanel.stripes.get(0).medias.size() eq 0}">
+                                <!--<ui:fragment rendered="#{editImages and DataEditorForm.galleryPanel.stripes.get(0).medias.size() eq 0}">
                                     <p:droppable id="unstructuredPagesDroppable"
                                                  scope="assignedPagesDroppable"
                                                  for="imagePreviewForm:unstructuredMediaList"
                                                  activeStyleClass="media-stripe-active">
                                         <p:ajax listener="#{DataEditorForm.galleryPanel.onPageDrop}"
-                                                update="@(.pageList)
-                                                        logicalTree
-                                                        paginationForm:paginationWrapperPanel"/>
+                                                update="@(.pageList)"/>
                                     </p:droppable>
-                                </ui:fragment>
+                                </ui:fragment>-->
                             </p:outputPanel>
                         </h:panelGroup>
                     </p:outputPanel>
@@ -450,7 +476,6 @@
                                     metadataAccordion:logicalMetadataWrapperPanel
                                     galleryWrapperPanel"/>
             </p:contextMenu>
-
         </h:form>
         <h:outputStylesheet name="webjars/openlayers/5.2.0/ol.css"/>
         <h:outputScript library="webjars" name="openlayers/5.2.0/ol.js" />


### PR DESCRIPTION
Related issues:
- #4195 

Conflicts with:
- #5011 

When navigating to the meta data editor, a lot of loading time is spent at initializing the drag-&-drop functionality of the gallery panel and structure tree. This can be tested by removing the authority to edit images of a process, which disables drag-&-drop in the meta data editor.

The problem can be traced back to the Primefaces components `<p:draggable />` and `<p:droppable />`. Unfortunately, they can only reference a single other component that is supposed to be made draggable or droppable via their `for="some-component-id"`-property. Because of this, and in order to make every thumbnail draggable, they have to be placed inside the `<p:dataList />` components and, thus, are repeated many times. Presumably, this causes the browser to initialize all event handlers for each drag-&-drop individually, which slows down the page drastically.

Luckily, Primefaces uses jQuery-UI in order to provide drag-&-drop functionality. This pull request removes `<p:draggable />` and `<p:droppable>` from the gallery panel and replaces it with corresponding Javascript code that initializes the drag-&-drop functionality via jQuery-UI directly. As a result, all thumbnails can be made draggable via one method call to jQuery-UI, which is much more efficient.

### Advantages

The loading time of a meta data editor with 1000 pages is reduced from 5.79 seconds to 3.33 seconds (desktop workstation) or 20.81 seconds to 9.94 seconds (laptop). 

Together with the following other pull requests
- #5114
- #5115 

the loading time is reduced from 5.79 seconds to 2.27 seconds (desktop workstation) or 20.81 seconds to 6.01 seconds (laptop).

### Drawbacks

**Compatibility**: Since components are made draggable outside of Primefaces, if those components are updated via Primefaces, they will loose all their custom event handlers. Therefore, a custom Javascript hook was implemented, which re-initializes drag-&-drop functionality after each update of any Primefaces components of the meta data editor. However, this does not slow down other parts of the meta data editor, because jQuery-UI is able to detect if a component is already draggable, and skip its re-initialization. Still, in the future, this hook or any other parts of the custom Javascript code may break in Primefaces v10 or v11.

**Maintainability**: Since this pull request removes Primefaces components and replaces them with custom Javascript code, the overall maintainability of the meta data editor decreases somewhat more. 

An alternative would be to reduce the number of draggable and droppable components via pagination as suggested in: 
- #5010