### PR TITLE
Reduce log level when external translation files are missing

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
@@ -99,7 +99,7 @@ abstract class CustomResourceBundle extends ResourceBundle {
             propertiesFileExistsMap.put(key, file.exists());
 
             if (!file.exists()) {
-                logger.error("Could not find external resource bundle '" + bundleName + "' at " + file);
+                logger.info("Could not find external resource bundle '" + bundleName + "' at " + file);
             }
         }
         return propertiesFileExistsMap.get(key);


### PR DESCRIPTION
Pull request #5095 introduced an explicit check for external translation files located at `/usr/local/kitodo/messages`. In case they are missing, an error message is logged. This error might be confusing for users of Kitodo.Production, since it is not a requirement to have custom translation messages and everything works just fine because translations files are loaded from the war file as a fallback.

This pull request reduces the log level of this scenario to an info level message.