### PR TITLE
Fix new checkstyle violation and lower amount of allowed violations

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <maxAllowedViolations>5</maxAllowedViolations>
+        <maxAllowedViolations>4</maxAllowedViolations>
         <cargo.plugin.version>1.9.7</cargo.plugin.version>
         <jsf.projectStage>Production</jsf.projectStage>
         <myfaces.resourceMaxTimeExpires>604800000</myfaces.resourceMaxTimeExpires>

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -115,17 +115,6 @@ public class ExportDms extends ExportMets {
         return exportSuccessful;
     }
 
-    private boolean exportCompletedChildren(List<Process> children) throws DataException {
-        for (Process child:children) {
-            if (processService.getProgress(child.getTasks(), null).equals(COMPLETED) && !child.isExported()) {
-                if (!startExport(child)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
     /**
      * Export to the DMS.
      *
@@ -210,6 +199,17 @@ public class ExportDms extends ExportMets {
         }
 
         return prepareExportLocation(process, gdzfile);
+    }
+
+    private boolean exportCompletedChildren(List<Process> children) throws DataException {
+        for (Process child:children) {
+            if (processService.getProgress(child.getTasks(), null).equals(COMPLETED) && !child.isExported()) {
+                if (!startExport(child)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private boolean prepareExportLocation(Process process,


### PR DESCRIPTION
Fixes introduced checkstyle error:

```
src/main/java/org/kitodo/export/ExportDms.java:[137] (coding) OverloadMethodsDeclarationOrder: Overload methods should not be split. Previous overloaded method located at line '94'.
```