### PR TITLE
Display confirmation dialog for image deletion

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -205,6 +205,7 @@ confirmClose=Schlie\u00DFen best\u00E4tigen
 confirmDelete=L\u00F6schen best\u00E4tigen
 confirmDeleteClient=Mandant "{0}" l\u00F6schen?
 confirmDeleteDocket=Laufzettel "{0}" l\u00F6schen?
+confirmDeleteImage=Bild wirklich l\u00F6schen?
 confirmDeleteImportConfiguration=Importkonfiguration "{0}" l\u00F6schen?
 confirmDeleteLdapgroup=LDAP-Gruppe "{0}" l\u00F6schen?
 confirmDeleteMappingFile=Abbildungsdatei "{0}" l\u00F6schen?

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -209,6 +209,7 @@ confirmClose=Confirm close
 confirmDelete=Confirm delete
 confirmDeleteClient=Delete client "{0}"?
 confirmDeleteDocket=Delete docket "{0}"?
+confirmDeleteImage=Really delete the image?
 confirmDeleteImportConfiguration=Delete import configuration "{0}"?
 confirmDeleteLdapgroup=Delete LDAP group "{0}"?
 confirmDeleteMappingFile=Delete mapping file "{0}"?

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -352,7 +352,10 @@
                                 physicalTree
                                 paginationForm:paginationWrapperPanel
                                 metadataAccordion:logicalMetadataWrapperPanel
-                                galleryWrapperPanel"/>
+                                galleryWrapperPanel">
+                    <p:confirm message="#{msgs.confirmDeleteImage}"
+                               icon="ui-icon-altert"/>
+                </p:menuitem>
             </p:contextMenu>
             <p:contextMenu id="stripeContextMenu"
                            widgetVar="stripeContextMenu"


### PR DESCRIPTION
When a user has the right to delete images in the metadata editor no confirmation dialog is shown for the deletion of images. I think it should be necessary to confirm the deletion.