### PR TITLE
Make ImportConfiguration table and MappingFile table sortable

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationListView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationListView.java
@@ -27,6 +27,7 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.exceptions.ImportConfigurationInUseException;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.model.LazyDTOModel;
 import org.kitodo.production.services.ServiceManager;
 import org.primefaces.PrimeFaces;
 
@@ -36,6 +37,14 @@ public class ImportConfigurationListView extends BaseForm {
 
     private static final Logger logger = LogManager.getLogger(ImportConfigurationListView.class);
     private final String importConfigurationEditPath = MessageFormat.format(REDIRECT_PATH, "importConfigurationEdit");
+
+    /**
+     * Empty default constructor that also sets the LazyDTOModel instance of this bean.
+     */
+    public ImportConfigurationListView() {
+        super();
+        super.setLazyDTOModel(new LazyDTOModel(ServiceManager.getImportConfigurationService()));
+    }
 
     /**
      * Get import configurations.

--- a/Kitodo/src/main/java/org/kitodo/production/forms/MappingFileListView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/MappingFileListView.java
@@ -24,6 +24,7 @@ import org.kitodo.data.database.beans.MappingFile;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.model.LazyDTOModel;
 import org.kitodo.production.services.ServiceManager;
 
 @Named("MappingFileListView")
@@ -32,6 +33,14 @@ public class MappingFileListView extends BaseForm {
 
     private static final Logger logger = LogManager.getLogger(MappingFileListView.class);
     private final String mappingFileEditPath = MessageFormat.format(REDIRECT_PATH, "mappingFileEdit");
+
+    /**
+     * Empty default constructor that also sets the LazyDTOModel instance of this bean.
+     */
+    public MappingFileListView() {
+        super();
+        super.setLazyDTOModel(new LazyDTOModel(ServiceManager.getMappingFileService()));
+    }
 
     /**
      * Get mapping files.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
@@ -69,8 +69,9 @@ public class ImportConfigurationService extends SearchDatabaseService<ImportConf
      * @return loaded data
      */
     @Override
-    public List loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) throws DataException {
-        return null;
+    @SuppressWarnings("unchecked")
+    public List<ImportConfiguration> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) {
+        return dao.getByQuery("FROM ImportConfiguration"  + getSort(sortField, sortOrder), filters, first, pageSize);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/MappingFileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/MappingFileService.java
@@ -63,8 +63,9 @@ public class MappingFileService extends SearchDatabaseService<MappingFile, Mappi
      * @return loaded data
      */
     @Override
-    public List loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) throws DataException {
-        return null;
+    @SuppressWarnings("unchecked")
+    public List<MappingFile> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters) {
+        return dao.getByQuery("FROM MappingFile"  + getSort(sortField, sortOrder), filters, first, pageSize);
     }
 
     /**
@@ -87,6 +88,6 @@ public class MappingFileService extends SearchDatabaseService<MappingFile, Mappi
      */
     @Override
     public Long countResults(Map filters) throws DAOException, DataException {
-        return null;
+        return countDatabaseRows();
     }
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/importConfigurations.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/importConfigurations.xhtml
@@ -19,7 +19,7 @@
 
     <!--@elvariable id="item" type="org.kitodo.data.database.beans.ImportConfiguration"-->
     <p:dataTable id="configurationTable"
-                 value="#{ImportConfigurationListView.importConfigurations}"
+                 value="#{ImportConfigurationListView.lazyDTOModel}"
                  var="item"
                  styleClass="default-layout"
                  first="#{ImportConfigurationListView.firstRow}"
@@ -27,32 +27,39 @@
                  paginator="true"
                  resizableColumns="true"
                  liveResize="true"
+                 sortBy="#{item.title}"
                  rows="#{LoginForm.loggedUser.tableSize}"
                  paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {JumpToPageInput} {NextPageLink} {LastPageLink}"
                  currentPageReportTemplate="#{msgs.currentPageReportTemplate}"
                  paginatorPosition="bottom">
 
-        <p:column headerText="#{msgs.title}">
+        <p:column headerText="#{msgs.title}" 
+                  sortBy="#{item.title}">
             <h:outputText value="#{item.title}"
                           title="#{item.title}"/>
         </p:column>
 
-        <p:column headerText="#{msgs['importConfig.field.configurationType']}">
+        <p:column headerText="#{msgs['importConfig.field.configurationType']}"
+                  sortBy="#{item.configurationType}">
             <h:outputText value="#{msgs[item.configurationTypeKey]}"
                           title="#{msgs[item.configurationTypeKey]}"/>
         </p:column>
 
-        <p:column headerText="#{msgs['importConfig.field.interfaceType']}">
+        <p:column headerText="#{msgs['importConfig.field.interfaceType']}" 
+                  sortBy="#{item.interfaceType}">
             <h:outputText value="#{item.interfaceType}"
                           title="#{item.interfaceType}"/>
         </p:column>
 
-        <p:column headerText="#{msgs['importConfig.field.metadataFormat']}">
+        <p:column headerText="#{msgs['importConfig.field.metadataFormat']}"
+                  sortBy="#{item.metadataFormat}">
             <h:outputText value="#{item.metadataFormat}"
                           title="#{item.metadataFormat}"/>
         </p:column>
 
-        <p:column headerText="#{msgs['importConfig.field.defaultImportDepth']}">
+        <p:column headerText="#{msgs['importConfig.field.defaultImportDepth']}"
+                  sortBy="#{item.defaultImportDepth}"
+                  styleClass="numeric">
             <h:outputText value="#{item.defaultImportDepth}"
                           title="#{item.defaultImportDepth}"/>
         </p:column>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/mappingFiles.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/mappingFiles.xhtml
@@ -19,7 +19,7 @@
 
    <!--@elvariable id="item" type="org.kitodo.data.database.beans.MappingFile"-->
    <p:dataTable id="mappingTable"
-                value="#{MappingFileListView.mappingFiles}"
+                value="#{MappingFileListView.lazyDTOModel}"
                 var="item"
                 styleClass="default-layout"
                 first="#{MappingFileListView.firstRow}"
@@ -27,33 +27,39 @@
                 paginator="true"
                 resizableColumns="true"
                 liveResize="true"
+                sortBy="#{item.title}"
                 rows="#{LoginForm.loggedUser.tableSize}"
                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {JumpToPageInput} {NextPageLink} {LastPageLink}"
                 currentPageReportTemplate="#{msgs.currentPageReportTemplate}"
                 paginatorPosition="bottom">
 
-      <p:column headerText="#{msgs.title}">
+      <p:column headerText="#{msgs.title}"
+                sortBy="#{item.title}">
          <h:outputText value="#{item.title}"
                        title="#{item.title}"/>
       </p:column>
 
-      <p:column headerText="#{msgs.file}">
+      <p:column headerText="#{msgs.file}"
+                sortBy="#{item.file}">
          <h:outputText value="#{item.file}"
                        title="#{item.file}"/>
       </p:column>
 
-      <p:column headerText="#{msgs['mappingFile.inputFormat']}">
+      <p:column headerText="#{msgs['mappingFile.inputFormat']}"
+                sortBy="#{item.inputMetadataFormat}">
          <h:outputText value="#{item.inputMetadataFormat}"
                        title="#{item.inputMetadataFormat}"/>
       </p:column>
 
-      <p:column headerText="#{msgs['mappingFile.outputFormat']}">
+      <p:column headerText="#{msgs['mappingFile.outputFormat']}"
+                sortBy="#{item.outputMetadataFormat}">
          <h:outputText value="#{item.outputMetadataFormat}"
                        title="#{item.outputMetadataFormat}"/>
       </p:column>
 
       <p:column headerText="#{msgs['importConfig.field.prestructuredImport']}"
-                styleClass="checkboxColumn">
+                styleClass="checkboxColumn genericSortIcon"
+                sortBy="#{item.prestructuredImport}">
          <h:outputText>
             <ui:fragment rendered="#{item.prestructuredImport}">
                <i class="fa fa-check-square-o fa-lg checkbox-checked"/>


### PR DESCRIPTION
Contributes to:
- #3792 

This pull request makes the table ImportConfiguration and MappingFile sortable by all columns.

![image](https://user-images.githubusercontent.com/6214043/199728330-ab614e58-c1a9-4f95-aa47-e67a51b723f4.png)

![image](https://user-images.githubusercontent.com/6214043/199728416-59b99b6b-236d-4287-9406-7fd0b6b4d16f.png)


Unfortunately, the sort order of the column "ConfigurationType" does not reflect the actual translated labels but the internal database representation of this field. Correct sorting would only be possible if translated labels would be available to the database somehow. 

Alternatively, items could be sorted in a buffer instead of a database query as demonstrated for the Authorities table in pull request #5373. In my opinion, this workaround should not be applied here, because users could (in theory) add arbitrary many ImportConfigurations that would exceed the buffer size, which would cause incorrect sorting behavior.