### PR TITLE
Fix process comments being indexed without a spacing

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/ProcessType.java
@@ -103,7 +103,7 @@ public class ProcessType extends BaseType<Process> {
         List<Comment> processComments = process.getComments();
         for (Comment comment : processComments) {
             if (Objects.nonNull(comment) && Objects.nonNull(comment.getMessage())) {
-                commentsMessages = commentsMessages.concat(comment.getMessage());
+                commentsMessages = commentsMessages.concat(comment.getMessage() + "\n");
             }
         }
         return commentsMessages;


### PR DESCRIPTION
Currently, process comments are appended without any spacing when indexed in ElasticSearch. This means that the last word of a comment is merged with the first word of the followup comment.

For example:
- Comment 1: `Hello World` 
- Comment 2: `Hi Kitodo`
Is indexed as `Hello WorldHi Kitodo`.

This is obviously not intended. I used a `newline`-separator instead of a single space such that phrase-queries like "World Hi" should not match, because the two words do not occur in the same comment directly after each other. Non-phrase queries will still match, because both words are contained in the combined comment text.