### PR TITLE
Performance Enable Gzip Compression

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -111,6 +111,17 @@
         <session-timeout>120</session-timeout>
     </session-config>
 
+    <!-- gzip filter compressing resources -->
+    <filter>
+        <filter-name>gzipResponseFilter</filter-name>
+        <filter-class>org.omnifaces.filter.GzipResponseFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>gzipResponseFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+
     <!-- Welcome files -->
     <welcome-file-list>
         <welcome-file>index.jsp</welcome-file>


### PR DESCRIPTION
Related Issues:
- #4195 

When loading a jsf page, the jsf instructions are sent as raw text to the browser. For large pages, e.g., a meta data editor with 1000 thumbnails, this results in a huge amount of data (~10 MB) that is transferred without compression. With compression enabled, only 3.4MB are transferred. On slow network connections, compression can improve loading times significantly.

This pull request enables gzip compression of all resources application-wide. 

Together with the following other pull requests
- #5113
- #5114

the loading time of the meta data editor with 1000 pages is reduced from 5.79 seconds to 2.27 seconds (desktop workstation) or 20.81 seconds to 6.01 seconds (laptop).