### PR TITLE
docs: fix all img src paths

### DIFF
--- a/docs/user/introduction/actions.md
+++ b/docs/user/introduction/actions.md
@@ -6,22 +6,22 @@ Aktionen sind in diesem Abschnitt definiert als Befehle, die ausgelöst werden k
 
 Die globalen Aktionen erscheinen in allen Bereichen von Kitodo.Production und sollen im Folgenden dargestellt und beschrieben werden:
 
-* <img src= "/user/pictures/IconBearbeiten.png" alt="Bild" height= "35" width= "35"> Bearbeiten
-* <img src= "/user/pictures/IconLoeschen.png" alt="Bild" height= "35" width= "35"> Löschen
-* <img src= "/user/pictures/IconDuplizieren.png" alt="Bild" height= "35" width= "35"> Duplizieren
-* <img src= "/user/pictures/IconAnzeigen.png" alt="Bild" height= "35" width= "35"> Anzeigen
-* <img src= "/user/pictures/IconArchivieren.png" alt="Bild" height= "35" width= "35"> Archivieren
+* <img src= "/docs/user/picturesIconBearbeiten.png" alt="Bild" height= "35" width= "35"> Bearbeiten
+* <img src= "/docs/user/picturesIconLoeschen.png" alt="Bild" height= "35" width= "35"> Löschen
+* <img src= "/docs/user/picturesIconDuplizieren.png" alt="Bild" height= "35" width= "35"> Duplizieren
+* <img src= "/docs/user/picturesIconAnzeigen.png" alt="Bild" height= "35" width= "35"> Anzeigen
+* <img src= "/docs/user/picturesIconArchivieren.png" alt="Bild" height= "35" width= "35"> Archivieren
 * EINS STATISTIK? 
 
 ## Spezifische Aktionen:
 
-* <img src= "/user/pictures/BearbeitungsstatusHochsetzen.png" alt="Bild" width= "200"> Bearbeitungsstatus hochsetzen
-* <img src= "/user/pictures/BearbeitungsstatusRuntersetzen.png" alt="Bild" width= "200">  Bearbeitungsstatus runtersetzen
-* <img src= "/user/pictures/HomeverzeichnisVerlinken.png" alt="Bild" width= "200">  Im Homeverzeichnis verlinken
-* <img src= "/user/pictures/VerlinkungHomeEntfernen.png" alt="Bild" width= "250">  Verlinkung aus Homeverzeichnis entfernen
-* <img src= "/user/pictures/ExportDMS.png" alt="Bild" width= "100">  Export DMS
-* <img src= "/user/pictures/ExceldateiErzeugen.png" alt="Bild" width= "150">  Exceldatei erzeugen
-* <img src= "/user/pictures/PDFErzeugen.png" alt="Bild" width= "125">  PDF erzeugen
+* <img src= "/docs/user/picturesBearbeitungsstatusHochsetzen.png" alt="Bild" width= "200"> Bearbeitungsstatus hochsetzen
+* <img src= "/docs/user/picturesBearbeitungsstatusRuntersetzen.png" alt="Bild" width= "200">  Bearbeitungsstatus runtersetzen
+* <img src= "/docs/user/picturesHomeverzeichnisVerlinken.png" alt="Bild" width= "200">  Im Homeverzeichnis verlinken
+* <img src= "/docs/user/picturesVerlinkungHomeEntfernen.png" alt="Bild" width= "250">  Verlinkung aus Homeverzeichnis entfernen
+* <img src= "/docs/user/picturesExportDMS.png" alt="Bild" width= "100">  Export DMS
+* <img src= "/docs/user/picturesExceldateiErzeugen.png" alt="Bild" width= "150">  Exceldatei erzeugen
+* <img src= "/docs/user/picturesPDFErzeugen.png" alt="Bild" width= "125">  PDF erzeugen
 
 
 

--- a/docs/user/introduction/homedirectory.md
+++ b/docs/user/introduction/homedirectory.md
@@ -6,4 +6,4 @@ Die Verlinkung mit dem Homeverzeichnis ermöglicht es, dass die Images eines Vor
 
 In der <i>Vorgangsliste</i>, können über die Aktionen des nach unten oder oben zeigenden Pfeils die Verlinkung hergestellt, bzw. entfernt werden.
 
-<center><img src= "/user/pictures/VorgangslisteHomeverzeichnisVerlinken.png" alt="Bild" width= 80% height= auto></center>
+<center><img src= "/docs/user/picturesVorgangslisteHomeverzeichnisVerlinken.png" alt="Bild" width= 80% height= auto></center>

--- a/docs/user/introduction/index.md
+++ b/docs/user/introduction/index.md
@@ -4,49 +4,49 @@ Kitodo wird Ihnen bei der ersten Nutzung sowohl optisch als auch in der Benutzun
 ###Ein Projekt ohne Produktionsvorlage anlegen
 <ol> 
 <li>Als erstes müssen Sie ein Projekt (falls noch nicht vorhanden) anlegen. Dazu klicken Sie im "<b>Dashboard</b>" auf "<b>Projekte</b>". 
-<center><img src= "/user/pictures/DashboardProjekte.png" alt="Bild" width= 75% height= auto></center>
+<center><img src= "/docs/user/picturesDashboardProjekte.png" alt="Bild" width= 75% height= auto></center>
 </li>
-<li> Anschließend gelangen Sie auf die Seite <i>Projekte</i>. Dort klicken Sie auf den Button "<b>Neu</b>" und in der Schaltfläche auf "<b>+ Neues Projekt</b>". <img src= "/user/pictures/NeuNeuesProjekt.png" alt="Bild"></li>
+<li> Anschließend gelangen Sie auf die Seite <i>Projekte</i>. Dort klicken Sie auf den Button "<b>Neu</b>" und in der Schaltfläche auf "<b>+ Neues Projekt</b>". <img src= "/docs/user/picturesNeuNeuesProjekt.png" alt="Bild"></li>
 <li> Auf der Seite <i>Neues Projekt</i> geben Sie die Daten für Ihr Projekt unter den 3 Reitern <i>Details</i>, <i>Technische Daten</i>, <i>Mets Parameter</i> ein. 
-<center><img src= "/user/pictures/EingabeNeuesProjekt.png" alt="Bild" width= 75% height= auto></center>
+<center><img src= "/docs/user/picturesEingabeNeuesProjekt.png" alt="Bild" width= 75% height= auto></center>
 </li>
 <li> Klicken Sie anschließend auf "<b>Speichern</b>". </li>
-<img src= "/user/pictures/NeuesProjektSpeichern.png" alt="Bild">
+<img src= "/docs/user/picturesNeuesProjektSpeichern.png" alt="Bild">
 <li> Das neu angelegte Projekt erscheint nun auf der Seite <i>Projekte</i> in der <i>Projektliste</i>.
-<center><img src= "/user/pictures/ProjekteProjektliste.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProjekteProjektliste.png" alt="Bild" width= 50% height= auto></center>
 </li>
 </ol>
 
 ###Einen Workflow für das Projekt erstellen
 <ol> 
 <li> Um einen neuen Workflow zu erstellen, klicken Sie auf den Button "<b>Neu +</b>" und anschließend auf "<b> + Neuer Workflow</b>"</li>
-<center><img src= "/user/pictures/NeuerWorkflow.png" alt="Bild" width= 100% height= auto></center>
+<center><img src= "/docs/user/picturesNeuerWorkflow.png" alt="Bild" width= 100% height= auto></center>
 <li> Sie gelangen auf die Seite "<b>Neuen Workflow anlegen</b>". Geben Sie dort zuerst den Titel für den Workflow ein. </li>
-<center><img src= "/user/pictures/NeuenWorkflowAnlegenTitel .png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesNeuenWorkflowAnlegenTitel .png" alt="Bild" width= 70% height= auto></center>
 <li> Nun können Sie mit den Symbolen auf der linken Seiten Ihren Workflo erstellen. Ziehen Sie dies Symbole einfach in die entsprechende Reihenfolge und Position. </li>
-<center><img src= "/user/pictures/WorkflowNeueAufgabe.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesWorkflowNeueAufgabe.png" alt="Bild" width= 70% height= auto></center>
 <li> Achten Sie dabei darauf, dass immer Verbindungen zwischen den Symbolen vorhanden sind. Klicken Sie dazu auf das jeweilige Symbol und wählen die Verbindung aus und klicken auf das folgende Symbol.</li>
-<center><img src= "/user/pictures/WorkflowVerbindung.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesWorkflowVerbindung.png" alt="Bild" width= 70% height= auto></center>
 <li> Durch einen Doppelklick auf das entsprechende Symbol können Sie diesen Namen geben und anschließend weitere Eigenschaften und Berechtigungen festlegen</li>
-<center><img src= "/user/pictures/WorkflowNameEigenschaften.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesWorkflowNameEigenschaften.png" alt="Bild" width= 70% height= auto></center>
 <li> Wenn Sie alle Eingaben vorgenommen haben, wählen Sie den <i>Status</i> "<b>Aktiv</b>" aus und klicken Sie auf "<b>Speichern</b>".</li>
-<center><img src= "/user/pictures/WorkflowAktivSpeichern.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesWorkflowAktivSpeichern.png" alt="Bild" width= 70% height= auto></center>
 <li> Anschließend wird Ihr erstellter Workflow unter dem Reiter "<i>Workflows</i>" angezeigt.
-<center><img src= "/user/pictures/WorkflowsListe.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesWorkflowsListe.png" alt="Bild" width= 70% height= auto></center>
 </ol> 
 
 ###Eine Produktionsvorlage erstellen
 <ol> 
 <li>Um eine neue Produktionsvorlage zu erstellen, klicken Sie auf den Button "<b>Neu +</b>" und anschließend auf "<b> + Neue Produktionsvorlage</b>".</li>
-<center><img src= "/user/pictures/NeueProduktionsvorlage.png" alt="Bild" width= 90% height= auto></center>
+<center><img src= "/docs/user/picturesNeueProduktionsvorlage.png" alt="Bild" width= 90% height= auto></center>
 <li> Anschließend gelangen Sie auf die Seite "<b>Neue Produktionsvorlage</b>". Geben Sie dort zuerst den Titel für die neue Produktionsvorlage ein. </li>
-<center><img src= "/user/pictures/ProduktionsvorlageTitel.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageTitel.png" alt="Bild" width= 70% height= auto></center>
 <li> Wählen Sie nun ein Projekt, einen <b>Workflow</b>, einen <b>Regelsatz</b> und einen <b>Laufzettel</b> für die Produktionsvorlage aus. </li>
-<center><img src= "/user/pictures/ProduktionsvorlageAuswahl.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageAuswahl.png" alt="Bild" width= 70% height= auto></center>
 <li> Klicken Sie anschließend auf "<b>Speichern</b>".
-<center><img src= "/user/pictures/ProduktionsvorlageSpeichern.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageSpeichern.png" alt="Bild" width= 70% height= auto></center>
 <li> Ihre neue Produktionsvorlage wird nun unter dem Reiter <i>Produktionsvorlagen</i> angezeigt.
-<center><img src= "/user/pictures/ProduktionsvorlagenListe.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlagenListe.png" alt="Bild" width= 50% height= auto></center>
 </ol> 
 
 ###Eine Produktionsvorlage für das Projekt auswählen
@@ -54,33 +54,33 @@ Kitodo wird Ihnen bei der ersten Nutzung sowohl optisch als auch in der Benutzun
 Nachdem nun Projekt, Workflow und Produktionsvorlage erstellt sind, muss (falls noch nicht geschehen) für das neue Projekt noch die Produktionsvorlage ausgewählt werden:
 <ol> 
 <li> Klicken Sie im Bereich <i>Projekte</i> auf die <i>Projektliste</i>.</li>
-<center><img src= "/user/pictures/Projektliste.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProjektliste.png" alt="Bild" width= 50% height= auto></center>
 <li> Klicken Sie neben dem jeweiligen Projekt auf die Aktion "<b>Bearbeiten</b>.</li>
-<center><img src= "/user/pictures/ProjektBearbeiten.png" alt="Bild" width= 100% height= auto></center>
+<center><img src= "/docs/user/picturesProjektBearbeiten.png" alt="Bild" width= 100% height= auto></center>
 <li> Klicken Sie auf den Reiter <i>Produktionsvorlagen</i> und entsperren Sie das Projekt, indem Sie auf den Button "<b>Gesperrt</b>" klicken.
-<center><img src= "/user/pictures/ProjektGesperrt.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProjektGesperrt.png" alt="Bild" width= 50% height= auto></center>
 <li>Klicken Sie nun auf den Button "<b>Produktionsvorlage hinzufügen</b>".</li>
-<center><img src= "/user/pictures/ProjektProduktionsvorlageHinzufügen.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProjektProduktionsvorlageHinzufügen.png" alt="Bild" width= 50% height= auto></center>
 <li>Wählen Sie nun eine Produktionsvorlage aus, indem Sie auf das "<b>+</b>" neben der gewünschten Produktionsvorlage klicken.
-<center><img src= "/user/pictures/ProduktionsvorlageHinzufügen.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageHinzufügen.png" alt="Bild" width= 70% height= auto></center>
 <li>Die ausgewählte Produktionsvorlage erscheint nun in Ihrem Projekt unter dem Abschnitt <i>Aufgabe</i>.
-<center><img src= "/user/pictures/ProduktionsvorlageAusgewählt.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageAusgewählt.png" alt="Bild" width= 70% height= auto></center>
 <li> Schießen Sie nun noch das Pop-up-Fenster indem Sie auf "<b>Schließen</b>" klicken.</li>
-<center><img src= "/user/pictures/ProduktionsvorlageSchließen.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageSchließen.png" alt="Bild" width= 50% height= auto></center>
 <li> "<b>Speichern</b>" Sie anschließend Ihre Änderung an dem Projekt.</li>
-<center><img src= "/user/pictures/ProduktionsvorlageSpeichern1.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageSpeichern1.png" alt="Bild" width= 70% height= auto></center>
 </ol> 
 
 ###Einen Vorgang anlegen
 <ol> 
 <li> Um einen neuen Vorgang anzulegen, klicken Sie in der <i>Projektliste</i> auf das Icon zum Ausklappen des jeweiligen Projekts.</i>
-<center><img src= "/user/pictures/ProjekteAusklappen.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProjekteAusklappen.png" alt="Bild" width= 50% height= auto></center>
 <li> Nun klicken Sie auf das Icon "<b>einen Vorgang auf Basis dieser Produktionsvorlage anlegen</b>". </li>
-<center><img src= "/user/pictures/ProjektlisteVorgangAnlegen.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProjektlisteVorgangAnlegen.png" alt="Bild" width= 70% height= auto></center>
 <li>Geben Sie unter den Reitern <i>OPAC abfragen</i>, <i>Vorgangsdaten</i>, <i>Zusätzliche Details</i> und <i>Suche</i> die Daten für den Vorgang ein. </li>
-<center><img src= "/user/pictures/VorgangAnlegenReiter.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesVorgangAnlegenReiter.png" alt="Bild" width= 70% height= auto></center>
 <li>Anschließend finden Sie den neuen Vorgang in der <i>Vorgangsliste</i> oder auf Ihrem <i>Kitodo-Desktop</i>.</li>
-<img src= "/user/pictures/VorgangslisteNeuerVorgang.png" alt="Bild" width= 50% height= auto><img src= "/user/pictures/NeuerVorgangDesktop.png" alt="Bild" width= 50% height= auto>
+<img src= "/docs/user/picturesVorgangslisteNeuerVorgang.png" alt="Bild" width= 50% height= auto><img src= "/docs/user/picturesNeuerVorgangDesktop.png" alt="Bild" width= 50% height= auto>
 </ol> 
 
 

--- a/docs/user/introduction/process.md
+++ b/docs/user/introduction/process.md
@@ -15,11 +15,11 @@ Ein Vorgang hat immer einen Titel (den Vorgangstitel), der in der Regel aus eine
 ###So legen Sie einen Vorgang an
 <ol> 
 <li> Um einen neuen Vorgang anzulegen, klicken Sie in der <i>Projektliste</i> auf das Icon zum Ausklappen des jeweiligen Projekts.</li>
-<center><img src= "/user/pictures/ProjekteAusklappen.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProjekteAusklappen.png" alt="Bild" width= 50% height= auto></center>
 <li> Nun klicken Sie auf das Icon "<b>Einen Vorgang auf Basis dieser Produktionsvorlage anlegen</b>". </li>
-<center><img src= "/user/pictures/ProjektlisteVorgangAnlegen.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesProjektlisteVorgangAnlegen.png" alt="Bild" width= 70% height= auto></center>
 <li>Geben Sie unter den Reitern <i>OPAC abfragen</i>, <i>Vorgangsdaten</i>, <i>Zusätzliche Details</i> und <i>Suche</i> die Daten für den Vorgang ein. </li>
-<center><img src= "/user/pictures/VorgangAnlegenReiter.png" alt="Bild" width= 70% height= auto></center>
+<center><img src= "/docs/user/picturesVorgangAnlegenReiter.png" alt="Bild" width= 70% height= auto></center>
 <li>Anschließend finden Sie den neuen Vorgang in der <i>Vorgangsliste</i> oder auf Ihrem <i>Kitodo-Desktop</i>.</li>
-<img src= "/user/pictures/VorgangslisteNeuerVorgang.png" alt="Bild" width= 50% height= auto><img src= "/user/pictures/NeuerVorgangDesktop.png" alt="Bild" width= 50% height= auto>
+<img src= "/docs/user/picturesVorgangslisteNeuerVorgang.png" alt="Bild" width= 50% height= auto><img src= "/docs/user/picturesNeuerVorgangDesktop.png" alt="Bild" width= 50% height= auto>
 </ol>

--- a/docs/user/introduction/processslip.md
+++ b/docs/user/introduction/processslip.md
@@ -7,16 +7,16 @@ In Kitodo.Production besteht die Möglichkeit, nach dem Anlegen eines Vorgangs d
 
 Beim Erstellen einer Produktionsvorlage, muss ein dazugehöriger Laufzettel ausgewählt werden. Dieser Laufzettel wird dann für die Vorgänge, welche die Produktionsvorlage verwenden, übernommen.
 
-<center><img src= "/user/pictures/ProduktionsvorlageLaufzettelAuswaehlen.png" alt="Bild" width= 80% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlageLaufzettelAuswaehlen.png" alt="Bild" width= 80% height= auto></center>
 
 ## Konfiguration des Laufzettels
 
 Das Layout oder die Inhalte des Laufzettels können in Kitodo.Production nicht bearbeitet werden. Die Laufzettelvorlagen werden im Hintergrund gespeichert und können in Kitodo.Production in dem Bereich <i>Projekte</i> unter dem Reiter <i>Laufzettel</i> angezeigt werden:
 
-<center><img src= "/user/pictures/ProjekteLaufzettel.png" alt="Bild" width= 80% height= auto></center>
+<center><img src= "/docs/user/picturesProjekteLaufzettel.png" alt="Bild" width= 80% height= auto></center>
 
 ## Laufzettel drucken
 
 Es gibt die Möglichkeit, den Druck von Laufzetteln in Kitodo.Production auszulösen. In der <i>Vorgangsliste</i> befindet sich in jeder Zeile zu einem Vorgang das Icon zum Ausdrucken des jeweiligen Laufzettels.
 
-<center><img src= "/user/pictures/VorgangslisteAusdruckLaufzettel.png" alt="Bild" width= 80% height= auto></center>
+<center><img src= "/docs/user/picturesVorgangslisteAusdruckLaufzettel.png" alt="Bild" width= 80% height= auto></center>

--- a/docs/user/introduction/productiontemplate.md
+++ b/docs/user/introduction/productiontemplate.md
@@ -8,4 +8,4 @@ Einer Produktionsvorlage muss immer ein Projekt zugewiesen werden. Diesem Projek
 
 Hier ist ersichtlich, dass eine Produktionsvorlage aus mehreren Aufgaben besteht und einem Projekt zugeordnet ist.
 
-<center><img src= "/user/pictures/ProduktionsvorlagenWorkflow.png" alt="Bild" width= 80% height= auto></center>
+<center><img src= "/docs/user/picturesProduktionsvorlagenWorkflow.png" alt="Bild" width= 80% height= auto></center>

--- a/docs/user/introduction/project.md
+++ b/docs/user/introduction/project.md
@@ -12,17 +12,17 @@ Es sollte jedoch auch bedacht werden, dass viele Projekte den Verwaltungsaufwand
 
 <ol> 
 <li>Um ein Projekt anzulegen, klicken Sie im "<b>Dashboard</b>" auf "<b>Projekte</b>". 
-<center><img src= "/user/pictures/DashboardProjekte.png" alt="Bild" width= 75% height= auto></center>
+<center><img src= "/docs/user/picturesDashboardProjekte.png" alt="Bild" width= 75% height= auto></center>
 </li>
-<li> Anschließend gelangen Sie auf die Seite <i>Projekte</i>. Dort klicken Sie auf den Button "<b>Neu</b>" und in der Schaltfläche auf "<b>+ Neues Projekt</b>". <img src= "/user/pictures/NeuNeuesProjekt.png" alt="Bild"></li>
+<li> Anschließend gelangen Sie auf die Seite <i>Projekte</i>. Dort klicken Sie auf den Button "<b>Neu</b>" und in der Schaltfläche auf "<b>+ Neues Projekt</b>". <img src= "/docs/user/picturesNeuNeuesProjekt.png" alt="Bild"></li>
 <li> Auf der Seite <i>Neues Projekt</i> geben Sie die Daten für Ihr Projekt unter den 3 Reitern <i>Details</i>, <i>Technische Daten</i>, <i>Mets Parameter</i> ein. 
-<center><img src= "/user/pictures/EingabeNeuesProjekt.png" alt="Bild" width= 75% height= auto></center>
+<center><img src= "/docs/user/picturesEingabeNeuesProjekt.png" alt="Bild" width= 75% height= auto></center>
 </li>
 <li> Wählen Sie eine Produktionsvorlage aus, indem Sie auf den Button "<b>Produktionsvorlage auswählen</b>" klicken.
-<center><img src= "/user/pictures/ProjektProduktionsvorlageHinzufügen.png" alt="Bild" width= 75% height= auto></center>
+<center><img src= "/docs/user/picturesProjektProduktionsvorlageHinzufügen.png" alt="Bild" width= 75% height= auto></center>
 <li> Klicken Sie anschließend auf "<b>Speichern</b>". </li>
-<img src= "/user/pictures/NeuesProjektSpeichern.png" alt="Bild">
+<img src= "/docs/user/picturesNeuesProjektSpeichern.png" alt="Bild">
 <li> Das neu angelegte Projekt erscheint nun auf der Seite <i>Projekte</i> in der <i>Projektliste</i>.
-<center><img src= "/user/pictures/ProjekteProjektliste.png" alt="Bild" width= 50% height= auto></center>
+<center><img src= "/docs/user/picturesProjekteProjektliste.png" alt="Bild" width= 50% height= auto></center>
 </li>
 </ol>


### PR DESCRIPTION
None of the images in the generated user documentation resolve correctly (neither on Github or in the ~~Github Pages~~ ReadTheDocs deployment). I found no existing issue on that. This just auto-replaces all such paths.