### PR TITLE
Fix missing user column in task table

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -86,7 +86,7 @@
 
             <p:column id="processingUserColumn"
                       headerText="#{msgs.lastEditingUser}"
-                      rendered="#{CurrentTaskForm.showColumn('task.lastProcessingUser')}">
+                      rendered="#{CurrentTaskForm.showColumn('task.lastEditingUser')}">
                 <h:outputText value="#{item.processingUser ne null ? item.processingUser.fullName : ''}"
                               title="#{item.processingUser ne null ? item.processingUser.fullName : ''}"/>
             </p:column>


### PR DESCRIPTION
The optional column "last editing user" is not shown in the task list when selecting it from the column configuration drop-down menu. This pull request fixes this problem. The column "last editing user" is now available.