### PR TITLE
Fix automatic setting of child count

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -399,7 +399,6 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                 project = processGenerator.getProject();
                 template = processGenerator.getTemplate();
                 updateRulesetAndDocType(getMainProcess().getRuleset());
-                processDataTab.prepare();
                 if (Objects.nonNull(project) && Objects.nonNull(project.getDefaultImportConfiguration())) {
                     setDefaultImportConfiguration(project.getDefaultImportConfiguration());
                 }
@@ -420,6 +419,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                         updateRulesetAndDocType(getMainProcess().getRuleset());
                     }
                 }
+                processDataTab.prepare();
             }
         } catch (ProcessGenerationException | DataException | DAOException | IOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);


### PR DESCRIPTION
Automatic setting of child process count (ruleset function `use="childCount"` doesn’t work with current master, as setting happens _after_ GUI init. Changes order of instruction so that the field gives the correct count number.