### PR TITLE
Use search delimiter even on hierachy search

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -640,7 +640,8 @@ public class ImportService {
         // ################ IMPORT #################
         importModule = initializeImportModule();
         DataRecord dataRecord = importModule.getFullRecordById(
-                createDataImportFromImportConfiguration(importConfiguration), identifier);
+                createDataImportFromImportConfiguration(importConfiguration),
+                getSearchTermWithDelimiter(identifier, importConfiguration));
         if (extractExemplars) {
             exemplarRecords = extractExemplarRecords(dataRecord, importConfiguration);
         }


### PR DESCRIPTION
While try to fix the access to an other catalogue I found out that the defined search delimiter was not used on hierarchy search. This pull request is fixing this.