### PR TITLE
Add input field for identifier prefix

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -571,6 +571,7 @@ importConfig.searchField=Suchfeld
 importConfig.searchFields=Suchfelder
 importConfig.searchFields.defaultField=Default-Suchfeld
 importConfig.searchFields.idSearchField=ID-Parameter
+importConfig.searchFields.idPrefix=ID-Prefix
 importConfig.searchFields.parentIdField=ID-Parameter der \u00DCberordnung
 importConfig.searchFields.selectDefaultField=Bitte Default-Suchfeld w\u00E4hlen
 importConfig.searchFields.selectIdSearchField=Bitte Suchfeld f\u00FCr Suche nach Identifier w\u00E4hlen

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -584,6 +584,7 @@ importConfig.searchField=Search field
 importConfig.searchFields=Search fields
 importConfig.searchFields.defaultField=Default search field
 importConfig.searchFields.idSearchField=ID parameter
+importConfig.searchFields.idPrefix=ID prefix
 importConfig.searchFields.parentIdField=ID parameter of parent record
 importConfig.searchFields.selectDefaultField=Please select default search field
 importConfig.searchFields.selectIdSearchField=Please select search field for ID search

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
@@ -80,12 +80,28 @@
                                   noSelectionOption="true"/>
                     <f:selectItems value="#{importConfigurationEditView.searchFields}"/>
                     <p:ajax event="change"
+                            update="editForm:importConfigurationTabView:idParameterPrefix"
                             oncomplete="toggleSave();"/>
                 </p:selectOneMenu>
                 <p:commandButton id="idSearchFieldHelp" type="button"
                                  styleClass="help-button" icon="fa fa-lg fa-question-circle-o"/>
                 <p:tooltip for="idSearchFieldHelp"
                            value="URL parameter for unique identifiers. This parameter is used for importing individual records from the search interface."/>
+            </div>
+            <div>
+                <p:outputLabel for="idParameterPrefix"
+                               value="#{msgs['importConfig.searchFields.idPrefix']}"/>
+                <p:inputText id="idParameterPrefix"
+                             styleClass="input-with-button"
+                             value="#{importConfigurationEditView.importConfiguration.idPrefix}"
+                             disabled="#{importConfigurationEditView.idSearchField eq null}">
+                    <p:ajax event="change"
+                            oncomplete="toggleSave();"/>
+                </p:inputText>
+                <p:commandButton id="idParameterPrefixHelp" type="button"
+                                 styleClass="help-button" icon="fa fa-lg fa-question-circle-o"/>
+                <p:tooltip for="idParameterPrefixHelp"
+                           value="This optional string will be prepended to each ID when querying datasets by ID. This can be used to simplify querying OAI interfaces for example, where each identifier must be preceedded with a valid set identification."/>
             </div>
             <div>
                 <p:outputLabel for="defaultSearchField" value="#{msgs['importConfig.searchFields.defaultField']}"/>


### PR DESCRIPTION
Fixes #5228 

(As it turned out, the database schema for import configurations already contained a field "idPrefix"; just the form to create or edit import configurations was missing a corresponding input field)