### PR TITLE
Prevent crash with IllegalArgumentException

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -442,7 +442,12 @@ public class Helper {
      */
     public static String getTranslation(String title, String... insertions) {
         String pattern = getString(desiredLanguage(), title);
-        String message = MessageFormat.format(pattern, (Object[]) insertions);
+        String message = pattern;
+        try {
+            message = MessageFormat.format(pattern, (Object[]) insertions);
+        } catch (IllegalArgumentException e) {
+            logger.catching(Level.WARN, e);
+        }
         return appendUnusedInsertions(message, insertions);
     }
 


### PR DESCRIPTION
`MessageFormat.format()` expects the pattern to contain placeholders like `{0}`, `{1}`, `{2}`, … If the pattern contains an error message which contains other data between `{` and `}`, such as a JSON array, it throws an exception itself, and prevents the error message from showing.

Fixes #5128