### PR TITLE
Update version of hibernate-validator

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -104,10 +104,6 @@
             <artifactId>weld-servlet</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -190,6 +190,10 @@
             <artifactId>jdom2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis-ext</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -537,14 +537,10 @@ from system library in Java 11+ -->
                 <version>${hibernate.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>5.4.3.Final</version>
+                <version>6.2.3.Final</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml</groupId>
-                        <artifactId>classmate</artifactId>
-                    </exclusion>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging</artifactId>


### PR DESCRIPTION
* update hibernate-validator from 5.4.3 to 6.2.3
* fix wrong dependency definition as it is used in Kitodo-Core and not in Kitodo-Datamanagement
* rename groupId as package was renamed in the past
