### PR TITLE
Fix tsl asl

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -26,7 +26,6 @@ import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.ProcessHelper;
 import org.kitodo.production.helper.TempProcess;
 import org.kitodo.production.services.ServiceManager;
-import org.kitodo.production.services.data.ImportService;
 import org.omnifaces.util.Ajax;
 import org.primefaces.PrimeFaces;
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -23,6 +23,7 @@ import org.kitodo.api.Metadata;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.helper.ProcessHelper;
 import org.kitodo.production.helper.TempProcess;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ImportService;
@@ -112,7 +113,7 @@ public abstract class MetadataImportDialog {
             if (process.getMetadataNodes().getLength() > 0) {
                 if (createProcessForm.getProcessDataTab().getDocType()
                         .equals(process.getWorkpiece().getLogicalStructure().getType())) {
-                    Collection<Metadata> metadata = ImportService.importMetadata(process.getMetadataNodes(), MdSec.DMD_SEC);
+                    Collection<Metadata> metadata = ProcessHelper.convertMetadata(process.getMetadataNodes(), MdSec.DMD_SEC);
                     return createProcessForm.getProcessMetadata().getProcessDetails().addMetadataIfNotExists(metadata);
                 } else {
                     Helper.setWarnMessage(Helper.getTranslation("errorAdditionalImport"));

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
@@ -171,7 +171,7 @@ public class ProcessDataTab {
 
             LinkedList<TempProcess> parents = new LinkedList<>();
             int processesSize = createProcessForm.getProcesses().size();
-            if( processesSize > 1 ) {
+            if ( processesSize > 1 ) {
                 int indexCurrent = createProcessForm.getProcesses().indexOf(createProcessForm.getCurrentProcess());
                 parents.addAll(createProcessForm.getProcesses().subList(indexCurrent + 1, processesSize));
             }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
@@ -65,7 +65,7 @@ public class ProcessDataTab {
                 this.docType = docType;
             } else {
                 this.docType = (String) allDocTypes.get(0).getValue();
-                Helper.setErrorMessage("docTypeNotFound", new Object[]{docType});
+                Helper.setErrorMessage("docTypeNotFound", new Object[] {docType });
             }
         }
     }
@@ -74,7 +74,8 @@ public class ProcessDataTab {
      * Update process metadata of currently selected process.
      */
     public void updateProcessMetadata() {
-        if (Objects.nonNull(docType) && Objects.nonNull(createProcessForm.getCurrentProcess())) {
+        if (Objects.nonNull(docType) && Objects.nonNull(createProcessForm.getCurrentProcess())
+                && Objects.nonNull(createProcessForm.getCurrentProcess().getWorkpiece())) {
             createProcessForm.getCurrentProcess().getWorkpiece().getLogicalStructure().setType(this.docType);
             if (this.docType.isEmpty()) {
                 createProcessForm.getProcessMetadata().setProcessDetails(ProcessFieldedMetadata.EMPTY);
@@ -90,7 +91,8 @@ public class ProcessDataTab {
         TempProcess currentProcess = createProcessForm.getCurrentProcess();
         if (StringUtils.isNotBlank(currentProcess.getAtstsl())) {
             for (ProcessDetail processDetail : currentProcess.getProcessMetadata().getProcessDetailsElements()) {
-                if (TitleGenerator.TSL_ATS.equals(processDetail.getMetadataID()) && processDetail instanceof ProcessTextMetadata) {
+                if (TitleGenerator.TSL_ATS.equals(processDetail.getMetadataID())
+                        && processDetail instanceof ProcessTextMetadata) {
                     ProcessTextMetadata processTextMetadata = (ProcessTextMetadata) processDetail;
                     if (StringUtils.isBlank(processTextMetadata.getValue())) {
                         processTextMetadata.setValue(currentProcess.getAtstsl());
@@ -162,12 +164,13 @@ public class ProcessDataTab {
     /**
      * Generate process titles and other details.
      */
-    public void generateProcessTitleAndTiffHeader() {
+    public void generateAtstslFields() {
         List<ProcessDetail> processDetails = this.createProcessForm.getProcessMetadata().getProcessDetailsElements();
         Process process = this.createProcessForm.getCurrentProcess().getProcess();
         try {
-            StructuralElementViewInterface docTypeView = createProcessForm.getRulesetManagement().getStructuralElementView(
-                    docType, createProcessForm.getAcquisitionStage(), createProcessForm.getPriorityList());
+            StructuralElementViewInterface docTypeView = createProcessForm.getRulesetManagement()
+                    .getStructuralElementView(docType, createProcessForm.getAcquisitionStage(),
+                        createProcessForm.getPriorityList());
             String processTitle = docTypeView.getProcessTitle().orElse("");
             if (processTitle.isEmpty()) {
                 Helper.setErrorMessage("newProcess.titleGeneration.creationRuleNotFound",

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessMetadata.java
@@ -20,6 +20,7 @@ import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.helper.ProcessHelper;
 import org.kitodo.production.services.data.ImportService;
 import org.primefaces.model.TreeNode;
 
@@ -39,7 +40,7 @@ public class ProcessMetadata {
      *          which its Metadata are wanted to be shown
      */
     public void initializeProcessDetails(LogicalDivision structure, CreateProcessForm form) {
-        processDetails = ImportService.initializeProcessDetails(structure, form.getRulesetManagement(),
+        processDetails = ProcessHelper.initializeProcessDetails(structure, form.getRulesetManagement(),
                 form.getAcquisitionStage(), form.getPriorityList());
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessMetadata.java
@@ -21,7 +21,6 @@ import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.ProcessHelper;
-import org.kitodo.production.services.data.ImportService;
 import org.primefaces.model.TreeNode;
 
 public class ProcessMetadata {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -1,0 +1,260 @@
+package org.kitodo.production.helper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kitodo.api.MdSec;
+import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataEntry;
+import org.kitodo.api.MetadataGroup;
+import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
+import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
+import org.kitodo.api.dataformat.LogicalDivision;
+import org.kitodo.data.database.beans.Process;
+import org.kitodo.exceptions.InvalidMetadataValueException;
+import org.kitodo.exceptions.NoSuchMetadataFieldException;
+import org.kitodo.exceptions.ProcessGenerationException;
+import org.kitodo.production.forms.createprocess.ProcessDetail;
+import org.kitodo.production.forms.createprocess.ProcessFieldedMetadata;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.process.TiffHeaderGenerator;
+import org.kitodo.production.process.TitleGenerator;
+import org.kitodo.production.services.ServiceManager;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class ProcessHelper {
+
+    private static final Logger logger = LogManager.getLogger(ProcessHelper.class);
+
+    /**
+     * Create and return a List of ProcessDetail objects for the given TempProcess
+     * 'tempProcess'.
+     *
+     * @param tempProcess
+     *            the TempProcess for which the List of ProcessDetail objects is
+     *            created
+     * @param managementInterface
+     *            RulesetManagementInterface used to create the metadata of the
+     *            process
+     * @param acquisitionStage
+     *            String containing the acquisitionStage
+     * @param priorityList
+     *            List of LanguageRange objects used as priority list
+     * @return List of ProcessDetail objects
+     * @throws InvalidMetadataValueException
+     *             thrown if TempProcess contains invalid metadata
+     * @throws NoSuchMetadataFieldException
+     *             thrown if TempProcess contains undefined metadata
+     */
+    public static List<ProcessDetail> transformToProcessDetails(TempProcess tempProcess,
+            RulesetManagementInterface managementInterface, String acquisitionStage,
+            List<Locale.LanguageRange> priorityList)
+            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
+        ProcessFieldedMetadata metadata = initializeProcessDetails(tempProcess.getWorkpiece().getLogicalStructure(),
+            managementInterface, acquisitionStage, priorityList);
+        metadata.preserve();
+        return metadata.getRows();
+    }
+
+    /**
+     * Create and return an instance of 'ProcessFieldedMetadata' for the given
+     * LogicalDivision 'structure', RulesetManagementInterface
+     * 'managementInterface', acquisition stage String 'stage' and List of
+     * LanguageRange 'priorityList'.
+     *
+     * @param structure
+     *            LogicalDivision for which to create a ProcessFieldedMetadata
+     * @param managementInterface
+     *            RulesetManagementInterface used to create ProcessFieldedMetadata
+     * @param stage
+     *            String containing acquisition stage used to create
+     *            ProcessFieldedMetadata
+     * @param priorityList
+     *            List of LanguageRange objects used to create
+     *            ProcessFieldedMetadata
+     * @return the created ProcessFieldedMetadata
+     */
+    public static ProcessFieldedMetadata initializeProcessDetails(LogicalDivision structure,
+            RulesetManagementInterface managementInterface, String stage, List<Locale.LanguageRange> priorityList) {
+        StructuralElementViewInterface divisionView = managementInterface.getStructuralElementView(structure.getType(),
+            stage, priorityList);
+        return new ProcessFieldedMetadata(structure, divisionView);
+    }
+
+    public static void generateAtstslFields(TempProcess tempProcess, List<TempProcess> parents, String acquisitionStage)
+            throws ProcessGenerationException, InvalidMetadataValueException, NoSuchMetadataFieldException,
+            IOException {
+        RulesetManagementInterface rulesetManagementInterface = ServiceManager.getRulesetService()
+                .openRuleset(tempProcess.getProcess().getRuleset());
+        List<Locale.LanguageRange> priorityList = ServiceManager.getUserService().getCurrentMetadataLanguage();
+        String docType = tempProcess.getWorkpiece().getLogicalStructure().getType();
+        List<ProcessDetail> processDetails = transformToProcessDetails(tempProcess, rulesetManagementInterface,
+            acquisitionStage, priorityList);
+        generateAtstslFields(tempProcess, processDetails, parents, docType, rulesetManagementInterface,
+            acquisitionStage, priorityList, null);
+    }
+
+    public static void generateAtstslFields(TempProcess tempProcess, List<ProcessDetail> processDetails,
+            List<TempProcess> parents, String docType, RulesetManagementInterface rulesetManagementInterface,
+            String acquisitionStage, List<Locale.LanguageRange> priorityList, Process parentProcess)
+            throws ProcessGenerationException {
+        String processTitleOfDocTypeView = getProcessTitleOfDocTypeView(rulesetManagementInterface, docType,
+            acquisitionStage, priorityList);
+
+        String currentTitle = TitleGenerator.getValueOfMetadataID(TitleGenerator.TITLE_DOC_MAIN, processDetails);
+        if (StringUtils.isBlank(currentTitle)) {
+            if (Objects.nonNull(parentProcess)) {
+                if (processTitleOfDocTypeView.startsWith("+")) {
+                    processTitleOfDocTypeView = '\'' + parentProcess.getTitle() + '\'' + processTitleOfDocTypeView;
+                }
+                currentTitle = getTitleFromLogicalStructure(parentProcess);
+            } else {
+                currentTitle = getTitleFromParents(parents, rulesetManagementInterface, acquisitionStage, priorityList);
+            }
+        }
+
+        tempProcess.setAtstsl(generateProcessTitleAndGetAtstsl(processDetails, processTitleOfDocTypeView,
+            tempProcess.getProcess(), currentTitle));
+        tempProcess.setTiffHeaderDocumentName(tempProcess.getProcess().getTitle());
+        String tiffDefinition = ServiceManager.getImportService().getTiffDefinition();
+        if (Objects.nonNull(tiffDefinition)) {
+            tempProcess.setTiffHeaderImageDescription(generateTiffHeader(processDetails, tempProcess.getAtstsl(),
+                ServiceManager.getImportService().getTiffDefinition(), docType));
+        }
+    }
+
+    public static String getProcessTitleOfDocTypeView(RulesetManagementInterface rulesetManagementInterface,
+            String docType, String acquisitionStage, List<Locale.LanguageRange> priorityList) {
+        StructuralElementViewInterface docTypeView = rulesetManagementInterface.getStructuralElementView(docType,
+            acquisitionStage, priorityList);
+        return docTypeView.getProcessTitle().orElse("");
+    }
+
+    /**
+     * Generate and set the title to process using current title parameter and gets
+     * the atstsl.
+     *
+     * @param title
+     *            of the work to generate atstsl
+     * @return String atstsl
+     */
+    public static String generateProcessTitleAndGetAtstsl(List<ProcessDetail> processDetails, String titleDefinition,
+            Process process, String title) throws ProcessGenerationException {
+        TitleGenerator titleGenerator = new TitleGenerator(null, processDetails);
+        String newTitle = titleGenerator.generateTitle(titleDefinition, null, title);
+        process.setTitle(newTitle);
+        // atstsl is created in title generator and next used in tiff header generator
+        return titleGenerator.getAtstsl();
+    }
+
+    /**
+     * Converts DOM node list of Kitodo metadata elements to metadata objects.
+     *
+     * @param nodes
+     *            node list to convert to metadata
+     * @param domain
+     *            domain of metadata
+     * @return metadata from node list
+     */
+    public static List<Metadata> convertMetadata(NodeList nodes, MdSec domain) {
+        List<Metadata> allMetadata = new ArrayList<>();
+        for (int index = 0; index < nodes.getLength(); index++) {
+            Node node = nodes.item(index);
+            if (!(node instanceof Element)) {
+                continue;
+            }
+            Element element = (Element) node;
+            Metadata metadata;
+            switch (element.getLocalName()) {
+                case "metadata":
+                    MetadataEntry entry = new MetadataEntry();
+                    entry.setValue(element.getTextContent());
+                    metadata = entry;
+                    break;
+                case "metadataGroup": {
+                    MetadataGroup group = new MetadataGroup();
+                    group.setGroup(convertMetadata(element.getChildNodes(), null));
+                    metadata = group;
+                    break;
+                }
+                default:
+                    continue;
+            }
+            metadata.setKey(element.getAttribute("name"));
+            metadata.setDomain(domain);
+            allMetadata.add(metadata);
+        }
+        return allMetadata;
+    }
+
+    /**
+     * Calculate tiff header.
+     */
+    private static String generateTiffHeader(List<ProcessDetail> processDetails, String atstsl, String tiffDefinition,
+            String docType) throws ProcessGenerationException {
+        TiffHeaderGenerator tiffHeaderGenerator = new TiffHeaderGenerator(atstsl, processDetails);
+        return tiffHeaderGenerator.generateTiffHeader(tiffDefinition, docType);
+    }
+
+    private static String getTitleFromLogicalStructure(Process process) {
+        try {
+            LegacyMetsModsDigitalDocumentHelper metsModsDigitalDocumentHelper = ServiceManager.getProcessService()
+                    .readMetadataFile(process);
+            return getTitleFromMetadata(
+                metsModsDigitalDocumentHelper.getWorkpiece().getLogicalStructure().getMetadata());
+        } catch (IOException | NullPointerException e) {
+            logger.error(e.getMessage(), e);
+        }
+        return StringUtils.EMPTY;
+    }
+
+    private static String getTitleFromParents(List<TempProcess> parents,
+            RulesetManagementInterface rulesetManagementInterface, String acquisitionStage,
+            List<Locale.LanguageRange> priorityList) {
+        if (parents.size() == 0) {
+            return StringUtils.EMPTY;
+        }
+
+        // get title of ancestors where TitleDocMain exists when several processes were
+        // imported
+        for (TempProcess tempProcess : parents) {
+            ProcessFieldedMetadata processFieldedMetadata = initializeTempProcessDetails(tempProcess,
+                rulesetManagementInterface, acquisitionStage, priorityList);
+            String title = getTitleFromMetadata(processFieldedMetadata.getChildMetadata());
+            if (StringUtils.isNotBlank(title)) {
+                return title;
+            }
+        }
+        return StringUtils.EMPTY;
+    }
+
+    private static ProcessFieldedMetadata initializeTempProcessDetails(TempProcess tempProcess,
+            RulesetManagementInterface rulesetManagementInterface, String acquisitionStage,
+            List<Locale.LanguageRange> priorityList) {
+        ProcessFieldedMetadata metadata = initializeProcessDetails(tempProcess.getWorkpiece().getLogicalStructure(),
+            rulesetManagementInterface, acquisitionStage, priorityList);
+        metadata.setMetadata(convertMetadata(tempProcess.getMetadataNodes(), MdSec.DMD_SEC));
+        return metadata;
+    }
+
+    private static String getTitleFromMetadata(Collection<Metadata> metadata) {
+        Optional<Metadata> metadataOptional = metadata.parallelStream()
+                .filter(metadataItem -> TitleGenerator.TITLE_DOC_MAIN.equals(metadataItem.getKey())).findFirst();
+        if (metadataOptional.isPresent() && metadataOptional.get() instanceof MetadataEntry) {
+            return ((MetadataEntry) metadataOptional.get()).getValue();
+        }
+        return StringUtils.EMPTY;
+    }
+
+}

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -117,8 +117,6 @@ public class ProcessHelper {
      *            current acquisition level
      * @param priorityList
      *            weighted list of user-preferred display languages
-     * @param acquisitionStage
-     *            current acquisition level
      * @throws ProcessGenerationException
      *             thrown if process title cannot be created
      * @throws InvalidMetadataValueException

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -1,9 +1,19 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
 package org.kitodo.production.helper;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -92,6 +102,24 @@ public class ProcessHelper {
         return new ProcessFieldedMetadata(structure, divisionView);
     }
 
+    /**
+     * Generates TSL/ATS dependent fields of temp process.
+     *
+     * @param tempProcess
+     *            the temp process to generate TSL/ATS dependent fields
+     * @param parents
+     *            the parent temp processes
+     * @param acquisitionStage
+     *            current acquisition level
+     * @throws ProcessGenerationException
+     *             thrown if process title cannot be created
+     * @throws InvalidMetadataValueException
+     *             thrown if process workpiece contains invalid metadata
+     * @throws NoSuchMetadataFieldException
+     *             thrown if process workpiece contains undefined metadata
+     * @throws IOException
+     *             thrown if ruleset file cannot be loaded
+     */
     public static void generateAtstslFields(TempProcess tempProcess, List<TempProcess> parents, String acquisitionStage)
             throws ProcessGenerationException, InvalidMetadataValueException, NoSuchMetadataFieldException,
             IOException {
@@ -105,6 +133,28 @@ public class ProcessHelper {
             acquisitionStage, priorityList, null);
     }
 
+    /**
+     * Generates TSL/ATS dependent fields of temp process.
+     *
+     * @param tempProcess
+     *            the temp process to generate TSL/ATS dependent fields
+     * @param processDetails
+     *            the process details of temp process
+     * @param parents
+     *            the parent temp processes of temp process
+     * @param docType
+     *            current division
+     * @param rulesetManagementInterface
+     *            interface that provides access to the ruleset
+     * @param acquisitionStage
+     *            current acquisition level
+     * @param priorityList
+     *            weighted list of user-preferred display languages
+     * @param parentProcess
+     *            the process of the selected title record
+     * @throws ProcessGenerationException
+     *             thrown if process title cannot be created
+     */
     public static void generateAtstslFields(TempProcess tempProcess, List<ProcessDetail> processDetails,
             List<TempProcess> parents, String docType, RulesetManagementInterface rulesetManagementInterface,
             String acquisitionStage, List<Locale.LanguageRange> priorityList, Process parentProcess)
@@ -134,28 +184,24 @@ public class ProcessHelper {
         }
     }
 
+    /**
+     * Get the process title of doc type view.
+     *
+     * @param rulesetManagementInterface
+     *            interface that provides access to the ruleset
+     * @param docType
+     *            current division
+     * @param acquisitionStage
+     *            current acquisition level
+     * @param priorityList
+     *            weighted list of user-preferred display languages
+     * @return the process title of doc type view
+     */
     public static String getProcessTitleOfDocTypeView(RulesetManagementInterface rulesetManagementInterface,
             String docType, String acquisitionStage, List<Locale.LanguageRange> priorityList) {
         StructuralElementViewInterface docTypeView = rulesetManagementInterface.getStructuralElementView(docType,
             acquisitionStage, priorityList);
         return docTypeView.getProcessTitle().orElse("");
-    }
-
-    /**
-     * Generate and set the title to process using current title parameter and gets
-     * the atstsl.
-     *
-     * @param title
-     *            of the work to generate atstsl
-     * @return String atstsl
-     */
-    public static String generateProcessTitleAndGetAtstsl(List<ProcessDetail> processDetails, String titleDefinition,
-            Process process, String title) throws ProcessGenerationException {
-        TitleGenerator titleGenerator = new TitleGenerator(null, processDetails);
-        String newTitle = titleGenerator.generateTitle(titleDefinition, null, title);
-        process.setTitle(newTitle);
-        // atstsl is created in title generator and next used in tiff header generator
-        return titleGenerator.getAtstsl();
     }
 
     /**
@@ -199,7 +245,24 @@ public class ProcessHelper {
     }
 
     /**
-     * Calculate tiff header.
+     * Generate and set the title to process using current title parameter and gets
+     * the atstsl.
+     *
+     * @param title
+     *            of the work to generate atstsl
+     * @return String atstsl
+     */
+    private static String generateProcessTitleAndGetAtstsl(List<ProcessDetail> processDetails, String titleDefinition,
+            Process process, String title) throws ProcessGenerationException {
+        TitleGenerator titleGenerator = new TitleGenerator(null, processDetails);
+        String newTitle = titleGenerator.generateTitle(titleDefinition, null, title);
+        process.setTitle(newTitle);
+        // atstsl is created in title generator and next used in tiff header generator
+        return titleGenerator.getAtstsl();
+    }
+
+    /**
+     * Generate tiff header.
      */
     private static String generateTiffHeader(List<ProcessDetail> processDetails, String atstsl, String tiffDefinition,
             String docType) throws ProcessGenerationException {
@@ -226,8 +289,6 @@ public class ProcessHelper {
             return StringUtils.EMPTY;
         }
 
-        // get title of ancestors where TitleDocMain exists when several processes were
-        // imported
         for (TempProcess tempProcess : parents) {
             ProcessFieldedMetadata processFieldedMetadata = initializeTempProcessDetails(tempProcess,
                 rulesetManagementInterface, acquisitionStage, priorityList);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
@@ -38,6 +38,8 @@ public class TempProcess {
 
     private NodeList metadataNodes;
 
+    private String atstsl;
+
     private String tiffHeaderDocumentName;
 
     private String tiffHeaderImageDescription;
@@ -214,5 +216,23 @@ public class TempProcess {
                 }
             }
         }
+    }
+
+    /**
+     * Get atstsl.
+     *
+     * @return value of atstsl
+     */
+    public String getAtstsl() {
+        return atstsl;
+    }
+
+    /**
+     * Set atstsl.
+     *
+     * @param atstsl as string
+     */
+    public void setAtstsl(String atstsl) {
+        this.atstsl = atstsl;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
@@ -76,7 +76,7 @@ public class TempProcess {
         this.workpiece.getLogicalStructure().setType(docType);
         if (nodeList.getLength() != 0) {
             this.workpiece.getLogicalStructure().getMetadata().addAll(
-                    ImportService.importMetadata(this.metadataNodes, MdSec.DMD_SEC));
+                    ProcessHelper.convertMetadata(this.metadataNodes, MdSec.DMD_SEC));
         }
         this.processMetadata = new ProcessMetadata();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/process/TitleGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/TitleGenerator.java
@@ -29,6 +29,11 @@ public class TitleGenerator extends Generator {
     public static final String TITLE_DOC_MAIN = "TitleDocMain";
 
     /**
+     * Metadata identifier for tsl/ats.
+     */
+    public static final String TSL_ATS = "TSL_ATS";
+
+    /**
      * Constructor for TitleGenerator.
      *
      * @param atstsl                     field used for title generation
@@ -171,11 +176,9 @@ public class TitleGenerator extends Generator {
             String rowMetadataID = row.getMetadataID();
             String rowValue = ImportService.getProcessDetailValue(row);
             // if it is the ATS or TSL field, then use the calculated atstsl if it does not already exist
-            if ("TSL_ATS".equals(rowMetadataID)) {
+            if (TSL_ATS.equals(rowMetadataID)) {
                 if (StringUtils.isBlank(rowValue)) {
-                    this.atstsl = createAtstsl(currentTitle, currentAuthors);
-                    ImportService.setProcessDetailValue(row, this.atstsl);
-                    rowValue = this.atstsl;
+                    rowValue = createAtstsl(currentTitle, currentAuthors);
                 }
                 this.atstsl = rowValue;
             }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -1060,16 +1060,22 @@ public class ImportService {
                                           String acquisitionStage, List<Locale.LanguageRange> priorityList)
             throws InvalidMetadataValueException, NoSuchMetadataFieldException, ProcessGenerationException,
             IOException {
+
+        List<ProcessDetail> processDetails = ProcessHelper.transformToProcessDetails(tempProcess, managementInterface,
+            acquisitionStage, priorityList);
+        String docType = tempProcess.getWorkpiece().getLogicalStructure().getType();
+
+        ProcessHelper.generateAtstslFields(tempProcess, processDetails, docType, managementInterface,
+            acquisitionStage, priorityList);
+
         if (!ProcessValidator.isProcessTitleCorrect(tempProcess.getProcess().getTitle())) {
             throw new ProcessGenerationException("Unable to create process");
         }
-        List<ProcessDetail> processDetails = ProcessHelper.transformToProcessDetails(tempProcess, managementInterface,
-                acquisitionStage, priorityList);
-        String docType = tempProcess.getWorkpiece().getLogicalStructure().getType();
+
         Process process = tempProcess.getProcess();
         process.setSortHelperImages(tempProcess.getGuessedImages());
         addProperties(tempProcess.getProcess(), tempProcess.getProcess().getTemplate(), processDetails, docType,
-                tempProcess.getProcess().getTitle());
+            tempProcess.getProcess().getTitle());
         ProcessService.checkTasks(process, docType);
         updateTasks(process);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -996,12 +996,12 @@ public class ImportService {
         StructuralElementViewInterface docTypeView = rulesetManagementInterface
                 .getStructuralElementView(docType, acquisitionStage, priorityList);
         String processTitle = docTypeView.getProcessTitle().orElse("");
-        String atstsl = ProcessService.generateProcessTitle(processDetails,
-                processTitle, tempProcess.getProcess());
+        tempProcess.setAtstsl(ProcessService.generateProcessTitle(processDetails,
+                processTitle, tempProcess.getProcess()));
         tempProcess.setTiffHeaderDocumentName(tempProcess.getProcess().getTitle());
         String tiffDefinition = ServiceManager.getImportService().getTiffDefinition();
         if (Objects.nonNull(tiffDefinition)) {
-            tempProcess.setTiffHeaderImageDescription(ProcessService.generateTiffHeader(processDetails, atstsl,
+            tempProcess.setTiffHeaderImageDescription(ProcessService.generateTiffHeader(processDetails, tempProcess.getAtstsl(),
                     tiffDefinition, docType));
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -1063,7 +1063,7 @@ public class ImportService {
         if (!ProcessValidator.isProcessTitleCorrect(tempProcess.getProcess().getTitle())) {
             throw new ProcessGenerationException("Unable to create process");
         }
-        List<ProcessDetail> processDetails = transformToProcessDetails(tempProcess, managementInterface,
+        List<ProcessDetail> processDetails = ProcessHelper.transformToProcessDetails(tempProcess, managementInterface,
                 acquisitionStage, priorityList);
         String docType = tempProcess.getWorkpiece().getLogicalStructure().getType();
         Process process = tempProcess.getProcess();

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -44,11 +45,8 @@ import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
-import org.kitodo.api.MetadataGroup;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
-import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
-import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.externaldatamanagement.DataImport;
 import org.kitodo.api.externaldatamanagement.ExternalDataImportInterface;
@@ -91,6 +89,7 @@ import org.kitodo.production.forms.createprocess.ProcessFieldedMetadata;
 import org.kitodo.production.forms.createprocess.ProcessSelectMetadata;
 import org.kitodo.production.forms.createprocess.ProcessTextMetadata;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.helper.ProcessHelper;
 import org.kitodo.production.helper.TempProcess;
 import org.kitodo.production.helper.XMLUtils;
 import org.kitodo.production.metadata.MetadataEditor;
@@ -109,6 +108,7 @@ import org.xml.sax.SAXParseException;
 public class ImportService {
 
     private static final Logger logger = LogManager.getLogger(ImportService.class);
+    public static final String ACQUISITION_STAGE_CREATE = "create";
 
     private static volatile ImportService instance = null;
     private static ExternalDataImportInterface importModule;
@@ -397,19 +397,7 @@ public class ImportService {
         } else {
             throw new ProcessGenerationException("Ruleset missing!");
         }
-        addTitleAndTiffHeaderDataToTempProcess(tempProcess);
         return tempProcess;
-    }
-
-    private void addTitleAndTiffHeaderDataToTempProcess(TempProcess tempProcess) throws IOException,
-            InvalidMetadataValueException, NoSuchMetadataFieldException, ProcessGenerationException {
-        RulesetManagementInterface managementInterface = ServiceManager.getRulesetService()
-                .openRuleset(tempProcess.getProcess().getRuleset());
-        String acquisitionStage = "create";
-        List<Locale.LanguageRange> priorityList = ServiceManager.getUserService().getCurrentMetadataLanguage();
-        List<ProcessDetail> processDetails = transformToProcessDetails(tempProcess, managementInterface,
-                acquisitionStage, priorityList);
-        createProcessTitle(tempProcess, managementInterface, acquisitionStage, priorityList, processDetails);
     }
 
     private String importProcessAndReturnParentID(String recordId, LinkedList<TempProcess> allProcesses,
@@ -497,6 +485,17 @@ public class ImportService {
         }
         importParents(recordId, importConfiguration, projectId, templateId, importDepth, processes, parentID, template,
                 parentMetadataKey);
+
+        ListIterator<TempProcess> processesIterator = processes.listIterator();
+        while (processesIterator.hasNext()) {
+            int fromIndex = processesIterator.nextIndex() + 1;
+            List<TempProcess> parents = new ArrayList<>();
+            if (fromIndex < processes.size()) {
+                parents = processes.subList(fromIndex, processes.size());
+            }
+            ProcessHelper.generateAtstslFields(processesIterator.next(), parents, ACQUISITION_STAGE_CREATE);
+        }
+
         return processes;
     }
 
@@ -720,46 +719,6 @@ public class ImportService {
     }
 
     /**
-     * Converts DOM node list of Kitodo metadata elements to metadata objects.
-     *
-     * @param nodes
-     *            node list to convert to metadata
-     * @param domain
-     *            domain of metadata
-     * @return metadata from node list
-     */
-    public static List<Metadata> importMetadata(NodeList nodes, MdSec domain) {
-        List<Metadata> allMetadata = new ArrayList<>();
-        for (int index = 0; index < nodes.getLength(); index++) {
-            Node node = nodes.item(index);
-            if (!(node instanceof Element)) {
-                continue;
-            }
-            Element element = (Element) node;
-            Metadata metadata;
-            switch (element.getLocalName()) {
-                case "metadata":
-                    MetadataEntry entry = new MetadataEntry();
-                    entry.setValue(element.getTextContent());
-                    metadata = entry;
-                    break;
-                case "metadataGroup": {
-                    MetadataGroup group = new MetadataGroup();
-                    group.setGroup(importMetadata(element.getChildNodes(), null));
-                    metadata = group;
-                    break;
-                }
-                default:
-                    continue;
-            }
-            metadata.setKey(element.getAttribute("name"));
-            metadata.setDomain(domain);
-            allMetadata.add(metadata);
-        }
-        return allMetadata;
-    }
-
-    /**
      * Get the value of a specific processDetail in the processDetails.
      *
      * @param processDetail
@@ -953,77 +912,6 @@ public class ImportService {
      */
     public boolean isParentElementConfigured(ImportConfiguration importConfiguration) throws ConfigException {
         return Objects.nonNull(importConfiguration.getParentElementType());
-    }
-
-    /**
-     * Create and return a List of ProcessDetail objects for the given TempProcess 'tempProcess'.
-     *
-     * @param tempProcess the TempProcess for which the List of ProcessDetail objects is created
-     * @param managementInterface RulesetManagementInterface used to create the metadata of the process
-     * @param acquisitionStage String containing the acquisitionStage
-     * @param priorityList List of LanguageRange objects used as priority list
-     * @return List of ProcessDetail objects
-     * @throws InvalidMetadataValueException thrown if TempProcess contains invalid metadata
-     * @throws NoSuchMetadataFieldException thrown if TempProcess contains undefined metadata
-     */
-    public static List<ProcessDetail> transformToProcessDetails(TempProcess tempProcess,
-                                                         RulesetManagementInterface managementInterface,
-                                                         String acquisitionStage,
-                                                         List<Locale.LanguageRange> priorityList)
-            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
-        ProcessFieldedMetadata metadata = initializeProcessDetails(tempProcess.getWorkpiece().getLogicalStructure(),
-                managementInterface, acquisitionStage, priorityList);
-        metadata.preserve();
-        return metadata.getRows();
-    }
-
-    /**
-     * Create a process title for the given TempProcess using the provided parameters.
-     *
-     * @param tempProcess the TempProcess for which the TifHeader is created
-     * @param rulesetManagementInterface RulesetManagementInterface used to create TifHeader
-     * @param acquisitionStage String containing name of acquisitionStage
-     * @param priorityList List of LanguageRange objects used as priority list
-     * @param processDetails List of ProcessDetail objects containing the metadata of the process
-     * @throws ProcessGenerationException thrown if generating the Process title or the TifHeader fails
-     */
-    public static void createProcessTitle(TempProcess tempProcess,
-                                          RulesetManagementInterface rulesetManagementInterface,
-                                          String acquisitionStage, List<Locale.LanguageRange> priorityList,
-                                          List<ProcessDetail> processDetails)
-            throws ProcessGenerationException {
-        String docType = tempProcess.getWorkpiece().getLogicalStructure().getType();
-        StructuralElementViewInterface docTypeView = rulesetManagementInterface
-                .getStructuralElementView(docType, acquisitionStage, priorityList);
-        String processTitle = docTypeView.getProcessTitle().orElse("");
-        tempProcess.setAtstsl(ProcessService.generateProcessTitle(processDetails,
-                processTitle, tempProcess.getProcess()));
-        tempProcess.setTiffHeaderDocumentName(tempProcess.getProcess().getTitle());
-        String tiffDefinition = ServiceManager.getImportService().getTiffDefinition();
-        if (Objects.nonNull(tiffDefinition)) {
-            tempProcess.setTiffHeaderImageDescription(ProcessService.generateTiffHeader(processDetails, tempProcess.getAtstsl(),
-                    tiffDefinition, docType));
-        }
-    }
-
-    /**
-     * Create and return an instance of 'ProcessFieldedMetadata' for the given LogicalDivision 'structure',
-     * RulesetManagementInterface 'managementInterface', acquisition stage String 'stage' and List of LanguageRange
-     * 'priorityList'.
-     *
-     * @param structure LogicalDivision for which to create a ProcessFieldedMetadata
-     * @param managementInterface RulesetManagementInterface used to create ProcessFieldedMetadata
-     * @param stage String containing acquisition stage used to create ProcessFieldedMetadata
-     * @param priorityList List of LanguageRange objects used to create ProcessFieldedMetadata
-     * @return the created ProcessFieldedMetadata
-     */
-    public static ProcessFieldedMetadata initializeProcessDetails(LogicalDivision structure,
-                                                                  RulesetManagementInterface managementInterface,
-                                                                  String stage,
-                                                                  List<Locale.LanguageRange> priorityList) {
-        StructuralElementViewInterface divisionView = managementInterface.getStructuralElementView(structure.getType(),
-                stage, priorityList);
-        return new ProcessFieldedMetadata(structure, divisionView);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -131,7 +131,6 @@ import org.kitodo.data.elasticsearch.index.type.enums.ProcessTypeField;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.InvalidImagesException;
-import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.export.ExportMets;
 import org.kitodo.production.dto.BatchDTO;
 import org.kitodo.production.dto.ProcessDTO;
@@ -140,7 +139,6 @@ import org.kitodo.production.dto.PropertyDTO;
 import org.kitodo.production.dto.TaskDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.exporter.ExportXmlLog;
-import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.SearchResultGeneration;
 import org.kitodo.production.helper.WebDav;
@@ -154,8 +152,6 @@ import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPre
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.metadata.copier.CopierData;
 import org.kitodo.production.metadata.copier.DataCopier;
-import org.kitodo.production.process.TiffHeaderGenerator;
-import org.kitodo.production.process.TitleGenerator;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ProjectSearchService;
 import org.kitodo.production.services.dataformat.MetsService;
@@ -2387,41 +2383,6 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             processesLinkedInLogicalDivision.addAll(getProcessesLinkedInLogicalDivision(child));
         }
         return processesLinkedInLogicalDivision;
-    }
-
-    /**
-     * Generate and set the title to process.
-     */
-    public static String generateProcessTitle(List<ProcessDetail> processDetails, String titleDefinition, Process process)
-            throws ProcessGenerationException {
-        return generateProcessTitleAndGetAtstsl(processDetails, titleDefinition, process,
-            TitleGenerator.getValueOfMetadataID(TitleGenerator.TITLE_DOC_MAIN, processDetails));
-    }
-
-    /**
-     * Generate and set the title to process using current title parameter and gets
-     * the atstsl.
-     *
-     * @param title
-     *            of the work to generate atstsl
-     * @return String atstsl
-     */
-    public static String generateProcessTitleAndGetAtstsl(List<ProcessDetail> processDetails, String titleDefinition,
-                                                          Process process, String title) throws ProcessGenerationException {
-        TitleGenerator titleGenerator = new TitleGenerator(null, processDetails);
-        String newTitle = titleGenerator.generateTitle(titleDefinition, null, title);
-        process.setTitle(newTitle);
-        // atstsl is created in title generator and next used in tiff header generator
-        return titleGenerator.getAtstsl();
-    }
-
-    /**
-     * Calculate tiff header.
-     */
-    public static String generateTiffHeader(List<ProcessDetail> processDetails, String atstsl,
-                                            String tiffDefinition, String docType) throws ProcessGenerationException {
-        TiffHeaderGenerator tiffHeaderGenerator = new TiffHeaderGenerator(atstsl, processDetails);
-        return tiffHeaderGenerator.generateTiffHeader(tiffDefinition, docType);
     }
 
     /**

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
@@ -77,7 +77,7 @@
                         </p:inputText>
                         <p:commandButton id="generateTitleButton"
                                          process="@this"
-                                         actionListener="#{CreateProcessForm.processDataTab.generateProcessTitleAndTiffHeader}"
+                                         actionListener="#{CreateProcessForm.processDataTab.generateAtstslFields}"
                                          icon="fa fa-cog" title="#{msgs.generate}" resetValues="true"/>
                     </div>
 

--- a/Kitodo/src/test/java/org/kitodo/production/forms/createprocess/ProcessDataTabTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/createprocess/ProcessDataTabTest.java
@@ -13,12 +13,14 @@ package org.kitodo.production.forms.createprocess;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
@@ -27,9 +29,40 @@ import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.production.helper.TempProcess;
+import org.kitodo.production.process.TitleGenerator;
 import org.primefaces.model.DefaultTreeNode;
 
 public class ProcessDataTabTest {
+
+    @Test
+    public void testGenerationOfAtstslField() throws Exception {
+        CreateProcessForm createProcessForm = new CreateProcessForm(Locale.LanguageRange.parse("en"));
+
+        Ruleset ruleset = new Ruleset();
+        ruleset.setFile("ruleset_test.xml");
+        createProcessForm.updateRulesetAndDocType(ruleset);
+
+        ProcessDataTab underTest = createProcessForm.getProcessDataTab();
+        underTest.setDocType("Child");
+
+        createProcessForm.setCurrentProcess(new TempProcess(new Process(), null));
+
+        DefaultTreeNode titleDocMainTreeNode = getTreeNode(TitleGenerator.TITLE_DOC_MAIN, TitleGenerator.TITLE_DOC_MAIN,
+            "TitleOfPa_1234567X");
+        DefaultTreeNode tslatsTreeNode = getTreeNode(TitleGenerator.TSL_ATS, TitleGenerator.TSL_ATS, "");
+        ProcessFieldedMetadata processDetails = new ProcessFieldedMetadata() {
+            {
+                treeNode.getChildren().add(titleDocMainTreeNode);
+                treeNode.getChildren().add(tslatsTreeNode);
+            }
+        };
+        createProcessForm.getProcessMetadata().setProcessDetails(processDetails);
+
+        underTest.generateAtstslFields();
+        assertEquals("TSL/ATS is does not match expected value", "Titl",
+            createProcessForm.getCurrentProcess().getAtstsl());
+
+    }
 
     @Test
     public void shouldCreateChildProcessTitlePrefixedByParentItile() throws Exception {
@@ -47,27 +80,31 @@ public class ProcessDataTabTest {
         underTest.setDocType("Child");
 
         createProcessForm.setCurrentProcess(new TempProcess(new Process(), null));
-        MetadataEntry metadata = new MetadataEntry();
-        metadata.setKey("ChildCount");
-        metadata.setValue("8888");
-        DefaultTreeNode metdataTreeNode = new DefaultTreeNode();
-        ProcessDetail processDetail = new ProcessTextMetadata(null,getSettingsObject(),metadata);
-        metdataTreeNode.setData(processDetail);
+        DefaultTreeNode metadataTreeNode = getTreeNode("ChildCount", "ChildCount", "8888");
         ProcessFieldedMetadata processDetails = new ProcessFieldedMetadata() {
             {
-                treeNode.getChildren().add(metdataTreeNode);
+                treeNode.getChildren().add(metadataTreeNode);
             }
         };
         createProcessForm.getProcessMetadata().setProcessDetails(processDetails);
 
-        underTest.generateProcessTitleAndTiffHeader();
+        underTest.generateAtstslFields();
 
         assertEquals("Process title could not be build", "TitlOfPa_1234567X_8888",
             createProcessForm.getCurrentProcess().getTiffHeaderDocumentName());
     }
 
-    private static SimpleMetadataViewInterface getSettingsObject() {
-        
+    private static DefaultTreeNode getTreeNode(String metadataId, String metadataKey, String metadataValue) {
+        DefaultTreeNode metdataTreeNode = new DefaultTreeNode();
+        MetadataEntry metadataEntry = new MetadataEntry();
+        metadataEntry.setKey(metadataKey);
+        metadataEntry.setValue(metadataValue);
+        metdataTreeNode.setData(new ProcessTextMetadata(null, getSettingsObject(metadataId), metadataEntry));
+        return metdataTreeNode;
+    }
+
+    private static SimpleMetadataViewInterface getSettingsObject(String metadataId) {
+
         SimpleMetadataViewInterface settings = new SimpleMetadataViewInterface() {
 
             @Override
@@ -77,8 +114,7 @@ public class ProcessDataTabTest {
 
             @Override
             public String getId() {
-                // TODO Auto-generated method stub
-                return "ChildCount";
+                return metadataId;
             }
 
             @Override
@@ -129,7 +165,8 @@ public class ProcessDataTabTest {
             @Override
             public boolean isValid(String value, List<Map<MetadataEntry, Boolean>> metadata) {
                 throw new UnsupportedOperationException("Not implemented");
-            }};
+            }
+        };
 
         return settings;
     }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/createprocess/ProcessDataTabTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/createprocess/ProcessDataTabTest.java
@@ -13,14 +13,12 @@ package org.kitodo.production.forms.createprocess;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
@@ -59,7 +57,7 @@ public class ProcessDataTabTest {
         createProcessForm.getProcessMetadata().setProcessDetails(processDetails);
 
         underTest.generateAtstslFields();
-        assertEquals("TSL/ATS is does not match expected value", "Titl",
+        assertEquals("TSL/ATS does not match expected value", "Titl",
             createProcessForm.getCurrentProcess().getAtstsl());
 
     }


### PR DESCRIPTION
Fixes #5208 and #5207.

Consolidates functionalities of TSL/ASL field generation from import and generating button in ProcessDataTab to new ProcessHelper. Now the hierachical import consider the parents of temp processes cause generation is executed after process hierarchy is imported.