### PR TITLE
Add task action to quickly add correction message

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CommentForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CommentForm.java
@@ -399,4 +399,11 @@ public class CommentForm extends BaseForm {
             return Helper.getTranslation("closeTask");
         }
     }
+
+    /**
+     * Returns true if a correction comment is allowed to be added.
+     */
+    public boolean isCorrectionCommentAllowed() {
+        return getSizeOfPreviousStepsForProblemReporting() > 0 && !isConcurrentTaskInWork() && !isCorrectionWorkflow();
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CommentForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CommentForm.java
@@ -131,7 +131,7 @@ public class CommentForm extends BaseForm {
         } catch (DAOException | CustomResponseException | DataException | IOException e) {
             Helper.setErrorMessage(ERROR_SAVING, logger, e);
         }
-        newComment();
+        newComment(false);
         if (comment.getType().equals(CommentType.ERROR)) {
             reportProblem(comment);
             return MessageFormat.format(REDIRECT_PATH, "tasks");
@@ -292,14 +292,14 @@ public class CommentForm extends BaseForm {
     /**
      * Set default comment.
      */
-    public void newComment() {
+    public void newComment(Boolean isCorrectionComment) {
         if (getSizeOfPreviousStepsForProblemReporting() > 0) {
             setCorrectionTaskId(getPreviousStepsForProblemReporting().get(0).getId().toString());
         } else {
             setCorrectionTaskId("");
         }
         setCommentMessage("");
-        setCorrectionComment(false);
+        setCorrectionComment(isCorrectionComment);
     }
 
     /**

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -228,6 +228,7 @@ correctionMessageSend=Korrekturmeldung senden
 correctionMessageSendAllTasks=Korrekturmeldung f\u00FCr alle Schritte senden
 correctionMessageSendCurrentTask=Korrekturmeldung f\u00FCr aktuellen Schritt senden
 correctionMessageSendPreviousTask=Korrekturmeldung an vorherige Station senden
+correctionMessageWrite=Korrekturmeldung schreiben
 correctionNecessary=Korrektur notwendig
 correctionPerformed=Korrektur durchgef\u00FChrt
 correctionReportProblem=Korrekturmeldung an vorherige Aufgabe konnte nicht gemeldet werden!

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -232,6 +232,7 @@ correctionMessageSend=Send correction message
 correctionMessageSendAllTasks=send correction message to all tasks
 correctionMessageSendCurrentTask=send correction message to current task
 correctionMessageSendPreviousTask=Send correction message to previous task
+correctionMessageWrite=Write correction message
 correctionNecessary=Correction required
 correctionPerformed=Correction performed
 correctionReportProblem=Correction issue message to previous task could not be reported!

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/comments.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/comments.xhtml
@@ -47,7 +47,7 @@
             </p:dataTable>
 
             <p:commandButton id="newButton"
-                             action="#{CommentForm.newComment()}"
+                             action="#{CommentForm.newComment(false)}"
                              oncomplete="PF('newCommentDialog').show()"
                              icon="fa fa-comment fa-lg"
                              styleClass="secondary"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/newCommentDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/newCommentDialog.xhtml
@@ -68,7 +68,7 @@
                         <p:outputLabel value="#{msgs.correctionMessage}" for="correctionMessageSwitch"/>
                         <p:selectBooleanCheckbox id="correctionMessageSwitch"
                                                  value="#{CommentForm.correctionComment}"
-                                                 disabled="#{CommentForm.sizeOfPreviousStepsForProblemReporting lt 1 || CommentForm.concurrentTaskInWork || CommentForm.correctionWorkflow}"
+                                                 disabled="#{!CommentForm.correctionCommentAllowed}"
                                                  title="#{CommentForm.correctionMessageSwitchTooltip}"
                                                  immediate="true"
                                                  styleClass="switch input">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -121,6 +121,7 @@
                     <p:commandLink id="addCorrectionComment"
                                    action="#{CommentForm.newComment(true)}"
                                    oncomplete="PF('newCommentDialog').show()"
+                                   rendered="#{CommentForm.correctionCommentAllowed}"
                                    update=":newCommentForm">
                         <h:outputText><i class="fa fa-commenting" /> #{msgs.correctionMessageWrite}</h:outputText>
                     </p:commandLink>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -117,6 +117,14 @@
                         <h:outputText><i class="fa fa-cog"/> #{msgs.generateMissingImages}</h:outputText>
                     </p:commandLink>
 
+                    <!-- add correction comment -->
+                    <p:commandLink id="addCorrectionComment"
+                                   action="#{CommentForm.newComment(true)}"
+                                   oncomplete="PF('newCommentDialog').show()"
+                                   update=":newCommentForm">
+                        <h:outputText><i class="fa fa-commenting" /> #{msgs.correctionMessageWrite}</h:outputText>
+                    </p:commandLink>
+
                     <!-- Edit Cancel-buttons -->
                     <p:commandLink id="cancel" action="#{CurrentTaskForm.releaseTask}" title="#{msgs.releaseTask}">
                         <h:outputText><i class="fa fa-ban"/> #{msgs.releaseTask}</h:outputText>


### PR DESCRIPTION
Closes #4430

This pull request adds a simple link to the list of available task actions, which shows the comment form to add a correction message

![bitmap](https://user-images.githubusercontent.com/6214043/172374256-c50bb5cd-ea8f-4e60-b316-e4b425ac344d.png)

Clicking the link shows the form and enables the correction switch.

![Screenshot from 2022-06-07 14-02-41](https://user-images.githubusercontent.com/6214043/172374393-54095bc3-165c-4cb0-bc17-1d1289e9e148.png)

