### PR TITLE
Catch NPE when unknown metadata and metadata groups are created during import

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -30,6 +30,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.exceptions.CatalogException;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.exceptions.ProcessGenerationException;
@@ -99,7 +100,11 @@ public class ProcessHelper {
             RulesetManagementInterface managementInterface, String stage, List<Locale.LanguageRange> priorityList) {
         StructuralElementViewInterface divisionView = managementInterface.getStructuralElementView(structure.getType(),
                 stage, priorityList);
-        return new ProcessFieldedMetadata(structure, divisionView);
+        try {
+            return new ProcessFieldedMetadata(structure, divisionView);
+        } catch (NullPointerException e) {
+            throw new CatalogException(Helper.getTranslation("importError.checkMapping"));
+        }
     }
 
     /**

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -78,6 +78,7 @@ errorImageValidation=Fehler bei der Bildvalidierung!
 errorImporting=Fehler beim Importieren von PPN {0}: {1}
 importFailedError=Der Import von {0} ist fehlgeschlagen. Die Fehlermeldung lautet\: {1}.
 imagePaginationError=Es wurden {1} Bilder gefunden, aber {0} Bilder erwartet. Bitte \u00FCberpr\u00FCfen Sie die Paginierung.
+importError.checkMapping=Bei der Transformation der geladenen XML-Daten in Kitodo-Metadaten ist ein Fehler aufgetreten. Bitte \u00FCberpr\u00FCfen Sie ihre Abbildungs- und Regelsatzdateien!
 importError.emptyDocument=Vorgang konnte nicht aus geladenem XML-Dokument erzeugt werden.
 invalidIdentifierCharacter=Der Wert des Identifikationsmerkmals {0} enth\u00E4lt ung\u00FCltige Zeichen.
 invalidIdentifierSame=Das Identifikationsmerkmal {0} enth\u00E4lt in {1} und {2} den gleichen Wert.

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -78,6 +78,7 @@ errorImageValidation=Error on image validation!
 errorImporting=Error importing PPN {0}: {1}
 importFailedError=The import of {0} failed. The error message is\: {1}
 imagePaginationError={1} images found but {0} images expected. Please check the pagination.
+importError.checkMapping=An error occurred while transforming imported XML to Kitodo metadata. Please check your mapping files ruleset and mapping files!
 importError.emptyDocument=Unable to create process from imported XML document.
 invalidIdentifierCharacter=The value of the identifier {0} contains invalid characters.
 invalidIdentifierSame=The identifier {0} has the same value in {1} and {2}.


### PR DESCRIPTION
This PR catches the `NullPointerException` that can occur during import that is decribed in #5217 and shows a corresponding error message. It does *not* fix the underlying issue, but just mitigates the problem.