### PR TITLE
fix wrong file directory input of maven resource plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
                                     <outputDirectory>${directory.modules}</outputDirectory>
                                     <resources>
                                         <resource>
-                                            <directory>Kitodo/modules/</directory>
+                                            <directory>${main.basedir}/Kitodo/modules/</directory>
                                             <include>*.jar</include>
                                             <filtering>false</filtering>
                                         </resource>


### PR DESCRIPTION
Fix of missing *.jars in modules directory configured "directory.modules" key in kitodo_config.properties