### PR TITLE
Enable editing ID prefix value for OAI import configurations

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/interfaceUrlParameters.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/interfaceUrlParameters.xhtml
@@ -79,6 +79,23 @@
                            value="#{msgs['tooltip.importConfig.oaiMetadataPrefixHelp']}"/>
             </div>
         </p:row>
+        <p:row rendered="#{importConfigurationEditView.importConfiguration.interfaceType eq 'OAI'}">
+            <div>
+                <p:outputLabel for="oaiIdParameterPrefix"
+                               value="#{msgs['importConfig.searchFields.idPrefix']}"/>
+                <p:inputText id="oaiIdParameterPrefix"
+                             styleClass="input-with-button"
+                             value="#{importConfigurationEditView.importConfiguration.idPrefix}"
+                             disabled="#{importConfigurationEditView.idSearchField eq null}">
+                    <p:ajax event="change"
+                            oncomplete="toggleSave();"/>
+                </p:inputText>
+                <p:commandButton id="oaiIdParameterPrefixHelp" type="button"
+                                 styleClass="help-button" icon="fa fa-lg fa-question-circle-o"/>
+                <p:tooltip for="oaiIdParameterPrefixHelp"
+                           value="#{msgs['tooltip.importConfig.idParameterPrefixHelp']}"/>
+            </div>
+        </p:row>
 
     </f:view>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/interfaceUrlParameters.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/interfaceUrlParameters.xhtml
@@ -85,8 +85,7 @@
                                value="#{msgs['importConfig.searchFields.idPrefix']}"/>
                 <p:inputText id="oaiIdParameterPrefix"
                              styleClass="input-with-button"
-                             value="#{importConfigurationEditView.importConfiguration.idPrefix}"
-                             disabled="#{importConfigurationEditView.idSearchField eq null}">
+                             value="#{importConfigurationEditView.importConfiguration.idPrefix}">
                     <p:ajax event="change"
                             oncomplete="toggleSave();"/>
                 </p:inputText>


### PR DESCRIPTION
`ImportConfiguration` objects have a field `idPrefix` which stores a static prefix for prepend to IDs when querying OAI interfaces. This value is meant to simplify querying OAI interfaces because without it, the user would always have to add that prefix manually.

At the moment, that static prefix cannot be edited in `ImportConfigurations` with search interface type `OAI`, making the whole setting pointless.

This pull request adds the field to the editing mask of OAI interfaces.