### PR TITLE
Replace org.apache.commons.lang with org.apache.commons.lang3

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -110,6 +110,10 @@
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.api.MetadataEntry;
 
 /**

--- a/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/OPACConfig.java
@@ -23,7 +23,7 @@ import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.externaldatamanagement.SearchInterfaceType;

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/UseXmlAttributeAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/UseXmlAttributeAccess.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.api.dataformat.MediaVariant;
 import org.kitodo.dataformat.metskitodo.MetsType.FileSec.FileGrp;
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
@@ -28,7 +28,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.data.database.persistence.MappingFileDAO;
 import org.kitodo.data.database.persistence.SearchFieldDAO;

--- a/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
+++ b/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.command.CommandInterface;

--- a/Kitodo-FileManagement/src/test/java/org/kitodo/ExecutionPermission.java
+++ b/Kitodo-FileManagement/src/test/java/org/kitodo/ExecutionPermission.java
@@ -18,7 +18,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 public class ExecutionPermission {
 

--- a/Kitodo-FileManagement/src/test/java/org/kitodo/filemanagement/FileManagementTest.java
+++ b/Kitodo-FileManagement/src/test/java/org/kitodo/filemanagement/FileManagementTest.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/Kitodo-Query-URL-Import/pom.xml
+++ b/Kitodo-Query-URL-Import/pom.xml
@@ -56,6 +56,10 @@
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
+++ b/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
@@ -44,7 +44,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPFileFilter;

--- a/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/XmlResponseHandler.java
+++ b/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/XmlResponseHandler.java
@@ -24,7 +24,7 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.jdom2.output.Format;

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -282,6 +282,10 @@
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/Kitodo/src/main/java/org/kitodo/config/ConfigProject.java
+++ b/Kitodo/src/main/java/org/kitodo/config/ConfigProject.java
@@ -27,7 +27,7 @@ import javax.faces.model.SelectItem;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.enums.KitodoConfigFile;

--- a/Kitodo/src/main/java/org/kitodo/production/converter/BeanConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/BeanConverter.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 import javax.faces.convert.ConverterException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.data.database.beans.BaseBean;

--- a/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
@@ -20,7 +20,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.inject.Named;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.production.forms.dataeditor.IllustratedSelectItem;
 import org.kitodo.production.helper.Helper;
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/LanguageForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/LanguageForm.java
@@ -26,7 +26,7 @@ import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
 import javax.inject.Named;
 
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.data.database.beans.User;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/LdapServerForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/LdapServerForm.java
@@ -26,7 +26,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.ConfigCore;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
@@ -34,7 +34,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.ConfigCore;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
@@ -23,7 +23,7 @@ import javax.faces.model.SelectItem;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.ConfigCore;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -39,7 +39,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -25,7 +25,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDataTab.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 
 import javax.faces.model.SelectItem;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.data.database.beans.Process;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
@@ -16,7 +16,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MetadataEntry;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SearchDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SearchDialog.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataformat.LogicalDivision;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 import javax.faces.model.SelectItem;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 import javax.faces.model.SelectItem;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Level;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseId;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/validators/AbsolutePathValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/validators/AbsolutePathValidator.java
@@ -18,7 +18,7 @@ import javax.faces.validator.FacesValidator;
 import javax.faces.validator.Validator;
 import javax.faces.validator.ValidatorException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @FacesValidator("AbsolutePathValidator")
 public class AbsolutePathValidator implements Validator<String> {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/validators/XPathValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/validators/XPathValidator.java
@@ -19,7 +19,7 @@ import javax.faces.validator.Validator;
 import javax.faces.validator.ValidatorException;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.production.helper.XMLUtils;
 
 @FacesValidator("XPathValidator")

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -32,7 +32,7 @@ import java.util.ResourceBundle;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -19,7 +19,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MdSec;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/EmptyTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/EmptyTask.java
@@ -16,7 +16,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.production.helper.Helper;

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyDTOModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyDTOModel.java
@@ -20,7 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyProcessDTOModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyProcessDTOModel.java
@@ -18,7 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.index.query.QueryShardException;
 import org.kitodo.data.exceptions.DataException;

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyTaskDTOModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyTaskDTOModel.java
@@ -18,7 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.index.query.QueryShardException;
 import org.kitodo.data.database.enums.TaskStatus;

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.production.helper.XMLUtils;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;

--- a/Kitodo/src/main/java/org/kitodo/production/process/ProcessValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/ProcessValidator.java
@@ -14,7 +14,7 @@ package org.kitodo.production.process;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.ConfigCore;

--- a/Kitodo/src/main/java/org/kitodo/production/process/TitleGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/TitleGenerator.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.StringTokenizer;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.services.data.ImportService;

--- a/Kitodo/src/main/java/org/kitodo/production/process/field/AdditionalField.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/field/AdditionalField.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 import javax.faces.model.SelectItem;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class AdditionalField {
 

--- a/Kitodo/src/main/java/org/kitodo/production/security/AESUtil.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/AESUtil.java
@@ -31,10 +31,9 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kitodo.production.helper.Helper;
 
 public class AESUtil {
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.Metadata;

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.text.StrTokenizer;
+import org.apache.commons.lang3.text.StrTokenizer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataformat.Workpiece;

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/MetadataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/MetadataScript.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.lang.text.StrTokenizer;
+import org.apache.commons.lang3.text.StrTokenizer;
 
 public class MetadataScript {
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.index.query.BoolQueryBuilder;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -40,7 +40,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MdSec;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
@@ -54,7 +54,7 @@ import javax.naming.ldap.StartTlsRequest;
 import javax.naming.ldap.StartTlsResponse;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.digests.MD4Digest;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/MassImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/MassImportService.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -20,7 +20,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataformat.LogicalDivision;

--- a/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;

--- a/Kitodo/src/test/java/org/kitodo/ExecutionPermission.java
+++ b/Kitodo/src/test/java/org/kitodo/ExecutionPermission.java
@@ -18,7 +18,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 public class ExecutionPermission {
 

--- a/Kitodo/src/test/java/org/kitodo/production/exporter/download/ExportMetsIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/exporter/download/ExportMetsIT.java
@@ -18,7 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/CreateProcessFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/CreateProcessFormIT.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedList;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;

--- a/Kitodo/src/test/java/org/kitodo/production/helper/tasks/HierarchyMigrationTaskIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/tasks/HierarchyMigrationTaskIT.java
@@ -20,7 +20,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/Kitodo/src/test/java/org/kitodo/production/helper/tasks/NewspaperMigrationTaskIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/tasks/NewspaperMigrationTaskIT.java
@@ -15,7 +15,7 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/CommandServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/CommandServiceTest.java
@@ -21,7 +21,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
@@ -29,7 +29,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.AfterClass;

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/UserServiceIT.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;

--- a/Kitodo/src/test/java/org/kitodo/production/services/file/FileServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/file/FileServiceTest.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;

--- a/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
@@ -23,7 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;

--- a/Kitodo/src/test/java/org/kitodo/selenium/AddingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/AddingST.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/Kitodo/src/test/java/org/kitodo/selenium/EditingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/EditingST.java
@@ -15,11 +15,9 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/Kitodo/src/test/java/org/kitodo/selenium/WorkingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/WorkingST.java
@@ -17,7 +17,7 @@ import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
@@ -13,7 +13,7 @@ package org.kitodo.selenium.testframework;
 
 import java.io.File;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.selenium.testframework.enums.BrowserType;

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -20,7 +20,7 @@ import java.net.URL;
 import java.net.URLConnection;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.plexus.archiver.UnArchiver;


### PR DESCRIPTION
The old "org.apache.commons.lang" package is not updated and maybe supported any more. So all package imports are replaced with a more up to date version "org,apache.commons.lang3" and needed dependencies into the modules are added where they are missing.

The old package is still "available" as a dependency of "commons-configuration" and should not used anymore. The "commons-configuration" package will be updated too in a separate pull request after this pull request is merged.