### PR TITLE
Save mapping file order for import configurations

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
@@ -25,6 +25,7 @@ import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.apache.commons.lang.StringUtils;
@@ -131,6 +132,7 @@ public class ImportConfiguration extends BaseBean {
     private Process defaultTemplateProcess;
 
     @ManyToMany(cascade = CascadeType.PERSIST)
+    @OrderColumn(name = "sorting")
     @JoinTable(name = "importconfiguration_x_mappingfile", joinColumns = {
             @JoinColumn(name = "importconfiguration_id",
                     foreignKey = @ForeignKey(name = "FK_importconfiguration_x_mappingfile_importconfiguration_id")) },

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_110__Add_sorting_column_to_importconfiguration_mappingfile_cross_table.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_110__Add_sorting_column_to_importconfiguration_mappingfile_cross_table.sql
@@ -1,0 +1,12 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+-- Migration: Add 'sorting' column to importconfiguration/mappingfile cross table
+ALTER TABLE importconfiguration_x_mappingfile ADD sorting INT(11) DEFAULT 0;


### PR DESCRIPTION
Fixes #5229 

**Note** @BartChris : since the order of mapping files in import configurations wasn't saved explicitly to the database yet, I had to initialize the new `sorting` column statically with `0`. This means that for import configurations with multiple mapping files that you created before this pull request, you need to edit the configuration again and re-assign the mapping files in the correct order. Then they will be saved correctly to the database.