### PR TITLE
Add relativepath placeholder

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -392,7 +392,8 @@ public class VariableReplacer {
         if (Objects.isNull(stringWithVariables)) {
             return false;
         }
-        return stringWithVariables.contains("(filename)") | stringWithVariables.contains("(basename)") | stringWithVariables.contains("(relativepath)");
+        return stringWithVariables.contains("(filename)") | stringWithVariables.contains("(basename)")
+                | stringWithVariables.contains("(relativepath)");
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -71,7 +71,7 @@ public class VariableReplacer {
     private static final Pattern VARIABLE_FINDER_REGEX = Pattern.compile(
                 "(\\$?)\\((?:(prefs|processid|processtitle|projectid|stepid|stepname)|"
                 + "(?:(meta|process|product|template)\\.(?:(firstchild|topstruct)\\.)?([^)]+)|"
-                + "(?:(filename|basename))))\\)");
+                + "(?:(filename|basename|relativepath))))\\)");
 
     /**
      * The map is filled with replacement instructions that are required for
@@ -392,7 +392,7 @@ public class VariableReplacer {
         if (Objects.isNull(stringWithVariables)) {
             return false;
         }
-        return stringWithVariables.contains("(filename)") | stringWithVariables.contains("(basename)");
+        return stringWithVariables.contains("(filename)") | stringWithVariables.contains("(basename)") | stringWithVariables.contains("(relativepath)");
     }
 
     /**
@@ -404,6 +404,8 @@ public class VariableReplacer {
                 return variableFinder.group(1) + FilenameUtils.getName(filename);
             case "basename":
                 return variableFinder.group(1) + FilenameUtils.getBaseName(filename);
+            case "relativepath":
+                return variableFinder.group(1) + filename;
             default:
                 logger.warn("Cannot replace \"{}\": no such case defined in switch", variableFinder.group());
                 return variableFinder.group();

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -20,6 +20,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.MetadataEntry;
@@ -141,12 +142,11 @@ public class SchemaService {
             for (Entry<MediaVariant, URI> mediaFileForMediaVariant : physicalDivision.getMediaFiles().entrySet()) {
                 for (Folder folder : folders) {
                     if (folder.getFileGroup().equals(mediaFileForMediaVariant.getKey().getUse())) {
-                        int lastSeparator = mediaFileForMediaVariant.getValue().toString().lastIndexOf('/');
-                        String lastSegment = mediaFileForMediaVariant.getValue().toString()
-                                .substring(lastSeparator + 1);
+                        String mediaFileWithPath = mediaFileForMediaVariant.getValue().toString(); 
+                        String mediaFilename = FilenameUtils.getName(mediaFileWithPath);
                         String mediaFile = variableReplacer.containsFiles(folder.getUrlStructure())
-                                ? variableReplacer.replaceWithFilename(folder.getUrlStructure(), lastSegment)
-                                : variableReplacer.replace(folder.getUrlStructure() + lastSegment);
+                                ? variableReplacer.replaceWithFilename(folder.getUrlStructure(), mediaFileWithPath)
+                                : variableReplacer.replace(folder.getUrlStructure() + mediaFilename);
                         mediaFileForMediaVariant.setValue(new URI(mediaFile));
                     }
                 }

--- a/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
@@ -104,6 +104,19 @@ public class VariableReplacerTest {
 
         assertEquals("String was replaced incorrectly!", expected, replaced);
     }
+    
+    @Test
+    public void shouldReplaceRelativePath() {
+        VariableReplacer variableReplacer = new VariableReplacer(null, prepareProcess(), null);
+
+        String testFilenameWithPath = "src/testFile.txt";
+
+        String replaced = variableReplacer.replaceWithFilename("-filename (relativepath) -hardcoded test",
+                testFilenameWithPath);
+        String expected = "-filename " + testFilenameWithPath + " -hardcoded test";
+
+        assertEquals("String was replaced incorrectly!", expected, replaced);
+    }
 
     @Test
     public void shouldContainFile() {


### PR DESCRIPTION
This pull request adds a further placeholder mentioned in [4916](https://github.com/kitodo/kitodo-production/issues/4916) for use in METS-paths in folder configurations:

- "relativepath": the referenced filename with relative path.

Given an image "jpgs/max/Image0001.jpg", the METS-path "http://www.example.com/content/(relativepath)" should now be resolved as "http://www.example.com/content/jpgs/max/Image0001.jpg".  