### PR TITLE
Sort ImportConfigurations alphabetically in 'Create new process' form

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.faces.context.FacesContext;
 import javax.xml.parsers.ParserConfigurationException;
@@ -29,7 +28,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
-import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.api.externaldatamanagement.SearchInterfaceType;
 import org.kitodo.api.externaldatamanagement.SingleHit;
 import org.kitodo.api.schemaconverter.ExemplarRecord;
@@ -161,9 +159,15 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
 
     @Override
     public List<ImportConfiguration> getImportConfigurations() {
-        return super.getImportConfigurations().stream()
-                .filter(importConfiguration -> ImportConfigurationType.OPAC_SEARCH.name()
-                        .equals(importConfiguration.getConfigurationType())).collect(Collectors.toList());
+        if (Objects.isNull(importConfigurations)) {
+            try {
+                importConfigurations = ServiceManager.getImportConfigurationService().getAllOpacSearchConfigurations();
+            } catch (IllegalArgumentException | DAOException e) {
+                Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
+                importConfigurations = new LinkedList<>();
+            }
+        }
+        return importConfigurations;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -28,7 +27,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
-import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.api.schemaconverter.DataRecord;
 import org.kitodo.api.schemaconverter.FileFormat;
 import org.kitodo.api.schemaconverter.MetadataFormat;
@@ -145,9 +143,15 @@ public class FileUploadDialog extends MetadataImportDialog {
 
     @Override
     public List<ImportConfiguration> getImportConfigurations() {
-        return super.getImportConfigurations().stream()
-                .filter(importConfiguration -> ImportConfigurationType.FILE_UPLOAD.name()
-                        .equals(importConfiguration.getConfigurationType())).collect(Collectors.toList());
+        if (Objects.isNull(importConfigurations)) {
+            try {
+                importConfigurations = ServiceManager.getImportConfigurationService().getAllFileUploadConfigurations();
+            } catch (IllegalArgumentException | DAOException e) {
+                Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
+                importConfigurations = new LinkedList<>();
+            }
+        }
+        return importConfigurations;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -44,6 +44,7 @@ public abstract class MetadataImportDialog {
     static final String FORM_CLIENTID = "editForm";
     static final String GROWL_MESSAGE =
             "PF('notifications').renderMessage({'summary':'SUMMARY','detail':'DETAIL','severity':'SEVERITY'});";
+    List<ImportConfiguration> importConfigurations = null;
 
     /**
      * Standard constructor.
@@ -103,12 +104,15 @@ public abstract class MetadataImportDialog {
      * @return list of catalogs
      */
     public List<ImportConfiguration> getImportConfigurations() {
-        try {
-            return ServiceManager.getImportConfigurationService().getAll();
-        } catch (IllegalArgumentException | DAOException e) {
-            Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
-            return new LinkedList<>();
+        if (Objects.isNull(importConfigurations)) {
+            try {
+                importConfigurations = ServiceManager.getImportConfigurationService().getAll();
+            } catch (IllegalArgumentException | DAOException e) {
+                Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
+                importConfigurations = new LinkedList<>();
+            }
         }
+        return importConfigurations;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
@@ -11,10 +11,13 @@
 
 package org.kitodo.production.services.data;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.exceptions.DAOException;
@@ -110,5 +113,32 @@ public class ImportConfigurationService extends SearchDatabaseService<ImportConf
             }
         }
         dao.remove(id);
+    }
+
+
+    /**
+     * Load and return all ImportConfigurations of type OPAC_SEARCH.
+     * @return list of OPAC_SEARCH type ImportConfigurations
+     * @throws DAOException when ImportConfigurations could not be loaded
+     */
+    public List<ImportConfiguration> getAllOpacSearchConfigurations() throws DAOException {
+        return getAllImportConfigurations(ImportConfigurationType.OPAC_SEARCH);
+    }
+
+    /**
+     * Load and return all ImportConfigurations of type FILE_UPLOAD.
+     * @return list of FILE_UPLOAD type ImportConfigurations
+     * @throws DAOException when ImportConfigurations could not be loaded
+     */
+    public List<ImportConfiguration> getAllFileUploadConfigurations() throws DAOException {
+        return getAllImportConfigurations(ImportConfigurationType.FILE_UPLOAD);
+    }
+
+    private List<ImportConfiguration> getAllImportConfigurations(ImportConfigurationType type) throws DAOException {
+        return getAll().stream()
+                .filter(importConfiguration -> type.name()
+                        .equals(importConfiguration.getConfigurationType()))
+                .sorted(Comparator.comparing(ImportConfiguration::getTitle))
+                .collect(Collectors.toList());
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
@@ -74,8 +74,8 @@ public class ImportingST extends BaseTestSelenium {
     public void checkOrderOfImportConfigurations() throws Exception {
         projectsPage.createNewProcess();
         List<String> importConfigurationNames = importPage.getImportConfigurationsTitles();
-        assertEquals("Wrong first import configuration", GBV, importConfigurationNames.get(1));
-        assertEquals("Wrong first import configuration", K10PLUS, importConfigurationNames.get(2));
-        assertEquals("Wrong first import configuration", KALLIOPE, importConfigurationNames.get(3));
+        assertEquals("Wrong first import configuration title", GBV, importConfigurationNames.get(1));
+        assertEquals("Wrong first import configuration title", K10PLUS, importConfigurationNames.get(2));
+        assertEquals("Wrong first import configuration title", KALLIOPE, importConfigurationNames.get(3));
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
@@ -13,6 +13,8 @@ package org.kitodo.selenium;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -28,7 +30,9 @@ import org.openqa.selenium.support.ui.Select;
 public class ImportingST extends BaseTestSelenium {
 
     private static final String PPN = "PPN";
+    private static final String GBV = "GBV";
     private static final String K10PLUS = "K10Plus";
+    private static final String KALLIOPE = "Kalliope";
     private static ProcessFromTemplatePage importPage;
     private static ProjectsPage projectsPage;
 
@@ -64,5 +68,14 @@ public class ImportingST extends BaseTestSelenium {
         Select searchFieldSelectMenu = new Select(importPage.getSearchFieldMenu());
         assertEquals("Wrong default search field selected", PPN,
                 searchFieldSelectMenu.getFirstSelectedOption().getAttribute("label"));
+    }
+
+    @Test
+    public void checkOrderOfImportConfigurations() throws Exception {
+        projectsPage.createNewProcess();
+        List<String> importConfigurationNames = importPage.getImportConfigurationsTitles();
+        assertEquals("Wrong first import configuration", GBV, importConfigurationNames.get(1));
+        assertEquals("Wrong first import configuration", K10PLUS, importConfigurationNames.get(2));
+        assertEquals("Wrong first import configuration", KALLIOPE, importConfigurationNames.get(3));
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -13,7 +13,9 @@ package org.kitodo.selenium.testframework.pages;
 
 import static org.awaitility.Awaitility.await;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.awaitility.core.ConditionTimeoutException;
 import org.kitodo.selenium.testframework.Browser;
@@ -127,6 +129,13 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
         clickElement(catalogSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
         clickElement(Browser.getDriver().findElement(By.id(catalogSelect.getAttribute("id") + "_1")));
         Thread.sleep(Browser.getDelayAfterCatalogSelection());
+    }
+
+    public List<String> getImportConfigurationsTitles() {
+        clickElement(catalogSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
+        WebElement selectMenuItems = Browser.getDriver().findElement(By.id("catalogSearchForm:catalogueSelectMenu_items"));
+        return selectMenuItems.findElements(By.className("ui-selectonemenu-list-item"))
+                .stream().map(WebElement::getText).collect(Collectors.toList());
     }
 
     public String createProcess() throws Exception {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -131,6 +131,10 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
         Thread.sleep(Browser.getDelayAfterCatalogSelection());
     }
 
+    /**
+     * Get list of ImportConfiguration titles.
+     * @return list of ImportConfiguration titles
+     */
     public List<String> getImportConfigurationsTitles() {
         clickElement(catalogSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
         WebElement selectMenuItems = Browser.getDriver().findElement(By.id("catalogSearchForm:catalogueSelectMenu_items"));


### PR DESCRIPTION
ImportConfigurations in the popup menu on the "Create new process" form were sorted in the order they were created. This was very confusing whenever more than just a few ImportConfigurations were available.

This pull request orders the ImportConfigurations in the mentioned form alphabetically and moves the business logic of loading and filtering them to the corresponding service class.