### PR TITLE
Autofocus search field in OPAC import dialog popup

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
@@ -53,6 +53,8 @@
                 </p:row>
             </p:panelGrid>
 
+            <p:focus for="catalogSearchForm:searchTerm"/>
+
             <p:panelGrid layout="grid" columns="2" cellpadding="10">
                 <p:row>
                     <div>
@@ -63,9 +65,6 @@
                                          disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration}"
                                          required="#{not empty param['catalogSearchForm:performCatalogSearch']}"
                                          value="#{CreateProcessForm.catalogImportDialog.hitModel.selectedField}">
-                            <f:selectItem itemValue="#{null}"
-                                          itemLabel="-- #{msgs.selectSearchField} --"
-                                          noSelectionOption="true"/>
                             <f:selectItems value="#{CreateProcessForm.catalogImportDialog.searchFields}" var="field"/>
                             <p:ajax update="catalogSearchForm:catalogSearchButton"/>
                         </p:selectOneMenu>


### PR DESCRIPTION
This pull request adds two small QOL improvements to the catalog import popup dialog:
- remove the `no selection option` of the `Search field` selection, so that a search field is always selected when the dialog is opened; thus even catalog search configurations of interface types `OAI` (which do not allow for custom search fields and therefor cannot define a default search field) now always come with the OAI `Identifier` search field pre-selected, saving the user two clicks during each import
- autofocus the `Search term` field when the popup dialog is opened when default import configuration and default search field are configured, saving the user another click