### PR TITLE
Remove unused dependency net.coobird.thumbnailator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,11 +255,6 @@ from system library in Java 11+ -->
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>net.coobird</groupId>
-                <artifactId>thumbnailator</artifactId>
-                <version>0.4.8</version>
-            </dependency>
-            <dependency>
                 <groupId>net.sf.barcode4j</groupId>
                 <artifactId>barcode4j-fop-ext</artifactId>
                 <version>2.1</version>


### PR DESCRIPTION
Package net.coobird.thumbnailator is defined in main pom.xml file but not used anywhere. So removing should not be an issue.