### PR TITLE
Remove commons-httpclient

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -74,10 +74,6 @@
             <version>3.6.1</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
         </dependency>

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
@@ -32,7 +33,6 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -108,7 +108,13 @@ public class FileService {
      *             an IOException
      */
     URI createMetaDirectory(URI parentFolderUri, String directoryName) throws IOException, CommandException {
-        URI directoryUri = asDirectory(parentFolderUri).resolve(URIUtil.encodePath(directoryName));
+        String encodedPath = "";
+        try {
+            encodedPath = (new URI(null, null, directoryName, null)).toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+        URI directoryUri = asDirectory(parentFolderUri).resolve(encodedPath);
         if (fileExist(directoryUri)) {
             logger.info("Metadata directory: {} already existed! No new directory was created", directoryName);
         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
         <com.h2database.h2.version>1.4.199</com.h2database.h2.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-configuration.version>1.10</commons-configuration.version>
-        <commons-httpclient.version>3.1</commons-httpclient.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-net.version>3.8.0</commons-net.version>
@@ -184,17 +183,6 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-httpclient</groupId>
-                <artifactId>commons-httpclient</artifactId>
-                <version>${commons-httpclient.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>


### PR DESCRIPTION
Replace last used method of commons-httpclient ` URIUtil.encodePath()`  with pure Java URI implementation.