### PR TITLE
Replace deprecated groupId jdom with org.jdom

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -49,7 +49,7 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>jdom</groupId>
+            <groupId>org.jdom</groupId>
             <artifactId>jdom</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ from system library in Java 11+ -->
                 <version>${jaxen.version}</version>
             </dependency>
             <dependency>
-                <groupId>jdom</groupId>
+                <groupId>org.jdom</groupId>
                 <artifactId>jdom</artifactId>
                 <version>1.1</version>
             </dependency>


### PR DESCRIPTION
While building the application with Maven the following message

`
[WARNING] The artifact jdom:jdom:jar:1.1 has been relocated to org.jdom:jdom:jar:1.1
`

is visible. This pull request is changing the deprecated groupId to the new groupId. The used version 1.1 is old (from 2008) and is containing  CVE-2021-33813 and some more CVEs ([CVE-2022-34169](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-34169), [CVE-2022-23437](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23437), ...) in it dependencies. But this should be changed in a separate pull request as switching to jdom 2.x need some work.