### PR TITLE
Allow to combine filters with alternatives and negations

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchForm.java
@@ -311,14 +311,16 @@ public class SearchForm {
         }
         if (StringUtils.isNotBlank(this.processPropertyValue)) {
             if (StringUtils.isNotBlank(this.processPropertyTitle)) {
-                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + this.processPropertyTitle + ":"
-                        + this.processPropertyValue + "\" ";
+                search += "\"" + this.processPropertyOperand + FilterString.PROPERTY.getFilterEnglish() 
+                        + this.processPropertyTitle + ":" + this.processPropertyValue + "\" ";
             } else {
-                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + "*:" + this.processPropertyValue + "\" ";
+                search += "\"" + this.processPropertyOperand + FilterString.PROPERTY.getFilterEnglish() 
+                        + "*:" + this.processPropertyValue + "\" ";
             }
         } else {
             if (StringUtils.isNotBlank(this.processPropertyTitle)) {
-                search += "\"" + FilterString.PROPERTY.getFilterEnglish() + this.processPropertyTitle + ":*\" ";
+                search += "\"" + this.processPropertyOperand + FilterString.PROPERTY.getFilterEnglish() 
+                        + this.processPropertyTitle + ":*\" ";
             }
         }
         return search;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -65,7 +65,8 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
 
     private static final Logger logger = LogManager.getLogger(FilterService.class);
     private static volatile FilterService instance = null;
-
+    
+    private static final Pattern CONDITION_PATTERN = Pattern.compile("\\(([^\\)]+)\\)|([^\\(\\)\\|]+)");
     public static final String FILTER_STRING = "filterString";
 
     /**
@@ -204,8 +205,12 @@ public class FilterService extends SearchService<Filter, FilterDTO, FilterDAO> {
      * @return a list of conditions after splitting the filter at the "|" character
      */
     private List<String> splitConditions(String filter) {
-        return Arrays.stream(filter.split("\\|")).filter(Objects::nonNull)
-            .map(String::trim).filter(Predicate.not(String::isEmpty)).collect(Collectors.toList());
+        return CONDITION_PATTERN.matcher(filter).results()
+            .flatMap(mr -> IntStream.rangeClosed(1, mr.groupCount()).mapToObj(mr::group))
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(Predicate.not(String::isEmpty))
+            .collect(Collectors.toList());
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/FilterServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/FilterServiceIT.java
@@ -405,14 +405,17 @@ public class FilterServiceIT {
     public void shouldBuildQueryAndFindByTaskServiceByClosedTasks() throws Exception {
         TaskService taskService = ServiceManager.getTaskService();
 
+        // this query will never return anything, since tasks are always filtered for "open" or "inwork" only
         QueryBuilder firstQuery = filterService.queryBuilder("\"stepdone:1\"", ObjectType.TASK, false, false);
         assertEquals("Incorrect amount of closed tasks with ordering 1!", 0,
             taskService.findByQuery(firstQuery, true).size());
 
+        // this query will never return anything, since tasks are always filtered for "open" or "inwork" only
         QueryBuilder secondQuery = filterService.queryBuilder("\"stepdone:Closed\"", ObjectType.TASK, false, false);
         assertEquals("Incorrect amount of closed tasks with title 'Closed'!", 0,
             taskService.findByQuery(secondQuery, true).size());
 
+        // this query will never exclude anything, because "done" tasks are never listed anyway
         QueryBuilder thirdQuery = filterService.queryBuilder("\"-stepdone:Closed\"", ObjectType.TASK, false, false);
         assertEquals("Incorrect amount of not closed tasks with title different than 'Closed'!", 4,
             taskService.findByQuery(thirdQuery, true).size());
@@ -422,17 +425,24 @@ public class FilterServiceIT {
     public void shouldBuildQueryAndFindByTaskServiceByOpenTasks() throws Exception {
         TaskService taskService = ServiceManager.getTaskService();
 
+        QueryBuilder allTasksQuery = filterService.queryBuilder("\"\"", ObjectType.TASK, false, false);
+        int numberOfAllTasks = taskService.findByQuery(allTasksQuery, true).size();
+        assertEquals("Incorrect number of all tasks!", 4, numberOfAllTasks);
+
         QueryBuilder firstQuery = filterService.queryBuilder("\"stepopen:4\"", ObjectType.TASK, false, false);
         assertEquals("Incorrect amount of open tasks with ordering 4!", 1,
             taskService.findByQuery(firstQuery, true).size());
 
         QueryBuilder secondQuery = filterService.queryBuilder("\"stepopen:Open\"", ObjectType.TASK, false, false);
-        assertEquals("Incorrect amount of open tasks with title 'Open'!", 1,
-            taskService.findByQuery(secondQuery, true).size());
+        int numberOfOpenTasks = taskService.findByQuery(secondQuery, true).size();
+        assertEquals("Incorrect amount of open tasks with title 'Open'!", 1, numberOfOpenTasks);
 
         QueryBuilder thirdQuery = filterService.queryBuilder("\"-stepopen:Open\"", ObjectType.TASK, false, false);
-        assertEquals("Incorrect amount of not open tasks with title different than 'Open'!", 2,
-            taskService.findByQuery(thirdQuery, true).size());
+        int numberOfNotOpenTasks = taskService.findByQuery(thirdQuery, true).size();
+        assertEquals(
+            "Incorrect amount of not open tasks with title different than 'Open'!", 
+            numberOfAllTasks - numberOfOpenTasks, numberOfNotOpenTasks
+        );
     }
 
     @Test
@@ -443,12 +453,12 @@ public class FilterServiceIT {
         assertEquals("Incorrect amount of tasks in progress with ordering 3!", 1,
             taskService.findByQuery(firstQuery, true).size());
 
-        QueryBuilder secondQuery = filterService.queryBuilder("\"-stepinwork:1\"", ObjectType.TASK, false, false);
-        assertEquals("Incorrect amount of tasks not in progress with ordering different than 1!", 2,
+        QueryBuilder secondQuery = filterService.queryBuilder("\"-stepinwork:3\"", ObjectType.TASK, false, false);
+        assertEquals("Incorrect amount of tasks not in progress with ordering different than 3!", 3,
             taskService.findByQuery(secondQuery, true).size());
 
         QueryBuilder thirdQuery = filterService.queryBuilder("\"-stepinwork:2\"", ObjectType.TASK, false, false);
-        assertEquals("Incorrect amount of tasks not in progress with ordering different than 2!", 2,
+        assertEquals("Incorrect amount of tasks not in progress with ordering different than 2!", 3,
             taskService.findByQuery(thirdQuery, true).size());
     }
 
@@ -471,14 +481,43 @@ public class FilterServiceIT {
     }
 
     @Test
-    public void shouldBuildQueryAndFindByTaskServiceByMultipleConditions() throws Exception {
+    public void shouldBuildQueryAndFindByTaskServiceWithDisjunctions() throws Exception {
         TaskService taskService = ServiceManager.getTaskService();
 
-        QueryBuilder firstQuery = filterService.queryBuilder("\"id:1\" \"-stepdone:3\"", ObjectType.TASK, false, false);
+        // check that two task conditions can be combined by disjunction
+        // returns "Progress" and "Open" tasks associated with any process that are either in state "inwork" or "open", respectively
+        QueryBuilder firstQuery = filterService.queryBuilder("\"stepinwork:Progress | stepopen:Open\"", ObjectType.TASK, false, false);
+        assertEquals("Incorrect amount of tasks for disjunction query \"stepinwork:Progress | stepopen:Open\"!", 2,
+            taskService.findByQuery(firstQuery, true).size());
+
+        // check that a task condition can be combined with a process condition by disjunction
+        // returns any tasks associated with process id=1 or "Next Open" tasks that are in state "open"
+        QueryBuilder secondQuery = filterService.queryBuilder("\"stepopen:Next Open | id:1\"", ObjectType.TASK, false, false);
+            assertEquals("Incorrect amount of tasks for disjunction query \"stepopen:Next Open | id:1\"!", 3,
+                taskService.findByQuery(secondQuery, true).size());
+
+        // check that default queries can be combined with task conditions by disjunction
+        // returns any tasks related to process "First process" or "Second process" but not "Progress" tasks in state "inwork"
+        QueryBuilder thirdQuery = filterService.queryBuilder("\"First | Second\" \"-stepinwork:Progress\"", ObjectType.TASK, false, false);
+            assertEquals("Incorrect amount of tasks for disjunction query \"First | Second\"!", 3,
+                taskService.findByQuery(thirdQuery, true).size());
+
+        // check that conditions can be optionally enclosed in parentheses, which masks the vertical line "|"
+        // returns tasks whose process title contains the string "First |" (aka none) or tasks in state "inwork" with title "Progress"
+        QueryBuilder fourthQuery = filterService.queryBuilder("\"(First |) | (stepinwork:Progress)\"", ObjectType.TASK, false, false);
+            assertEquals("Incorrect amount of tasks for disjunction query \"(First |) | (stepinwork:Progress)\"!", 1,
+                taskService.findByQuery(fourthQuery, true).size());
+    }
+
+    @Test
+    public void shouldBuildQueryAndFindByTaskServiceByMultipleConditions() throws Exception {
+        TaskService taskService = ServiceManager.getTaskService();     
+
+        QueryBuilder firstQuery = filterService.queryBuilder("\"id:1\" \"-stepinwork:3\"", ObjectType.TASK, false, false);
         assertEquals("Incorrect amount of not closed tasks with ordering 4 assigned to process with id 1!", 1,
             taskService.findByQuery(firstQuery, true).size());
 
-        QueryBuilder secondQuery = filterService.queryBuilder("\"id:1\" \"-stepdone:4\"", ObjectType.TASK, false,
+        QueryBuilder secondQuery = filterService.queryBuilder("\"id:1\" \"-stepopen:4\"", ObjectType.TASK, false,
             false);
         assertEquals("Incorrect amount of not closed tasks with ordering 4 assigned to process with id 1!", 1,
             taskService.findByQuery(secondQuery, true).size());

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/FilterServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/FilterServiceIT.java
@@ -493,20 +493,20 @@ public class FilterServiceIT {
         // check that a task condition can be combined with a process condition by disjunction
         // returns any tasks associated with process id=1 or "Next Open" tasks that are in state "open"
         QueryBuilder secondQuery = filterService.queryBuilder("\"stepopen:Next Open | id:1\"", ObjectType.TASK, false, false);
-            assertEquals("Incorrect amount of tasks for disjunction query \"stepopen:Next Open | id:1\"!", 3,
-                taskService.findByQuery(secondQuery, true).size());
+        assertEquals("Incorrect amount of tasks for disjunction query \"stepopen:Next Open | id:1\"!", 3,
+            taskService.findByQuery(secondQuery, true).size());
 
         // check that default queries can be combined with task conditions by disjunction
         // returns any tasks related to process "First process" or "Second process" but not "Progress" tasks in state "inwork"
         QueryBuilder thirdQuery = filterService.queryBuilder("\"First | Second\" \"-stepinwork:Progress\"", ObjectType.TASK, false, false);
-            assertEquals("Incorrect amount of tasks for disjunction query \"First | Second\"!", 3,
-                taskService.findByQuery(thirdQuery, true).size());
+        assertEquals("Incorrect amount of tasks for disjunction query \"First | Second\"!", 3,
+            taskService.findByQuery(thirdQuery, true).size());
 
         // check that conditions can be optionally enclosed in parentheses, which masks the vertical line "|"
         // returns tasks whose process title contains the string "First |" (aka none) or tasks in state "inwork" with title "Progress"
         QueryBuilder fourthQuery = filterService.queryBuilder("\"(First |) | (stepinwork:Progress)\"", ObjectType.TASK, false, false);
-            assertEquals("Incorrect amount of tasks for disjunction query \"(First |) | (stepinwork:Progress)\"!", 1,
-                taskService.findByQuery(fourthQuery, true).size());
+        assertEquals("Incorrect amount of tasks for disjunction query \"(First |) | (stepinwork:Progress)\"!", 1,
+            taskService.findByQuery(fourthQuery, true).size());
     }
 
     @Test


### PR DESCRIPTION
Related Issues:
- Fixes #4981

This pull request adds the ability to specify alternatives for conditions in a single filter (and to negate conditions). In part, this was already possible for some properties, e.g. the id property using the following filter (selecting processes for multiple ids):

> "id:81279 81278"

Another example is the filtering for tasks by their order range (1=Scanning, 2=QC, 3=Structure, 4=Export):

> "stepinwork:1-2"

As far a I know, the most recent documentation for the current filter syntax can be found in the "[Anwenderdokumentation Kitodo 1.11](https://github.com/kitodo/kitodo-production/wiki/Suche-und-Filtern)".

However, it was not possible to combine alternatives for arbitrary conditions. This pull request allows to add alternative conditions by separating them using a vertical line character "|" in a filter. For example, in order to filter tasks that are either currently in progress in the step "Scanning" or already done in step "QC", you can now use the following syntax:

> "stepinwork:Scanning | steplocked:QC"

Additionally, negations can now be applied to every condition universally by adding a "-" (minus) as a prefix. Again, for some properties this was already implemented. For example, it was possible to write the following filter before:

> "-stepinwork:Scanning"

However, the result of that filter was not the exact inverse of the non-negated filter `stepinwork:Scanning`. The previous implementation applied the negation to both parts of the filter, meaning the fact that the task is a `Scanning` task and the fact that it is a task that is currently in progress. As a result, the list of tasks would not include any `Scanning`-tasks and also not include any tasks currently in progress (independent of their name). The exact inverse (and in my opinion more intuitive interpretation of the negation) would be to just exclude `Scanning`-tasks that are currently in progress. This pull request changes the semantics of this filter. Therefore, users should be notified about this change when upgrading.

This also affects the Integration Tests, which have not yet been updated (TODO).