### PR TITLE
Default record xpaths in import configurations

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
@@ -52,6 +52,42 @@ public class ImportConfigurationEditView extends BaseForm {
     private static final List<String> SCHEMES = List.of("https", "http", "ftp");
     private static final List<String> PARENT_ELEMENT_TYPES = Collections.singletonList("reference");
     private static final List<String> PARENT_ELEMENT_TRIM_MODES = Collections.singletonList("parenthesis");
+    private static final List<String> DEFAULT_ID_XPATHS;
+    private static final List<String> DEFAULT_TITLE_XPATHS;
+
+    static {
+        DEFAULT_ID_XPATHS = List.of(
+                ".//*[local-name()='recordInfo']/*[local-name()='recordIdentifier']/text()",
+                ".//*[local-name()='datafield'][@tag='245']/*[local-name()='subfield'][@code='a']/text()",
+                ".//*[local-name()='datafield'][@tag='003@']/*[local-name()='subfield'][@code='0']/text()"
+        );
+    }
+
+    static {
+        DEFAULT_TITLE_XPATHS = List.of(
+                ".//*[local-name()='titleInfo']/*[local-name()='title']/text()",
+                ".//*[local-name()='controlfield'][@tag='001']/text()",
+                ".//*[local-name()='datafield'][@tag='021A']/*[local-name()='subfield'][@code='a']/text()"
+        );
+    }
+
+    /**
+     * Return list of default record ID XPaths.
+     *
+     * @return list of default record ID XPaths
+     */
+    public List<String> getRecordIdXPathDefault() {
+        return DEFAULT_ID_XPATHS;
+    }
+
+    /**
+     * Return list of default record title XPaths.
+     *
+     * @return list of default record title XPaths.
+     */
+    public List<String> getRecordTitleXPathDefault() {
+        return DEFAULT_TITLE_XPATHS;
+    }
 
     /**
      * Load import configuration by ID.

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -744,6 +744,10 @@ section#content-section {
     width: calc(100% - 44px);
 }
 
+.input-with-button > input.ui-selectonemenu-label.ui-inputfield {
+    width: 100%;
+}
+
 .ui-panelgrid-cell .ui-selectonemenu.input-with-button {
     display: inline-block;
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/formatRow.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/formatRow.xhtml
@@ -39,11 +39,15 @@
                           rendered="#{importConfigurationEditView.importConfiguration.interfaceType eq 'SRU'}">
                 <p:outputLabel for="metadataRecordIdXPath"
                                value="#{msgs['importConfig.field.metadataRecordIDXPath']} *"/>
-                <p:inputText id="metadataRecordIdXPath"
-                             styleClass="input-with-button"
-                             validator="XPathValidator"
-                             required="#{not empty param['editForm:save'] and importConfigurationEditView.importConfiguration.interfaceType eq 'SRU'}"
-                             value="#{importConfigurationEditView.importConfiguration.metadataRecordIdXPath}"/>
+                <p:selectOneMenu id="metadataRecordIdXPath"
+                                 styleClass="input-with-button"
+                                 autoWidth="false"
+                                 value="#{importConfigurationEditView.importConfiguration.metadataRecordIdXPath}"
+                                 validator="XPathValidator"
+                                 required="#{not empty param['editForm:save'] and importConfigurationEditView.importConfiguration.interfaceType eq 'SRU'}"
+                                 editable="#{true}">
+                    <f:selectItems value="#{importConfigurationEditView.recordIdXPathDefault}"/>
+                </p:selectOneMenu>
                 <p:commandButton id="metadataRecordIdXPathHelp"
                                  type="button"
                                  styleClass="help-button"
@@ -97,11 +101,15 @@
                           rendered="#{importConfigurationEditView.importConfiguration.interfaceType eq 'SRU'}">
                 <p:outputLabel for="metadataRecordTitleXPath"
                                value="#{msgs['importConfig.field.metadataRecordTitleXPath']} *"/>
-                <p:inputText id="metadataRecordTitleXPath"
-                             styleClass="input-with-button"
-                             validator="XPathValidator"
-                             required="#{not empty param['editForm:save'] and importConfigurationEditView.importConfiguration.interfaceType eq 'SRU'}"
-                             value="#{importConfigurationEditView.importConfiguration.metadataRecordTitleXPath}"/>
+                <p:selectOneMenu id="metadataRecordTitleXPath"
+                                 styleClass="input-with-button"
+                                 autoWidth="false"
+                                 value="#{importConfigurationEditView.importConfiguration.metadataRecordIdXPath}"
+                                 validator="XPathValidator"
+                                 required="#{not empty param['editForm:save'] and importConfigurationEditView.importConfiguration.interfaceType eq 'SRU'}"
+                                 editable="#{true}">
+                    <f:selectItems value="#{importConfigurationEditView.recordTitleXPathDefault}"/>
+                </p:selectOneMenu>
                 <p:commandButton id="metadataRecordTitleXPathHelp"
                                  type="button"
                                  styleClass="help-button"


### PR DESCRIPTION
Provide default xpaths for ID and title when editing import configurations.

Fixes #5317 