### PR TITLE
Avoid duplicated links in the exported METS by using a LinkedHashSet

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -13,14 +13,15 @@ package org.kitodo.production.metadata;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -359,7 +360,7 @@ public class MetadataEditor {
     }
 
     private static Collection<View> getViewsFromChildrenRecursive(LogicalDivision structure) {
-        List<View> viewsFromChildren = new ArrayList<>(structure.getViews());
+        Set<View> viewsFromChildren = new LinkedHashSet<>(structure.getViews());
         for (LogicalDivision child : structure.getChildren()) {
             viewsFromChildren.addAll(getViewsFromChildrenRecursive(child));
         }


### PR DESCRIPTION
fixes https://github.com/kitodo/kitodo-production/issues/5286