### PR TITLE
Fix unreliable SeleniumTest causes failed builds

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/ConfigConversionST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ConfigConversionST.java
@@ -66,7 +66,9 @@ public class ConfigConversionST extends BaseTestSelenium {
         importConfigurationsTab.clickMappingFileOkButton();
 
         await("Wait for 'Results' dialog to be displayed")
-                .atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(Browser.getDriver()
+                .atMost(5, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> assertTrue(Browser.getDriver()
                         .findElementById("importResultsForm:successfulImports").isDisplayed() && Browser.getDriver()
                         .findElementById("importResultsForm:failedImports").isDisplayed()));
 


### PR DESCRIPTION
Fixes #5378 

This seems to be a frequent problem with selenium that is triggered when HTML elements are dynamically added and removed from the DOM (which happens often in Primefaces) such that the current reference to a specific HTML element is not valid any more. This pull request adds the `ignoreExceptions`-clause to ignore this problem, which is also used in all the other selenium tests when waiting for similar conditions. 