### PR TITLE
Refactor CSS rule for scrolling in popup dialogs

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1375,9 +1375,14 @@ Popup dialogs
     height: 100%;
 }
 
-.ui-dialog:not(#calendarSettingsDialog):not(#calendarDayDialog):not(#resetPasswordDialog):not(#changePasswordDialog):not(#dialogAddDocStrucTypeDialog):not(#addSearchFieldDialog):not(#editSearchFieldDialog) div.dialogFieldWrapper {
+.ui-dialog div.dialogFieldWrapper {
     max-height: calc(100% - 100px);
     overflow-y: scroll;
+}
+
+.ui-dialog div.not-scrollable.dialogFieldWrapper {
+    max-height: initial;
+    overflow-y: hidden;
 }
 
 #dialogAddDocStrucTypeForm\:dialogAddDocStrucTypeFormContent {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/calendarDayDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/calendarDayDialog.xhtml
@@ -47,7 +47,7 @@
         </h:panelGrid>
         <h:form id="calendarDayForm">
             <h:panelGroup layout="block"
-                          styleClass="dialogFieldWrapper">
+                          styleClass="not-scrollable dialogFieldWrapper">
                 <p:panelGrid columns="1" layout="grid">
                     <p:repeat
                             value="#{CalendarForm.calendarSheet.get(date.dayOfMonth - 1).get(date.monthValue - 1).issues}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/calendarSettingsDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/calendarSettingsDialog.xhtml
@@ -26,7 +26,7 @@
             <p:panelGrid columns="1" layout="grid">
                 <h3>#{msgs['calendar.year.settings']}</h3>
                 <h:panelGroup layout="block"
-                              styleClass="dialogFieldWrapper">
+                              styleClass="not-scrollable dialogFieldWrapper">
                     <div>
                         <h:outputLabel value="#{msgs['calendar.year.begin']}"
                                        for="calendarYearBegin"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/newSearchFieldDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/newSearchFieldDialog.xhtml
@@ -25,7 +25,7 @@
         <h:form id="addSearchFieldForm">
             <h3>#{msgs['importConfig.addSearchField']}</h3>
             <h:panelGroup layout="block"
-                          styleClass="dialogFieldWrapper">
+                          styleClass="not-scrollable dialogFieldWrapper">
                 <p:panelGrid columns="1" layout="grid">
                     <p:row>
                         <div>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/updateSearchFieldDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/updateSearchFieldDialog.xhtml
@@ -25,7 +25,7 @@
         <h:form id="editSearchFieldForm">
             <h3>#{msgs['importConfig.editSearchField']}</h3>
             <h:panelGroup layout="block"
-                          styleClass="dialogFieldWrapper">
+                          styleClass="not-scrollable dialogFieldWrapper">
                 <p:panelGrid columns="1" layout="grid">
                     <p:row>
                         <div>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addDocStrucType.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/addDocStrucType.xhtml
@@ -35,7 +35,7 @@
 
             <h:panelGroup id="dialogAddDocStrucTypeFormContent"
                           layout="block"
-                          styleClass="dialogFieldWrapper">
+                          styleClass="not-scrollable dialogFieldWrapper">
 
                 <h:panelGroup id="parentElement"
                               layout="block">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/changePasswordPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/changePasswordPopup.xhtml
@@ -29,7 +29,7 @@
                 <p:panelGrid id="passwordGrid" columns="1" layout="grid">
                     <p:row>
                         <h:panelGroup layout="block"
-                                      styleClass="dialogFieldWrapper">
+                                      styleClass="not-scrollable dialogFieldWrapper">
                             <div>
                                 <!-- old password -->
                                 <h:outputLabel for="oldPassword" value="#{msgs.oldPassword}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/resetPasswordPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/resetPasswordPopup.xhtml
@@ -28,7 +28,7 @@
                 <p:panelGrid id="passwordGrid" columns="1" layout="grid">
                     <p:row>
                         <h:panelGroup layout="block"
-                                      styleClass="dialogFieldWrapper">
+                                      styleClass="not-scrollable dialogFieldWrapper">
                             <div>
                                 <!-- new password -->
                                 <p:outputLabel for="newPassword"


### PR DESCRIPTION
Add new CSS class `not-scrollable` to simplify rules for scrolling in popup dialogs.