### PR TITLE
Fix broken images in Indexing page by fixing EncodingFilter

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/servletfilter/EncodingFilter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/servletfilter/EncodingFilter.java
@@ -63,7 +63,6 @@ public class EncodingFilter implements Filter {
             request.setCharacterEncoding(encoding);
         }
 
-        response.setContentType("text/html; charset=" + encoding);
         response.setCharacterEncoding(encoding);
 
         chain.doFilter(request, response);


### PR DESCRIPTION
The `EncodingFilter` always sets the content type to `text/html` independent of the actual content that is served. This is obviously not correct since resources like images, javascript files, font files and others should be served with their respective content type values, e.g. `image/png`. Tomcat usually detects these content/mime types automatically.

This will fix the broken images on the indexing page, which were not parsed correctly by browsers because the SVG files were served as `text/html` instead of `image/svg+xhtml`. JSF files are still served as `text/html;charset=UTF-8`.

I couldn't find any justification in the commit history of Kitodo why this filter was implemented this way. I didn't observe any problems so far. 