### PR TITLE
Fix update of "ID parameter of parent record" in ImportConfiguration

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/newSearchFieldDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/newSearchFieldDialog.xhtml
@@ -74,7 +74,8 @@
                                  action="#{importConfigurationEditView.addSearchField(addSearchFieldDialogView.searchField)}"
                                  update="editForm:importConfigurationTabView:searchFieldTable
                                                            editForm:importConfigurationTabView:defaultSearchField
-                                                           editForm:importConfigurationTabView:idSearchField"
+                                                           editForm:importConfigurationTabView:idSearchField
+                                                           editForm:importConfigurationTabView:parentIdSearchField"
                                  oncomplete="PF('addSearchFieldDialog').hide();toggleSave();"
                                  value="#{msgs.apply}"
                                  styleClass="primary right"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
@@ -51,7 +51,8 @@
                                        action="#{importConfigurationEditView.removeSearchField(field)}"
                                        update="editForm:importConfigurationTabView:searchFieldTable
                                                            editForm:importConfigurationTabView:defaultSearchField
-                                                           editForm:importConfigurationTabView:idSearchField"
+                                                           editForm:importConfigurationTabView:idSearchField
+                                                           editForm:importConfigurationTabView:parentIdSearchField"
                                        oncomplete="toggleSave()">
                             <i class="fa fa-trash-o fa-lg"/>
                         </p:commandLink>


### PR DESCRIPTION
Added updates of parentIdSearchField when searchfields are added or removed ([#5244](https://github.com/kitodo/kitodo-production/issues/5244#issue-1304719354))