### PR TITLE
Performance MetaDataEditor When Selecting Many Images

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -700,12 +700,12 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
         // slow for large amounts of selected images. Instead, just check whether the first logical division matches 
         // all others in a simple loop.
         Boolean theSameLogicalDivisions = true;
-        LogicalDivision firstSelectetMediaLogicalDivison = null;
+        LogicalDivision firstSelectedMediaLogicalDivison = null;
         for (Pair<PhysicalDivision, LogicalDivision> pair : selectedMedia) {
-            if (Objects.isNull(firstSelectetMediaLogicalDivison)) {
-                firstSelectetMediaLogicalDivison = pair.getRight();
+            if (Objects.isNull(firstSelectedMediaLogicalDivison)) {
+                firstSelectedMediaLogicalDivison = pair.getRight();
             } else {
-                if (!Objects.equals(firstSelectetMediaLogicalDivison, pair.getRight())) {
+                if (!Objects.equals(firstSelectedMediaLogicalDivison, pair.getRight())) {
                     theSameLogicalDivisions = false;
                     break;
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -685,6 +685,8 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
 
     /**
      * Checks and returns if consecutive physical divisions in one structure element are selected or not.
+     * 
+     * <p>Note: This method is called potentially thousands of times when rendering large galleries.</p>
      */
     public boolean consecutivePagesSelected() {
         if (selectedMedia.isEmpty()) {
@@ -692,8 +694,24 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
         }
         int maxOrder = selectedMedia.stream().mapToInt(m -> m.getLeft().getOrder()).max().orElseThrow(NoSuchElementException::new);
         int minOrder = selectedMedia.stream().mapToInt(m -> m.getLeft().getOrder()).min().orElseThrow(NoSuchElementException::new);
-        return selectedMedia.size() - 1 == maxOrder - minOrder
-                && selectedMedia.stream().map(Pair::getValue).distinct().count() == 1;
+
+        // Check whether the set of selected media all belong to the same logical division, otherwise the selection 
+        // is not consecutive. However, do not use stream().distinct(), which will do pairwise comparisons, which is 
+        // slow for large amounts of selected images. Instead, just check whether the first logical division matches 
+        // all others in a simple loop.
+        Boolean theSameLogicalDivisions = true;
+        LogicalDivision firstSelectetMediaLogicalDivison = null;
+        for (Pair<PhysicalDivision, LogicalDivision> pair : selectedMedia) {
+            if (Objects.isNull(firstSelectetMediaLogicalDivison)) {
+                firstSelectetMediaLogicalDivison = pair.getRight();
+            } else {
+                if (!Objects.equals(firstSelectetMediaLogicalDivison, pair.getRight())) {
+                    theSameLogicalDivisions = false;
+                    break;
+                }
+            }
+        }
+        return selectedMedia.size() - 1 == maxOrder - minOrder && theSameLogicalDivisions;
     }
 
     void setSelectedMedia(List<Pair<PhysicalDivision, LogicalDivision>> media) {


### PR DESCRIPTION
Related Issues:
- #4196

In a meta data editor with 2000 images, the method [`DataEditorForm.consecutivePagesSelected`](https://github.com/kitodo/kitodo-production/blob/ed3b6c6301630e0d045156e49d3171b5328ae3ac/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java#L689-L701) is called over 2000 times when selecting an image. For large gallery sections (>100 images) and large selections (>10 images), it's execution time is relatively slow (milliseconds), which adds up when called over 2000 times to multiple seconds.

For example, when selecting 50 images in a gallery section of 500 images:

https://user-images.githubusercontent.com/6214043/167098111-67aada5c-90f2-487e-ada8-27e367249a84.mp4

Or, when selecting:
- 1 image in a gallery section of 80 images: 21.6 ms. 
- 1 image in a gallery section of 500 images: 483ms
- 10 images in a gallery section of 80 images: 105ms
- 10 images in a gallery section of 500 images: 2.8 seconds
- 100 images in a gallery section of 500 images: 23.7 seconds

Most of it's execution time seems to be related to the [`distinct().count()`](https://github.com/kitodo/kitodo-production/blob/ed3b6c6301630e0d045156e49d3171b5328ae3ac/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java#L696) call. For large selections, this should be slower, since it involves pairwise comparisons. However, I'm not sure why it is also slower for large gallery sections, since the size of a gallery section should not have any influence here.

Anyway, the proposed implementation improves the runtime of the method signficantly. The same selection of 50 images loads much faster:

https://user-images.githubusercontent.com/6214043/167098512-fc9994f6-9eaf-4504-a846-634fe494d4f5.mp4

The execution time of `DataEditorForm.consecutivePagesSelected` is reduced to about 36ms in the worst case (selecting 500 images in a gallery section of 500).

The remaining delay when selecting images is related to the full reloading of the gallery, structure and pagination panel.




