### PR TITLE
Remember sort order and pagination of the process and search result list

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.enterprise.context.SessionScoped;
+import javax.faces.context.FacesContext;
 import javax.inject.Named;
 
 import org.apache.logging.log4j.LogManager;
@@ -313,7 +314,9 @@ public class SearchResultForm extends ProcessListBaseView {
      * in the default order.</p>
      */
     public void resetSearchResultTableViewState() {
-        PrimeFaces.current().multiViewState().clear(SEARCH_RESULT_VIEW_ID, SEARCH_RESULT_TABLE_ID);
+        if (!Objects.isNull(FacesContext.getCurrentInstance())) {
+            PrimeFaces.current().multiViewState().clear(SEARCH_RESULT_VIEW_ID, SEARCH_RESULT_TABLE_ID);
+        }
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
@@ -44,6 +44,9 @@ import org.primefaces.PrimeFaces;
 public class SearchResultForm extends ProcessListBaseView {
     private static final Logger logger = LogManager.getLogger(SearchResultForm.class);
 
+    private static final String SEARCH_RESULT_VIEW_ID = "/pages/searchResult.xhtml";
+    private static final String SEARCH_RESULT_TABLE_ID = "searchResultTabView:searchResultForm:searchResultTable";
+
     private List<ProcessDTO> filteredList = new ArrayList<>();
     private List<ProcessDTO> resultList = new ArrayList<>();
     private String searchQuery;
@@ -76,6 +79,7 @@ public class SearchResultForm extends ProcessListBaseView {
         setCurrentTaskStatusFilter(null);
         setCurrentProjectFilter(null);
         setCurrentTaskFilter(null);
+        resetSearchResultTableViewState();
         return searchResultListPath;
     }
 
@@ -297,6 +301,19 @@ public class SearchResultForm extends ProcessListBaseView {
      */
     public void setCurrentProjectFilter(Integer currentProjectFilter) {
         this.currentProjectFilter = currentProjectFilter;
+    }
+
+    /**
+     * This method resets the view state of the search result table, which was
+     * enabled by adding "multiViewState=true" to the DataTable component.
+     * 
+     * <p>This affects both the pagination state and the sort order of 
+     * the table. It should be called whenever a new search is triggered such 
+     * that the user is presented with the most relevant results (page 1) 
+     * in the default order.</p>
+     */
+    public void resetSearchResultTableViewState() {
+        PrimeFaces.current().multiViewState().clear(SEARCH_RESULT_VIEW_ID, SEARCH_RESULT_TABLE_ID);
     }
 
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -35,7 +35,8 @@
                      rows="#{LoginForm.loggedUser.tableSize}"
                      paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {JumpToPageInput} {NextPageLink} {LastPageLink}"
                      currentPageReportTemplate="#{msgs.currentPageReportTemplate}"
-                     paginatorPosition="bottom">
+                     paginatorPosition="bottom"
+                     multiViewState="true">
 
 
             <p:ajax event="page"

--- a/Kitodo/src/main/webapp/pages/searchResult.xhtml
+++ b/Kitodo/src/main/webapp/pages/searchResult.xhtml
@@ -43,7 +43,8 @@
                                  rows="#{LoginForm.loggedUser.tableSize}"
                                  paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {NextPageLink} {LastPageLink}"
                                  currentPageReportTemplate="#{msgs.currentPageReportTemplate}"
-                                 paginatorPosition="bottom">
+                                 paginatorPosition="bottom"
+                                 multiViewState="true">
                         <p:ajax event="rowToggle"
                                 oncomplete="registerRowToggleEvents();" />
 

--- a/Kitodo/src/test/java/org/kitodo/selenium/ProcessesSortingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ProcessesSortingST.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.selenium;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.selenium.testframework.BaseTestSelenium;
+import org.kitodo.selenium.testframework.Pages;
+import org.kitodo.selenium.testframework.pages.ProcessesPage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the processes list for various requirements related to sorting it.
+ */
+public class ProcessesSortingST extends BaseTestSelenium {
+
+    @SuppressWarnings("unused")
+    private static final Logger logger = LogManager.getLogger(ProcessesSortingST.class);
+
+    private static ProcessesPage processesPage;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        processesPage = Pages.getProcessesPage();
+    }
+
+    @Before
+    public void login() throws Exception {
+        Pages.getLoginPage().goTo().performLoginAsAdmin();
+    }
+
+    @After
+    public void logout() throws Exception {
+        Pages.getTopNavigation().logout();
+    }
+
+    /**
+     * Verifies that clicking the header of the title column of the processes list 
+     * will indeed trigger that processes are sorted by title.
+     */
+    @Test
+    public void sortByProcessTitle() throws Exception {
+        processesPage.goTo();
+
+        // check that default sort order (descending by id) has second process as first element in the process list
+        assertEquals("Second process", processesPage.getProcessTitles().get(0));
+
+        // click on column header to trigger ascending order by process title
+        processesPage.clickProcessesTitleColumnForSorting();
+
+        // check that first process is now first element in list of processes
+        assertEquals("First process", processesPage.getProcessTitles().get(0));
+
+        // click again to trigger descending order for process title
+        processesPage.clickProcessesTitleColumnForSorting();
+
+        // check that second process is again first element in list of processes 
+        assertEquals("Second process", processesPage.getProcessTitles().get(0));   
+    }
+
+    /**
+     * Verifies that the current sorting of the processes list is remembered
+     * even when reloading the processes page.
+     */
+    @Test
+    public void sortOrderIsRememberedAfterReload() throws Exception {
+        processesPage.goTo();
+
+        // check that default sort order (descending by id) has second process as first element in the process list
+        assertEquals("Second process", processesPage.getProcessTitles().get(0));
+
+        // click on column header to trigger ascending order by process title
+        processesPage.clickProcessesTitleColumnForSorting();
+
+        // check that first process is now first element in list of processes
+        assertEquals("First process", processesPage.getProcessTitles().get(0));
+
+        // reload page
+        processesPage.goTo();
+
+        // check that first process is still first element in list of processes
+        assertEquals("First process", processesPage.getProcessTitles().get(0));
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessesPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessesPage.java
@@ -17,7 +17,6 @@ import static org.kitodo.selenium.testframework.Browser.getTableDataByColumn;
 
 import java.io.File;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.kitodo.config.KitodoConfig;
@@ -40,6 +39,7 @@ public class ProcessesPage extends Page<ProcessesPage> {
     private static final String PROCESS_TITLE = "Second process";
     private static final String WAIT_FOR_ACTIONS_BUTTON = "Wait for actions menu button";
     private static final String WAIT_FOR_ACTIONS_MENU = "Wait for actions menu to open";
+    private static final String WAIT_FOR_TITLE_COLUMN_SORT = "Wait for title column sorting";
 
     @SuppressWarnings("unused")
     @FindBy(id = PROCESSES_TAB_VIEW)
@@ -354,15 +354,10 @@ public class ProcessesPage extends Page<ProcessesPage> {
         processesTableTitleColumn.click();
 
         // wait for the sorting to be applied (which requires ajax request to backend)
-        await("title column sorting changed")
+        await(WAIT_FOR_TITLE_COLUMN_SORT)
             .pollDelay(200, TimeUnit.MILLISECONDS)
             .atMost(10, TimeUnit.SECONDS)
             .ignoreExceptions()
-            .until(new Callable<Boolean>() {
-                public Boolean call() {
-                    // check aria-sort attribute has changed (either empty, "ascending" or "descending")
-                    return !processesTableTitleColumn.getAttribute("aria-sort").equals(previousAriaSort);
-                }
-            });
+            .until(() -> !processesTableTitleColumn.getAttribute("aria-sort").equals(previousAriaSort));
     }
 }


### PR DESCRIPTION
Related Issues:
- Fixes #3293
- Fixes #5002

This push request enables the option "[multiViewState](https://www.primefaces.org/showcase-v8/ui/data/datatable/tableState.xhtml)" for the process list and search result list. It preserves the state of the pagination and column sorting in the current session (while visiting other pages).

Process List Demo:


https://user-images.githubusercontent.com/6214043/191482210-4f52474c-00a1-4668-add8-61d621a8a5bc.mp4


The same is enabled for the search result list. However, the state is reset (page=1, ordering=default) for each new search request (in order to show the results in their default ordering by relevance).

Search Result Demo:

https://user-images.githubusercontent.com/6214043/191483347-325ceabe-36e4-4ecb-8623-2eab6f5255ab.mp4


