### PR TITLE
Performance MetaDataEditor Lazy Loading of Gallery Thumbnails

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -283,7 +283,8 @@
                             <p:panel a:data-order="#{media.order}">
                                 <h:panelGroup layout="block" styleClass="thumbnail-container">
                                         <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
-                                                        rendered="#{media.showingInPreview}">
+                                                        rendered="#{media.showingInPreview}"
+                                                        a:loading="lazy">
                                             <f:param name="id"
                                                      value="#{media.id}"/>
                                             <f:param name="process"
@@ -323,7 +324,8 @@
                                                            styleClass="thumbnail-container"
                                                            a:data-order="#{media.order}">
                                                 <h:outputText><p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
-                                                                              rendered="#{media.showingInPreview}">
+                                                                              rendered="#{media.showingInPreview}"
+                                                                              a:loading="lazy">
                                                     <f:param name="mediaId"
                                                              value="#{media.id}" />
                                                     <f:param name="process"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -120,7 +120,8 @@
                                                        a:data-order="#{media.order}"
                                                        a:data-stripe="#{DataEditorForm.galleryPanel.stripes.indexOf(stripe)}">
                                             <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
-                                                            rendered="#{media.showingInPreview}">
+                                                            rendered="#{media.showingInPreview}"
+                                                            a:loading="lazy">
                                                 <f:param name="mediaId"
                                                          value="#{media.id}" />
                                                 <f:param name="process"
@@ -208,7 +209,8 @@
                                                            a:data-stripe="0">
                                                     <!-- only render those pages that are not assigned to a stripe (structure) here! -->
                                                     <p:graphicImage value="#{DataEditorForm.galleryPanel.previewData}"
-                                                                    rendered="#{media.showingInPreview}">
+                                                                    rendered="#{media.showingInPreview}"
+                                                                    a:loading="lazy">
                                                         <f:param name="mediaId"
                                                                  value="#{media.id}"/>
                                                         <f:param name="process"


### PR DESCRIPTION
Related Issues:
- #4195

When navigating to the meta data editor, all gallery thumbnails are loaded right at the start of the page load, even though - for large galleries - most thumbnails are not visible at the start.

This pull request adds the property `loading="lazy"` to all thumbnails, which is a [standard attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) for the `img`-tag supported by most [modern browsers](https://caniuse.com/loading-lazy-attr) (edge, firefox, chrome, opera, safari) except some mobile browsers.

### Advantages

The number of HTTP requests when loading a meta data editor with 1000 pages is reduced significantly, e.g., from 1044 requests to 104 requests. Depending on the network performance, this can reduce loading times significantly. For high performance networks (wired local area networks) the loading time is reduced only slightly from 5.79 seconds to 5.67 seconds (desktop workstation) or 20.81 seconds to 17.43 seconds (laptop).

Together with the following other pull requests
- #5113 
- #5115 

the loading time is reduced from 5.79 seconds to 2.27 seconds (desktop workstation) or 20.81 seconds to 6.01 seconds (laptop).

### Disadvantages

When scrolling the gallery, thumbnails are not yet available and will be loaded during scrolling. Meaning, there will be a slight delay before thumbnails are visible.

https://user-images.githubusercontent.com/6214043/165929772-91e08092-d0fa-43b5-a11b-bccdeedc770f.mp4

**Update 2022-05-04**: For large galleries (e.g. 2000 images), when switching between gallery view and preview view, Chrome freezed because the same image thumbnail was dynamically changed from lazy to non-lazy because not all img-tags had been marked lazy in gallery.xhtml, see https://github.com/kitodo/kitodo-production/pull/5114/commits/32d21d6d5a8656e7aef056610c280e8a56340626 .

**Update 2022-05-06**: Seems to work fine now, no further problems detected.