### PR TITLE
Prevent NPE during mass import by updating records table in time

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1537,6 +1537,10 @@ Mass import
     border: none;
 }
 
+#editForm\:recordsTable input.ui-inputtext {
+    width: 100%;
+}
+
 #editForm\:csvSeparator {
     display: block;
     width: 60px;

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/massImportTab.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/massImportTab.xhtml
@@ -66,8 +66,15 @@
                                              update="editForm:recordsTableWrapper"/>
                         </f:facet>
                         <p:cellEditor>
-                            <f:facet name="output"><h:outputText value="#{record.csvCells.get(columnIndex).value}" title="#{record.csvCells.get(columnIndex).value}"/></f:facet>
-                            <f:facet name="input"><p:inputText value="#{record.csvCells.get(columnIndex).value}" style="width:100%"/></f:facet>
+                            <f:facet name="output">
+                                <h:outputText value="#{record.csvCells.get(columnIndex).value}"
+                                              title="#{record.csvCells.get(columnIndex).value}"/>
+                            </f:facet>
+                            <f:facet name="input">
+                                <p:inputText value="#{record.csvCells.get(columnIndex).value}">
+                                    <p:ajax update="editForm:recordsTable"/>
+                                </p:inputText>
+                            </f:facet>
                         </p:cellEditor>
                     </p:columns>
                     <p:column styleClass="remove-column">


### PR DESCRIPTION
When the user manually adds an entry to the list of IDs that should be imported in the mass import form and then immediately clicks on the button "Start mass import" before clicking somewhere else on the page, a NullPointerException will be thrown because the new ID has not yet been added to the bean property containing the list of record IDs to import. This happens because the `cellEdit` event (which the user causes by exiting the datatable cell), is triggered _after_ the form submission.

These changes prevent this potential NullPointerException by adding another ajax event listener that updates the list of IDs as soon as the user triggers a "bluer" event by leaving the input field with the new ID. This event is triggered before the `cellEdit` event and also _before_ form submission.