### PR TITLE
Performance loading Mets workpiece

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -37,6 +37,8 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataformat.MediaVariant;
 import org.kitodo.api.dataformat.PhysicalDivision;
 import org.kitodo.api.dataformat.ProcessingNote;
@@ -82,6 +84,8 @@ import org.kitodo.utils.JAXBContextCache;
  * @see "https://www.zvdd.de/fileadmin/AGSDD-Redaktion/METS_Anwendungsprofil_2.0.pdf"
  */
 public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
+    private static final Logger logger = LogManager.getLogger(MetsXmlElementAccess.class);
+
     /**
      * The data object of this mets XML element access.
      */
@@ -135,11 +139,16 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         Map<String, FileXmlElementAccess> divIDsToPhysicalDivisions = new HashMap<>();
         if (optionalPhysicalStructMap.isPresent()) {
             DivType div = optionalPhysicalStructMap.get().getDiv();
-            FileXmlElementAccess fileXmlElementAccess = new FileXmlElementAccess(div, mets, useXmlAttributeAccess);
+            Map<FileType, String> fileUseByFileCach = createFileUseByFileCache(mets);
+            FileXmlElementAccess fileXmlElementAccess = new FileXmlElementAccess(
+                div, mets, useXmlAttributeAccess, fileUseByFileCach
+            );
             PhysicalDivision physicalDivision = fileXmlElementAccess.getPhysicalDivision();
             workpiece.setPhysicalStructure(physicalDivision);
             divIDsToPhysicalDivisions.put(div.getID(), fileXmlElementAccess);
-            readMeadiaUnitsTreeRecursive(div, mets, useXmlAttributeAccess, physicalDivision, divIDsToPhysicalDivisions);
+            readMediaUnitsTreeRecursive(
+                div, mets, useXmlAttributeAccess, physicalDivision, divIDsToPhysicalDivisions, fileUseByFileCach
+            );
         }
         if (mets.getStructLink() == null) {
             mets.setStructLink(new StructLink());
@@ -153,19 +162,24 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
             }
         }
         workpiece.setLogicalStructure(getStructMapsStreamByType(mets, "LOGICAL")
-                .map(structMap -> new DivXmlElementAccess(structMap.getDiv(), mets, physicalDivisionsMap, 1)).collect(Collectors.toList())
+                .map(structMap -> new DivXmlElementAccess(structMap.getDiv(), mets, physicalDivisionsMap, 1))
+                .collect(Collectors.toList())
                 .iterator().next());
     }
 
-    private void readMeadiaUnitsTreeRecursive(DivType div, Mets mets, Map<String, MediaVariant> useXmlAttributeAccess,
-            PhysicalDivision physicalDivision, Map<String, FileXmlElementAccess> divIDsToPhysicalDivisions) {
-
+    private void readMediaUnitsTreeRecursive(DivType div, Mets mets, Map<String, MediaVariant> useXmlAttributeAccess,
+            PhysicalDivision physicalDivision, Map<String, FileXmlElementAccess> divIDsToPhysicalDivisions, 
+            Map<FileType, String> fileUseByFileCach) {
         for (DivType child : div.getDiv()) {
-            FileXmlElementAccess fileXmlElementAccess = new FileXmlElementAccess(child, mets, useXmlAttributeAccess);
+            FileXmlElementAccess fileXmlElementAccess = new FileXmlElementAccess(
+                child, mets, useXmlAttributeAccess, fileUseByFileCach
+            );
             PhysicalDivision childPhysicalDivision = fileXmlElementAccess.getPhysicalDivision();
             physicalDivision.getChildren().add(childPhysicalDivision);
             divIDsToPhysicalDivisions.put(child.getID(), fileXmlElementAccess);
-            readMeadiaUnitsTreeRecursive(child, mets, useXmlAttributeAccess, childPhysicalDivision, divIDsToPhysicalDivisions);
+            readMediaUnitsTreeRecursive(
+                child, mets, useXmlAttributeAccess, childPhysicalDivision, divIDsToPhysicalDivisions, fileUseByFileCach
+            );
         }
     }
 
@@ -407,5 +421,27 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
             return smLink;
         }).collect(Collectors.toList()));
         return structLink;
+    }
+
+    /**
+     * Create a map that stores a file's use parameter for each existing file (e.g. MAX, THUMB, LOCAL). 
+     * 
+     * @param mets the mets file
+     * @return the map from file to file group use
+     */
+    private Map<FileType, String> createFileUseByFileCache(Mets mets) {
+        HashMap<FileType, String> fileUseMap = new HashMap<>();
+        for (FileGrp fileGrp : mets.getFileSec().getFileGrp()) {
+            String use = fileGrp.getUSE();
+            for (FileType file : fileGrp.getFile()) {
+                if (fileUseMap.containsKey(file)) {
+                    logger.error("file with id " + file.getID() + " is part of multiple groups");
+                } else {
+                    fileUseMap.put(file, use);
+                }
+            }
+            
+        }
+        return fileUseMap;
     }
 }


### PR DESCRIPTION
Related issues:
- #4195 

Loading a mets file ("meta.xml") via `MetsService.loadWorkpiece` is slow in case there are many images referenced in the xml. An xml that contains 2000 images needs ~1.5 seconds to load (desktop workstation). 

The problem is that the xml file is traversed multiple times to figure out the "use" parameter for each image file (e.g. THUMB, MAX, LOCAL). By pre-loading this parameter for each file and using that as a cache while generating `PhysicalDivision`, the loading time improves drastically to around 0.1 seconds.

This affects multiple parts of kitodo-production (wherever `MetsService.loadWorkpiece` is [called](https://github.com/kitodo/kitodo-production/search?q=loadWorkpiece&type=code)), e.g.:
- when opening the meta data editor
- when calculating process statistics via the "number of metadata" button at the bottom of a process list
- ...