### PR TITLE
Add amount of meta data to index to improve performance

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -123,6 +123,15 @@ public class Process extends BaseTemplateBean {
     private List<Map<String, Object>> metadata;
 
     @Transient
+    private int numberOfMetadata;
+
+    @Transient
+    private int numberOfImages;
+
+    @Transient
+    private int numberOfStructures;
+
+    @Transient
     private String baseType;
 
     /**
@@ -587,5 +596,59 @@ public class Process extends BaseTemplateBean {
     @Override
     public int hashCode() {
         return Objects.hash(this.getId());
+    }
+
+    /**
+     * Get amount of structure elements.
+     *
+     * @return Amount of structure elements
+     */
+    public int getNumberOfStructures() {
+        return numberOfStructures;
+    }
+
+    /**
+     * Get amount of meta data elements.
+     *
+     * @return Amount of meta data elements
+     */
+    public int getNumberOfMetadata() {
+        return numberOfMetadata;
+    }
+
+    /**
+     * Set amount of meta data elements.
+     *
+     * @param numberOfMetadata Integer value of amount of meta data elements
+     */
+    public void setNumberOfMetadata(int numberOfMetadata) {
+        this.numberOfMetadata = numberOfMetadata;
+    }
+
+    /**
+     * Get amount of images.
+     *
+     * @return Integer value of amount of images
+     */
+    public int getNumberOfImages() {
+        return numberOfImages;
+    }
+
+    /**
+     * Set amount of images.
+     *
+     * @param numberOfImages Integer value of amount of images
+     */
+    public void setNumberOfImages(int numberOfImages) {
+        this.numberOfImages = numberOfImages;
+    }
+
+    /**
+     * Set amount of structure elements.
+     *
+     * @param numberOfStructures Integer value of amount of structure elements
+     */
+    public void setNumberOfStructures(int numberOfStructures) {
+        this.numberOfStructures = numberOfStructures;
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.kitodo.api.dataformat.PhysicalDivision;
+import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Comment;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Property;
@@ -63,6 +65,9 @@ public class ProcessType extends BaseType<Process> {
         jsonObject.put(ProcessTypeField.PARENT_ID.getKey(), processParentId);
         jsonObject.put(ProcessTypeField.TASKS.getKey(), addObjectRelation(process.getTasks(), true));
         jsonObject.put(ProcessTypeField.METADATA.getKey(), process.getMetadata());
+        jsonObject.put(ProcessTypeField.NUMBER_OF_METADATA.getKey(), process.getNumberOfMetadata());
+        jsonObject.put(ProcessTypeField.NUMBER_OF_IMAGES.getKey(), process.getNumberOfImages());
+        jsonObject.put(ProcessTypeField.NUMBER_OF_STRUCTURES.getKey(), process.getNumberOfStructures());
         jsonObject.put(ProcessTypeField.PROPERTIES.getKey(), getProperties(process));
         jsonObject.put(ProcessTypeField.BASE_TYPE.getKey(), process.getBaseType());
         jsonObject.put(ProcessTypeField.IN_CHOICE_LIST_SHOWN.getKey(), process.getInChoiceListShown());

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
@@ -17,8 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.kitodo.api.dataformat.PhysicalDivision;
-import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Comment;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Property;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/ProcessTypeField.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/ProcessTypeField.java
@@ -41,6 +41,9 @@ public enum ProcessTypeField implements TypeInterface {
     TEMPLATES("templates"),
     WORKPIECES("workpieces"),
     METADATA("meta"),
+    NUMBER_OF_METADATA("numberOfMetadata"),
+    NUMBER_OF_IMAGES("numberOfImages"),
+    NUMBER_OF_STRUCTURES("numberOfStructures"),
     BASE_TYPE("baseType"),
     IN_CHOICE_LIST_SHOWN("inChoiceListShown");
 

--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/ProcessTypeTest.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/index/type/ProcessTypeTest.java
@@ -284,7 +284,7 @@ public class ProcessTypeTest {
         Process process = prepareData().get(0);
         Map<String, Object> actual = processType.createDocument(process);
 
-        assertEquals("Amount of keys is incorrect!", 28, actual.keySet().size());
+        assertEquals("Amount of keys is incorrect!", 31, actual.keySet().size());
 
         List<Map<String, Object>> batches = ProcessTypeField.BATCHES.getJsonArray(actual);
         Map<String, Object> batch = batches.get(0);

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
@@ -37,6 +37,9 @@ public class ProcessDTO extends BaseTemplateDTO {
     private Integer sortHelperDocstructs;
     private Integer sortHelperImages;
     private Integer sortHelperMetadata;
+    private Integer numberOfMetadata;
+    private Integer numberOfImages;
+    private Integer numberOfStructures;
     private String sortHelperStatus;
     private String baseType;
 
@@ -399,5 +402,59 @@ public class ProcessDTO extends BaseTemplateDTO {
      */
     public void setBaseType(String baseType) {
         this.baseType = baseType;
+    }
+
+    /**
+     * Get numberOfMetadata .
+     *
+     * @return value of numberOfMetadata
+     */
+    public Integer getNumberOfMetadata() {
+        return numberOfMetadata;
+    }
+
+    /**
+     * Set numberOfMetadata.
+     *
+     * @param numberOfMetadata as Integer
+     */
+    public void setNumberOfMetadata(Integer numberOfMetadata) {
+        this.numberOfMetadata = numberOfMetadata;
+    }
+
+    /**
+     * Get numberOfImages.
+     *
+     * @return value of numberOfImages
+     */
+    public Integer getNumberOfImages() {
+        return numberOfImages;
+    }
+
+    /**
+     * Set numberOfImages.
+     *
+     * @param numberOfImages as Integer
+     */
+    public void setNumberOfImages(Integer numberOfImages) {
+        this.numberOfImages = numberOfImages;
+    }
+
+    /**
+     * Get numberOfStructures.
+     *
+     * @return value of numberOfStructures
+     */
+    public Integer getNumberOfStructures() {
+        return numberOfStructures;
+    }
+
+    /**
+     * Set numberOfStructures.
+     *
+     * @param numberOfStructures as Integer
+     */
+    public void setNumberOfStructures(Integer numberOfStructures) {
+        this.numberOfStructures = numberOfStructures;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
@@ -21,7 +21,6 @@ import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
-import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.services.data.base.SearchService;
 
 public class IndexWorker implements Runnable {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/IndexWorker.java
@@ -11,6 +11,7 @@
 
 package org.kitodo.production.helper;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -78,7 +79,7 @@ public class IndexWorker implements Runnable {
                     indexChunks(batchSize);
                 }
             }
-        } catch (CustomResponseException | DAOException | DataException | HibernateException e) {
+        } catch (CustomResponseException | DAOException  | HibernateException | IOException e) {
             logger.error(e.getMessage(), e);
         }
     }
@@ -92,7 +93,7 @@ public class IndexWorker implements Runnable {
     }
 
     @SuppressWarnings("unchecked")
-    private void indexChunks(int batchSize) throws CustomResponseException, DAOException, DataException {
+    private void indexChunks(int batchSize) throws CustomResponseException, DAOException, IOException {
         List<Object> objectsToIndex;
         int indexLimit = ConfigCore.getIntParameterOrDefaultValue(ParameterCore.ELASTICSEARCH_INDEXLIMIT);
         while (this.indexedObjects < indexLimit) {
@@ -112,7 +113,7 @@ public class IndexWorker implements Runnable {
     }
 
     @SuppressWarnings("unchecked")
-    private void indexObjects(List<Object> objectsToIndex) throws CustomResponseException, DAOException {
+    private void indexObjects(List<Object> objectsToIndex) throws CustomResponseException, DAOException, IOException {
         this.searchService.addAllObjectsToIndex(objectsToIndex);
         this.indexedObjects = this.indexedObjects + objectsToIndex.size();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -11,11 +11,8 @@
 
 package org.kitodo.production.helper;
 
-import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -25,14 +22,11 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.sort.SortOrder;
-import org.kitodo.api.dataformat.PhysicalDivision;
-import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.elasticsearch.index.type.enums.ProcessTypeField;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.services.ServiceManager;
-import org.kitodo.production.services.dataformat.MetsService;
 
 public class SearchResultGeneration {
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -133,7 +133,7 @@ public class SearchResultGeneration {
                     RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(ProcessTypeField.ID.toString());
                     rangeQueryBuilder.gte(queriedIds).lt(queriedIds + elasticsearchLimit);
                     BoolQueryBuilder queryForFilter = getQueryForFilter(ObjectType.PROCESS);
-                    queryForFilter.should(rangeQueryBuilder);
+                    queryForFilter.must(rangeQueryBuilder);
                     processDTOS = ServiceManager.getProcessService().findByQuery(queryForFilter,
                         ServiceManager.getProcessService().sortById(SortOrder.ASC), true);
                     queriedIds += elasticsearchLimit;
@@ -172,26 +172,9 @@ public class SearchResultGeneration {
         row.createCell(0).setCellValue(processDTO.getTitle());
         row.createCell(1).setCellValue(processDTO.getId());
         row.createCell(2).setCellValue(processDTO.getCreationDate());
-
-        URI metadataFilePath;
-        int numberOfProcessImages = 0;
-        int numberOfProcessStructuralElements = 0;
-        int numberOfProcessMetadata = 0;
-        try {
-            metadataFilePath = ServiceManager.getFileService().getMetadataFilePath(processDTO);
-            Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metadataFilePath);
-            numberOfProcessImages = (int) Workpiece.treeStream(workpiece.getPhysicalStructure())
-                    .filter(physicalDivision -> Objects.equals(physicalDivision.getType(), PhysicalDivision.TYPE_PAGE)).count();
-            numberOfProcessStructuralElements = (int) Workpiece.treeStream(workpiece.getLogicalStructure()).count();
-            numberOfProcessMetadata = Math.toIntExact(MetsService.countLogicalMetadata(workpiece));
-
-        } catch (IOException e) {
-            logger.debug("Metadata file not found for process with id: {}", processDTO.getId());
-        }
-
-        row.createCell(3).setCellValue(numberOfProcessImages);
-        row.createCell(4).setCellValue(numberOfProcessStructuralElements);
-        row.createCell(5).setCellValue(numberOfProcessMetadata);
+        row.createCell(3).setCellValue(processDTO.getNumberOfImages());
+        row.createCell(4).setCellValue(processDTO.getNumberOfStructures());
+        row.createCell(5).setCellValue(processDTO.getNumberOfMetadata());
         row.createCell(6).setCellValue(processDTO.getProject().getTitle());
         row.createCell(7).setCellValue(processDTO.getSortHelperStatus());
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -204,7 +204,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      *            List of BaseIndexedBean objects
      */
     @SuppressWarnings("unchecked")
-    public void addAllObjectsToIndex(List<T> baseIndexedBeans) throws CustomResponseException, DAOException {
+    public void addAllObjectsToIndex(List<T> baseIndexedBeans) throws CustomResponseException, DAOException, IOException {
         indexer.setMethod(HttpMethod.PUT);
         if (!baseIndexedBeans.isEmpty()) {
             indexer.performMultipleRequests(baseIndexedBeans, type, true);

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -78,7 +78,21 @@ public class MetsService {
      *             not found)
      */
     public String getBaseType(URI uri) throws IOException {
-        LogicalDivision logicalDivision = loadWorkpiece(uri).getLogicalStructure();
+        Workpiece workpiece = loadWorkpiece(uri);
+        return getBaseType(workpiece);
+
+    }
+
+    /**
+     * Returns the type of the top element of the logical structure, and thus the
+     * type of the workpiece.
+     *
+     * @param workpiece
+     *            the workpiece
+     * @return the type of root element of the logical structure of the workpiece
+     */
+    public String getBaseType(Workpiece workpiece) {
+        LogicalDivision logicalDivision = workpiece.getLogicalStructure();
         String type = logicalDivision.getType();
         while (Objects.isNull(type) && !logicalDivision.getChildren().isEmpty()) {
             logicalDivision = logicalDivision.getChildren().get(0);
@@ -150,12 +164,12 @@ public class MetsService {
      * @param workpiece the workpiece to count tags.
      * @return the number of tags
      */
-    public static long countLogicalMetadata(Workpiece workpiece) {
-        return Workpiece.treeStream(workpiece.getLogicalStructure())
+    public static int countLogicalMetadata(Workpiece workpiece) {
+        return Math.toIntExact(Workpiece.treeStream(workpiece.getLogicalStructure())
                 .flatMap(logicalDivision -> logicalDivision.getMetadata().parallelStream())
                 .filter(metadata -> !(metadata instanceof MetadataEntry)
                         || Objects.nonNull(((MetadataEntry) metadata).getValue())
                                 && !((MetadataEntry) metadata).getValue().isEmpty())
-                .mapToInt(metadata -> 1).count();
+                .mapToInt(metadata -> 1).count());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -78,8 +78,7 @@ public class MetsService {
      *             not found)
      */
     public String getBaseType(URI uri) throws IOException {
-        Workpiece workpiece = loadWorkpiece(uri);
-        return getBaseType(workpiece);
+        return getBaseType(loadWorkpiece(uri));
 
     }
 

--- a/Kitodo/src/main/resources/elasticsearch_mappings/process.json
+++ b/Kitodo/src/main/resources/elasticsearch_mappings/process.json
@@ -172,6 +172,15 @@
           }
         }
       },
+      "numberOfMetadata": {
+        "type": "long"
+      },
+      "numberOfImages": {
+        "type": "long"
+      },
+      "numberOfStructures": {
+        "type": "long"
+      },
       "project": {
         "properties": {
           "id": {


### PR DESCRIPTION
Improve performance for creating the excel file inside the process list with thousand of processes. For archive this the only needed data from the meta data file is moved into the index as every other data for the excel file is already taken from the index. Instead of reading thousand of meta data files which consumes a lot of time the needed data is available after search.

This is a co-work from @Kathrin-Huber  (general logic) and @henning-gerhardt  (test, cleanup, ...) and commit history is squashed as this changes needs a lot of round tripping.

After merging this pull request the index for processes must be rebuild.