### PR TITLE
Add field 'identifier_metadata' to ImportConfigurations

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
@@ -154,6 +154,9 @@ public class ImportConfiguration extends BaseBean {
     @Column(name = "oai_metadata_prefix")
     private String oaiMetadataPrefix;
 
+    @Column(name = "identifier_metadata")
+    private String identifierMetadata;
+
     /**
      * Default constructor.
      */
@@ -798,6 +801,24 @@ public class ImportConfiguration extends BaseBean {
      */
     public void setOaiMetadataPrefix(String oaiMetadataPrefix) {
         this.oaiMetadataPrefix = oaiMetadataPrefix;
+    }
+
+    /**
+     * Get identifierMetadata.
+     *
+     * @return value of identifierMetadata
+     */
+    public String getIdentifierMetadata() {
+        return identifierMetadata;
+    }
+
+    /**
+     * Set identifierMetadata.
+     *
+     * @param identifierMetadata as java.lang.String
+     */
+    public void setIdentifierMetadata(String identifierMetadata) {
+        this.identifierMetadata = identifierMetadata;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_111__Add_identifier_metadata_column_to_import_configuration.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_111__Add_identifier_metadata_column_to_import_configuration.sql
@@ -1,0 +1,12 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+-- Migration: Add 'identifier_metadata' column to importconfiguration
+ALTER TABLE importconfiguration ADD identifier_metadata varchar(255) NOT NULL DEFAULT 'CatalogIDDigital';

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
@@ -85,7 +85,7 @@ public class FileUploadDialog extends MetadataImportDialog {
                 String parentID = importService.getParentID(internalDocument, higherLevelIdentifier.toArray()[0]
                                 .toString(), importConfiguration.getParentElementTrimMode());
                 importService.checkForParent(parentID, createProcessForm.getTemplate().getRuleset().getId(),
-                    createProcessForm.getProject().getId());
+                    createProcessForm.getProject().getId(), importConfiguration.getIdentifierMetadata());
                 if (Objects.isNull(importService.getParentTempProcess())) {
                     TempProcess parentTempProcess = extractParentRecordFromFile(uploadedFile, internalDocument);
                     if (Objects.nonNull(parentTempProcess)) {

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -531,6 +531,7 @@ imagesRead=Images lesen
 imagesWrite=Images schreiben
 importConfig.addSearchField=Suchfeld hinzuf\u00fcgen
 importConfig.assignedAsDefaultConfig=Importkonfiguration ''{0}'' wird derzeit als Standardkonfiguration von Projekt ''{1}'' verwendet!
+importConfig.catalogIdMetadata=Metadatum f\u00fcr Katalog-ID
 importConfig.configuration=Importkonfiguration
 importConfig.configurations=Importkonfigurationen
 importConfig.defaultConfiguration=Default-Konfiguration

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -544,6 +544,7 @@ imagesWrite=Write images
 importChildren=Import child processes
 importConfig.addSearchField=Add search field
 importConfig.assignedAsDefaultConfig=Import configuration ''{0}'' is configured as default configuration of project ''{1}''!
+importConfig.catalogIdMetadata=Metadata for catalog ID
 importConfig.configuration=Import configuration
 importConfig.configurations=Import configurations
 importConfig.defaultConfiguration=Default configuration

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
@@ -147,6 +147,20 @@
                 <p:tooltip for="parentIdSearchFieldHelp"
                            value="The parent ID search field is used to query for records whose parent record has the provided ID value (not supported by all interfaces)"/>
             </div>
+            <div>
+                <p:outputLabel for="catalogIdMetadata"
+                               value="#{msgs['importConfig.catalogIdMetadata']}"/>
+                <p:inputText id="catalogIdMetadata"
+                             styleClass="input-with-button"
+                             value="#{importConfigurationEditView.importConfiguration.identifierMetadata}">
+                    <p:ajax event="change"
+                            oncomplete="toggleSave();"/>
+                </p:inputText>
+                <p:commandButton id="catalogIdMetadataHelp" type="button"
+                                 styleClass="help-button" icon="fa fa-lg fa-question-circle-o"/>
+                <p:tooltip for="catalogIdMetadataHelp"
+                           value="Metadata key used to store the catalog ID of the imported record. (Note: this metadata must exist in the ruleset used during process creation!)"/>
+            </div>
         </p:row>
     </f:view>
 </ui:composition>

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -1466,6 +1466,7 @@ public class MockDatabase {
         kalliopeConfiguration.setPrestructuredImport(false);
         kalliopeConfiguration.setReturnFormat(FileFormat.XML.name());
         kalliopeConfiguration.setMetadataFormat(MetadataFormat.MODS.name());
+        kalliopeConfiguration.setIdentifierMetadata("CatalogIDDigital");
         kalliopeConfiguration.setMappingFiles(Collections.singletonList(ServiceManager.getMappingFileService()
                 .getById(1)));
 


### PR DESCRIPTION
This pull request adds the field 'identifier_metadata' to the `ImportConfiguration` class. This field was previously configurable in the `kitodo_opac.xml` file but was lost in the transition to the new `ImportConfiguration` class. It contains the ID of the metadata that is to be used for saving the catalog ID of a record in the internal metadata format of Kitodo.Production. 
This metadata is required to link new processes to existing parent processes for configurations where the catalog ID is saved in a metadata field different from the default field 'CatalogIDDigital'.