### PR TITLE
Remove unnecessary `equals` method from 'SearchField' class

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/SearchField.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/SearchField.java
@@ -11,8 +11,6 @@
 
 package org.kitodo.data.database.beans;
 
-import java.util.Objects;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -130,17 +128,4 @@ public class SearchField extends BaseBean {
     public void setImportConfiguration(ImportConfiguration importConfiguration) {
         this.importConfiguration = importConfiguration;
     }
-
-    @Override
-    public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object instanceof SearchField) {
-            SearchField searchField = (SearchField) object;
-            return Objects.equals(this.getId(), searchField.getId());
-        }
-        return false;
-    }
-
 }


### PR DESCRIPTION
Fixes #5420 by removing the unnecessary `equals` method from `SearchField`. 

The bug was caused by `UpdateSearchFieldDialogView.setSearchField`, line 49, where the index of a `SearchField` in the list of current search fields was determined using `indexOf`. `indexOf` uses the `equals` method of classes, which in the case of `SearchField` is overwritten and compares the ids of `SearchFields`. 

New `ImportConfigurations` only contain unsaved `SearchFields`, though, and the ID of unsaved objects is always `null`, which in turn led to `indexOf` always returning `0` as the matching index, because _all_ unsaved `SearchFields` had the same ID (e.g. `null`).

By default, `ArrayList.indexOf` compares list elements by **reference**, which is sufficient for our use of `SearchField` objects and thus fixes the reported bug.