### PR TITLE
Fix NPE when using navigation shortcuts in gallery panel

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -826,10 +826,13 @@ public class GalleryPanel {
         String physicalDivisionOrder = params.get("page");
         String stripeIndex = params.get("stripe");
         String selectionType = params.get("selectionType");
-        int pageX = Integer.parseInt(params.get("pageX"));
-        int pageY = Integer.parseInt(params.get("pageY"));
         boolean triggerContextMenu = Boolean.parseBoolean(params.get("triggerContextMenu"));
-        String createEvent = "(function(){let e=new Event('mousedown');e.pageX=" + pageX + ";e.pageY=" + pageY + ";return e})()";
+        String createEvent = "";
+        if (triggerContextMenu) {
+            int pageX = Integer.parseInt(params.get("pageX"));
+            int pageY = Integer.parseInt(params.get("pageY"));
+            createEvent = "(function(){let e=new Event('mousedown');e.pageX=" + pageX + ";e.pageY=" + pageY + ";return e})()";
+        }
 
         if (StringUtils.isNotBlank(physicalDivisionOrder)) {
             selectMedia(physicalDivisionOrder, stripeIndex, selectionType);

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -143,6 +143,15 @@ metadataEditor.gallery = {
                 this.handleSingleSelect(event, target, treeNodeId);
             }
 
+            this.handleSelectionUpdates(treeNodeId);
+        },
+
+        /**
+         * Updates other components of the meta data editor after changes to the current gallery selection.
+         * 
+         * @param treeNodeId treeNodeId of newly selected thumbnail
+         */
+        handleSelectionUpdates(treeNodeId) {
             // update selection in other components of the meta data editor
             metadataEditor.pagination.markManyAsSelected(this.findSelectedTreeNodeIds());
             if (metadataEditor.physicalTree.isAvailable() || metadataEditor.logicalTree.isHideMediaChecked()) {
@@ -821,11 +830,10 @@ metadataEditor.shortcuts = {
         }
         let newIndex = currentIndex + delta;
         if (currentIndex >= 0 && newIndex >= 0 && newIndex < selectableThumbnails.length) {
-            metadataEditor.gallery.sendSelectionToBackend(
-                selectableThumbnails[newIndex].dataset.order, 
-                selectableThumbnails[newIndex].dataset.stripe, 
-                "default"
-            );
+            let newThumbnailContainer = selectableThumbnails[newIndex];
+            let treeNodeId = newThumbnailContainer.dataset.logicaltreenodeid;
+            metadataEditor.gallery.pages.handleSingleSelect(null, $(newThumbnailContainer), treeNodeId);
+            metadataEditor.gallery.pages.handleSelectionUpdates(treeNodeId);
             let galleryViewMode = this.getGalleryViewMode();
             if (galleryViewMode === "LIST") {
                 scrollToStructureThumbnail(selectableThumbnails.eq(newIndex), $("#imagePreviewForm\\:structuredPagesField"));


### PR DESCRIPTION
When using the keyboard shortcuts to change the currently selected image in the gallery panel, an NPE is raised:

![Screenshot from 2022-06-08 13-29-23](https://user-images.githubusercontent.com/6214043/172605956-4ed4bac5-4252-476a-9f82-f9ef101f2fdd.png)

This pull request fixes this NPE and updates the shortcut code to work with the recent Javascript based selection management as introduced with pull request:
- #5147

Keyboard navigation in the gallery panel now works:

https://user-images.githubusercontent.com/6214043/172606809-99b23365-23f5-482b-a512-8753417ead6e.mp4


