### PR TITLE
Update used actions to new version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: copy files
         run: |
@@ -50,7 +50,7 @@ jobs:
         run:
             mysql -u root -proot kitodo < $GITHUB_WORKSPACE/Kitodo/setup/default.sql
       - name: set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'


### PR DESCRIPTION
Updating used GitHub actions to new versions to get solve the warning

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-java, actions/setup-java, actions/checkout
```

on the actions overview after a build process is done.