### PR TITLE
Add required LoC resources to repository

### DIFF
--- a/Kitodo-DataFormat/pom.xml
+++ b/Kitodo-DataFormat/pom.xml
@@ -69,27 +69,7 @@
                     </filesets>
                 </configuration>
             </plugin>
-            <plugin>
-                <!--Download xsd for mets-->
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <version>1.3.0</version>
-                <executions>
-                    <execution>
-                        <id>mets</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>https://www.loc.gov/standards/mets/version111/mets.xsd</url>
-                            <outputFileName>mets.xsd</outputFileName>
-                            <outputDirectory>${project.build.directory}/downloaded-sources/xsd</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--copy kitodo xsd to target folder-->
+            <!--copy XML schema definitions to target folder-->
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>${maven-resources-plugin.version}</version>

--- a/Kitodo-DataFormat/src/main/resources/xsd/mets.xsd
+++ b/Kitodo-DataFormat/src/main/resources/xsd/mets.xsd
@@ -1,0 +1,1768 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!-- METS: Metadata Encoding and Transmission Standard -->
+<!--
+This document is available under the Creative Commons CC0 1.0 Universal Public Domain Dedication (http://creativecommons.org/publicdomain/zero/1.0/).
+The Digital Library Federation, as creator of this document, has waived all rights to it worldwide under copyright law, including
+all related and neighboring rights, to the extent allowed by law. For the full text see http://creativecommons.org/publicdomain/zero/1.0/legalcode.
+-->
+<!--
+Prepared for the Digital Library Federation by Jerome McDonough, New York University,
+with the assistance of Michael Alexander (British Library), Joachim Bauer (Content Conversion Specialists, Germany),
+Rick Beaubien (University of California), Terry Catapano (Columbia University), Morgan Cundiff (Library of Congress),
+Susan Dahl (University of Alberta), Markus Enders (State and University Library, Göttingen/British Library),
+Richard Gartner (Bodleian Library at Oxford/King's College, London), Thomas Habing (University of Illinois at Urbana-Champaign),
+Nancy Hoebelheinrich (Stanford University/Knowledge Motifs LLC), Arwen Hutt (U.C. San Diego),
+Mark Kornbluh (Michigan State University), Cecilia Preston (Preston & Lynch), Merrilee Proffitt (Research Libraries Group),
+Clay Redding (Library of Congress), Jenn Riley (Indiana University), Richard Rinehart (Berkeley Art Museum/Pacific Film Archive),
+Mackenzie Smith (Massachusetts Institute of Technology), Tobias Steinke (German National Library),
+Taylor Surface (OCLC), Brian Tingle (California Digital Library) and Robin Wendler (Harvard University),
+Robert Wolfe (Massachusetts Institute of Technology), Patrick Yott (Brown University).
+-->
+<!-- May, 2015 -->
+<!-- Version 1.11 -->
+<!-- Change History -->
+<!-- April 23, 2001: Alpha Draft completed -->
+<!-- June 7, 2001: Beta completed -->
+<!-- 6/7/2001 Beta Changes:
+	1. add 'Time' as a possible time code value, as well as TCF.
+	2. Make dmdSec ID attribute required; make ID attribute optional on MDRef/MDWrap.
+	3. Add 'Label' attribute to StructMap, along with 'Type'.
+	4. Add DDI and FGDC as potential metadata schemes to enumeration.
+	5. Enable an "otherMDtype" attribute for MDWrap/MDRef and any other element where
+	    there's an 'other' in the enumerated possibilities.
+	6. Add a "profile" attribute to METS element.
+	7. Revised mptr declaration so that it's like FLocat/MDRef (and not like XLink)
+	8. Extend internal documentation of <area> attributes.
+	9. Add "other" to the possible set of LOCTYPEs.
+	10. Change ADMIDS to ADMID on FileGrp.
+	11. Change "N" to "Order" on <div> element.
+	12. Change "Number" to "order label" on <div> element
+	13. Add createdate and lastmoddate attributes to mets element.
+	14. Allow <div> and <area> elements to link to administrative metadata sections.
+	15. Normalize attribute pointing facilities for file element and mdRef.
+	16. Provide a LOCTYPE of "other" and an "otherloctype" attribute for pointing to external files.
+	17. Drop PDI from enumeration of LOCTYPES.
+	18. Make MDTYPE required in mdRef and mdWrap.
+	19. Rename preservationMD to digiprovMD.
+	20. Add optional CHECKSUM attribute to FContent element.
+	21. Modularize declarations of fileGrpType and mdSecType attributes and enumerations to
+		simplify maintenance.
+	22. Add TYPE attribute to structMap.
+	23. Declare structMap element using structMapType rather than direct declaration.
+	24. Add area element as possible subelement to <div>, along with par and seq.
+	25. Change mdSec model to ALL, to enable differing order of mdRef/mdWrap elements.
+	26. Extend documentation on <par> and <seq> elements.
+ -->
+<!-- October 22, 2001: Gamma completed -->
+<!-- 10/22/2001 Gamma changes:
+ 	1. Added optional fileSec element beneath METS root element to contain fileGrps.
+ 	2. Created subsidiary schema file xlink.xsd for XLink attributes, restored XLink attributes
+ 	to mptr element, and added XLink support to mdRef and FLocat.
+ 	3. Created new element metsHdr to handle metadata regarding METS document
+ 	itself (analogous to TEI Header).  Moved CREATEDATE and LASTMODDATE attributes
+ 	to metsHdr, and added new RECORDSTATUS attribute.  Added new subsidiary elements
+ 	agent and altRecordID to metsHdr.
+ 	4. Made CREATEDATE and LASTMODDATE attributes type xsd:dateTime to allow more precise
+ 	recording of when work was done.
+ 	5. Changed all attributes using data type of xsd:binary to xsd:base64Binary to conform to final
+ 	W3C schema recommendations.
+ 	6. Cleaned up annotations/documentation.
+ -->
+<!-- December 19, 2001: Epsilon and PROTOFINAL completed-->
+<!-- 12/19/2001 Epsilon changes:
+ 	1. Changed sequence operator for StructMap so that only 1 root div element is permitted.
+	2. Add new roles to agent element's role attribute and support for extensible 'other' role.
+	3. Add support for extensible 'other' type attribute on agent element.
+	4. Yet more documentation clean up.
+	5. Relocate CHECKSUM attribute from FContent to File element.
+	6. Change the file element's CREATED attribute and fileGroup's VERSDATE attribute to
+	a type of xsd:dateTime
+	7. Change attribute name DMD for div element to DMDID for consistency's sake.
+	8. Added new behaviorSec for support of referencing executable code from METS object
+ -->
+<!-- February 8, 2002: Zeta bug fix to final -->
+<!-- 2/8/2002 Zeta changes:
+
+ 	1. Eliminated redundant VRA in metadata type enumeration.
+ 	2. Changed mdWrap content model, adding xmlData element to eliminate
+ 		ambiguous content model
+ -->
+<!-- June 3, 2002: Version 1.1 -->
+<!-- 6/3/2002 v1.1 changes:
+
+  	1. Add new structLink section for recording hyperlinks between media represented by structMap nodes.
+	2. Allow a <par> element to
+	contain a <seq> -->
+<!-- Dec. 27, 2002: Version 1.2 -->
+<!-- 12/27/2002 v1.2 changes:
+1. Add “USE” attribute to FileGrp, File, FLocat and FContent;
+2. Make FLocat repeatable;
+3. Have FContent mimic mdWrap in using separate binData/xmlData sections;
+4. Copyright statement added;
+5. Allow both FLocat and Fcontent in single file element;
+6. Allow behaviorSec elements to group through GROUPID attribute;
+7. allow descriptive and administrative metadata sections to be grouped through GROUPID attribute;
+8. allow <file> element to point to descriptive metadata via DMDID attribute;
+9. allow descriptive metadata and all forms of administrative metadata to point to administrative metadata via ADMID attribute;
+10. CREATED and STATUS attributes added to all desc. and adm. metadata sections; and
+11. clean up documentation in elements to reflect reality.
+-->
+<!-- May 8, 2003: Version 1.3 -->
+<!-- 05/05/2003 v1.3 changes:
+
+1. Change “2. OBJID: a primary identifier assigned to the original source document” to “2. OBJID: a primary identifier assigned to the METS object.”
+2. Add MODS to MDTYPEs.
+3. Modify <file> attributes so that instead of just CHECKSUM we have CHECKSUM and CHECKSUMTYPE, where CHECKSUMTYPE is a controlled vocabulary as follows:
+     HAVAL, MD5, SHA-1, SHA-256, SHA-384, SHA-512, TIGER, WHIRLPOOL
+4.Alter BehaviorSec to make it recursive, and add a new behavior element to wrap mechanism and interfaceDef elements.
+-->
+<!-- May 1, 2004: Version 1.4 -->
+<!-- 05/01/2003 v1.4 changes:
+
+1. Moved attribute documentation out of element documentation
+(thank you, Brian Tingle).
+2. New CONTENTIDS attribute (and URIs simpleType) added to div, fptr,
+mptr and area elements for mapping MPEG21 DII Identifier values
+3. XLink namespace URI changed to conform with XLink recommendation.
+4. ID Attribute added to FContent.
+5. ID Attribute addedt to structLink.
+6. ID Attribute added to smLink.
+7. "LOM" added as metadata type.
+ -->
+ <!-- April 12, 2005: Version 1.5 -->
+ <!-- 04/12/2005 v1.5 changes:
+
+ 1. Made file element recursive to deal with PREMIS Onion Layer model and
+ support XFDU-ish unpacking specification.
+ 2. Add <stream> element beneath <file> to allow linking of metadata to
+ subfile structures.
+ 3. Modify structLink TO and FROM attributes to put them in XLink namespace.
+ 4. Make processContents "lax" for all xsd:any elements.
+ -->
+ <!-- October 18, 2006: Version 1.6 -->
+ <!-- 10/18/2006 v1.6 changes:
+
+ 1. add ID to stream and transformFile
+ 2. add ADMID to metsHdr
+ 3. make smLink/@xlink:to and smLink/@xlink:from required
+ -->
+<!-- October 16, 2007/ Jan 20, 2008: Version 1.7 -->
+<!-- 10/16/2007 01/30/2008  v 1.7 changes:
+
+1. create parType complex type to allow a seq to contain a par
+2. create FILECORE attribute group with MIMETYPE, SIZE, CHECKSUM, CHECKSUMTYPE;
+     change fileType, mdWrapType and mdRefType use the attribute group, so mdType and mdRef end
+     up with new SIZE, CHECKSUM, and CHECKSUMTYPE attributes (file does not change)
+20080130
+2a. CREATED added to FILECORE
+3. PREMIS:OBJECT PREMIS:AGENT PREMIS:RIGHTS PREMIS:EVENT added to MDTYPE value enumeration
+-->
+<!-- April 2009: Version 1.8 -->
+<!-- Version 1.8 changes:
+	1. Add CRC32, Adler-32, MNP to the enumerated values constraining CHECKSUMTYPE to align with MIX messageDigestAlgorithm constraints.
+	2. Add TEXTMD and METSRIGHTS to the enumeration values constraining MDTYPE.
+	3. Add an MDTYPEVERSION attribute as a companion to the MDTYPE attribute in the mdRef and mdWrap elements.
+	4. ID and STRUCTID attributes on the behavior element made optional.  Depending on whether the behavior applies to a transformFile element or div elements in the structMap, only one or the other of the attributes would pertain.
+	5. Documentation aligned with the METS Primer, and corrected.
+	6. xml:lang="en" atttribute value added to every <documentation> element
+	7. xlink:extendedLink support added to the <structLink> element by means of a new <smLinkGrp> element, and its child <smLocatorLink> and <smArcLink> elements.
+-->
+<!--February 2010: Version 1.9-->
+<!--Version 1.9 Changes:
+	1. Added a <metsDocumentID> element to the <metsHdr> for recording a unique identifier for the METS document itself where this is different from the OBJID, the identifier for the entire digital object represented by the METS document.
+	2. Added "ISO 19115:2003 NAP" to the enumerated values for the MDTYPE attribute in the METADATA attribute group.
+	3. Added "XPTR" to the enumerated values for the BETYPE attribute on the areaType data type
+	4. Added BEGIN, END and BETYPE attributes to the <file> and <stream> elements for specifying the location of a nested file or a stream within it's parent file.
+-->
+<!-- March 2012: Version 1.9.1 -->
+<!-- Version 1.9.1 Changes:
+	1.  Added 'EAC-CPF' as potential metadata scheme to MDTYPE enumeration
+		EAC-CPF = Encoded Archival Context - Corporate Bodies, Persons, and Families
+		http://eac.staatsbibliothek-berlin.de/eac-cpf-schema.html
+-->
+<!-- July 2013: Version 1.10 -->
+<!-- Version 1.10 Changes:
+	1.	Added 'LIDO' as potential metadata scheme to MDTYPE enumeration
+		LIDO = Lightweight Information Describing Objects
+		http://network.icom.museum/cidoc/working-groups/data-harvesting-and-interchange/lido-technical/specification/
+	2.	Added xsd:anyAttribute with namespace ##other and processContents lax to these METS elements:
+			mets
+				metsHdr
+				dmdSec
+				amdSec
+					techMD
+					rightsMD
+					sourceMD
+					digiprovMD
+				fileSec
+					fileGrp
+						file
+				structMap
+						fptr
+				structLink
+				behaviorSec
+		This will allow arbitrary new attributes to be added to these elements to support local needs.
+-->
+<!-- January 2015: Version 1.10.1 -->
+<!-- Version 1.10.1 Changes:
+	1. Fixed bug:  The anyAttribute declaration was inadvertently added to the FLocat element when it should have been on the file element.  This
+	   has been corrected in this version.
+-->
+<!-- May 2015: Version 1.11 -->
+<!-- Version 1.11 Changes:
+	1.	Added new attributes, ORDER, ORDERLABEL, and LABEL, to these METS elements:
+			par
+			seq
+			area
+	2.	Also added xsd:anyAttribute with namespace ##other and processContents lax to these elements.  This will allow arbitrary new attributes to be added to these elements to support local needs.
+-->
+
+<xsd:schema targetNamespace="http://www.loc.gov/METS/" xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+
+	<xsd:element name="mets">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">METS: Metadata Encoding and Transmission Standard.
+				METS is intended to provide a standardized XML format for transmission of complex digital library objects between systems.  As such, it can be seen as filling a role similar to that defined for the Submission Information Package (SIP), Archival Information Package (AIP) and Dissemination Information Package (DIP) in the Reference Model for an Open Archival Information System. The root element &lt;mets&gt; establishes the container for the information being stored and/or transmitted by the standard.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="metsType"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="metsType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">metsType: Complex Type for METS Sections
+			A METS document consists of seven possible subsidiary sections: metsHdr (METS document header), dmdSec (descriptive metadata section), amdSec (administrative metadata section), fileGrp (file inventory group), structLink (structural map linking), structMap (structural map) and behaviorSec (behaviors section).
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="metsHdr" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+					The mets header element &lt;metsHdr&gt; captures metadata about the METS document itself, not the digital object the METS document encodes. Although it records a more limited set of metadata, it is very similar in function and purpose to the headers employed in other schema such as the Text Encoding Initiative (TEI) or in the Encoded Archival Description (EAD).
+			</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="agent" minOccurs="0" maxOccurs="unbounded">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">agent:
+								The agent element &lt;agent&gt; provides for various parties and their roles with respect to the METS record to be documented.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:sequence>
+									<xsd:element name="name" type="xsd:string">
+										<xsd:annotation>
+											<xsd:documentation xml:lang="en">
+											The element &lt;name&gt; can be used to record the full name of the document agent.
+											</xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+									<xsd:element name="note" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+										<xsd:annotation>
+											<xsd:documentation xml:lang="en">
+											The &lt;note&gt; element can be used to record any additional information regarding the agent's activities with respect to the METS document.
+											</xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:sequence>
+								<xsd:attribute name="ID" type="xsd:ID" use="optional">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+								<xsd:attribute name="ROLE" use="required">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">ROLE (string/R): Specifies the function of the agent with respect to the METS record. The allowed values are:
+CREATOR: The person(s) or institution(s) responsible for the METS document.
+EDITOR: The person(s) or institution(s) that prepares the metadata for encoding.
+ARCHIVIST: The person(s) or institution(s) responsible for the document/collection.
+PRESERVATION: The person(s) or institution(s) responsible for preservation functions.
+DISSEMINATOR: The person(s) or institution(s) responsible for dissemination functions.
+CUSTODIAN: The person(s) or institution(s) charged with the oversight of a document/collection.
+IPOWNER: Intellectual Property Owner: The person(s) or institution holding copyright, trade or service marks or other intellectual property rights for the object.
+OTHER: Use OTHER if none of the preceding values pertains and clarify the type and location specifier being used in the OTHERROLE attribute (see below).
+										</xsd:documentation>
+									</xsd:annotation>
+									<xsd:simpleType>
+										<xsd:restriction base="xsd:string">
+											<xsd:enumeration value="CREATOR"/>
+											<xsd:enumeration value="EDITOR"/>
+											<xsd:enumeration value="ARCHIVIST"/>
+											<xsd:enumeration value="PRESERVATION"/>
+											<xsd:enumeration value="DISSEMINATOR"/>
+											<xsd:enumeration value="CUSTODIAN"/>
+											<xsd:enumeration value="IPOWNER"/>
+											<xsd:enumeration value="OTHER"/>
+										</xsd:restriction>
+									</xsd:simpleType>
+								</xsd:attribute>
+								<xsd:attribute name="OTHERROLE" type="xsd:string" use="optional">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">OTHERROLE (string/O): Denotes a role not contained in the allowed values set if OTHER is indicated in the ROLE attribute.
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+								<xsd:attribute name="TYPE" use="optional">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">TYPE (string/O): is used to specify the type of AGENT. It must be one of the following values:
+INDIVIDUAL: Use if an individual has served as the agent.
+ORGANIZATION: Use if an institution, corporate body, association, non-profit enterprise, government, religious body, etc. has served as the agent.
+OTHER: Use OTHER if none of the preceding values pertain and clarify the type of agent specifier being used in the OTHERTYPE attribute
+										</xsd:documentation>
+									</xsd:annotation>
+									<xsd:simpleType>
+										<xsd:restriction base="xsd:string">
+											<xsd:enumeration value="INDIVIDUAL"/>
+											<xsd:enumeration value="ORGANIZATION"/>
+											<xsd:enumeration value="OTHER"/>
+										</xsd:restriction>
+									</xsd:simpleType>
+								</xsd:attribute>
+								<xsd:attribute name="OTHERTYPE" type="xsd:string" use="optional">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">OTHERTYPE (string/O): Specifies the type of agent when the value OTHER is indicated in the TYPE attribute.
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+							</xsd:complexType>
+						</xsd:element>
+						<xsd:element name="altRecordID" minOccurs="0" maxOccurs="unbounded">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The alternative record identifier element &lt;altRecordID&gt; allows one to use alternative record identifier values for the digital object represented by the METS document; the primary record identifier is stored in the OBJID attribute in the root &lt;mets&gt; element.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:simpleContent>
+									<xsd:extension base="xsd:string">
+										<xsd:attribute name="ID" type="xsd:ID" use="optional">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+												</xsd:documentation>
+											</xsd:annotation>
+										</xsd:attribute>
+										<xsd:attribute name="TYPE" type="xsd:string" use="optional">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">TYPE (string/O): A description of the identifier type (e.g., OCLC record number, LCCN, etc.).
+												</xsd:documentation>
+											</xsd:annotation>
+										</xsd:attribute>
+									</xsd:extension>
+								</xsd:simpleContent>
+							</xsd:complexType>
+						</xsd:element>
+						<xsd:element name="metsDocumentID" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The metsDocument identifier element &lt;metsDocumentID&gt; allows a unique identifier to be assigned to the METS document itself.  This may be different from the OBJID attribute value in the root &lt;mets&gt; element, which uniquely identifies the entire digital object represented by the METS document.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:simpleContent>
+									<xsd:extension base="xsd:string">
+										<xsd:attribute name="ID" type="xsd:ID" use="optional">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+												</xsd:documentation>
+											</xsd:annotation>
+										</xsd:attribute>
+										<xsd:attribute name="TYPE" type="xsd:string" use="optional">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">TYPE (string/O): A description of the identifier type.
+												</xsd:documentation>
+											</xsd:annotation>
+										</xsd:attribute>
+									</xsd:extension>
+								</xsd:simpleContent>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ADMID (IDREFS/O): Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document that contain administrative metadata pertaining to the METS document itself.  For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="CREATEDATE" type="xsd:dateTime" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">CREATEDATE (dateTime/O): Records the date/time the METS document was created.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="LASTMODDATE" type="xsd:dateTime" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">LASTMODDATE (dateTime/O): Is used to indicate the date/time the METS document was last modified.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="RECORDSTATUS" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">RECORDSTATUS (string/O): Specifies the status of the METS document. It is used for internal processing purposes.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:anyAttribute namespace="##other" processContents="lax"/>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="dmdSec" type="mdSecType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A descriptive metadata section &lt;dmdSec&gt; records descriptive metadata pertaining to the METS object as a whole or one of its components. The &lt;dmdSec&gt; element conforms to same generic datatype as the &lt;techMD&gt;, &lt;rightsMD&gt;, &lt;sourceMD&gt; and &lt;digiprovMD&gt; elements, and supports the same sub-elements and attributes. A descriptive metadata element can either wrap the metadata  (mdWrap) or reference it in an external location (mdRef) or both.  METS allows multiple &lt;dmdSec&gt; elements; and descriptive metadata can be associated with any METS element that supports a DMDID attribute.  Descriptive metadata can be expressed according to many current description standards (i.e., MARC, MODS, Dublin Core, TEI Header, EAD, VRA, FGDC, DDI) or a locally produced XML schema.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="amdSec" type="amdSecType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The administrative metadata section &lt;amdSec&gt; contains the administrative metadata pertaining to the digital object, its components and any original source material from which the digital object is derived. The &lt;amdSec&gt; is separated into four sub-sections that accommodate technical metadata (techMD), intellectual property rights (rightsMD), analog/digital source metadata (sourceMD), and digital provenance metadata (digiprovMD). Each of these subsections can either wrap the metadata  (mdWrap) or reference it in an external location (mdRef) or both. Multiple instances of the &lt;amdSec&gt; element can occur within a METS document and multiple instances of its subsections can occur in one &lt;amdSec&gt; element. This allows considerable flexibility in the structuring of the administrative metadata. METS does not define a vocabulary or syntax for encoding administrative metadata. Administrative metadata can be expressed within the amdSec sub-elements according to many current community defined standards, or locally produced XML schemas. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="fileSec" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The overall purpose of the content file section element &lt;fileSec&gt; is to provide an inventory of and the location for the content files that comprise the digital object being described in the METS document.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="fileGrp" maxOccurs="unbounded">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									A sequence of file group elements &lt;fileGrp&gt; can be used group the digital files comprising the content of a METS object either into a flat arrangement or, because each file group element can itself contain one or more  file group elements,  into a nested (hierarchical) arrangement. In the case where the content files are images of different formats and resolutions, for example, one could group the image content files by format and create a separate &lt;fileGrp&gt; for each image format/resolution such as:
+-- one &lt;fileGrp&gt; for the thumbnails of the images
+-- one &lt;fileGrp&gt; for the higher resolution JPEGs of the image
+-- one &lt;fileGrp&gt; for the master archival TIFFs of the images
+For a text resource with a variety of content file types one might group the content files at the highest level by type,  and then use the &lt;fileGrp&gt; element’s nesting capabilities to subdivide a &lt;fileGrp&gt; by format within the type, such as:
+-- one &lt;fileGrp&gt; for all of the page images with nested &lt;fileGrp&gt; elements for each image format/resolution (tiff, jpeg, gif)
+-- one &lt;fileGrp&gt; for a PDF version of all the pages of the document
+-- one &lt;fileGrp&gt; for  a TEI encoded XML version of the entire document or each of its pages.
+A &lt;fileGrp&gt; may contain zero or more &lt;fileGrp&gt; elements and or &lt;file&gt; elements.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:complexContent>
+									<xsd:extension base="fileGrpType"/>
+								</xsd:complexContent>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:anyAttribute namespace="##other" processContents="lax"/>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="structMap" type="structMapType" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The structural map section &lt;structMap&gt; is the heart of a METS document. It provides a means for organizing the digital content represented by the &lt;file&gt; elements in the &lt;fileSec&gt; of the METS document into a coherent hierarchical structure. Such a hierarchical structure can be presented to users to facilitate their comprehension and navigation of the digital content. It can further be applied to any purpose requiring an understanding of the structural relationship of the content files or parts of the content files. The organization may be specified to any level of granularity (intellectual and or physical) that is desired. Since the &lt;structMap&gt; element is repeatable, more than one organization can be applied to the digital content represented by the METS document.  The hierarchical structure specified by a &lt;structMap&gt; is encoded as a tree of nested &lt;div&gt; elements. A &lt;div&gt; element may directly point to content via child file pointer &lt;fptr&gt; elements (if the content is represented in the &lt;fileSec&lt;) or child METS pointer &lt;mptr&gt; elements (if the content is represented by an external METS document). The &lt;fptr&gt; element may point to a single whole &lt;file&gt; element that manifests its parent &lt;div&lt;, or to part of a &lt;file&gt; that manifests its &lt;div&lt;. It can also point to multiple files or parts of files that must be played/displayed either in sequence or in parallel to reveal its structural division. In addition to providing a means for organizing content, the &lt;structMap&gt; provides a mechanism for linking content at any hierarchical level with relevant descriptive and administrative metadata.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="structLink" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The structural link section element &lt;structLink&gt; allows for the specification of hyperlinks between the different components of a METS structure that are delineated in a structural map. This element is a container for a single, repeatable element, &lt;smLink&gt; which indicates a hyperlink between two nodes in the structural map. The &lt;structLink&gt; section in the METS document is identified using its XML ID attributes.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:complexContent>
+						<xsd:extension base="structLinkType"/>
+					</xsd:complexContent>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="behaviorSec" type="behaviorSecType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A behavior section element &lt;behaviorSec&gt; associates executable behaviors with content in the METS document by means of a repeatable behavior &lt;behavior&gt; element. This element has an interface definition &lt;interfaceDef&gt; element that represents an abstract definition of the set of behaviors represented by a particular behavior section. A &lt;behavior&gt; element also has a &lt;mechanism&gt; element which is used to point to a module of executable code that implements and runs the behavior defined by the interface definition. The &lt;behaviorSec&gt; element, which is repeatable as well as nestable, can be used to group individual behaviors within the structure of the METS document. Such grouping can be useful for organizing families of behaviors together or to indicate other relationships between particular behaviors.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="OBJID" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">OBJID (string/O): Is the primary identifier assigned to the METS object as a whole. Although this attribute is not required, it is strongly recommended. This identifier is used to tag the entire METS object to external systems, in contrast with the ID identifier.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">LABEL (string/O): Is a simple title string used to identify the object/entity being described in the METS document for the user.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="TYPE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">TYPE (string/O): Specifies the class or type of the object, e.g.: book, journal, stereograph, dataset, video, etc.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="PROFILE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">PROFILE (string/O): Indicates to which of the registered profile(s) the METS document conforms. For additional information about PROFILES see Chapter 5 of the METS Primer.
+			</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:complexType name="amdSecType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">amdSecType: Complex Type for Administrative Metadata Sections
+			The administrative metadata section consists of four possible subsidiary sections: techMD (technical metadata for text/image/audio/video files), rightsMD (intellectual property rights metadata), sourceMD (analog/digital source metadata), and digiprovMD (digital provenance metadata, that is, the history of migrations/translations performed on a digital library object from it's original digital capture/encoding).
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="techMD" type="mdSecType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A technical metadata element &lt;techMD&gt; records technical metadata about a component of the METS object, such as a digital content file. The &lt;techMD&gt; element conforms to same generic datatype as the &lt;dmdSec&gt;, &lt;rightsMD&gt;, &lt;sourceMD&gt; and &lt;digiprovMD&gt; elements, and supports the same sub-elements and attributes.  A technical metadata element can either wrap the metadata  (mdWrap) or reference it in an external location (mdRef) or both.  METS allows multiple &lt;techMD&gt; elements; and technical metadata can be associated with any METS element that supports an ADMID attribute. Technical metadata can be expressed according to many current technical description standards (such as MIX and textMD) or a locally produced XML schema.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="rightsMD" type="mdSecType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						An intellectual property rights metadata element &lt;rightsMD&gt; records information about copyright and licensing pertaining to a component of the METS object. The &lt;rightsMD&gt; element conforms to same generic datatype as the &lt;dmdSec&gt;, &lt;techMD>, &lt;sourceMD&gt; and &lt;digiprovMD&gt; elements, and supports the same sub-elements and attributes. A rights metadata element can either wrap the metadata  (mdWrap) or reference it in an external location (mdRef) or both.  METS allows multiple &lt;rightsMD&gt; elements; and rights metadata can be associated with any METS element that supports an ADMID attribute. Rights metadata can be expressed according current rights description standards (such as CopyrightMD and rightsDeclarationMD) or a locally produced XML schema.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="sourceMD" type="mdSecType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A source metadata element &lt;sourceMD&gt; records descriptive and administrative metadata about the source format or media of a component of the METS object such as a digital content file. It is often used for discovery, data administration or preservation of the digital object. The &lt;sourceMD&gt; element conforms to same generic datatype as the &lt;dmdSec&gt;, &lt;techMD&gt;, &lt;rightsMD&gt;,  and &lt;digiprovMD&gt; elements, and supports the same sub-elements and attributes.  A source metadata element can either wrap the metadata  (mdWrap) or reference it in an external location (mdRef) or both.  METS allows multiple &lt;sourceMD&gt; elements; and source metadata can be associated with any METS element that supports an ADMID attribute. Source metadata can be expressed according to current source description standards (such as PREMIS) or a locally produced XML schema.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="digiprovMD" type="mdSecType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A digital provenance metadata element &lt;digiprovMD&gt; can be used to record any preservation-related actions taken on the various files which comprise a digital object (e.g., those subsequent to the initial digitization of the files such as transformation or migrations) or, in the case of born digital materials, the files’ creation. In short, digital provenance should be used to record information that allows both archival/library staff and scholars to understand what modifications have been made to a digital object and/or its constituent parts during its life cycle. This information can then be used to judge how those processes might have altered or corrupted the object’s ability to accurately represent the original item. One might, for example, record master derivative relationships and the process by which those derivations have been created. Or the &lt;digiprovMD&gt; element could contain information regarding the migration/transformation of a file from its original digitization (e.g., OCR, TEI, etc.,)to its current incarnation as a digital object (e.g., JPEG2000). The &lt;digiprovMD&gt; element conforms to same generic datatype as the &lt;dmdSec&gt;,  &lt;techMD&gt;, &lt;rightsMD&gt;, and &lt;sourceMD&gt; elements, and supports the same sub-elements and attributes. A digital provenance metadata element can either wrap the metadata  (mdWrap) or reference it in an external location (mdRef) or both.  METS allows multiple &lt;digiprovMD> elements; and digital provenance metadata can be associated with any METS element that supports an ADMID attribute. Digital provenance metadata can be expressed according to current digital provenance description standards (such as PREMIS) or a locally produced XML schema.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:complexType name="fileGrpType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">fileGrpType: Complex Type for File Groups
+				The file group is used to cluster all of the digital files composing a digital library object in a hierarchical arrangement (fileGrp is recursively defined to enable the creation of the hierarchy).  Any file group may contain zero or more file elements.  File elements in turn can contain one or more FLocat elements (a pointer to a file containing content for this object) and/or a FContent element (the contents of the file, in either XML or  Base64 encoding).
+				</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element name="fileGrp" type="fileGrpType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="file" minOccurs="0" maxOccurs="unbounded" type="fileType" >
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The file element &lt;file&gt; provides access to the content files for the digital object being described by the METS document. A &lt;file&gt; element may contain one or more &lt;FLocat&gt; elements which provide pointers to a content file and/or a &lt;FContent&gt; element which wraps an encoded version of the file. Embedding files using &lt;FContent&gt; can be a valuable feature for exchanging digital objects between repositories or for archiving versions of digital objects for off-site storage. All &lt;FLocat&gt; and &lt;FContent&gt; elements should identify and/or contain identical copies of a single file. The &lt;file&gt; element is recursive, thus allowing sub-files or component files of a larger file to be listed in the inventory. Alternatively, by using the &lt;stream&gt; element, a smaller component of a file or of a related file can be placed within a &lt;file&gt; element. Finally, by using the &lt;transformFile&gt; element, it is possible to include within a &lt;file&gt; element a different version of a file that has undergone a transformation for some reason, such as format migration.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:choice>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="VERSDATE" type="xsd:dateTime" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">VERSDATE (dateTime/O): An optional dateTime attribute specifying the date this version/fileGrp of the digital object was created.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ADMID (IDREF/O): Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document applicable to all of the files in a particular file group. For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="USE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">USE (string/O): A tagging attribute to indicate the intended use of files within this file group (e.g., master, reference, thumbnails for image files). A USE attribute can be expressed at the&lt;fileGrp&gt; level, the &lt;file&gt; level, the &lt;FLocat&gt; level and/or the &lt;FContent&gt; level.  A USE attribute value at the &lt;fileGrp&gt; level should pertain to all of the files in the &lt;fileGrp&gt;.  A USE attribute at the &lt;file&gt; level should pertain to all copies of the file as represented by subsidiary &lt;FLocat&gt; and/or &lt;FContent&gt; elements.  A USE attribute at the &lt;FLocat&gt; or &lt;FContent&gt; level pertains to the particular copy of the file that is either referenced (&lt;FLocat&gt;) or wrapped (&lt;FContent&gt;).
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:complexType name="structMapType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">structMapType: Complex Type for Structural Maps
+			The structural map (structMap) outlines a hierarchical structure for the original object being encoded, using a series of nested div elements.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="div" type="divType">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The structural divisions of the hierarchical organization provided by a &lt;structMap&gt; are represented by division &lt;div&gt; elements, which can be nested to any depth. Each &lt;div&gt; element can represent either an intellectual (logical) division or a physical division. Every &lt;div&gt; node in the structural map hierarchy may be connected (via subsidiary &lt;mptr&gt; or &lt;fptr&gt; elements) to content files which represent that div's portion of the whole document.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="TYPE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">TYPE (string/O): Identifies the type of structure represented by the &lt;structMap&gt;. For example, a &lt;structMap&gt; that represented a purely logical or intellectual structure could be assigned a TYPE value of “logical” whereas a &lt;structMap&gt; that represented a purely physical structure could be assigned a TYPE value of “physical”. However, the METS schema neither defines nor requires a common vocabulary for this attribute. A METS profile, however, may well constrain the values for the &lt;structMap&gt; TYPE.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">LABEL (string/O): Describes the &lt;structMap&gt; to viewers of the METS document. This would be useful primarily where more than one &lt;structMap&gt; is provided for a single object. A descriptive LABEL value, in that case, could clarify to users the purpose of each of the available structMaps.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:complexType name="divType">
+
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">divType: Complex Type for Divisions
+					The METS standard represents a document structurally as a series of nested div elements, that is, as a hierarchy (e.g., a book, which is composed of chapters, which are composed of subchapters, which are composed of text).  Every div node in the structural map hierarchy may be connected (via subsidiary mptr or fptr elements) to content files which represent that div's portion of the whole document.
+
+SPECIAL NOTE REGARDING DIV ATTRIBUTE VALUES:
+to clarify the differences between the ORDER, ORDERLABEL, and LABEL attributes for the &lt;div&gt; element, imagine a text with 10 roman numbered pages followed by 10 arabic numbered pages. Page iii would have an ORDER of &quot;3&quot;, an ORDERLABEL of &quot;iii&quot; and a LABEL of &quot;Page iii&quot;, while page 3 would have an ORDER of &quot;13&quot;, an ORDERLABEL of &quot;3&quot; and a LABEL of &quot;Page 3&quot;.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="mptr" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						Like the &lt;fptr&gt; element, the METS pointer element &lt;mptr&gt; represents digital content that manifests its parent &lt;div&gt; element. Unlike the &lt;fptr&gt;, which either directly or indirectly points to content represented in the &lt;fileSec&gt; of the parent METS document, the &lt;mptr&gt; element points to content represented by an external METS document. Thus, this element allows multiple discrete and separate METS documents to be organized at a higher level by a separate METS document. For example, METS documents representing the individual issues in the series of a journal could be grouped together and organized by a higher level METS document that represents the entire journal series. Each of the &lt;div&gt; elements in the &lt;structMap&gt; of the METS document representing the journal series would point to a METS document representing an issue.  It would do so via a child &lt;mptr&gt; element. Thus the &lt;mptr&gt; element gives METS users considerable flexibility in managing the depth of the &lt;structMap&gt; hierarchy of individual METS documents. The &lt;mptr&gt; element points to an external METS document by means of an xlink:href attribute and associated XLink attributes.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="LOCATION"/>
+					<xsd:attributeGroup ref="xlink:simpleLink"/>
+				    <xsd:attribute name="CONTENTIDS" type="URIs" use="optional">
+			            <xsd:annotation>
+			            	<xsd:documentation xml:lang="en">CONTENTIDS (URI/O): Content IDs for the content represented by the &lt;mptr&gt; (equivalent to DIDL DII or Digital Item Identifier, a unique external ID).
+				            </xsd:documentation>
+			            </xsd:annotation>
+               	    </xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="fptr" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The &lt;fptr&gt; or file pointer element represents digital content that manifests its parent &lt;div&gt; element. The content represented by an &lt;fptr&gt; element must consist of integral files or parts of files that are represented by &lt;file&gt; elements in the &lt;fileSec&gt;. Via its FILEID attribute,  an &lt;fptr&gt; may point directly to a single integral &lt;file&gt; element that manifests a structural division. However, an &lt;fptr&gt; element may also govern an &lt;area&gt; element,  a &lt;par&gt;, or  a &lt;seq&gt;  which in turn would point to the relevant file or files. A child &lt;area&gt; element can point to part of a &lt;file&gt; that manifests a division, while the &lt;par&gt; and &lt;seq&gt; elements can point to multiple files or parts of files that together manifest a division. More than one &lt;fptr&gt; element can be associated with a &lt;div&gt; element. Typically sibling &lt;fptr&gt; elements represent alternative versions, or manifestations, of the same content
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:choice>
+						<xsd:element name="par" type="parType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The &lt;par&gt; or parallel files element aggregates pointers to files, parts of files, and/or sequences of files or parts of files that must be played or displayed simultaneously to manifest a block of digital content represented by an &lt;fptr&gt; element. This might be the case, for example, with multi-media content, where a still image might have an accompanying audio track that comments on the still image. In this case, a &lt;par&gt; element would aggregate two &lt;area&gt; elements, one of which pointed to the image file and one of which pointed to the audio file that must be played in conjunction with the image. The &lt;area&gt; element associated with the image could be further qualified with SHAPE and COORDS attributes if only a portion of the image file was pertinent and the &lt;area&gt; element associated with the audio file could be further qualified with BETYPE, BEGIN, EXTTYPE, and EXTENT attributes if only a portion of the associated audio file should be played in conjunction with the image.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="seq" type="seqType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The sequence of files element &lt;seq&gt; aggregates pointers to files,  parts of files and/or parallel sets of files or parts of files  that must be played or displayed sequentially to manifest a block of digital content. This might be the case, for example, if the parent &lt;div&gt; element represented a logical division, such as a diary entry, that spanned multiple pages of a diary and, hence, multiple page image files. In this case, a &lt;seq&gt; element would aggregate multiple, sequentially arranged &lt;area&gt; elements, each of which pointed to one of the image files that must be presented sequentially to manifest the entire diary entry. If the diary entry started in the middle of a page, then the first &lt;area&gt; element (representing the page on which the diary entry starts) might be further qualified, via its SHAPE and COORDS attributes, to specify the specific, pertinent area of the associated image file.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="area" type="areaType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The area element &lt;area&gt; typically points to content consisting of just a portion or area of a file represented by a &lt;file&gt; element in the &lt;fileSec&gt;. In some contexts, however, the &lt;area&gt; element can also point to content represented by an integral file. A single &lt;area&gt; element would appear as the direct child of a &lt;fptr&gt; element when only a portion of a &lt;file&gt;, rather than an integral &lt;file&gt;, manifested the digital content represented by the &lt;fptr&gt;. Multiple &lt;area&gt; elements would appear as the direct children of a &lt;par&gt; element or a &lt;seq&gt; element when multiple files or parts of files manifested the digital content represented by an &lt;fptr&gt; element. When used in the context of a &lt;par&gt; or &lt;seq&gt; element an &lt;area&gt; element can point either to an integral file or to a segment of a file as necessary.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:choice>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="FILEID" type="xsd:IDREF" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">FILEID (IDREF/O): An optional attribute that provides the XML ID identifying the &lt;file&gt; element that links to and/or contains the digital content represented by the &lt;fptr&gt;. A &lt;fptr&gt; element should only have a FILEID attribute value if it does not have a child &lt;area&gt;, &lt;par&gt; or &lt;seq&gt; element. If it has a child element, then the responsibility for pointing to the relevant content falls to this child element or its descendants.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				    <xsd:attribute name="CONTENTIDS" type="URIs" use="optional">
+			            <xsd:annotation>
+			            	<xsd:documentation xml:lang="en">CONTENTIDS (URI/O): Content IDs for the content represented by the &lt;fptr&gt; (equivalent to DIDL DII or Digital Item Identifier, a unique external ID).
+				            </xsd:documentation>
+			            </xsd:annotation>
+               	    </xsd:attribute>
+					<xsd:anyAttribute namespace="##other" processContents="lax"></xsd:anyAttribute>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="div" type="divType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="ORDERLABELS"/>
+		<xsd:attribute name="DMDID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">DMDID (IDREFS/O): Contains the ID attribute values identifying the &lt;dmdSec&gt;, elements in the METS document that contain or link to descriptive metadata pertaining to the structural division represented by the current &lt;div&gt; element.  For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ADMID (IDREFS/O): Contains the ID attribute values identifying the &lt;rightsMD&gt;, &lt;sourceMD&gt;, &lt;techMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document that contain or link to administrative metadata pertaining to the structural division represented by the &lt;div&gt; element. Typically the &lt;div&gt; ADMID attribute would be used to identify the &lt;rightsMD&gt; element or elements that pertain to the &lt;div&gt;, but it could be used anytime there was a need to link a &lt;div&gt; with pertinent administrative metadata. For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="TYPE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">TYPE (string/O): An attribute that specifies the type of structural division that the &lt;div&gt; element represents. Possible &lt;div&gt; TYPE attribute values include: chapter, article, page, track, segment, section etc. METS places no constraints on the possible TYPE values. Suggestions for controlled vocabularies for TYPE may be found on the METS website.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	    <xsd:attribute name="CONTENTIDS" type="URIs" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CONTENTIDS (URI/O): Content IDs for the content represented by the &lt;div&gt; (equivalent to DIDL DII or Digital Item Identifier, a unique external ID).
+				</xsd:documentation>
+			</xsd:annotation>
+	    </xsd:attribute>
+		<xsd:attribute ref="xlink:label">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">xlink:label - an xlink label to be referred to by an smLink element</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="parType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">parType: Complex Type for Parallel Files
+				The &lt;par&gt; or parallel files element aggregates pointers to files, parts of files, and/or sequences of files or parts of files that must be played or displayed simultaneously to manifest a block of digital content represented by an &lt;fptr&gt; element.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="area" type="areaType" minOccurs="0"/>
+			<xsd:element name="seq" type="seqType" minOccurs="0"/>
+		</xsd:choice>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="ORDERLABELS"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"></xsd:anyAttribute>
+	</xsd:complexType>
+	<xsd:complexType name="seqType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">seqType: Complex Type for Sequences of Files
+					The seq element should be used to link a div to a set of content files when those files should be played/displayed sequentially to deliver content to a user.  Individual &lt;area&gt; subelements within the seq element provide the links to the files or portions thereof.
+				</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="area" type="areaType" minOccurs="0"/>
+			<xsd:element name="par" type="parType" minOccurs="0"/>
+		</xsd:choice>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="ORDERLABELS"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"></xsd:anyAttribute>
+	</xsd:complexType>
+	<xsd:complexType name="areaType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">areaType: Complex Type for Area Linking
+				The area element provides for more sophisticated linking between a div element and content files representing that div, be they text, image, audio, or video files.  An area element can link a div to a point within a file, to a one-dimension segment of a file (e.g., text segment, image line, audio/video clip), or a two-dimensional section of a file 	(e.g, subsection of an image, or a subsection of the  video display of a video file.  The area element has no content; all information is recorded within its various attributes.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="FILEID" type="xsd:IDREF" use="required">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">FILEID (IDREF/R): An attribute which provides the XML ID value that identifies the &lt;file&gt; element in the &lt;fileSec&gt; that then points to and/or contains the digital content represented by the &lt;area&gt; element. It must contain an ID value represented in an ID attribute associated with a &lt;file&gt; element in the &lt;fileSec&gt; element in the same METS document.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="SHAPE" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">SHAPE (string/O): An attribute that can be used as in HTML to define the shape of the relevant area within the content file pointed to by the &lt;area&gt; element. Typically this would be used with image content (still image or video frame) when only a portion of an integal image map pertains. If SHAPE is specified then COORDS must also be present. SHAPE should be used in conjunction with COORDS in the manner defined for the shape and coords attributes on an HTML4 &lt;area&gt; element. SHAPE must contain one of the following values:
+RECT
+CIRCLE
+POLY
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="RECT"/>
+					<xsd:enumeration value="CIRCLE"/>
+					<xsd:enumeration value="POLY"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="COORDS" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">COORDS (string/O): Specifies the coordinates in an image map for the shape of the pertinent area as specified in the SHAPE attribute. While technically optional, SHAPE and COORDS must both appear together to define the relevant area of image content. COORDS should be used in conjunction with SHAPE in the manner defined for the COORDs and SHAPE attributes on an HTML4 &lt;area&gt; element. COORDS must be a comma delimited string of integer value pairs representing coordinates (plus radius in the case of CIRCLE) within an image map. Number of coordinates pairs depends on shape: RECT: x1, y1, x2, y2; CIRC: x1, y1; POLY: x1, y1, x2, y2, x3, y3 . . .
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="BEGIN" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">BEGIN (string/O): An attribute that specifies the point in the content file where the relevant section of content begins. It can be used in conjunction with either the END attribute or the EXTENT attribute as a means of defining the relevant portion of the referenced file precisely. It can only be interpreted meaningfully in conjunction with the BETYPE or EXTTYPE, which specify the kind of beginning/ending point values or beginning/extent values that are being used. The BEGIN attribute can be used with or without a companion END or EXTENT element. In this case, the end of the content file is assumed to be the end point.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="END" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">END (string/O): An attribute that specifies the point in the content file where the relevant section of content ends. It can only be interpreted meaningfully in conjunction with the BETYPE, which specifies the kind of ending point values being used. Typically the END attribute would only appear in conjunction with a BEGIN element.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="BETYPE" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">BETYPE: Begin/End Type.
+					BETYPE (string/O): An attribute that specifies the kind of BEGIN and/or END values that are being used. For example, if BYTE is specified, then the BEGIN and END point values represent the byte offsets into a file. If IDREF is specified, then the BEGIN element specifies the ID value that identifies the element in a structured text file where the relevant section of the file begins; and the END value (if present) would specify the ID value that identifies the element with which the relevant section of the file ends. Must be one of the following values:
+BYTE
+IDREF
+SMIL
+MIDI
+SMPTE-25
+SMPTE-24
+SMPTE-DF30
+SMPTE-NDF30
+SMPTE-DF29.97
+SMPTE-NDF29.97
+TIME
+TCF
+XPTR
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="BYTE"/>
+					<xsd:enumeration value="IDREF"/>
+					<xsd:enumeration value="SMIL"/>
+					<xsd:enumeration value="MIDI"/>
+					<xsd:enumeration value="SMPTE-25"/>
+					<xsd:enumeration value="SMPTE-24"/>
+					<xsd:enumeration value="SMPTE-DF30"/>
+					<xsd:enumeration value="SMPTE-NDF30"/>
+					<xsd:enumeration value="SMPTE-DF29.97"/>
+					<xsd:enumeration value="SMPTE-NDF29.97"/>
+					<xsd:enumeration value="TIME"/>
+					<xsd:enumeration value="TCF"/>
+					<xsd:enumeration value="XPTR"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="EXTENT" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">EXTENT (string/O): An attribute that specifies the extent of the relevant section of the content file. Can only be interpreted meaningfully in conjunction with the EXTTYPE which specifies the kind of value that is being used. Typically the EXTENT attribute would only appear in conjunction with a BEGIN element and would not be used if the BEGIN point represents an IDREF.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="EXTTYPE" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">EXTTYPE (string/O): An attribute that specifies the kind of EXTENT values that are being used. For example if BYTE is specified then EXTENT would represent a byte count. If TIME is specified the EXTENT would represent a duration of time. EXTTYPE must be one of the following values:
+BYTE
+SMIL
+MIDI
+SMPTE-25
+SMPTE-24
+SMPTE-DF30
+SMPTE-NDF30
+SMPTE-DF29.97
+SMPTE-NDF29.97
+TIME
+TCF.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="BYTE"/>
+					<xsd:enumeration value="SMIL"/>
+					<xsd:enumeration value="MIDI"/>
+					<xsd:enumeration value="SMPTE-25"/>
+					<xsd:enumeration value="SMPTE-24"/>
+					<xsd:enumeration value="SMPTE-DF30"/>
+					<xsd:enumeration value="SMPTE-NDF30"/>
+					<xsd:enumeration value="SMPTE-DF29.97"/>
+					<xsd:enumeration value="SMPTE-NDF29.97"/>
+					<xsd:enumeration value="TIME"/>
+					<xsd:enumeration value="TCF"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ADMID (IDREFS/O): Contains the ID attribute values identifying the &lt;rightsMD&gt;, &lt;sourceMD&gt;, &lt;techMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document that contain or link to administrative metadata pertaining to the content represented by the &lt;area&gt; element. Typically the &lt;area&gt; ADMID attribute would be used to identify the &lt;rightsMD&gt; element or elements that pertain to the &lt;area&gt;, but it could be used anytime there was a need to link an &lt;area&gt; with pertinent administrative metadata. For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	    <xsd:attribute name="CONTENTIDS" type="URIs" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CONTENTIDS (URI/O): Content IDs for the content represented by the &lt;area&gt; (equivalent to DIDL DII or Digital Item Identifier, a unique external ID).
+				</xsd:documentation>
+			</xsd:annotation>
+	    </xsd:attribute>
+		<xsd:attributeGroup ref="ORDERLABELS"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"></xsd:anyAttribute>
+	</xsd:complexType>
+	<xsd:complexType name="structLinkType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">structLinkType: Complex Type for Structural Map Linking
+				The Structural Map Linking section allows for the specification of hyperlinks between different components of a METS structure delineated in a structural map.  structLink contains a single, repeatable element, smLink.  Each smLink element indicates a hyperlink between two nodes in the structMap.  The structMap nodes recorded in smLink are identified using their XML ID attribute	values.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="smLink">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The Structural Map Link element &lt;smLink&gt; identifies a hyperlink between two nodes in the structural map. You would use &lt;smLink&gt;, for instance, to note the existence of hypertext links between web pages, if you wished to record those links within METS. NOTE: &lt;smLink&gt; is an empty element. The location of the &lt;smLink&gt; element to which the &lt;smLink&gt; element is pointing MUST be stored in the xlink:href attribute.
+				</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute ref="xlink:arcrole" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">
+								 xlink:arcrole - the role of the link, as per the xlink specification.  See http://www.w3.org/TR/xlink/
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute ref="xlink:title" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">
+								xlink:title - a title for the link (if needed), as per the xlink specification.  See http://www.w3.org/TR/xlink/
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute ref="xlink:show" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">
+								xlink:show - see the xlink specification at http://www.w3.org/TR/xlink/
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute ref="xlink:actuate" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">
+								xlink:actuate - see the xlink specification at http://www.w3.org/TR/xlink/
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute ref="xlink:to" use="required">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">
+								xlink:to - the value of the label for the element in the structMap you are linking to.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute ref="xlink:from" use="required">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">
+								xlink:from - the value of the label for the element in the structMap you are linking from.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="smLinkGrp">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The structMap link group element &lt;smLinkGrp&gt; provides an implementation of xlink:extendLink, and provides xlink compliant mechanisms for establishing xlink:arcLink type links between 2 or more &lt;div&gt; elements in &lt;structMap&gt; element(s) occurring within the same METS document or different METS documents.  The smLinkGrp could be used as an alternative to the &lt;smLink&gt; element to establish a one-to-one link between &lt;div&gt; elements in the same METS document in a fully xlink compliant manner.  However, it can also be used to establish one-to-many or many-to-many links between &lt;div&gt; elements. For example, if a METS document contains two &lt;structMap&gt; elements, one of which represents a purely logical structure and one of which represents a purely physical structure, the &lt;smLinkGrp&gt; element would provide a means of mapping a &lt;div&gt; representing a logical entity (for example, a newspaper article) with multiple &lt;div&gt; elements in the physical &lt;structMap&gt; representing the physical areas that  together comprise the logical entity (for example, the &lt;div&gt; elements representing the page areas that together comprise the newspaper article).
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="smLocatorLink" minOccurs="2" maxOccurs="unbounded" >
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The structMap locator link element &lt;smLocatorLink&gt; is of xlink:type &quot;locator&quot;.  It provides a means of identifying a &lt;div&gt; element that will participate in one or more of the links specified by means of &lt;smArcLink&gt; elements within the same &lt;smLinkGrp&gt;. The participating &lt;div&gt; element that is represented by the &lt;smLocatorLink&gt; is identified by means of a URI in the associate xlink:href attribute.  The lowest level of this xlink:href URI value should be a fragment identifier that references the ID value that identifies the relevant &lt;div&gt; element.  For example, &quot;xlink:href=&apos;#div20&apos;&quot; where &quot;div20&quot; is the ID value that identifies the pertinent &lt;div&gt; in the current METS document. Although not required by the xlink specification, an &lt;smLocatorLink&gt; element will typically include an xlink:label attribute in this context, as the &lt;smArcLink&gt; elements will reference these labels to establish the from and to sides of each arc link.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:attribute name="ID" type="xsd:ID">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+								<xsd:attributeGroup ref="xlink:locatorLink"/>
+							</xsd:complexType>
+						</xsd:element>
+						<xsd:element name="smArcLink" minOccurs="1" maxOccurs="unbounded">
+							<xsd:complexType>
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">
+										The structMap arc link element &lt;smArcLink&gt; is of xlink:type &quot;arc&quot; It can be used to establish a traversal link between two &lt;div&gt; elements as identified by &lt;smLocatorLink&gt; elements within the same smLinkGrp element. The associated xlink:from and xlink:to attributes identify the from and to sides of the arc link by referencing the xlink:label attribute values on the participating smLocatorLink elements.
+									</xsd:documentation>
+								</xsd:annotation>
+								<xsd:attribute name="ID" type="xsd:ID">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+								<xsd:attributeGroup ref="xlink:arcLink"/>
+								<xsd:attribute name="ARCTYPE" type="xsd:string">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">ARCTYPE (string/O):The ARCTYPE attribute provides a means of specifying the relationship between the &lt;div&gt; elements participating in the arc link, and hence the purpose or role of the link.  While it can be considered analogous to the xlink:arcrole attribute, its type is a simple string, rather than anyURI.  ARCTYPE has no xlink specified meaning, and the xlink:arcrole attribute should be used instead of or in addition to the ARCTYPE attribute when full xlink compliance is desired with respect to specifying the role or purpose of the arc link.
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+								<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">ADMID (IDREFS/O): Contains the ID attribute values identifying the &lt;sourceMD&gt;, &lt;techMD&gt;, &lt;digiprovMD&gt; and/or &lt;rightsMD&gt; elements within the &lt;amdSec&gt; of the METS document that contain or link to administrative metadata pertaining to &lt;smArcLink&gt;. Typically the &lt;smArcLink&gt; ADMID attribute would be used to identify one or more &lt;sourceMD&gt; and/or &lt;techMD&gt; elements that refine or clarify the relationship between the xlink:from and xlink:to sides of the arc. For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+					<xsd:attribute name="ID" type="xsd:ID"/>
+					<xsd:attribute name="ARCLINKORDER" default="unordered">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ARCLINKORDER (enumerated string/O): ARCLINKORDER is used to indicate whether the order of the smArcLink elements aggregated by the smLinkGrp element is significant. If the order is significant, then a value of &quot;ordered&quot; should be supplied.  Value defaults to &quot;unordered&quot; Note that the ARLINKORDER attribute has no xlink specified meaning.</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="ordered"/>
+								<xsd:enumeration value="unordered"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="xlink:extendedLink"/>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:choice>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:complexType name="behaviorSecType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">behaviorSecType: Complex Type for Behavior Sections
+			Behaviors are executable code which can be associated with parts of a METS object.  The behaviorSec element is used to group individual behaviors within a hierarchical structure.  Such grouping can be useful to organize families of behaviors together or to indicate other relationships between particular behaviors.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="behaviorSec" type="behaviorSecType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="behavior" type="behaviorType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A behavior element &lt;behavior&gt; can be used to associate executable behaviors with content in the METS document. This element has an interface definition &lt;interfaceDef&gt; element that represents an abstract definition of a set of behaviors represented by a particular behavior. A &lt;behavior&gt; element also has a behavior mechanism &lt;mechanism&gt; element, a module of executable code that implements and runs the behavior defined abstractly by the interface definition.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="CREATED" type="xsd:dateTime" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CREATED (dateTime/O): Specifies the date and time of creation for the &lt;behaviorSec&gt;
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">LABEL (string/O): A text description of the behavior section.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:complexType name="behaviorType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">behaviorType: Complex Type for Behaviors
+			 A behavior can be used to associate executable behaviors with content in the METS object.  A behavior element has an interface definition element that represents an abstract definition  of the set  of behaviors represented by a particular behavior.  A behavior element also has an behavior  mechanism which is a module of executable code that implements and runs the behavior defined abstractly by the interface definition.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="interfaceDef" type="objectType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The interface definition &lt;interfaceDef&gt; element contains a pointer to an abstract definition of a single behavior or a set of related behaviors that are associated with the content of a METS object. The interface definition object to which the &lt;interfaceDef&gt; element points using xlink:href could be another digital object, or some other entity, such as a text file which describes the interface or a Web Services Description Language (WSDL) file. Ideally, an interface definition object contains metadata that describes a set of behaviors or methods. It may also contain files that describe the intended usage of the behaviors, and possibly files that represent different expressions of the interface definition.
+			</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mechanism" type="objectType">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+					A mechanism element &lt;mechanism&gt; contains a pointer to an executable code module that implements a set of behaviors defined by an interface definition. The &lt;mechanism&gt; element will be a pointer to another object (a mechanism object). A mechanism object could be another METS object, or some other entity (e.g., a WSDL file). A mechanism object should contain executable code, pointers to executable code, or specifications for binding to network services (e.g., web services).
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. In the case of a &lt;behavior&gt; element that applies to a &lt;transformFile&gt; element, the ID value must be present and would be referenced from the transformFile/@TRANSFORMBEHAVIOR attribute. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="STRUCTID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">STRUCTID (IDREFS/O): An XML IDREFS attribute used to link a &lt;behavior&gt;  to one or more &lt;div&gt; elements within a &lt;structMap&gt; in the METS document. The content to which the STRUCTID points is considered input to the executable behavior mechanism defined for the behavior.  If the &lt;behavior&gt; applies to one or more &lt;div&gt; elements, then the STRUCTID attribute must be present.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="BTYPE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">BTYPE (string/O): The behavior type provides a means of categorizing the related behavior.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="CREATED" type="xsd:dateTime" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CREATED (dateTime/O): The dateTime of creation for the behavior.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">LABEL (string/O): A text description of the behavior.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="GROUPID" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">GROUPID (string/O): An identifier that establishes a correspondence between the given behavior and other behaviors, typically used to facilitate versions of behaviors.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ADMID (IDREFS/O): An optional attribute listing the XML ID values of administrative metadata sections within the METS document pertaining to this behavior.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="objectType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">objectType: complexType for interfaceDef and mechanism elements
+				The mechanism and behavior elements point to external objects--an interface definition object or an executable code object respectively--which together constitute a behavior that can be applied to one or more &lt;div&gt; elements in a &lt;structMap&gt;.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="ID" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">LABEL (string/O): A text description of the entity represented.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="LOCATION"/>
+		<xsd:attributeGroup ref="xlink:simpleLink"/>
+	</xsd:complexType>
+	<xsd:complexType name="mdSecType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">mdSecType: Complex Type for Metadata Sections
+			A generic framework for pointing to/including metadata within a METS document, a la Warwick Framework.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:all>
+			<xsd:element name="mdRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The metadata reference element &lt;mdRef&gt; element is a generic element used throughout the METS schema to provide a pointer to metadata which resides outside the METS document.  NB: &lt;mdRef&gt; is an empty element.  The location of the metadata must be recorded in the xlink:href attribute, supplemented by the XPTR attribute as needed.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="LOCATION"/>
+					<xsd:attributeGroup ref="xlink:simpleLink"/>
+					<xsd:attributeGroup ref="METADATA"/>
+					<xsd:attributeGroup ref="FILECORE"/>
+					<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">LABEL (string/O): Provides a label to display to the viewer of the METS document that identifies the associated metadata.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="XPTR" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">XPTR (string/O): Locates the point within a file to which the &lt;mdRef&gt; element refers, if applicable.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="mdWrap" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A metadata wrapper element &lt;mdWrap&gt; provides a wrapper around metadata embedded within a METS document. The element is repeatable. Such metadata can be in one of two forms: 1) XML-encoded metadata, with the XML-encoding identifying itself as belonging to a namespace other than the METS document namespace. 2) Any arbitrary binary or textual form, PROVIDED that the metadata is Base64 encoded and wrapped in a &lt;binData&gt; element within the internal descriptive metadata element.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:choice>
+						<xsd:element name="binData" type="xsd:base64Binary" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The binary data wrapper element &lt;binData&gt; is used to contain Base64 encoded metadata.												</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="xmlData" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									The xml data wrapper element &lt;xmlData&gt; is used to contain XML encoded metadata. The content of an &lt;xmlData&gt; element can be in any namespace or in no namespace. As permitted by the XML Schema Standard, the processContents attribute value for the metadata in an &lt;xmlData&gt; is set to “lax”. Therefore, if the source schema and its location are identified by means of an XML schemaLocation attribute, then an XML processor will validate the elements for which it can find declarations. If a source schema is not identified, or cannot be found at the specified schemaLocation, then an XML validator will check for well-formedness, but otherwise skip over the elements appearing in the &lt;xmlData&gt; element.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:sequence>
+									<xsd:any namespace="##any" maxOccurs="unbounded" processContents="lax"/>
+								</xsd:sequence>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:choice>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="METADATA"/>
+					<xsd:attributeGroup ref="FILECORE"/>
+					<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">LABEL: an optional string attribute providing a label to display to the viewer of the METS document identifying the metadata.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:all>
+		<xsd:attribute name="ID" type="xsd:ID" use="required">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/R): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. The ID attribute on the &lt;dmdSec&gt;, &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt; and &lt;digiprovMD&gt; elements (which are all of mdSecType) is required, and its value should be referenced from one or more DMDID attributes (when the ID identifies a &lt;dmdSec&gt; element) or ADMID attributes (when the ID identifies a &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt; or &lt;digiprovMD&gt; element) that are associated with other elements in the METS document. The following elements support references to a &lt;dmdSec&gt; via a DMDID attribute: &lt;file&gt;, &lt;stream&gt;, &lt;div&gt;.  The following elements support references to &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt; and &lt;digiprovMD&gt; elements via an ADMID attribute: &lt;metsHdr&gt;, &lt;dmdSec&gt;, &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt;, &lt;digiprovMD&gt;, &lt;fileGrp&gt;, &lt;file&gt;, &lt;stream&gt;, &lt;div&gt;, &lt;area&gt;, &lt;behavior&gt;. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="GROUPID" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">GROUPID (string/O): This identifier is used to indicate that different metadata sections may be considered as part of a group. Two metadata sections with the same GROUPID value are to be considered part of the same group. For example this facility might be used to group changed versions of the same metadata if previous versions are maintained in a file for tracking purposes.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ADMID (IDREFS/O): Contains the ID attribute values of the &lt;digiprovMD&gt;, &lt;techMD&gt;, &lt;sourceMD&gt; and/or &lt;rightsMD&gt; elements within the &lt;amdSec&gt; of the METS document that contain administrative metadata pertaining to the current mdSecType element. Typically used in this context to reference preservation metadata (digiprovMD) which applies to the current metadata. For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="CREATED" type="xsd:dateTime" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CREATED (dateTime/O): Specifies the date and time of creation for the metadata.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="STATUS" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">STATUS (string/O): Indicates the status of this metadata (e.g., superseded, current, etc.).
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax" />
+	</xsd:complexType>
+	<xsd:complexType name="fileType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">fileType: Complex Type for Files
+				The file element provides access to content files for a METS object.  A file element may contain one or more FLocat elements, which provide pointers to a content file, and/or an FContent element, which wraps an encoded version of the file. Note that ALL FLocat and FContent elements underneath a single file element should identify/contain identical copies of a single file.
+			</xsd:documentation>
+		</xsd:annotation>
+
+		<xsd:sequence>
+			<xsd:element name="FLocat" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The file location element &lt;FLocat&gt; provides a pointer to the location of a content file. It uses the XLink reference syntax to provide linking information indicating the actual location of the content file, along with other attributes specifying additional linking information. NOTE: &lt;FLocat&gt; is an empty element. The location of the resource pointed to MUST be stored in the xlink:href attribute.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="LOCATION"/>
+					<xsd:attribute name="USE" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">USE (string/O): A tagging attribute to indicate the intended use of the specific copy of the file  represented by the &lt;FLocat&gt; element (e.g., service master, archive master). A USE attribute can be expressed at the&lt;fileGrp&gt; level, the &lt;file&gt; level, the &lt;FLocat&gt; level and/or the &lt;FContent&gt; level.  A USE attribute value at the &lt;fileGrp&gt; level should pertain to all of the files in the &lt;fileGrp&gt;.  A USE attribute at the &lt;file&gt; level should pertain to all copies of the file as represented by subsidiary &lt;FLocat&gt; and/or &lt;FContent&gt; elements.  A USE attribute at the &lt;FLocat&gt; or &lt;FContent&gt; level pertains to the particular copy of the file that is either referenced (&lt;FLocat&gt;) or wrapped (&lt;FContent&gt;).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="xlink:simpleLink"/>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="FContent" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The file content element &lt;FContent&gt; is used to identify a content file contained internally within a METS document. The content file must be either Base64 encoded and contained within the subsidiary &lt;binData&gt; wrapper element, or consist of XML information and be contained within the subsidiary &lt;xmlData&gt; wrapper element.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:choice>
+						<xsd:element name="binData" type="xsd:base64Binary" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									A binary data wrapper element &lt;binData&gt; is used to contain a Base64 encoded file.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="xmlData" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">
+									An xml data wrapper element &lt;xmlData&gt; is used to contain  an XML encoded file. The content of an &lt;xmlData&gt; element can be in any namespace or in no namespace. As permitted by the XML Schema Standard, the processContents attribute value for the metadata in an &lt;xmlData&gt; element is set to “lax”. Therefore, if the source schema and its location are identified by means of an xsi:schemaLocation attribute, then an XML processor will validate the elements for which it can find declarations. If a source schema is not identified, or cannot be found at the specified schemaLocation, then an XML validator will check for well-formedness, but otherwise skip over the elements appearing in the &lt;xmlData&gt; element.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:sequence>
+									<xsd:any namespace="##any" maxOccurs="unbounded" processContents="lax"/>
+								</xsd:sequence>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:choice>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="USE" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation xml:lang="en">USE (string/O): A tagging attribute to indicate the intended use of the specific copy of the file represented by the &lt;FContent&gt; element (e.g., service master, archive master). A USE attribute can be expressed at the&lt;fileGrp&gt; level, the &lt;file&gt; level, the &lt;FLocat&gt; level and/or the &lt;FContent&gt; level.  A USE attribute value at the &lt;fileGrp&gt; level should pertain to all of the files in the &lt;fileGrp&gt;.  A USE attribute at the &lt;file&gt; level should pertain to all copies of the file as represented by subsidiary &lt;FLocat&gt; and/or &lt;FContent&gt; elements.  A USE attribute at the &lt;FLocat&gt; or &lt;FContent&gt; level pertains to the particular copy of the file that is either referenced (&lt;FLocat&gt;) or wrapped (&lt;FContent&gt;).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="stream" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						A component byte stream element &lt;stream&gt; may be composed of one or more subsidiary streams. An MPEG4 file, for example, might contain separate audio and video streams, each of which is associated with technical metadata. The repeatable &lt;stream&gt; element provides a mechanism to record the existence of separate data streams within a particular file, and the opportunity to associate &lt;dmdSec&gt; and &lt;amdSec&gt; with those subsidiary data streams if desired. </xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:complexContent>
+						<xsd:restriction base="xsd:anyType">
+							<xsd:attribute name="ID" type="xsd:ID" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="streamType" type="xsd:string" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">streamType (string/O): The IANA MIME media type for the bytestream.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="OWNERID" type="xsd:string" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">OWNERID (string/O): Used to provide a unique identifier (which could include a URI) assigned to the file. This identifier may differ from the URI used to retrieve the file.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">ADMID (IDREFS/O): Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document that contain administrative metadata pertaining to the bytestream. For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="DMDID" type="xsd:IDREFS" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">DMDID (IDREFS/O): Contains the ID attribute values identifying the &lt;dmdSec&gt;, elements in the METS document that contain or link to descriptive metadata pertaining to the content file stream represented by the current &lt;stream&gt; element.  For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="BEGIN" type="xsd:string" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">BEGIN (string/O): An attribute that specifies the point in the parent &lt;file&gt; where the current &lt;stream&gt; begins. It can be used in conjunction with the END attribute as a means of defining the location of the stream within its parent file. However, the BEGIN attribute can be used with or without a companion END attribute. When no END attribute is specified, the end of the parent file is assumed also to be the end point of the stream. The BEGIN and END attributes can only be interpreted meaningfully in conjunction with a BETYPE attribute, which specifies the kind of beginning/ending point values that are being used.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="END" type="xsd:string" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">END (string/O): An attribute that specifies the point in the parent &lt;file&gt; where the &lt;stream&gt; ends. It can only be interpreted meaningfully in conjunction with the BETYPE, which specifies the kind of ending point values being used. Typically the END attribute would only appear in conjunction with a BEGIN attribute.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="BETYPE" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">BETYPE: Begin/End Type.
+										BETYPE (string/O): An attribute that specifies the kind of BEGIN and/or END values that are being used. Currently BYTE is the only valid value that can be used in conjunction with nested &lt;file&gt; or &lt;stream&gt; elements.
+									</xsd:documentation>
+								</xsd:annotation>
+								<xsd:simpleType>
+									<xsd:restriction base="xsd:string">
+										<xsd:enumeration value="BYTE"/>
+									</xsd:restriction>
+								</xsd:simpleType>
+							</xsd:attribute>
+						</xsd:restriction>
+					</xsd:complexContent>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="transformFile" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">
+						The transform file element &lt;transformFile&gt; provides a means to access any subsidiary files listed below a &lt;file&gt; element by indicating the steps required to "unpack" or transform the subsidiary files. This element is repeatable and might provide a link to a &lt;behavior&gt; in the &lt;behaviorSec&gt; that performs the transformation.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:complexContent>
+						<xsd:restriction base="xsd:anyType">
+							<xsd:attribute name="ID" type="xsd:ID" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">ID (ID/O): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="TRANSFORMTYPE" use="required">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">TRANSFORMTYPE (string/R): Is used to indicate the type of transformation needed to render content of a file accessible. This may include unpacking a file into subsidiary files/streams. The controlled value constraints for this XML string include “decompression” and “decryption”. Decompression is defined as the action of reversing data compression, i.e., the process of encoding information using fewer bits than an unencoded representation would use by means of specific encoding schemas. Decryption is defined as the process of restoring data that has been obscured to make it unreadable without special knowledge (encrypted data) to its original form. </xsd:documentation>
+								</xsd:annotation>
+								<xsd:simpleType>
+									<xsd:restriction base="xsd:string">
+										<xsd:enumeration value="decompression"></xsd:enumeration>
+										<xsd:enumeration value="decryption"></xsd:enumeration>
+									</xsd:restriction>
+								</xsd:simpleType>
+							</xsd:attribute>
+							<xsd:attribute name="TRANSFORMALGORITHM" type="xsd:string" use="required">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">TRANSFORM-ALGORITHM (string/R): Specifies the decompression or decryption routine used to access the contents of the file. Algorithms for compression can be either loss-less or lossy.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="TRANSFORMKEY" type="xsd:string" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">TRANSFORMKEY (string/O): A key to be used with the transform algorithm for accessing the file’s contents.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="TRANSFORMBEHAVIOR" type="xsd:IDREF" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">TRANSFORMBEHAVIOR (string/O): An IDREF to a behavior element for this transformation.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+							<xsd:attribute name="TRANSFORMORDER" type="xsd:positiveInteger" use="required">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">TRANSFORMORDER (postive-integer/R): The order in which the instructions must be followed in order to unpack or transform the container file.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+						</xsd:restriction>
+					</xsd:complexContent>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="file" type="fileType" minOccurs="0" maxOccurs="unbounded"></xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="ID" type="xsd:ID" use="required">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ID (ID/R): This attribute uniquely identifies the element within the METS document, and would allow the element to be referenced unambiguously from another element or document via an IDREF or an XPTR. Typically, the ID attribute value on a &lt;file&gt; element would be referenced from one or more FILEID attributes (which are of type IDREF) on &lt;fptr&gt;and/or &lt;area&gt; elements within the &lt;structMap&gt;.  Such references establish links between  structural divisions (&lt;div&gt; elements) and the specific content files or parts of content files that manifest them. For more information on using ID attributes for internal and external linking see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="SEQ" type="xsd:int" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">SEQ (integer/O): Indicates the sequence of this &lt;file&gt; relative to the others in its &lt;fileGrp&gt;.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="FILECORE"></xsd:attributeGroup>
+		<xsd:attribute name="OWNERID" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">OWNERID (string/O): A unique identifier assigned to the file by its owner.  This may be a URI which differs from the URI used to retrieve the file.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ADMID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ADMID (IDREFS/O): Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;, &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document that contain administrative metadata pertaining to the file. For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="DMDID" type="xsd:IDREFS" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">DMDID (IDREFS/O): Contains the ID attribute values identifying the &lt;dmdSec&gt;, elements in the METS document that contain or link to descriptive metadata pertaining to the content file represented by the current &lt;file&gt; element.  For more information on using METS IDREFS and IDREF type attributes for internal linking, see Chapter 4 of the METS Primer.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="GROUPID" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">GROUPID (string/O): An identifier that establishes a correspondence between this file and files in other file groups. Typically, this will be used to associate a master file in one file group with the derivative files made from it in other file groups.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="USE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">USE (string/O): A tagging attribute to indicate the intended use of all copies of the file aggregated by the &lt;file&gt; element (e.g., master, reference, thumbnails for image files). A USE attribute can be expressed at the&lt;fileGrp&gt; level, the &lt;file&gt; level, the &lt;FLocat&gt; level and/or the &lt;FContent&gt; level.  A USE attribute value at the &lt;fileGrp&gt; level should pertain to all of the files in the &lt;fileGrp&gt;.  A USE attribute at the &lt;file&gt; level should pertain to all copies of the file as represented by subsidiary &lt;FLocat&gt; and/or &lt;FContent&gt; elements.  A USE attribute at the &lt;FLocat&gt; or &lt;FContent&gt; level pertains to the particular copy of the file that is either referenced (&lt;FLocat&gt;) or wrapped (&lt;FContent&gt;).
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="BEGIN" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">BEGIN (string/O): An attribute that specifies the point in the parent &lt;file&gt; where the current &lt;file&gt; begins.  When used in conjunction with a &lt;file&gt; element, this attribute is only meaningful when this element is nested, and its parent &lt;file&gt; element represents a container file. It can be used in conjunction with the END attribute as a means of defining the location of the current file within its parent file. However, the BEGIN attribute can be used with or without a companion END attribute. When no END attribute is specified, the end of the parent file is assumed also to be the end point of the current file. The BEGIN and END attributes can only be interpreted meaningfully in conjunction with a BETYPE attribute, which specifies the kind of beginning/ending point values that are being used.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="END" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">END (string/O): An attribute that specifies the point in the parent &lt;file&gt; where the current, nested &lt;file&gt; ends. It can only be interpreted meaningfully in conjunction with the BETYPE, which specifies the kind of ending point values being used. Typically the END attribute would only appear in conjunction with a BEGIN attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="BETYPE" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">BETYPE: Begin/End Type.
+					BETYPE (string/O): An attribute that specifies the kind of BEGIN and/or END values that are being used. Currently BYTE is the only valid value that can be used in conjunction with nested &lt;file&gt; or &lt;stream&gt; elements.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="BYTE"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="URIs">
+	    <xsd:list itemType="xsd:anyURI"/>
+	</xsd:simpleType>
+
+	<xsd:attributeGroup name="ORDERLABELS">
+		<xsd:attribute name="ORDER" type="xsd:integer" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ORDER (integer/O): A representation of the element's order among its siblings (e.g., its absolute, numeric sequence). For an example, and clarification of the distinction between ORDER and ORDERLABEL, see the description of the ORDERLABEL attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ORDERLABEL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">ORDERLABEL (string/O): A representation of the element's order among its siblings (e.g., “xii”), or of any non-integer native numbering system. It is presumed that this value will still be machine actionable (e.g., it would support ‘go to page ___’ function), and it should not be used as a replacement/substitute for the LABEL attribute. To understand the differences between ORDER, ORDERLABEL and LABEL, imagine a text with 10 roman numbered pages followed by 10 arabic numbered pages. Page iii would have an ORDER of “3”, an ORDERLABEL of “iii” and a LABEL of “Page iii”, while page 3 would have an ORDER of “13”, an ORDERLABEL of “3” and a LABEL of “Page 3”.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="LABEL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">LABEL (string/O): An attribute used, for example, to identify a &lt;div&gt; to an end user viewing the document. Thus a hierarchical arrangement of the &lt;div&gt; LABEL values could provide a table of contents to the digital content represented by a METS document and facilitate the users’ navigation of the digital object. Note that a &lt;div&gt; LABEL should be specific to its level in the structural map. In the case of a book with chapters, the book &lt;div&gt; LABEL should have the book title and the chapter &lt;div&gt;; LABELs should have the individual chapter titles, rather than having the chapter &lt;div&gt; LABELs combine both book title and chapter title . For further of the distinction between LABEL and ORDERLABEL see the description of the ORDERLABEL attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="METADATA">
+		<xsd:attribute name="MDTYPE" use="required">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">MDTYPE (string/R): Is used to indicate the type of the associated metadata. It must have one of the following values:
+MARC: any form of MARC record
+MODS: metadata in the Library of Congress MODS format
+EAD: Encoded Archival Description finding aid
+DC: Dublin Core
+NISOIMG: NISO Technical Metadata for Digital Still Images
+LC-AV: technical metadata specified in the Library of Congress A/V prototyping project
+VRA: Visual Resources Association Core
+TEIHDR: Text Encoding Initiative Header
+DDI: Data Documentation Initiative
+FGDC: Federal Geographic Data Committee metadata
+LOM: Learning Object Model
+PREMIS:  PREservation Metadata: Implementation Strategies
+PREMIS:OBJECT: PREMIS Object entiry
+PREMIS:AGENT: PREMIS Agent entity
+PREMIS:RIGHTS: PREMIS Rights entity
+PREMIS:EVENT: PREMIS Event entity
+TEXTMD: textMD Technical metadata for text
+METSRIGHTS: Rights Declaration Schema
+ISO 19115:2003 NAP: North American Profile of ISO 19115:2003 descriptive metadata
+EAC-CPF: Encoded Archival Context - Corporate Bodies, Persons, and Families
+LIDO: Lightweight Information Describing Objects
+OTHER: metadata in a format not specified above
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="MARC"/>
+					<xsd:enumeration value="MODS"/>
+					<xsd:enumeration value="EAD"/>
+					<xsd:enumeration value="DC"/>
+					<xsd:enumeration value="NISOIMG"/>
+					<xsd:enumeration value="LC-AV"/>
+					<xsd:enumeration value="VRA"/>
+					<xsd:enumeration value="TEIHDR"/>
+					<xsd:enumeration value="DDI"/>
+					<xsd:enumeration value="FGDC"/>
+				    <xsd:enumeration value="LOM"/>
+					<xsd:enumeration value="PREMIS"/>
+					<xsd:enumeration value="PREMIS:OBJECT"/>
+					<xsd:enumeration value="PREMIS:AGENT"/>
+					<xsd:enumeration value="PREMIS:RIGHTS"/>
+					<xsd:enumeration value="PREMIS:EVENT"/>
+					<xsd:enumeration value="TEXTMD"/>
+					<xsd:enumeration value="METSRIGHTS"/>
+					<xsd:enumeration value="ISO 19115:2003 NAP"/>
+					<xsd:enumeration value="EAC-CPF"/>
+					<xsd:enumeration value="LIDO"/>
+					<xsd:enumeration value="OTHER"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="OTHERMDTYPE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">OTHERMDTYPE (string/O): Specifies the form of metadata in use when the value OTHER is indicated in the MDTYPE attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="MDTYPEVERSION" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">MDTYPEVERSION(string/O): Provides a means for recording the version of the type of metadata (as recorded in the MDTYPE or OTHERMDTYPE attribute) that is being used.  This may represent the version of the underlying data dictionary or metadata model rather than a schema version. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="LOCATION">
+		<xsd:attribute name="LOCTYPE" use="required">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">LOCTYPE (string/R): Specifies the locator type used in the xlink:href attribute. Valid values for LOCTYPE are:
+					ARK
+					URN
+					URL
+					PURL
+					HANDLE
+					DOI
+					OTHER
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="ARK"/>
+					<xsd:enumeration value="URN"/>
+					<xsd:enumeration value="URL"/>
+					<xsd:enumeration value="PURL"/>
+					<xsd:enumeration value="HANDLE"/>
+					<xsd:enumeration value="DOI"/>
+					<xsd:enumeration value="OTHER"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="OTHERLOCTYPE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">OTHERLOCTYPE (string/O): Specifies the locator type when the value OTHER is used in the LOCTYPE attribute. Although optional, it is strongly recommended when OTHER is used.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="FILECORE">
+		<xsd:attribute name="MIMETYPE" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">MIMETYPE (string/O): The IANA MIME media type for the associated file or wrapped content. Some values for this attribute can be found on the IANA website.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="SIZE" type="xsd:long" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">SIZE (long/O): Specifies the size in bytes of the associated file or wrapped content.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="CREATED" type="xsd:dateTime" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CREATED (dateTime/O): Specifies the date and time of creation for the associated file or wrapped content.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="CHECKSUM" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CHECKSUM (string/O): Provides a checksum value for the associated file or wrapped content.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="CHECKSUMTYPE" use="optional">
+			<xsd:annotation>
+				<xsd:documentation xml:lang="en">CHECKSUMTYPE (enumerated string/O): Specifies the checksum algorithm used to produce the value contained in the CHECKSUM attribute.  CHECKSUMTYPE must contain one of the following values:
+					Adler-32
+					CRC32
+					HAVAL
+					MD5
+					MNP
+					SHA-1
+					SHA-256
+					SHA-384
+					SHA-512
+					TIGER
+					WHIRLPOOL
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="Adler-32"/>
+					<xsd:enumeration value="CRC32"/>
+					<xsd:enumeration value="HAVAL"/>
+					<xsd:enumeration value="MD5"/>
+					<xsd:enumeration value="MNP"/>
+					<xsd:enumeration value="SHA-1"/>
+					<xsd:enumeration value="SHA-256"/>
+					<xsd:enumeration value="SHA-384"/>
+					<xsd:enumeration value="SHA-512"/>
+					<xsd:enumeration value="TIGER"/>
+					<xsd:enumeration value="WHIRLPOOL"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+</xsd:schema>

--- a/Kitodo-DataFormat/src/main/resources/xsd/xlink.xsd
+++ b/Kitodo-DataFormat/src/main/resources/xsd/xlink.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- METS XLink Schema, v. 2, Nov. 15, 2004 -->
+<schema targetNamespace="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" elementFormDefault="qualified">
+  <!--  global attributes  --> 
+  <attribute name="href"  type="anyURI"/>
+  <attribute name="role" type="string"/>
+  <attribute name="arcrole" type="string"/>
+  <attribute name="title" type="string" /> 
+  <attribute name="show">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="new" /> 
+	<enumeration value="replace" /> 
+	<enumeration value="embed" /> 
+	<enumeration value="other" /> 
+	<enumeration value="none" /> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="actuate">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="onLoad" /> 
+	<enumeration value="onRequest" /> 
+	<enumeration value="other" /> 
+	<enumeration value="none" /> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="label" type="string" /> 
+  <attribute name="from" type="string" /> 
+  <attribute name="to" type="string" /> 
+  <attributeGroup name="simpleLink">
+    <attribute name="type" type="string" fixed="simple" form="qualified" /> 
+    <attribute ref="xlink:href" use="optional" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:arcrole" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:show" use="optional" /> 
+    <attribute ref="xlink:actuate" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="extendedLink">
+    <attribute name="type" type="string" fixed="extended" form="qualified" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="locatorLink">
+    <attribute name="type" type="string" fixed="locator" form="qualified" /> 
+    <attribute ref="xlink:href" use="required" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:label" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="arcLink">
+    <attribute name="type" type="string" fixed="arc" form="qualified" /> 
+    <attribute ref="xlink:arcrole" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:show" use="optional" /> 
+    <attribute ref="xlink:actuate" use="optional" /> 
+    <attribute ref="xlink:from" use="optional" /> 
+    <attribute ref="xlink:to" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="resourceLink">
+    <attribute name="type" type="string" fixed="resource" form="qualified" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:label" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="titleLink">
+    <attribute name="type" type="string" fixed="title" form="qualified" /> 
+  </attributeGroup>
+  <attributeGroup name="emptyLink">
+    <attribute name="type" type="string" fixed="none" form="qualified" /> 
+  </attributeGroup>
+</schema>

--- a/Kitodo-XML-SchemaConverter/src/main/resources/xslt/MARC21slimUtils.xsl
+++ b/Kitodo-XML-SchemaConverter/src/main/resources/xslt/MARC21slimUtils.xsl
@@ -1,0 +1,188 @@
+<?xml version='1.0'?>
+<xsl:stylesheet version="1.0" xmlns:marc="http://www.loc.gov/MARC21/slim"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!-- 08/08/08: tmee added corrected chopPunctuation templates for 260c -->
+	<!-- 08/19/04: ntra added "marc:" prefix to datafield element -->
+	<!-- 12/14/07: ntra added url encoding template -->
+	<!-- url encoding -->
+
+	<xsl:variable name="ascii">
+		<xsl:text> !"#$%&amp;'()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~</xsl:text>
+	</xsl:variable>
+
+	<xsl:variable name="latin1">
+		<xsl:text> ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ</xsl:text>
+	</xsl:variable>
+	<!-- Characters that usually don't need to be escaped -->
+	<xsl:variable name="safe">
+		<xsl:text>!'()*-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~</xsl:text>
+	</xsl:variable>
+
+	<xsl:variable name="hex">0123456789ABCDEF</xsl:variable>
+
+
+	<xsl:template name="datafield">
+		<xsl:param name="tag"/>
+		<xsl:param name="ind1">
+			<xsl:text> </xsl:text>
+		</xsl:param>
+		<xsl:param name="ind2">
+			<xsl:text> </xsl:text>
+		</xsl:param>
+		<xsl:param name="subfields"/>
+		<xsl:element name="marc:datafield">
+			<xsl:attribute name="tag">
+				<xsl:value-of select="$tag"/>
+			</xsl:attribute>
+			<xsl:attribute name="ind1">
+				<xsl:value-of select="$ind1"/>
+			</xsl:attribute>
+			<xsl:attribute name="ind2">
+				<xsl:value-of select="$ind2"/>
+			</xsl:attribute>
+			<xsl:copy-of select="$subfields"/>
+		</xsl:element>
+	</xsl:template>
+
+	<xsl:template name="subfieldSelect">
+		<xsl:param name="codes">abcdefghijklmnopqrstuvwxyz</xsl:param>
+		<xsl:param name="delimeter">
+			<xsl:text> </xsl:text>
+		</xsl:param>
+		<xsl:variable name="str">
+			<xsl:for-each select="marc:subfield">
+				<xsl:if test="contains($codes, @code)">
+					<xsl:value-of select="text()"/>
+					<xsl:value-of select="$delimeter"/>
+				</xsl:if>
+			</xsl:for-each>
+		</xsl:variable>
+		<xsl:value-of select="substring($str,1,string-length($str)-string-length($delimeter))"/>
+	</xsl:template>
+
+	<xsl:template name="buildSpaces">
+		<xsl:param name="spaces"/>
+		<xsl:param name="char">
+			<xsl:text> </xsl:text>
+		</xsl:param>
+		<xsl:if test="$spaces>0">
+			<xsl:value-of select="$char"/>
+			<xsl:call-template name="buildSpaces">
+				<xsl:with-param name="spaces" select="$spaces - 1"/>
+				<xsl:with-param name="char" select="$char"/>
+			</xsl:call-template>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="chopPunctuation">
+		<xsl:param name="chopString"/>
+		<xsl:param name="punctuation">
+			<xsl:text>.:,;/ </xsl:text>
+		</xsl:param>
+		<xsl:variable name="length" select="string-length($chopString)"/>
+		<xsl:choose>
+			<xsl:when test="$length=0"/>
+			<xsl:when test="contains($punctuation, substring($chopString,$length,1))">
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
+					<xsl:with-param name="punctuation" select="$punctuation"/>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:when test="not($chopString)"/>
+			<xsl:otherwise>
+				<xsl:value-of select="$chopString"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template name="chopPunctuationFront">
+		<xsl:param name="chopString"/>
+		<xsl:variable name="length" select="string-length($chopString)"/>
+		<xsl:choose>
+			<xsl:when test="$length=0"/>
+			<xsl:when test="contains('.:,;/[ ', substring($chopString,1,1))">
+				<xsl:call-template name="chopPunctuationFront">
+					<xsl:with-param name="chopString" select="substring($chopString,2,$length - 1)"
+					/>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:when test="not($chopString)"/>
+			<xsl:otherwise>
+				<xsl:value-of select="$chopString"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template name="chopPunctuationBack">
+		<xsl:param name="chopString"/>
+		<xsl:param name="punctuation">
+			<xsl:text>.:,;/] </xsl:text>
+		</xsl:param>
+		<xsl:variable name="length" select="string-length($chopString)"/>
+		<xsl:choose>
+			<xsl:when test="$length=0"/>
+			<xsl:when test="contains($punctuation, substring($chopString,$length,1))">
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
+					<xsl:with-param name="punctuation" select="$punctuation"/>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:when test="not($chopString)"/>
+			<xsl:otherwise>
+				<xsl:value-of select="$chopString"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- nate added 12/14/2007 for lccn.loc.gov: url encode ampersand, etc. -->
+	<xsl:template name="url-encode">
+
+		<xsl:param name="str"/>
+
+		<xsl:if test="$str">
+			<xsl:variable name="first-char" select="substring($str,1,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($safe,$first-char)">
+					<xsl:value-of select="$first-char"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:variable name="codepoint">
+						<xsl:choose>
+							<xsl:when test="contains($ascii,$first-char)">
+								<xsl:value-of
+									select="string-length(substring-before($ascii,$first-char)) + 32"
+								/>
+							</xsl:when>
+							<xsl:when test="contains($latin1,$first-char)">
+								<xsl:value-of
+									select="string-length(substring-before($latin1,$first-char)) + 160"/>
+								<!-- was 160 -->
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:message terminate="no">Warning: string contains a character
+									that is out of range! Substituting "?".</xsl:message>
+								<xsl:text>63</xsl:text>
+							</xsl:otherwise>
+						</xsl:choose>
+					</xsl:variable>
+					<xsl:variable name="hex-digit1"
+						select="substring($hex,floor($codepoint div 16) + 1,1)"/>
+					<xsl:variable name="hex-digit2" select="substring($hex,$codepoint mod 16 + 1,1)"/>
+					<!-- <xsl:value-of select="concat('%',$hex-digit2)"/> -->
+					<xsl:value-of select="concat('%',$hex-digit1,$hex-digit2)"/>
+				</xsl:otherwise>
+			</xsl:choose>
+			<xsl:if test="string-length($str) &gt; 1">
+				<xsl:call-template name="url-encode">
+					<xsl:with-param name="str" select="substring($str,2)"/>
+				</xsl:call-template>
+			</xsl:if>
+		</xsl:if>
+	</xsl:template>
+</xsl:stylesheet>
+<!-- Stylus Studio meta-information - (c)1998-2002 eXcelon Corp.
+<metaInformation>
+<scenarios/><MapperInfo srcSchemaPath="" srcSchemaRoot="" srcSchemaPathIsRelative="yes" srcSchemaInterpretAsXML="no" destSchemaPath="" destSchemaRoot="" destSchemaPathIsRelative="yes" destSchemaInterpretAsXML="no"/>
+</metaInformation>
+-->

--- a/Kitodo-XML-SchemaConverter/src/main/resources/xslt/marc21slim2mods.xsl
+++ b/Kitodo-XML-SchemaConverter/src/main/resources/xslt/marc21slim2mods.xsl
@@ -1,0 +1,5508 @@
+<xsl:stylesheet xmlns="http://www.loc.gov/mods/v3" xmlns:marc="http://www.loc.gov/MARC21/slim"
+	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	exclude-result-prefixes="xlink marc" version="1.0">
+	<xsl:include href="./src/main/resources/xslt/MARC21slimUtils.xsl"/>
+	<xsl:output encoding="UTF-8" indent="yes" method="xml"/>
+	<xsl:strip-space elements="*"/>
+
+	<!-- Maintenance note: For each revision, change the content of <recordInfo><recordOrigin> to reflect the new revision number.
+	MARC21slim2MODS3-4 (Revision 1.95) 20141219
+
+Revision 1.95 - Added a xsl:when to deal with '#' and ' ' in $leader19 and $controlField008-18 - ws 2014/12/19
+Revision 1.94 - Leader 07 b mapping changed from "continuing" to "serial" tmee 2014/02/21
+Revision 1.93 - Fixed personal name transform for ind1=0 tmee 2014/01/31
+Revision 1.92 - Removed duplicate code for 856 1.51 tmee tmee 2014/01/31
+Revision 1.91 - Fixed createnameFrom720 duplication tmee tmee 2014/01/31
+Revision 1.90 - Fixed 520 displayLabel tmee tmee 2014/01/31
+Revision 1.89 - Fixed 008-06 when value = 's' for cartographics tmee tmee 2014/01/31
+Revision 1.88 - Fixed 510c mapping - tmee 2013/08/29
+Revision 1.87 - Fixed expressions of <accessCondition> type values - tmee 2013/08/29
+Revision 1.86 - Fixed 008 <frequency> subfield to occur w/i <originiInfo> - tmee 2013/08/29
+Revision 1.85 - Fixed 245 $c - tmee 2013/03/07
+Revision 1.84 - Fixed 1.35 and 1.36 date mapping for 008 when 008/06=e,p,r,s,t so only 008/07-10 displays, rather than 008/07-14 - tmee 2013/02/01
+Revision 1.83 - Deleted mapping for 534 to note - tmee 2013/01/18
+Revision 1.82 - Added mapping for 264 ind 0,1,2,3 to originInfo - 2013/01/15 tmee
+Revision 1.81 - Added mapping for 336$a$2, 337$a$2, 338$a$2 - 2012/12/03 tmee
+Revision 1.80 - Added 100/700 mapping for "family" - 2012/09/10 tmee
+Revision 1.79 - Added 245 $s mapping - 2012/07/11 tmee
+Revision 1.78 - Fixed 852 mapping <shelfLocation> was changed to <shelfLocator> - 2012/05/07 tmee
+Revision 1.77 - Fixed 008-06 when value = 's' - 2012/04/19 tmee
+Revision 1.76 - Fixed 242 - 2012/02/01 tmee
+Revision 1.75 - Fixed 653 - 2012/01/31 tmee
+Revision 1.74 - Fixed 510 note - 2011/07/15 tmee
+Revision 1.73 - Fixed 506 540 - 2011/07/11 tmee
+Revision 1.72 - Fixed frequency error - 2011/07/07 and 2011/07/14 tmee
+Revision 1.71 - Fixed subject titles for subfields t - 2011/04/26 tmee
+Revision 1.70 - Added mapping for OCLC numbers in 035s to go into <identifier type="oclc"> 2011/02/27 - tmee
+Revision 1.69 - Added mapping for untyped identifiers for 024 - 2011/02/27 tmee
+Revision 1.68 - Added <subject><titleInfo> mapping for 600/610/611 subfields t,p,n - 2010/12/22 tmee
+Revision 1.67 - Added frequency values and authority="marcfrequency" for 008/18 - 2010/12/09 tmee
+Revision 1.66 - Fixed 008/06=c,d,i,m,k,u, from dateCreated to dateIssued - 2010/12/06 tmee
+Revision 1.65 - Added back marcsmd and marccategory for 007 cr- 2010/12/06 tmee
+Revision 1.64 - Fixed identifiers - removed isInvalid template - 2010/12/06 tmee
+Revision 1.63 - Fixed descriptiveStandard value from aacr2 to aacr - 2010/12/06 tmee
+Revision 1.62 - Fixed date mapping for 008/06=e,p,r,s,t - 2010/12/01 tmee
+Revision 1.61 - Added 007 mappings for marccategory - 2010/11/12 tmee
+Revision 1.60 - Added altRepGroups and 880 linkages for relevant fields, see mapping - 2010/11/26 tmee
+Revision 1.59 - Added scriptTerm type=text to language for 546b and 066c - 2010/09/23 tmee
+Revision 1.58 - Expanded script template to include code conversions for extended scripts - 2010/09/22 tmee
+Revision 1.57 - Added Ldr/07 and Ldr/19 mappings - 2010/09/17 tmee
+Revision 1.56 - Mapped 1xx usage="primary" - 2010/09/17 tmee
+Revision 1.55 - Mapped UT 240/1xx nameTitleGroup - 2010/09/17 tmee
+MODS 3.4
+Revision 1.54 - Fixed 086 redundancy - 2010/07/27 tmee
+Revision 1.53 - Added direct href for MARC21slimUtils - 2010/07/27 tmee
+Revision 1.52 - Mapped 046 subfields c,e,k,l - 2010/04/09 tmee
+Revision 1.51 - Corrected 856 transform - 2010/01/29 tmee
+Revision 1.50 - Added 210 $2 authority attribute in <titleInfo type=”abbreviated”> 2009/11/23 tmee
+Revision 1.49 - Aquifer revision 1.14 - Added 240s (version) data to <titleInfo type="uniform"><title> 2009/11/23 tmee
+Revision 1.48 - Aquifer revision 1.27 - Added mapping of 242 second indicator (for nonfiling characters) to <titleInfo><nonSort > subelement  2007/08/08 tmee/dlf
+Revision 1.47 - Aquifer revision 1.26 - Mapped 300 subfield f (type of unit) - and g (size of unit) 2009 ntra
+Revision 1.46 - Aquifer revision 1.25 - Changed mapping of 767 so that <type="otherVersion>  2009/11/20  tmee
+Revision 1.45 - Aquifer revision 1.24 - Changed mapping of 765 so that <type="otherVersion>  2009/11/20  tmee
+Revision 1.44 - Added <recordInfo><recordOrigin> canned text about the version of this stylesheet 2009 ntra
+Revision 1.43 - Mapped 351 subfields a,b,c 2009/11/20 tmee
+Revision 1.42 - Changed 856 second indicator=1 to go to <location><url displayLabel=”electronic resource”> instead of to <relatedItem type=”otherVersion”><url> 2009/11/20 tmee
+Revision 1.41 - Aquifer revision 1.9 Added variable and choice protocol for adding usage=”primary display” 2009/11/19 tmee
+Revision 1.40 - Dropped <note> for 510 and added <relatedItem type="isReferencedBy"> for 510 2009/11/19 tmee
+Revision 1.39 - Aquifer revision 1.23 Changed mapping for 762 (Subseries Entry) from <relatedItem type="series"> to <relatedItem type="constituent"> 2009/11/19 tmee
+Revision 1.38 - Aquifer revision 1.29 Dropped 007s for electronic versions 2009/11/18 tmee
+Revision 1.37 - Fixed date redundancy in output (with questionable dates) 2009/11/16 tmee
+Revision 1.36 - If mss material (Ldr/06=d,p,f,t) map 008 dates and 260$c/$g dates to dateCreated 2009/11/24, otherwise map 008 and 260$c/$g to dateIssued 2010/01/08 tmee
+Revision 1.35 - Mapped appended detailed dates from 008/07-10 and 008/11-14 to dateIssued or DateCreated w/encoding="marc" 2010/01/12 tmee
+Revision 1.34 - Mapped 045b B.C. and C.E. date range info to iso8601-compliant dates in <subject><temporal> 2009/01/08 ntra
+Revision 1.33 - Mapped Ldr/06 "o" to <typeOfResource>kit 2009/11/16 tmee
+Revision 1.32 - Mapped specific note types from the MODS Note Type list <http://www.loc.gov/standards/mods/mods-notes.html> tmee 2009/11/17
+Revision 1.31 - Mapped 540 to <accessCondition type="use and reproduction"> and 506 to <accessCondition type="restriction on access"> and delete mappings of 540 and 506 to <note>
+Revision 1.30 - Mapped 037c to <identifier displayLabel=""> 2009/11/13 tmee
+Revision 1.29 - Corrected schemaLocation to 3.3 2009/11/13 tmee
+Revision 1.28 - Changed mapping from 752,662 g going to mods:hierarchicalGeographic/area instead of "region" 2009/07/30 ntra
+Revision 1.27 - Mapped 648 to <subject> 2009/03/13 tmee
+Revision 1.26 - Added subfield $s mapping for 130/240/730  2008/10/16 tmee
+Revision 1.25 - Mapped 040e to <descriptiveStandard> and Leader/18 to <descriptive standard>aacr2  2008/09/18 tmee
+Revision 1.24 - Mapped 852 subfields $h, $i, $j, $k, $l, $m, $t to <shelfLocation> and 852 subfield $u to <physicalLocation> with @xlink 2008/09/17 tmee
+Revision 1.23 - Commented out xlink/uri for subfield 0 for 130/240/730, 100/700, 110/710, 111/711 as these are currently unactionable  2008/09/17 tmee
+Revision 1.22 - Mapped 022 subfield $l to type "issn-l" subfield $m to output identifier element with corresponding @type and @invalid eq 'yes'2008/09/17 tmee
+Revision 1.21 - Mapped 856 ind2=1 or ind2=2 to <relatedItem><location><url>  2008/07/03 tmee
+Revision 1.20 - Added genre w/@auth="contents of 2" and type= "musical composition"  2008/07/01 tmee
+Revision 1.19 - Added genre offprint for 008/24+ BK code 2  2008/07/01  tmee
+Revision 1.18 - Added xlink/uri for subfield 0 for 130/240/730, 100/700, 110/710, 111/711  2008/06/26 tmee
+Revision 1.17 - Added mapping of 662 2008/05/14 tmee
+Revision 1.16 - Changed @authority from "marc" to "marcgt" for 007 and 008 codes mapped to a term in <genre> 2007/07/10 tmee
+Revision 1.15 - For field 630, moved call to part template outside title element  2007/07/10 tmee
+Revision 1.14 - Fixed template isValid and fields 010, 020, 022, 024, 028, and 037 to output additional identifier elements with corresponding @type and @invalid eq 'yes' when subfields z or y (in the case of 022) exist in the MARCXML ::: 2007/01/04 17:35:20 cred
+Revision 1.13 - Changed order of output under cartographics to reflect schema  2006/11/28 tmee
+Revision 1.12 - Updated to reflect MODS 3.2 Mapping  2006/10/11 tmee
+Revision 1.11 - The attribute objectPart moved from <languageTerm> to <language>  2006/04/08  jrad
+Revision 1.10 - MODS 3.1 revisions to language and classification elements (plus ability to find marc:collection embedded in wrapper elements such as SRU zs: wrappers)  2006/02/06  ggar
+Revision 1.09 - Subfield $y was added to field 242 2004/09/02 10:57 jrad
+Revision 1.08 - Subject chopPunctuation expanded and attribute fixes 2004/08/12 jrad
+Revision 1.07 - 2004/03/25 08:29 jrad
+Revision 1.06 - Various validation fixes 2004/02/20 ntra
+Revision 1.05 - MODS2 to MODS3 updates, language unstacking and de-duping, chopPunctuation expanded  2003/10/02 16:18:58  ntra
+Revision 1.03 - Additional Changes not related to MODS Version 2.0 by ntra
+Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
+	-->
+
+	<xsl:template match="/">
+		<xsl:choose>
+			<xsl:when test="//marc:collection">
+				<modsCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+					xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+					<xsl:for-each select="//marc:collection/marc:record">
+						<mods version="3.4">
+							<xsl:call-template name="marcRecord"/>
+						</mods>
+					</xsl:for-each>
+				</modsCollection>
+			</xsl:when>
+			<xsl:otherwise>
+				<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.4"
+					xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+					<xsl:for-each select="//marc:record">
+						<xsl:call-template name="marcRecord"/>
+					</xsl:for-each>
+				</mods>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+	<xsl:template name="marcRecord">
+		<xsl:variable name="leader" select="marc:leader"/>
+		<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+		<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+		<xsl:variable name="leader19" select="substring($leader,20,1)"/>
+		<xsl:variable name="controlField008" select="marc:controlfield[@tag='008']"/>
+		<xsl:variable name="typeOf008">
+			<xsl:choose>
+				<xsl:when test="$leader6='a'">
+					<xsl:choose>
+						<xsl:when
+							test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'"
+							>BK</xsl:when>
+						<xsl:when test="$leader7='b' or $leader7='i' or $leader7='s'">SE</xsl:when>
+					</xsl:choose>
+				</xsl:when>
+				<xsl:when test="$leader6='t'">BK</xsl:when>
+				<xsl:when test="$leader6='p'">MM</xsl:when>
+				<xsl:when test="$leader6='m'">CF</xsl:when>
+				<xsl:when test="$leader6='e' or $leader6='f'">MP</xsl:when>
+				<xsl:when test="$leader6='g' or $leader6='k' or $leader6='o' or $leader6='r'"
+					>VM</xsl:when>
+				<xsl:when test="$leader6='c' or $leader6='d' or $leader6='i' or $leader6='j'"
+					>MU</xsl:when>
+			</xsl:choose>
+		</xsl:variable>
+
+		<!-- titleInfo -->
+
+		<xsl:for-each select="marc:datafield[@tag='245']">
+			<xsl:call-template name="createTitleInfoFrom245"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='210']">
+			<xsl:call-template name="createTitleInfoFrom210"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='246']">
+			<xsl:call-template name="createTitleInfoFrom246"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='240']">
+			<xsl:call-template name="createTitleInfoFrom240"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='740']">
+			<xsl:call-template name="createTitleInfoFrom740"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='130']">
+			<xsl:call-template name="createTitleInfoFrom130"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='730']">
+			<xsl:call-template name="createTitleInfoFrom730"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='242']">
+			<titleInfo type="translated">
+				<!--09/01/04 Added subfield $y-->
+				<xsl:for-each select="marc:subfield[@code='y']">
+					<xsl:attribute name="lang">
+						<xsl:value-of select="text()"/>
+					</xsl:attribute>
+				</xsl:for-each>
+
+				<!-- AQ1.27 tmee/dlf -->
+				<xsl:variable name="title">
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:call-template name="subfieldSelect">
+								<!-- 1/04 removed $h, b -->
+								<xsl:with-param name="codes">a</xsl:with-param>
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+				</xsl:variable>
+				<xsl:variable name="titleChop">
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="$title"/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</xsl:variable>
+				<xsl:choose>
+					<xsl:when test="@ind2>0">
+						<nonSort>
+							<xsl:value-of select="substring($titleChop,1,@ind2)"/>
+						</nonSort>
+						<title>
+							<xsl:value-of select="substring($titleChop,@ind2+1)"/>
+						</title>
+					</xsl:when>
+					<xsl:otherwise>
+						<title>
+							<xsl:value-of select="$titleChop"/>
+						</title>
+					</xsl:otherwise>
+				</xsl:choose>
+
+				<!-- 1/04 fix -->
+				<xsl:call-template name="subtitle"/>
+				<xsl:call-template name="part"/>
+			</titleInfo>
+		</xsl:for-each>
+
+		<!-- name -->
+
+		<xsl:for-each select="marc:datafield[@tag='100']">
+			<xsl:call-template name="createNameFrom100"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='110']">
+			<xsl:call-template name="createNameFrom110"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='111']">
+			<xsl:call-template name="createNameFrom111"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='700']">
+			<xsl:call-template name="createNameFrom700"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='710']">
+			<xsl:call-template name="createNameFrom710"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='711']">
+			<xsl:call-template name="createNameFrom711"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='720']">
+			<xsl:call-template name="createNameFrom720"/>
+		</xsl:for-each>
+
+		<!--old 7XXs
+		<xsl:for-each select="marc:datafield[@tag='700'][not(marc:subfield[@code='t'])]">
+			<name type="personal">
+				<xsl:call-template name="nameABCDQ"/>
+				<xsl:call-template name="affiliation"/>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='710'][not(marc:subfield[@code='t'])]">
+			<name type="corporate">
+				<xsl:call-template name="nameABCDN"/>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='711'][not(marc:subfield[@code='t'])]">
+			<name type="conference">
+				<xsl:call-template name="nameACDEQ"/>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='720'][not(marc:subfield[@code='t'])]">
+		<name>
+		<xsl:if test="@ind1=1">
+		<xsl:attribute name="type">
+		<xsl:text>personal</xsl:text>
+		</xsl:attribute>
+		</xsl:if>
+		<namePart>
+		<xsl:value-of select="marc:subfield[@code='a']"/>
+		</namePart>
+		<xsl:call-template name="role"/>
+		</name>
+		</xsl:for-each>
+-->
+
+		<typeOfResource>
+			<xsl:if test="$leader7='c'">
+				<xsl:attribute name="collection">yes</xsl:attribute>
+			</xsl:if>
+			<xsl:if test="$leader6='d' or $leader6='f' or $leader6='p' or $leader6='t'">
+				<xsl:attribute name="manuscript">yes</xsl:attribute>
+			</xsl:if>
+			<xsl:choose>
+				<xsl:when test="$leader6='a' or $leader6='t'">text</xsl:when>
+				<xsl:when test="$leader6='e' or $leader6='f'">cartographic</xsl:when>
+				<xsl:when test="$leader6='c' or $leader6='d'">notated music</xsl:when>
+				<xsl:when test="$leader6='i'">sound recording-nonmusical</xsl:when>
+				<xsl:when test="$leader6='j'">sound recording-musical</xsl:when>
+				<xsl:when test="$leader6='k'">still image</xsl:when>
+				<xsl:when test="$leader6='g'">moving image</xsl:when>
+				<xsl:when test="$leader6='r'">three dimensional object</xsl:when>
+				<xsl:when test="$leader6='m'">software, multimedia</xsl:when>
+				<xsl:when test="$leader6='p'">mixed material</xsl:when>
+			</xsl:choose>
+		</typeOfResource>
+		<xsl:if test="substring($controlField008,26,1)='d'">
+			<genre authority="marcgt">globe</genre>
+		</xsl:if>
+		<xsl:if
+			test="marc:controlfield[@tag='007'][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
+			<genre authority="marcgt">remote-sensing image</genre>
+		</xsl:if>
+		<xsl:if test="$typeOf008='MP'">
+			<xsl:variable name="controlField008-25" select="substring($controlField008,26,1)"/>
+			<xsl:choose>
+				<xsl:when
+					test="$controlField008-25='a' or $controlField008-25='b' or $controlField008-25='c' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
+					<genre authority="marcgt">map</genre>
+				</xsl:when>
+				<xsl:when
+					test="$controlField008-25='e' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
+					<genre authority="marcgt">atlas</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='SE'">
+			<xsl:variable name="controlField008-21" select="substring($controlField008,22,1)"/>
+			<xsl:choose>
+				<xsl:when test="$controlField008-21='d'">
+					<genre authority="marcgt">database</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-21='l'">
+					<genre authority="marcgt">loose-leaf</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-21='m'">
+					<genre authority="marcgt">series</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-21='n'">
+					<genre authority="marcgt">newspaper</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-21='p'">
+					<genre authority="marcgt">periodical</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-21='w'">
+					<genre authority="marcgt">web site</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='BK' or $typeOf008='SE'">
+			<xsl:variable name="controlField008-24" select="substring($controlField008,25,4)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-24,'a')">
+					<genre authority="marcgt">abstract or summary</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'b')">
+					<genre authority="marcgt">bibliography</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'c')">
+					<genre authority="marcgt">catalog</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'d')">
+					<genre authority="marcgt">dictionary</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'e')">
+					<genre authority="marcgt">encyclopedia</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'f')">
+					<genre authority="marcgt">handbook</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'g')">
+					<genre authority="marcgt">legal article</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'i')">
+					<genre authority="marcgt">index</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'k')">
+					<genre authority="marcgt">discography</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'l')">
+					<genre authority="marcgt">legislation</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'m')">
+					<genre authority="marcgt">theses</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'n')">
+					<genre authority="marcgt">survey of literature</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'o')">
+					<genre authority="marcgt">review</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'p')">
+					<genre authority="marcgt">programmed text</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'q')">
+					<genre authority="marcgt">filmography</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'r')">
+					<genre authority="marcgt">directory</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'s')">
+					<genre authority="marcgt">statistics</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'t')">
+					<genre authority="marcgt">technical report</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'v')">
+					<genre authority="marcgt">legal case and case notes</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'w')">
+					<genre authority="marcgt">law report or digest</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-24,'z')">
+					<genre authority="marcgt">treaty</genre>
+				</xsl:when>
+			</xsl:choose>
+			<xsl:variable name="controlField008-29" select="substring($controlField008,30,1)"/>
+			<xsl:choose>
+				<xsl:when test="$controlField008-29='1'">
+					<genre authority="marcgt">conference publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='CF'">
+			<xsl:variable name="controlField008-26" select="substring($controlField008,27,1)"/>
+			<xsl:choose>
+				<xsl:when test="$controlField008-26='a'">
+					<genre authority="marcgt">numeric data</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-26='e'">
+					<genre authority="marcgt">database</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-26='f'">
+					<genre authority="marcgt">font</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-26='g'">
+					<genre authority="marcgt">game</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='BK'">
+			<xsl:if test="substring($controlField008,25,1)='j'">
+				<genre authority="marcgt">patent</genre>
+			</xsl:if>
+			<xsl:if test="substring($controlField008,25,1)='2'">
+				<genre authority="marcgt">offprint</genre>
+			</xsl:if>
+			<xsl:if test="substring($controlField008,31,1)='1'">
+				<genre authority="marcgt">festschrift</genre>
+			</xsl:if>
+			<xsl:variable name="controlField008-34" select="substring($controlField008,35,1)"/>
+			<xsl:if
+				test="$controlField008-34='a' or $controlField008-34='b' or $controlField008-34='c' or $controlField008-34='d'">
+				<genre authority="marcgt">biography</genre>
+			</xsl:if>
+			<xsl:variable name="controlField008-33" select="substring($controlField008,34,1)"/>
+			<xsl:choose>
+				<xsl:when test="$controlField008-33='e'">
+					<genre authority="marcgt">essay</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='d'">
+					<genre authority="marcgt">drama</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='c'">
+					<genre authority="marcgt">comic strip</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='l'">
+					<genre authority="marcgt">fiction</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='h'">
+					<genre authority="marcgt">humor, satire</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='i'">
+					<genre authority="marcgt">letter</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='f'">
+					<genre authority="marcgt">novel</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='j'">
+					<genre authority="marcgt">short story</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='s'">
+					<genre authority="marcgt">speech</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='MU'">
+			<xsl:variable name="controlField008-30-31" select="substring($controlField008,31,2)"/>
+			<xsl:if test="contains($controlField008-30-31,'b')">
+				<genre authority="marcgt">biography</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'c')">
+				<genre authority="marcgt">conference publication</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'d')">
+				<genre authority="marcgt">drama</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'e')">
+				<genre authority="marcgt">essay</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'f')">
+				<genre authority="marcgt">fiction</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'o')">
+				<genre authority="marcgt">folktale</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'h')">
+				<genre authority="marcgt">history</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'k')">
+				<genre authority="marcgt">humor, satire</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'m')">
+				<genre authority="marcgt">memoir</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'p')">
+				<genre authority="marcgt">poetry</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'r')">
+				<genre authority="marcgt">rehearsal</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'g')">
+				<genre authority="marcgt">reporting</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'s')">
+				<genre authority="marcgt">sound</genre>
+			</xsl:if>
+			<xsl:if test="contains($controlField008-30-31,'l')">
+				<genre authority="marcgt">speech</genre>
+			</xsl:if>
+		</xsl:if>
+		<xsl:if test="$typeOf008='VM'">
+			<xsl:variable name="controlField008-33" select="substring($controlField008,34,1)"/>
+			<xsl:choose>
+				<xsl:when test="$controlField008-33='a'">
+					<genre authority="marcgt">art original</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='b'">
+					<genre authority="marcgt">kit</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='c'">
+					<genre authority="marcgt">art reproduction</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='d'">
+					<genre authority="marcgt">diorama</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='f'">
+					<genre authority="marcgt">filmstrip</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='g'">
+					<genre authority="marcgt">legal article</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='i'">
+					<genre authority="marcgt">picture</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='k'">
+					<genre authority="marcgt">graphic</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='l'">
+					<genre authority="marcgt">technical drawing</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='m'">
+					<genre authority="marcgt">motion picture</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='n'">
+					<genre authority="marcgt">chart</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='o'">
+					<genre authority="marcgt">flash card</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='p'">
+					<genre authority="marcgt">microscope slide</genre>
+				</xsl:when>
+				<xsl:when
+					test="$controlField008-33='q' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
+					<genre authority="marcgt">model</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='r'">
+					<genre authority="marcgt">realia</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='s'">
+					<genre authority="marcgt">slide</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='t'">
+					<genre authority="marcgt">transparency</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='v'">
+					<genre authority="marcgt">videorecording</genre>
+				</xsl:when>
+				<xsl:when test="$controlField008-33='w'">
+					<genre authority="marcgt">toy</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+
+		<!-- genre -->
+
+		<xsl:for-each select="marc:datafield[@tag=047]">
+			<xsl:call-template name="createGenreFrom047"/>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=336]">
+			<xsl:call-template name="createGenreFrom336"/>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=655]">
+			<xsl:call-template name="createGenreFrom655"/>
+		</xsl:for-each>
+
+		<!-- originInfo 250 and 260 -->
+
+		<originInfo>
+			<xsl:call-template name="scriptCode"/>
+			<xsl:for-each
+				select="marc:datafield[(@tag=260 or @tag=250) and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
+				<xsl:call-template name="z2xx880"/>
+			</xsl:for-each>
+
+			<xsl:variable name="MARCpublicationCode"
+				select="normalize-space(substring($controlField008,16,3))"/>
+			<xsl:if test="translate($MARCpublicationCode,'|','')">
+				<place>
+					<placeTerm>
+						<xsl:attribute name="type">code</xsl:attribute>
+						<xsl:attribute name="authority">marccountry</xsl:attribute>
+						<xsl:value-of select="$MARCpublicationCode"/>
+					</placeTerm>
+				</place>
+			</xsl:if>
+			<xsl:for-each select="marc:datafield[@tag=044]/marc:subfield[@code='c']">
+				<place>
+					<placeTerm>
+						<xsl:attribute name="type">code</xsl:attribute>
+						<xsl:attribute name="authority">iso3166</xsl:attribute>
+						<xsl:value-of select="."/>
+					</placeTerm>
+				</place>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=260]/marc:subfield[@code='a']">
+				<place>
+					<placeTerm>
+						<xsl:attribute name="type">text</xsl:attribute>
+						<xsl:call-template name="chopPunctuationFront">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="chopPunctuation">
+									<xsl:with-param name="chopString" select="."/>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</placeTerm>
+				</place>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=046]/marc:subfield[@code='m']">
+				<dateValid point="start">
+					<xsl:value-of select="."/>
+				</dateValid>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=046]/marc:subfield[@code='n']">
+				<dateValid point="end">
+					<xsl:value-of select="."/>
+				</dateValid>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=046]/marc:subfield[@code='j']">
+				<dateModified>
+					<xsl:value-of select="."/>
+				</dateModified>
+			</xsl:for-each>
+
+			<!-- tmee 1.52 -->
+
+			<xsl:for-each select="marc:datafield[@tag=046]/marc:subfield[@code='c']">
+				<dateIssued encoding="marc" point="start">
+					<xsl:value-of select="."/>
+				</dateIssued>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=046]/marc:subfield[@code='e']">
+				<dateIssued encoding="marc" point="end">
+					<xsl:value-of select="."/>
+				</dateIssued>
+			</xsl:for-each>
+
+			<xsl:for-each select="marc:datafield[@tag=046]/marc:subfield[@code='k']">
+				<dateCreated encoding="marc" point="start">
+					<xsl:value-of select="."/>
+				</dateCreated>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=046]/marc:subfield[@code='l']">
+				<dateCreated encoding="marc" point="end">
+					<xsl:value-of select="."/>
+				</dateCreated>
+			</xsl:for-each>
+
+			<!-- tmee 1.35 1.36 dateIssued/nonMSS vs dateCreated/MSS -->
+			<xsl:for-each
+				select="marc:datafield[@tag=260]/marc:subfield[@code='b' or @code='c' or @code='g']">
+				<xsl:choose>
+					<xsl:when test="@code='b'">
+						<publisher>
+							<xsl:call-template name="chopPunctuation">
+								<xsl:with-param name="chopString" select="."/>
+								<xsl:with-param name="punctuation">
+									<xsl:text>:,;/ </xsl:text>
+								</xsl:with-param>
+							</xsl:call-template>
+						</publisher>
+					</xsl:when>
+					<xsl:when test="(@code='c')">
+						<xsl:if test="$leader6='d' or $leader6='f' or $leader6='p' or $leader6='t'">
+							<dateCreated>
+								<xsl:call-template name="chopPunctuation">
+									<xsl:with-param name="chopString" select="."/>
+								</xsl:call-template>
+							</dateCreated>
+						</xsl:if>
+
+						<xsl:if
+							test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+							<dateIssued>
+								<xsl:call-template name="chopPunctuation">
+									<xsl:with-param name="chopString" select="."/>
+								</xsl:call-template>
+							</dateIssued>
+						</xsl:if>
+					</xsl:when>
+					<xsl:when test="@code='g'">
+						<xsl:if test="$leader6='d' or $leader6='f' or $leader6='p' or $leader6='t'">
+							<dateCreated>
+								<xsl:value-of select="."/>
+							</dateCreated>
+						</xsl:if>
+						<xsl:if
+							test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+							<dateCreated>
+								<xsl:value-of select="."/>
+							</dateCreated>
+						</xsl:if>
+					</xsl:when>
+				</xsl:choose>
+			</xsl:for-each>
+			<xsl:variable name="dataField260c">
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString"
+						select="marc:datafield[@tag=260]/marc:subfield[@code='c']"/>
+				</xsl:call-template>
+			</xsl:variable>
+			<xsl:variable name="controlField008-7-10"
+				select="normalize-space(substring($controlField008, 8, 4))"/>
+			<xsl:variable name="controlField008-11-14"
+				select="normalize-space(substring($controlField008, 12, 4))"/>
+			<xsl:variable name="controlField008-6"
+				select="normalize-space(substring($controlField008, 7, 1))"/>
+
+
+
+			<!-- tmee 1.35 and 1.36 and 1.84-->
+
+			<xsl:if
+				test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and ($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+				<xsl:if test="$controlField008-7-10 and ($controlField008-7-10 != $dataField260c)">
+					<dateCreated encoding="marc">
+						<xsl:value-of select="$controlField008-7-10"/>
+					</dateCreated>
+				</xsl:if>
+			</xsl:if>
+
+			<xsl:if
+				test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+				<xsl:if test="$controlField008-7-10 and ($controlField008-7-10 != $dataField260c)">
+					<dateIssued encoding="marc">
+						<xsl:value-of select="$controlField008-7-10"/></dateIssued>
+				</xsl:if>
+			</xsl:if>
+
+			<xsl:if
+				test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
+				<xsl:if test="$controlField008-7-10">
+					<dateIssued encoding="marc" point="start">
+						<xsl:value-of select="$controlField008-7-10"/>
+					</dateIssued>
+				</xsl:if>
+			</xsl:if>
+
+			<xsl:if
+				test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
+				<xsl:if test="$controlField008-11-14">
+					<dateIssued encoding="marc" point="end">
+						<xsl:value-of select="$controlField008-11-14"/>
+					</dateIssued>
+				</xsl:if>
+			</xsl:if>
+
+			<xsl:if test="$controlField008-6='q'">
+				<xsl:if test="$controlField008-7-10">
+					<dateIssued encoding="marc" point="start" qualifier="questionable">
+						<xsl:value-of select="$controlField008-7-10"/>
+					</dateIssued>
+				</xsl:if>
+			</xsl:if>
+			<xsl:if test="$controlField008-6='q'">
+				<xsl:if test="$controlField008-11-14">
+					<dateIssued encoding="marc" point="end" qualifier="questionable">
+						<xsl:value-of select="$controlField008-11-14"/>
+					</dateIssued>
+				</xsl:if>
+			</xsl:if>
+
+
+			<!-- tmee 1.77 008-06 dateIssued for value 's' 1.89 removed 20130920
+			<xsl:if test="$controlField008-6='s'">
+				<xsl:if test="$controlField008-7-10">
+					<dateIssued encoding="marc">
+						<xsl:value-of select="$controlField008-7-10"/>
+					</dateIssued>
+				</xsl:if>
+			</xsl:if>
+			-->
+
+			<xsl:if test="$controlField008-6='t'">
+				<xsl:if test="$controlField008-11-14">
+					<copyrightDate encoding="marc">
+						<xsl:value-of select="$controlField008-11-14"/>
+					</copyrightDate>
+				</xsl:if>
+			</xsl:if>
+			<xsl:for-each
+				select="marc:datafield[@tag=033][@ind1=0 or @ind1=1]/marc:subfield[@code='a']">
+				<dateCaptured encoding="iso8601">
+					<xsl:value-of select="."/>
+				</dateCaptured>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=033][@ind1=2]/marc:subfield[@code='a'][1]">
+				<dateCaptured encoding="iso8601" point="start">
+					<xsl:value-of select="."/>
+				</dateCaptured>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=033][@ind1=2]/marc:subfield[@code='a'][2]">
+				<dateCaptured encoding="iso8601" point="end">
+					<xsl:value-of select="."/>
+				</dateCaptured>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=250]/marc:subfield[@code='a']">
+				<edition>
+					<xsl:value-of select="."/>
+				</edition>
+			</xsl:for-each>
+
+			<!--1.94 -->
+
+			<xsl:for-each select="marc:leader">
+				<issuance>
+					<xsl:choose>
+						<xsl:when
+							test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'"
+							>monographic</xsl:when>
+						<xsl:when test="$leader7='b'">continuing</xsl:when>
+						<xsl:when
+							test="$leader7='m' and ($leader19='a' or $leader19='b' or $leader19='c')"
+							>multipart monograph</xsl:when>
+						<!-- 1.95 20141219-->
+						<xsl:when test="$leader7='m' and ($leader19=' ')">single unit</xsl:when>
+						<xsl:when test="$leader7='m' and ($leader19='#')">single unit</xsl:when>
+						<xsl:when test="$leader7='i'">integrating resource</xsl:when>
+						<xsl:when test="$leader7='b' or $leader7='s'">serial</xsl:when>
+					</xsl:choose>
+				</issuance>
+			</xsl:for-each>
+			<xsl:for-each select="marc:datafield[@tag=310]|marc:datafield[@tag=321]">
+				<frequency authority="marcfrequency">
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">ab</xsl:with-param>
+					</xsl:call-template>
+				</frequency>
+			</xsl:for-each>
+
+			<!--	1.67 1.72 updated fixed location issue 201308 1.86	-->
+
+			<xsl:if test="$typeOf008='SE'">
+				<xsl:for-each select="marc:controlfield[@tag=008]">
+					<xsl:variable name="controlField008-18" select="substring($controlField008,19,1)"/>
+					<xsl:variable name="frequency">
+						<frequency>
+							<xsl:choose>
+								<xsl:when test="$controlField008-18='a'">Annual</xsl:when>
+								<xsl:when test="$controlField008-18='b'">Bimonthly</xsl:when>
+								<xsl:when test="$controlField008-18='c'">Semiweekly</xsl:when>
+								<xsl:when test="$controlField008-18='d'">Daily</xsl:when>
+								<xsl:when test="$controlField008-18='e'">Biweekly</xsl:when>
+								<xsl:when test="$controlField008-18='f'">Semiannual</xsl:when>
+								<xsl:when test="$controlField008-18='g'">Biennial</xsl:when>
+								<xsl:when test="$controlField008-18='h'">Triennial</xsl:when>
+								<xsl:when test="$controlField008-18='i'">Three times a week</xsl:when>
+								<xsl:when test="$controlField008-18='j'">Three times a month</xsl:when>
+								<xsl:when test="$controlField008-18='k'">Continuously updated</xsl:when>
+								<xsl:when test="$controlField008-18='m'">Monthly</xsl:when>
+								<xsl:when test="$controlField008-18='q'">Quarterly</xsl:when>
+								<xsl:when test="$controlField008-18='s'">Semimonthly</xsl:when>
+								<xsl:when test="$controlField008-18='t'">Three times a year</xsl:when>
+								<xsl:when test="$controlField008-18='u'">Unknown</xsl:when>
+								<xsl:when test="$controlField008-18='w'">Weekly</xsl:when>
+								<!-- 1.95 20141219-->
+								<xsl:when test="$controlField008-18=' '">Completely irregular</xsl:when>
+								<xsl:when test="$controlField008-18='#'">Completely irregular</xsl:when>
+								<xsl:otherwise/>
+							</xsl:choose>
+						</frequency>
+					</xsl:variable>
+					<xsl:if test="$frequency!=''">
+						<frequency>
+							<xsl:value-of select="$frequency"/>
+						</frequency>
+					</xsl:if>
+				</xsl:for-each>
+			</xsl:if>
+		</originInfo>
+
+
+		<!-- originInfo - 264 -->
+
+		<xsl:for-each select="marc:datafield[@tag=264][@ind2=0]">
+			<originInfo displayLabel="producer">
+				<!-- Template checks for altRepGroup - 880 $6 -->
+				<xsl:call-template name="xxx880"/>
+				<place>
+					<placeTerm>
+						<xsl:value-of select="marc:subfield[@code='a']"/>
+					</placeTerm>
+				</place>
+				<publisher>
+					<xsl:value-of select="marc:subfield[@code='b']"/>
+				</publisher>
+				<dateOther type="production">
+					<xsl:value-of select="marc:subfield[@code='c']"/>
+				</dateOther>
+			</originInfo>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=264][@ind2=1]">
+			<originInfo displayLabel="publisher">
+				<!-- Template checks for altRepGroup - 880 $6 1.88 20130829 added chopPunc-->
+				<xsl:call-template name="xxx880"/>
+				<place>
+					<placeTerm>
+
+						<xsl:attribute name="type">text</xsl:attribute>
+						<xsl:call-template name="chopPunctuationFront">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="chopPunctuation">
+									<xsl:with-param name="chopString" select="."/>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+
+					</placeTerm>
+				</place>
+				<publisher>
+					<xsl:value-of select="marc:subfield[@code='b']"/>
+				</publisher>
+				<dateIssued>
+					<xsl:value-of select="marc:subfield[@code='c']"/>
+				</dateIssued>
+			</originInfo>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=264][@ind2=2]">
+			<originInfo displayLabel="distributor">
+				<!-- Template checks for altRepGroup - 880 $6 -->
+				<xsl:call-template name="xxx880"/>
+				<place>
+					<placeTerm>
+						<xsl:value-of select="marc:subfield[@code='a']"/>
+					</placeTerm>
+				</place>
+				<publisher>
+					<xsl:value-of select="marc:subfield[@code='b']"/>
+				</publisher>
+				<dateOther type="distribution">
+					<xsl:value-of select="marc:subfield[@code='c']"/>
+				</dateOther>
+			</originInfo>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=264][@ind2=3]">
+			<originInfo displayLabel="manufacturer">
+				<!-- Template checks for altRepGroup - 880 $6 -->
+				<xsl:call-template name="xxx880"/>
+				<place>
+					<placeTerm>
+						<xsl:value-of select="marc:subfield[@code='a']"/>
+					</placeTerm>
+				</place>
+				<publisher>
+					<xsl:value-of select="marc:subfield[@code='b']"/>
+				</publisher>
+				<dateOther type="manufacture">
+					<xsl:value-of select="marc:subfield[@code='c']"/>
+				</dateOther>
+			</originInfo>
+		</xsl:for-each>
+
+
+
+
+
+		<xsl:for-each select="marc:datafield[@tag=880]">
+			<xsl:variable name="related_datafield"
+				select="substring-before(marc:subfield[@code='6'],'-')"/>
+			<xsl:variable name="occurence_number"
+				select="substring( substring-after(marc:subfield[@code='6'],'-') , 1 , 2 )"/>
+			<xsl:variable name="hit"
+				select="../marc:datafield[@tag=$related_datafield and contains(marc:subfield[@code='6'] , concat('880-' , $occurence_number))]/@tag"/>
+
+			<xsl:choose>
+				<xsl:when test="$hit='260'">
+					<originInfo>
+						<xsl:call-template name="scriptCode"/>
+						<xsl:for-each
+							select="../marc:datafield[@tag=260 and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
+							<xsl:call-template name="z2xx880"/>
+						</xsl:for-each>
+						<xsl:if test="marc:subfield[@code='a']">
+							<place>
+								<placeTerm type="text">
+									<xsl:value-of select="marc:subfield[@code='a']"/>
+								</placeTerm>
+							</place>
+						</xsl:if>
+						<xsl:if test="marc:subfield[@code='b']">
+							<publisher>
+								<xsl:value-of select="marc:subfield[@code='b']"/>
+							</publisher>
+						</xsl:if>
+						<xsl:if test="marc:subfield[@code='c']">
+							<dateIssued>
+								<xsl:value-of select="marc:subfield[@code='c']"/>
+							</dateIssued>
+						</xsl:if>
+						<xsl:if test="marc:subfield[@code='g']">
+							<dateCreated>
+								<xsl:value-of select="marc:subfield[@code='g']"/>
+							</dateCreated>
+						</xsl:if>
+						<xsl:for-each
+							select="../marc:datafield[@tag=880]/marc:subfield[@code=6][contains(text(),'250')]">
+							<edition>
+								<xsl:value-of select="following-sibling::marc:subfield"/>
+							</edition>
+						</xsl:for-each>
+					</originInfo>
+				</xsl:when>
+				<xsl:when test="$hit='300'">
+					<physicalDescription>
+						<xsl:for-each select="../marc:datafield[@tag=300]">
+							<xsl:call-template name="z3xx880"/>
+						</xsl:for-each>
+						<extent>
+							<xsl:for-each select="marc:subfield">
+								<xsl:if test="@code='a' or @code='3' or @code='b' or @code='c'">
+									<xsl:value-of select="."/>
+									<xsl:text> </xsl:text>
+								</xsl:if>
+							</xsl:for-each>
+						</extent>
+						<!-- form 337 338 -->
+						<form>
+							<xsl:attribute name="authority">
+								<xsl:value-of select="marc:subfield[@code='2']"/>
+							</xsl:attribute>
+							<xsl:call-template name="xxx880"/>
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">a</xsl:with-param>
+							</xsl:call-template>
+						</form>
+						<form>
+							<xsl:attribute name="authority">
+								<xsl:value-of select="marc:subfield[@code='2']"/>
+							</xsl:attribute>
+							<xsl:call-template name="xxx880"/>
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">ab</xsl:with-param>
+							</xsl:call-template>
+						</form>
+					</physicalDescription>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:for-each>
+
+		<!-- language 041 -->
+		<xsl:variable name="controlField008-35-37"
+			select="normalize-space(translate(substring($controlField008,36,3),'|#',''))"/>
+		<xsl:if test="$controlField008-35-37">
+			<language>
+				<languageTerm authority="iso639-2b" type="code">
+					<xsl:value-of select="substring($controlField008,36,3)"/>
+				</languageTerm>
+			</language>
+		</xsl:if>
+		<xsl:for-each select="marc:datafield[@tag=041]">
+			<xsl:for-each
+				select="marc:subfield[@code='a' or @code='b' or @code='d' or @code='e' or @code='f' or @code='g' or @code='h']">
+				<xsl:variable name="langCodes" select="."/>
+				<xsl:choose>
+					<xsl:when test="../marc:subfield[@code='2']='rfc3066'">
+						<!-- not stacked but could be repeated -->
+						<xsl:call-template name="rfcLanguages">
+							<xsl:with-param name="nodeNum">
+								<xsl:value-of select="1"/>
+							</xsl:with-param>
+							<xsl:with-param name="usedLanguages">
+								<xsl:text/>
+							</xsl:with-param>
+							<xsl:with-param name="controlField008-35-37">
+								<xsl:value-of select="$controlField008-35-37"/>
+							</xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:otherwise>
+						<!-- iso -->
+						<xsl:variable name="allLanguages">
+							<xsl:copy-of select="$langCodes"/>
+						</xsl:variable>
+						<xsl:variable name="currentLanguage">
+							<xsl:value-of select="substring($allLanguages,1,3)"/>
+						</xsl:variable>
+						<xsl:call-template name="isoLanguage">
+							<xsl:with-param name="currentLanguage">
+								<xsl:value-of select="substring($allLanguages,1,3)"/>
+							</xsl:with-param>
+							<xsl:with-param name="remainingLanguages">
+								<xsl:value-of
+									select="substring($allLanguages,4,string-length($allLanguages)-3)"
+								/>
+							</xsl:with-param>
+							<xsl:with-param name="usedLanguages">
+								<xsl:if test="$controlField008-35-37">
+									<xsl:value-of select="$controlField008-35-37"/>
+								</xsl:if>
+							</xsl:with-param>
+						</xsl:call-template>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:for-each>
+		</xsl:for-each>
+
+		<!-- physicalDescription -->
+
+		<xsl:variable name="physicalDescription">
+			<!--3.2 change tmee 007/11 -->
+			<xsl:if test="$typeOf008='CF' and marc:controlfield[@tag=007][substring(.,12,1)='a']">
+				<digitalOrigin>reformatted digital</digitalOrigin>
+			</xsl:if>
+			<xsl:if test="$typeOf008='CF' and marc:controlfield[@tag=007][substring(.,12,1)='b']">
+				<digitalOrigin>digitized microfilm</digitalOrigin>
+			</xsl:if>
+			<xsl:if test="$typeOf008='CF' and marc:controlfield[@tag=007][substring(.,12,1)='d']">
+				<digitalOrigin>digitized other analog</digitalOrigin>
+			</xsl:if>
+			<xsl:variable name="controlField008-23" select="substring($controlField008,24,1)"/>
+			<xsl:variable name="controlField008-29" select="substring($controlField008,30,1)"/>
+			<xsl:variable name="check008-23">
+				<xsl:if
+					test="$typeOf008='BK' or $typeOf008='MU' or $typeOf008='SE' or $typeOf008='MM'">
+					<xsl:value-of select="true()"/>
+				</xsl:if>
+			</xsl:variable>
+			<xsl:variable name="check008-29">
+				<xsl:if test="$typeOf008='MP' or $typeOf008='VM'">
+					<xsl:value-of select="true()"/>
+				</xsl:if>
+			</xsl:variable>
+			<xsl:choose>
+				<xsl:when
+					test="($check008-23 and $controlField008-23='f') or ($check008-29 and $controlField008-29='f')">
+					<form authority="marcform">braille</form>
+				</xsl:when>
+				<xsl:when
+					test="($controlField008-23=' ' and ($leader6='c' or $leader6='d')) or (($typeOf008='BK' or $typeOf008='SE') and ($controlField008-23=' ' or $controlField008='r'))">
+					<form authority="marcform">print</form>
+				</xsl:when>
+				<xsl:when
+					test="$leader6 = 'm' or ($check008-23 and $controlField008-23='s') or ($check008-29 and $controlField008-29='s')">
+					<form authority="marcform">electronic</form>
+				</xsl:when>
+				<!-- 1.33 -->
+				<xsl:when test="$leader6 = 'o'">
+					<form authority="marcform">kit</form>
+				</xsl:when>
+				<xsl:when
+					test="($check008-23 and $controlField008-23='b') or ($check008-29 and $controlField008-29='b')">
+					<form authority="marcform">microfiche</form>
+				</xsl:when>
+				<xsl:when
+					test="($check008-23 and $controlField008-23='a') or ($check008-29 and $controlField008-29='a')">
+					<form authority="marcform">microfilm</form>
+				</xsl:when>
+			</xsl:choose>
+
+			<!-- 1/04 fix -->
+			<xsl:if test="marc:datafield[@tag=130]/marc:subfield[@code='h']">
+				<form authority="gmd">
+					<xsl:call-template name="chopBrackets">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="marc:datafield[@tag=130]/marc:subfield[@code='h']"
+							/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:if>
+			<xsl:if test="marc:datafield[@tag=240]/marc:subfield[@code='h']">
+				<form authority="gmd">
+					<xsl:call-template name="chopBrackets">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="marc:datafield[@tag=240]/marc:subfield[@code='h']"
+							/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:if>
+			<xsl:if test="marc:datafield[@tag=242]/marc:subfield[@code='h']">
+				<form authority="gmd">
+					<xsl:call-template name="chopBrackets">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="marc:datafield[@tag=242]/marc:subfield[@code='h']"
+							/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:if>
+			<xsl:if test="marc:datafield[@tag=245]/marc:subfield[@code='h']">
+				<form authority="gmd">
+					<xsl:call-template name="chopBrackets">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="marc:datafield[@tag=245]/marc:subfield[@code='h']"
+							/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:if>
+			<xsl:if test="marc:datafield[@tag=246]/marc:subfield[@code='h']">
+				<form authority="gmd">
+					<xsl:call-template name="chopBrackets">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="marc:datafield[@tag=246]/marc:subfield[@code='h']"
+							/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:if>
+			<xsl:if test="marc:datafield[@tag=730]/marc:subfield[@code='h']">
+				<form authority="gmd">
+					<xsl:call-template name="chopBrackets">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="marc:datafield[@tag=730]/marc:subfield[@code='h']"
+							/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:if>
+			<xsl:for-each select="marc:datafield[@tag=256]/marc:subfield[@code='a']">
+				<form>
+					<xsl:value-of select="."/>
+				</form>
+			</xsl:for-each>
+			<xsl:for-each select="marc:controlfield[@tag=007][substring(text(),1,1)='c']">
+				<xsl:choose>
+					<xsl:when test="substring(text(),14,1)='a'">
+						<reformattingQuality>access</reformattingQuality>
+					</xsl:when>
+					<xsl:when test="substring(text(),14,1)='p'">
+						<reformattingQuality>preservation</reformattingQuality>
+					</xsl:when>
+					<xsl:when test="substring(text(),14,1)='r'">
+						<reformattingQuality>replacement</reformattingQuality>
+					</xsl:when>
+				</xsl:choose>
+			</xsl:for-each>
+			<!--3.2 change tmee 007/01 -->
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='b']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">chip cartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='c']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">computer optical disc cartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='j']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">magnetic disc</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='m']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">magneto-optical disc</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='o']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">optical disc</form>
+			</xsl:if>
+
+			<!-- 1.38 AQ 1.29 tmee 	1.66 added marccategory and marcsmd as part of 3.4 -->
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='r']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">remote</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='a']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">tape cartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='f']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">tape cassette</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='h']">
+				<form authority="marccategory">electronic resource</form>
+				<form authority="marcsmd">tape reel</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='a']">
+				<form authority="marccategory">globe</form>
+				<form authority="marcsmd">celestial globe</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='e']">
+				<form authority="marccategory">globe</form>
+				<form authority="marcsmd">earth moon globe</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='b']">
+				<form authority="marccategory">globe</form>
+				<form authority="marcsmd">planetary or lunar globe</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='c']">
+				<form authority="marccategory">globe</form>
+				<form authority="marcsmd">terrestrial globe</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='o'][substring(text(),2,1)='o']">
+				<form authority="marccategory">kit</form>
+				<form authority="marcsmd">kit</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
+				<form authority="marccategory">map</form>
+				<form authority="marcsmd">atlas</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='g']">
+				<form authority="marccategory">map</form>
+				<form authority="marcsmd">diagram</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
+				<form authority="marccategory">map</form>
+				<form authority="marcsmd">map</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
+				<form authority="marccategory">map</form>
+				<form authority="marcsmd">model</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='k']">
+				<form authority="marccategory">map</form>
+				<form authority="marcsmd">profile</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
+				<form authority="marcsmd">remote-sensing image</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='s']">
+				<form authority="marccategory">map</form>
+				<form authority="marcsmd">section</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='y']">
+				<form authority="marccategory">map</form>
+				<form authority="marcsmd">view</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='a']">
+				<form authority="marccategory">microform</form>
+				<form authority="marcsmd">aperture card</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='e']">
+				<form authority="marccategory">microform</form>
+				<form authority="marcsmd">microfiche</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='f']">
+				<form authority="marccategory">microform</form>
+				<form authority="marcsmd">microfiche cassette</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='b']">
+				<form authority="marccategory">microform</form>
+				<form authority="marcsmd">microfilm cartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='c']">
+				<form authority="marccategory">microform</form>
+				<form authority="marcsmd">microfilm cassette</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='d']">
+				<form authority="marccategory">microform</form>
+				<form authority="marcsmd">microfilm reel</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='g']">
+				<form authority="marccategory">microform</form>
+				<form authority="marcsmd">microopaque</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='c']">
+				<form authority="marccategory">motion picture</form>
+				<form authority="marcsmd">film cartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='f']">
+				<form authority="marccategory">motion picture</form>
+				<form authority="marcsmd">film cassette</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='r']">
+				<form authority="marccategory">motion picture</form>
+				<form authority="marcsmd">film reel</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='n']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">chart</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='c']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">collage</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='d']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">drawing</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='o']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">flash card</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='e']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">painting</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='f']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">photomechanical print</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='g']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">photonegative</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='h']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">photoprint</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='i']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">picture</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='j']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">print</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='l']">
+				<form authority="marccategory">nonprojected graphic</form>
+				<form authority="marcsmd">technical drawing</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='q'][substring(text(),2,1)='q']">
+				<form authority="marccategory">notated music</form>
+				<form authority="marcsmd">notated music</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='d']">
+				<form authority="marccategory">projected graphic</form>
+				<form authority="marcsmd">filmslip</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='c']">
+				<form authority="marccategory">projected graphic</form>
+				<form authority="marcsmd">filmstrip cartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='o']">
+				<form authority="marccategory">projected graphic</form>
+				<form authority="marcsmd">filmstrip roll</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='f']">
+				<form authority="marccategory">projected graphic</form>
+				<form authority="marcsmd">other filmstrip type</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='s']">
+				<form authority="marccategory">projected graphic</form>
+				<form authority="marcsmd">slide</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='t']">
+				<form authority="marccategory">projected graphic</form>
+				<form authority="marcsmd">transparency</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='r'][substring(text(),2,1)='r']">
+				<form authority="marccategory">remote-sensing image</form>
+				<form authority="marcsmd">remote-sensing image</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='e']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">cylinder</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='q']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">roll</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='g']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">sound cartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='s']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">sound cassette</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='d']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">sound disc</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='t']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">sound-tape reel</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='i']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">sound-track film</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='w']">
+				<form authority="marccategory">sound recording</form>
+				<form authority="marcsmd">wire recording</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='c']">
+				<form authority="marccategory">tactile material</form>
+				<form authority="marcsmd">braille</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='b']">
+				<form authority="marccategory">tactile material</form>
+				<form authority="marcsmd">combination</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='a']">
+				<form authority="marccategory">tactile material</form>
+				<form authority="marcsmd">moon</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='d']">
+				<form authority="marccategory">tactile material</form>
+				<form authority="marcsmd">tactile, with no writing system</form>
+			</xsl:if>
+
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='c']">
+				<form authority="marccategory">text</form>
+				<form authority="marcsmd">braille</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='b']">
+				<form authority="marccategory">text</form>
+				<form authority="marcsmd">large print</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='a']">
+				<form authority="marccategory">text</form>
+				<form authority="marcsmd">regular print</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='d']">
+				<form authority="marccategory">text</form>
+				<form authority="marcsmd">text in looseleaf binder</form>
+			</xsl:if>
+
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='c']">
+				<form authority="marccategory">videorecording</form>
+				<form authority="marcsmd">videocartridge</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='f']">
+				<form authority="marccategory">videorecording</form>
+				<form authority="marcsmd">videocassette</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='d']">
+				<form authority="marccategory">videorecording</form>
+				<form authority="marcsmd">videodisc</form>
+			</xsl:if>
+			<xsl:if
+				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='r']">
+				<form authority="marccategory">videorecording</form>
+				<form authority="marcsmd">videoreel</form>
+			</xsl:if>
+
+			<xsl:for-each
+				select="marc:datafield[@tag=856]/marc:subfield[@code='q'][string-length(.)&gt;1]">
+				<internetMediaType>
+					<xsl:value-of select="."/>
+				</internetMediaType>
+			</xsl:for-each>
+
+			<xsl:for-each select="marc:datafield[@tag=300]">
+				<extent>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">abce3fg</xsl:with-param>
+					</xsl:call-template>
+				</extent>
+			</xsl:for-each>
+
+
+			<xsl:for-each select="marc:datafield[@tag=337]">
+				<form type="media">
+					<xsl:attribute name="authority">
+						<xsl:value-of select="marc:subfield[@code=2]"/>
+					</xsl:attribute>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">a</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:for-each>
+
+			<xsl:for-each select="marc:datafield[@tag=338]">
+				<form type="carrier">
+					<xsl:attribute name="authority">
+						<xsl:value-of select="marc:subfield[@code=2]"/>
+					</xsl:attribute>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">a</xsl:with-param>
+					</xsl:call-template>
+				</form>
+			</xsl:for-each>
+
+
+			<!-- 1.43 tmee 351 $3$a$b$c-->
+			<xsl:for-each select="marc:datafield[@tag=351]">
+				<note type="arrangement">
+					<xsl:for-each select="marc:subfield[@code='3']">
+						<xsl:value-of select="."/>
+						<xsl:text>: </xsl:text>
+					</xsl:for-each>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">abc</xsl:with-param>
+					</xsl:call-template>
+				</note>
+			</xsl:for-each>
+
+		</xsl:variable>
+
+
+		<xsl:if test="string-length(normalize-space($physicalDescription))">
+			<physicalDescription>
+				<xsl:for-each select="marc:datafield[@tag=300]">
+					<!-- Template checks for altRepGroup - 880 $6 -->
+					<xsl:call-template name="z3xx880"/>
+				</xsl:for-each>
+				<xsl:for-each select="marc:datafield[@tag=337]">
+					<!-- Template checks for altRepGroup - 880 $6 -->
+					<xsl:call-template name="xxx880"/>
+				</xsl:for-each>
+				<xsl:for-each select="marc:datafield[@tag=338]">
+					<!-- Template checks for altRepGroup - 880 $6 -->
+					<xsl:call-template name="xxx880"/>
+				</xsl:for-each>
+
+				<xsl:copy-of select="$physicalDescription"/>
+			</physicalDescription>
+		</xsl:if>
+
+
+		<xsl:for-each select="marc:datafield[@tag=520]">
+			<xsl:call-template name="createAbstractFrom520"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=505]">
+			<xsl:call-template name="createTOCFrom505"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=521]">
+			<xsl:call-template name="createTargetAudienceFrom521"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=506]">
+			<xsl:call-template name="createAccessConditionFrom506"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=540]">
+			<xsl:call-template name="createAccessConditionFrom540"/>
+		</xsl:for-each>
+
+
+		<xsl:if test="$typeOf008='BK' or $typeOf008='CF' or $typeOf008='MU' or $typeOf008='VM'">
+			<xsl:variable name="controlField008-22" select="substring($controlField008,23,1)"/>
+			<xsl:choose>
+				<!-- 01/04 fix -->
+				<xsl:when test="$controlField008-22='d'">
+					<targetAudience authority="marctarget">adolescent</targetAudience>
+				</xsl:when>
+				<xsl:when test="$controlField008-22='e'">
+					<targetAudience authority="marctarget">adult</targetAudience>
+				</xsl:when>
+				<xsl:when test="$controlField008-22='g'">
+					<targetAudience authority="marctarget">general</targetAudience>
+				</xsl:when>
+				<xsl:when
+					test="$controlField008-22='b' or $controlField008-22='c' or $controlField008-22='j'">
+					<targetAudience authority="marctarget">juvenile</targetAudience>
+				</xsl:when>
+				<xsl:when test="$controlField008-22='a'">
+					<targetAudience authority="marctarget">preschool</targetAudience>
+				</xsl:when>
+				<xsl:when test="$controlField008-22='f'">
+					<targetAudience authority="marctarget">specialized</targetAudience>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+
+		<!-- 1.32 tmee Drop note mapping for 510 and map only to <relatedItem>
+		<xsl:for-each select="marc:datafield[@tag=510]">
+			<note type="citation/reference">
+				<xsl:call-template name="uri"/>
+				<xsl:variable name="str">
+					<xsl:for-each select="marc:subfield[@code!='6' or @code!='8']">
+						<xsl:value-of select="."/>
+						<xsl:text> </xsl:text>
+					</xsl:for-each>
+				</xsl:variable>
+				<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+			</note>
+		</xsl:for-each>
+		-->
+
+		<!-- 245c 362az 502-585 5XX-->
+
+		<xsl:for-each select="marc:datafield[@tag=245]">
+			<xsl:call-template name="createNoteFrom245c"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=362]">
+			<xsl:call-template name="createNoteFrom362"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=500]">
+			<xsl:call-template name="createNoteFrom500"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=502]">
+			<xsl:call-template name="createNoteFrom502"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=504]">
+			<xsl:call-template name="createNoteFrom504"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=508]">
+			<xsl:call-template name="createNoteFrom508"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=511]">
+			<xsl:call-template name="createNoteFrom511"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=515]">
+			<xsl:call-template name="createNoteFrom515"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=518]">
+			<xsl:call-template name="createNoteFrom518"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=524]">
+			<xsl:call-template name="createNoteFrom524"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=530]">
+			<xsl:call-template name="createNoteFrom530"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=533]">
+			<xsl:call-template name="createNoteFrom533"/>
+		</xsl:for-each>
+		<!--
+		<xsl:for-each select="marc:datafield[@tag=534]">
+			<xsl:call-template name="createNoteFrom534"/>
+		</xsl:for-each>
+-->
+
+		<xsl:for-each select="marc:datafield[@tag=535]">
+			<xsl:call-template name="createNoteFrom535"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=536]">
+			<xsl:call-template name="createNoteFrom536"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=538]">
+			<xsl:call-template name="createNoteFrom538"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=541]">
+			<xsl:call-template name="createNoteFrom541"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=545]">
+			<xsl:call-template name="createNoteFrom545"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=546]">
+			<xsl:call-template name="createNoteFrom546"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=561]">
+			<xsl:call-template name="createNoteFrom561"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=562]">
+			<xsl:call-template name="createNoteFrom562"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=581]">
+			<xsl:call-template name="createNoteFrom581"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=583]">
+			<xsl:call-template name="createNoteFrom583"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=585]">
+			<xsl:call-template name="createNoteFrom585"/>
+		</xsl:for-each>
+
+		<xsl:for-each
+			select="marc:datafield[@tag=501 or @tag=507 or @tag=513 or @tag=514 or @tag=516 or @tag=522 or @tag=525 or @tag=526 or @tag=544 or @tag=547 or @tag=550 or @tag=552 or @tag=555 or @tag=556 or @tag=565 or @tag=567 or @tag=580 or @tag=584 or @tag=586]">
+			<xsl:call-template name="createNoteFrom5XX"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=034]">
+			<xsl:call-template name="createSubGeoFrom034"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=043]">
+			<xsl:call-template name="createSubGeoFrom043"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=045]">
+			<xsl:call-template name="createSubTemFrom045"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=255]">
+			<xsl:call-template name="createSubGeoFrom255"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=600]">
+			<xsl:call-template name="createSubNameFrom600"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=610]">
+			<xsl:call-template name="createSubNameFrom610"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=611]">
+			<xsl:call-template name="createSubNameFrom611"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=630]">
+			<xsl:call-template name="createSubTitleFrom630"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=648]">
+			<xsl:call-template name="createSubChronFrom648"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=650]">
+			<xsl:call-template name="createSubTopFrom650"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=651]">
+			<xsl:call-template name="createSubGeoFrom651"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=653]">
+			<xsl:call-template name="createSubFrom653"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=656]">
+			<xsl:call-template name="createSubFrom656"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=662]">
+			<xsl:call-template name="createSubGeoFrom662752"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=752]">
+			<xsl:call-template name="createSubGeoFrom662752"/>
+		</xsl:for-each>
+
+		<!-- createClassificationFrom 0XX-->
+		<xsl:for-each select="marc:datafield[@tag='050']">
+			<xsl:call-template name="createClassificationFrom050"/>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='060']">
+			<xsl:call-template name="createClassificationFrom060"/>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='080']">
+			<xsl:call-template name="createClassificationFrom080"/>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='082']">
+			<xsl:call-template name="createClassificationFrom082"/>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='084']">
+			<xsl:call-template name="createClassificationFrom084"/>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='086']">
+			<xsl:call-template name="createClassificationFrom086"/>
+		</xsl:for-each>
+
+		<!--	location	-->
+
+		<xsl:for-each select="marc:datafield[@tag=852]">
+			<xsl:call-template name="createLocationFrom852"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=856]">
+			<xsl:call-template name="createLocationFrom856"/>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=490][@ind1=0]">
+			<xsl:call-template name="createRelatedItemFrom490"/>
+		</xsl:for-each>
+
+
+		<xsl:for-each select="marc:datafield[@tag=440]">
+			<relatedItem type="series">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">av</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+			</relatedItem>
+		</xsl:for-each>
+
+		<!-- tmee 1.40 1.74 1.88 fixed 510c mapping 20130829-->
+
+		<xsl:for-each select="marc:datafield[@tag=510]">
+			<relatedItem type="isReferencedBy">
+				<xsl:for-each select="marc:subfield[@code='a']">
+					<titleInfo>
+						<title>
+							<xsl:value-of select="."/>
+						</title>
+					</titleInfo>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='b']">
+					<originInfo>
+						<dateOther type="coverage">
+							<xsl:value-of select="."/>
+						</dateOther>
+					</originInfo>
+				</xsl:for-each>
+
+				<part>
+					<detail type="part">
+						<number>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">c</xsl:with-param>
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+						</number>
+					</detail>
+					</part>
+			</relatedItem>
+		</xsl:for-each>
+
+
+		<xsl:for-each select="marc:datafield[@tag=534]">
+			<relatedItem type="original">
+				<xsl:call-template name="relatedTitle"/>
+				<xsl:call-template name="relatedName"/>
+				<xsl:if test="marc:subfield[@code='b' or @code='c']">
+					<originInfo>
+						<xsl:for-each select="marc:subfield[@code='c']">
+							<publisher>
+								<xsl:value-of select="."/>
+							</publisher>
+						</xsl:for-each>
+						<xsl:for-each select="marc:subfield[@code='b']">
+							<edition>
+								<xsl:value-of select="."/>
+							</edition>
+						</xsl:for-each>
+					</originInfo>
+				</xsl:if>
+				<xsl:call-template name="relatedIdentifierISSN"/>
+				<xsl:for-each select="marc:subfield[@code='z']">
+					<identifier type="isbn">
+						<xsl:value-of select="."/>
+					</identifier>
+				</xsl:for-each>
+				<xsl:call-template name="relatedNote"/>
+			</relatedItem>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=700][marc:subfield[@code='t']]">
+			<relatedItem>
+				<xsl:call-template name="constituentOrRelatedType"/>
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="specialSubfieldSelect">
+									<xsl:with-param name="anyCodes">tfklmorsv</xsl:with-param>
+									<xsl:with-param name="axis">t</xsl:with-param>
+									<xsl:with-param name="afterCodes">g</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+				<name type="personal">
+					<namePart>
+						<xsl:call-template name="specialSubfieldSelect">
+							<xsl:with-param name="anyCodes">aq</xsl:with-param>
+							<xsl:with-param name="axis">t</xsl:with-param>
+							<xsl:with-param name="beforeCodes">g</xsl:with-param>
+						</xsl:call-template>
+					</namePart>
+					<xsl:call-template name="termsOfAddress"/>
+					<xsl:call-template name="nameDate"/>
+					<xsl:call-template name="role"/>
+				</name>
+				<xsl:call-template name="relatedForm"/>
+				<xsl:call-template name="relatedIdentifierISSN"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=710][marc:subfield[@code='t']]">
+			<relatedItem>
+				<xsl:call-template name="constituentOrRelatedType"/>
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="specialSubfieldSelect">
+									<xsl:with-param name="anyCodes">tfklmorsv</xsl:with-param>
+									<xsl:with-param name="axis">t</xsl:with-param>
+									<xsl:with-param name="afterCodes">dg</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="relatedPartNumName"/>
+				</titleInfo>
+				<name type="corporate">
+					<xsl:for-each select="marc:subfield[@code='a']">
+						<namePart>
+							<xsl:value-of select="."/>
+						</namePart>
+					</xsl:for-each>
+					<xsl:for-each select="marc:subfield[@code='b']">
+						<namePart>
+							<xsl:value-of select="."/>
+						</namePart>
+					</xsl:for-each>
+					<xsl:variable name="tempNamePart">
+						<xsl:call-template name="specialSubfieldSelect">
+							<xsl:with-param name="anyCodes">c</xsl:with-param>
+							<xsl:with-param name="axis">t</xsl:with-param>
+							<xsl:with-param name="beforeCodes">dgn</xsl:with-param>
+						</xsl:call-template>
+					</xsl:variable>
+					<xsl:if test="normalize-space($tempNamePart)">
+						<namePart>
+							<xsl:value-of select="$tempNamePart"/>
+						</namePart>
+					</xsl:if>
+					<xsl:call-template name="role"/>
+				</name>
+				<xsl:call-template name="relatedForm"/>
+				<xsl:call-template name="relatedIdentifierISSN"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=711][marc:subfield[@code='t']]">
+			<relatedItem>
+				<xsl:call-template name="constituentOrRelatedType"/>
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="specialSubfieldSelect">
+									<xsl:with-param name="anyCodes">tfklsv</xsl:with-param>
+									<xsl:with-param name="axis">t</xsl:with-param>
+									<xsl:with-param name="afterCodes">g</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="relatedPartNumName"/>
+				</titleInfo>
+				<name type="conference">
+					<namePart>
+						<xsl:call-template name="specialSubfieldSelect">
+							<xsl:with-param name="anyCodes">aqdc</xsl:with-param>
+							<xsl:with-param name="axis">t</xsl:with-param>
+							<xsl:with-param name="beforeCodes">gn</xsl:with-param>
+						</xsl:call-template>
+					</namePart>
+				</name>
+				<xsl:call-template name="relatedForm"/>
+				<xsl:call-template name="relatedIdentifierISSN"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=730][@ind2=2]">
+			<relatedItem>
+				<xsl:call-template name="constituentOrRelatedType"/>
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">adfgklmorsv</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+				<xsl:call-template name="relatedForm"/>
+				<xsl:call-template name="relatedIdentifierISSN"/>
+			</relatedItem>
+		</xsl:for-each>
+
+
+		<xsl:for-each select="marc:datafield[@tag=740][@ind2=2]">
+			<relatedItem>
+				<xsl:call-template name="constituentOrRelatedType"/>
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:value-of select="marc:subfield[@code='a']"/>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+				<xsl:call-template name="relatedForm"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=760]">
+			<relatedItem type="series">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+
+		<!--AQ1.23 tmee/dlf -->
+		<xsl:for-each select="marc:datafield[@tag=762]">
+			<relatedItem type="constituent">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+
+		<!-- AQ1.5, AQ1.7 deleted tags 777 and 787 from the following select for relatedItem mapping -->
+		<!-- 1.45 and 1.46 - AQ1.24 and 1.25 tmee-->
+		<xsl:for-each
+			select="marc:datafield[@tag=765]|marc:datafield[@tag=767]|marc:datafield[@tag=775]">
+			<relatedItem type="otherVersion">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=770]|marc:datafield[@tag=774]">
+			<relatedItem type="constituent">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+
+
+		<xsl:for-each select="marc:datafield[@tag=772]|marc:datafield[@tag=773]">
+			<relatedItem type="host">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=776]">
+			<relatedItem type="otherFormat">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=780]">
+			<relatedItem type="preceding">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=785]">
+			<relatedItem type="succeeding">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=786]">
+			<relatedItem type="original">
+				<xsl:call-template name="relatedItem76X-78X"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=800]">
+			<relatedItem type="series">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="specialSubfieldSelect">
+									<xsl:with-param name="anyCodes">tfklmorsv</xsl:with-param>
+									<xsl:with-param name="axis">t</xsl:with-param>
+									<xsl:with-param name="afterCodes">g</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+				<name type="personal">
+					<namePart>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="specialSubfieldSelect">
+									<xsl:with-param name="anyCodes">aq</xsl:with-param>
+									<xsl:with-param name="axis">t</xsl:with-param>
+									<xsl:with-param name="beforeCodes">g</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</namePart>
+					<xsl:call-template name="termsOfAddress"/>
+					<xsl:call-template name="nameDate"/>
+					<xsl:call-template name="role"/>
+				</name>
+				<xsl:call-template name="relatedForm"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=810]">
+			<relatedItem type="series">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="specialSubfieldSelect">
+									<xsl:with-param name="anyCodes">tfklmorsv</xsl:with-param>
+									<xsl:with-param name="axis">t</xsl:with-param>
+									<xsl:with-param name="afterCodes">dg</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="relatedPartNumName"/>
+				</titleInfo>
+				<name type="corporate">
+					<xsl:for-each select="marc:subfield[@code='a']">
+						<namePart>
+							<xsl:value-of select="."/>
+						</namePart>
+					</xsl:for-each>
+					<xsl:for-each select="marc:subfield[@code='b']">
+						<namePart>
+							<xsl:value-of select="."/>
+						</namePart>
+					</xsl:for-each>
+					<namePart>
+						<xsl:call-template name="specialSubfieldSelect">
+							<xsl:with-param name="anyCodes">c</xsl:with-param>
+							<xsl:with-param name="axis">t</xsl:with-param>
+							<xsl:with-param name="beforeCodes">dgn</xsl:with-param>
+						</xsl:call-template>
+					</namePart>
+					<xsl:call-template name="role"/>
+				</name>
+				<xsl:call-template name="relatedForm"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=811]">
+			<relatedItem type="series">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="specialSubfieldSelect">
+									<xsl:with-param name="anyCodes">tfklsv</xsl:with-param>
+									<xsl:with-param name="axis">t</xsl:with-param>
+									<xsl:with-param name="afterCodes">g</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="relatedPartNumName"/>
+				</titleInfo>
+				<name type="conference">
+					<namePart>
+						<xsl:call-template name="specialSubfieldSelect">
+							<xsl:with-param name="anyCodes">aqdc</xsl:with-param>
+							<xsl:with-param name="axis">t</xsl:with-param>
+							<xsl:with-param name="beforeCodes">gn</xsl:with-param>
+						</xsl:call-template>
+					</namePart>
+					<xsl:call-template name="role"/>
+				</name>
+				<xsl:call-template name="relatedForm"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='830']">
+			<relatedItem type="series">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">adfgklmorsv</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+				<xsl:call-template name="relatedForm"/>
+			</relatedItem>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='856'][@ind2='2']/marc:subfield[@code='q']">
+			<relatedItem>
+				<internetMediaType>
+					<xsl:value-of select="."/>
+				</internetMediaType>
+			</relatedItem>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='880']">
+			<xsl:apply-templates select="self::*" mode="trans880"/>
+		</xsl:for-each>
+
+
+		<!-- 856, 020, 024, 022, 028, 010, 035, 037 -->
+
+		<xsl:for-each select="marc:datafield[@tag='020']">
+			<xsl:if test="marc:subfield[@code='a']">
+				<identifier type="isbn">
+					<xsl:value-of select="marc:subfield[@code='a']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='020']">
+			<xsl:if test="marc:subfield[@code='z']">
+				<identifier type="isbn" invalid="yes">
+					<xsl:value-of select="marc:subfield[@code='z']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='024'][@ind1='0']">
+			<xsl:if test="marc:subfield[@code='a']">
+				<identifier type="isrc">
+					<xsl:value-of select="marc:subfield[@code='a']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='024'][@ind1='2']">
+			<xsl:if test="marc:subfield[@code='a']">
+				<identifier type="ismn">
+					<xsl:value-of select="marc:subfield[@code='a']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='024'][@ind1='4']">
+			<identifier type="sici">
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">ab</xsl:with-param>
+				</xsl:call-template>
+			</identifier>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='024'][@ind1='8']">
+			<identifier>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</identifier>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='022'][marc:subfield[@code='a']]">
+			<xsl:if test="marc:subfield[@code='a']">
+				<identifier type="issn">
+					<xsl:value-of select="marc:subfield[@code='a']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='022'][marc:subfield[@code='z']]">
+			<xsl:if test="marc:subfield[@code='z']">
+				<identifier type="issn" invalid="yes">
+					<xsl:value-of select="marc:subfield[@code='z']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='022'][marc:subfield[@code='y']]">
+			<xsl:if test="marc:subfield[@code='y']">
+				<identifier type="issn" invalid="yes">
+					<xsl:value-of select="marc:subfield[@code='y']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='022'][marc:subfield[@code='l']]">
+			<xsl:if test="marc:subfield[@code='l']">
+				<identifier type="issn-l">
+					<xsl:value-of select="marc:subfield[@code='l']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='022'][marc:subfield[@code='m']]">
+			<xsl:if test="marc:subfield[@code='m']">
+				<identifier type="issn-l" invalid="yes">
+					<xsl:value-of select="marc:subfield[@code='m']"/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='010'][marc:subfield[@code='a']]">
+			<identifier type="lccn">
+				<xsl:value-of select="normalize-space(marc:subfield[@code='a'])"/>
+			</identifier>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag='010'][marc:subfield[@code='z']]">
+			<identifier type="lccn" invalid="yes">
+				<xsl:value-of select="normalize-space(marc:subfield[@code='z'])"/>
+			</identifier>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='028']">
+			<identifier>
+				<xsl:attribute name="type">
+					<xsl:choose>
+						<xsl:when test="@ind1='0'">issue number</xsl:when>
+						<xsl:when test="@ind1='1'">matrix number</xsl:when>
+						<xsl:when test="@ind1='2'">music plate</xsl:when>
+						<xsl:when test="@ind1='3'">music publisher</xsl:when>
+						<xsl:when test="@ind1='4'">videorecording identifier</xsl:when>
+					</xsl:choose>
+				</xsl:attribute>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">
+						<xsl:choose>
+							<xsl:when test="@ind1='0'">ba</xsl:when>
+							<xsl:otherwise>ab</xsl:otherwise>
+						</xsl:choose>
+					</xsl:with-param>
+				</xsl:call-template>
+			</identifier>
+		</xsl:for-each>
+
+		<xsl:for-each
+			select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(OCoLC)')]]">
+			<identifier type="oclc">
+				<xsl:value-of
+					select="normalize-space(substring-after(marc:subfield[@code='a'], '(OCoLC)'))"/>
+			</identifier>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag='037']">
+			<identifier type="stock number">
+				<xsl:if test="marc:subfield[@code='c']">
+					<xsl:attribute name="displayLabel">
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">c</xsl:with-param>
+						</xsl:call-template>
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">ab</xsl:with-param>
+				</xsl:call-template>
+			</identifier>
+		</xsl:for-each>
+
+
+		<!-- 1.51 tmee 20100129-->
+		<xsl:for-each select="marc:datafield[@tag='856'][marc:subfield[@code='u']]">
+			<xsl:if
+				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov') ">
+				<identifier>
+					<xsl:attribute name="type">
+						<xsl:if
+							test="starts-with(marc:subfield[@code='u'],'urn:doi') or starts-with(marc:subfield[@code='u'],'doi')"
+							>doi</xsl:if>
+						<xsl:if
+							test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov')"
+							>hdl</xsl:if>
+					</xsl:attribute>
+					<xsl:value-of
+						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
+					/>
+				</identifier>
+			</xsl:if>
+			<xsl:if
+				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl')">
+				<identifier type="hdl">
+					<xsl:if test="marc:subfield[@code='y' or @code='3' or @code='z']">
+						<xsl:attribute name="displayLabel">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">y3z</xsl:with-param>
+							</xsl:call-template>
+						</xsl:attribute>
+					</xsl:if>
+					<xsl:value-of
+						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
+					/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+
+		<xsl:for-each select="marc:datafield[@tag=024][@ind1=1]">
+			<identifier type="upc">
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</identifier>
+		</xsl:for-each>
+
+
+		<!-- 1.51 tmee 20100129 removed duplicate code 20131217
+		<xsl:for-each select="marc:datafield[@tag='856'][marc:subfield[@code='u']]">
+			<xsl:if
+				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov') ">
+				<identifier>
+					<xsl:attribute name="type">
+						<xsl:if
+							test="starts-with(marc:subfield[@code='u'],'urn:doi') or starts-with(marc:subfield[@code='u'],'doi')"
+							>doi</xsl:if>
+						<xsl:if
+							test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov')"
+							>hdl</xsl:if>
+					</xsl:attribute>
+					<xsl:value-of
+						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
+					/>
+				</identifier>
+			</xsl:if>
+
+			<xsl:if
+				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl')">
+				<identifier type="hdl">
+					<xsl:if test="marc:subfield[@code='y' or @code='3' or @code='z']">
+						<xsl:attribute name="displayLabel">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">y3z</xsl:with-param>
+							</xsl:call-template>
+						</xsl:attribute>
+					</xsl:if>
+					<xsl:value-of
+						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
+					/>
+				</identifier>
+			</xsl:if>
+		</xsl:for-each>
+		-->
+
+
+		<xsl:for-each select="marc:datafield[@tag=856][@ind2=2][marc:subfield[@code='u']]">
+			<relatedItem>
+				<location>
+					<url>
+						<xsl:if test="marc:subfield[@code='y' or @code='3']">
+							<xsl:attribute name="displayLabel">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">y3</xsl:with-param>
+								</xsl:call-template>
+							</xsl:attribute>
+						</xsl:if>
+						<xsl:if test="marc:subfield[@code='z']">
+							<xsl:attribute name="note">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">z</xsl:with-param>
+								</xsl:call-template>
+							</xsl:attribute>
+						</xsl:if>
+						<xsl:value-of select="marc:subfield[@code='u']"/>
+					</url>
+				</location>
+			</relatedItem>
+		</xsl:for-each>
+
+		<recordInfo>
+			<xsl:for-each select="marc:leader[substring($leader,19,1)='a']">
+				<descriptionStandard>aacr</descriptionStandard>
+			</xsl:for-each>
+
+			<xsl:for-each select="marc:datafield[@tag=040]">
+				<xsl:if test="marc:subfield[@code='e']">
+					<descriptionStandard>
+						<xsl:value-of select="marc:subfield[@code='e']"/>
+					</descriptionStandard>
+				</xsl:if>
+				<recordContentSource authority="marcorg">
+					<xsl:value-of select="marc:subfield[@code='a']"/>
+				</recordContentSource>
+			</xsl:for-each>
+			<xsl:for-each select="marc:controlfield[@tag=008]">
+				<recordCreationDate encoding="marc">
+					<xsl:value-of select="substring(.,1,6)"/>
+				</recordCreationDate>
+			</xsl:for-each>
+
+			<xsl:for-each select="marc:controlfield[@tag=005]">
+				<recordChangeDate encoding="iso8601">
+					<xsl:value-of select="."/>
+				</recordChangeDate>
+			</xsl:for-each>
+			<xsl:for-each select="marc:controlfield[@tag=001]">
+				<recordIdentifier>
+					<xsl:if test="../marc:controlfield[@tag=003]">
+						<xsl:attribute name="source">
+							<xsl:value-of select="../marc:controlfield[@tag=003]"/>
+						</xsl:attribute>
+					</xsl:if>
+					<xsl:value-of select="."/>
+				</recordIdentifier>
+			</xsl:for-each>
+
+			<recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4.xsl
+				(Revision 1.95 2014/12/19)</recordOrigin>
+
+			<xsl:for-each select="marc:datafield[@tag=040]/marc:subfield[@code='b']">
+				<languageOfCataloging>
+					<languageTerm authority="iso639-2b" type="code">
+						<xsl:value-of select="."/>
+					</languageTerm>
+				</languageOfCataloging>
+			</xsl:for-each>
+		</recordInfo>
+	</xsl:template>
+
+	<xsl:template name="displayForm">
+		<xsl:for-each select="marc:subfield[@code='c']">
+			<displayForm>
+				<xsl:value-of select="."/>
+			</displayForm>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="affiliation">
+		<xsl:for-each select="marc:subfield[@code='u']">
+			<affiliation>
+				<xsl:value-of select="."/>
+			</affiliation>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="uri">
+		<xsl:for-each select="marc:subfield[@code='u']|marc:subfield[@code='0']">
+			<xsl:attribute name="xlink:href">
+				<xsl:value-of select="."/>
+			</xsl:attribute>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="role">
+		<xsl:for-each select="marc:subfield[@code='e']">
+			<role>
+				<roleTerm type="text">
+					<xsl:value-of select="."/>
+				</roleTerm>
+			</role>
+		</xsl:for-each>
+		<xsl:for-each select="marc:subfield[@code='4']">
+			<role>
+				<roleTerm authority="marcrelator" type="code">
+					<xsl:value-of select="."/>
+				</roleTerm>
+			</role>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="part">
+		<xsl:variable name="partNumber">
+			<xsl:call-template name="specialSubfieldSelect">
+				<xsl:with-param name="axis">n</xsl:with-param>
+				<xsl:with-param name="anyCodes">n</xsl:with-param>
+				<xsl:with-param name="afterCodes">fgkdlmor</xsl:with-param>
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:variable name="partName">
+			<xsl:call-template name="specialSubfieldSelect">
+				<xsl:with-param name="axis">p</xsl:with-param>
+				<xsl:with-param name="anyCodes">p</xsl:with-param>
+				<xsl:with-param name="afterCodes">fgkdlmor</xsl:with-param>
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:if test="string-length(normalize-space($partNumber))">
+			<partNumber>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString" select="$partNumber"/>
+				</xsl:call-template>
+			</partNumber>
+		</xsl:if>
+		<xsl:if test="string-length(normalize-space($partName))">
+			<partName>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString" select="$partName"/>
+				</xsl:call-template>
+			</partName>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="relatedPart">
+		<xsl:if test="@tag=773">
+			<xsl:for-each select="marc:subfield[@code='g']">
+				<part>
+					<text>
+						<xsl:value-of select="."/>
+					</text>
+				</part>
+			</xsl:for-each>
+			<xsl:for-each select="marc:subfield[@code='q']">
+				<part>
+					<xsl:call-template name="parsePart"/>
+				</part>
+			</xsl:for-each>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="relatedPartNumName">
+		<xsl:variable name="partNumber">
+			<xsl:call-template name="specialSubfieldSelect">
+				<xsl:with-param name="axis">g</xsl:with-param>
+				<xsl:with-param name="anyCodes">g</xsl:with-param>
+				<xsl:with-param name="afterCodes">pst</xsl:with-param>
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:variable name="partName">
+			<xsl:call-template name="specialSubfieldSelect">
+				<xsl:with-param name="axis">p</xsl:with-param>
+				<xsl:with-param name="anyCodes">p</xsl:with-param>
+				<xsl:with-param name="afterCodes">fgkdlmor</xsl:with-param>
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:if test="string-length(normalize-space($partNumber))">
+			<partNumber>
+				<xsl:value-of select="$partNumber"/>
+			</partNumber>
+		</xsl:if>
+		<xsl:if test="string-length(normalize-space($partName))">
+			<partName>
+				<xsl:value-of select="$partName"/>
+			</partName>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="relatedName">
+		<xsl:for-each select="marc:subfield[@code='a']">
+			<name>
+				<namePart>
+					<xsl:value-of select="."/>
+				</namePart>
+			</name>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedForm">
+		<xsl:for-each select="marc:subfield[@code='h']">
+			<physicalDescription>
+				<form>
+					<xsl:value-of select="."/>
+				</form>
+			</physicalDescription>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedExtent">
+		<xsl:for-each select="marc:subfield[@code='h']">
+			<physicalDescription>
+				<extent>
+					<xsl:value-of select="."/>
+				</extent>
+			</physicalDescription>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedNote">
+		<xsl:for-each select="marc:subfield[@code='n']">
+			<note>
+				<xsl:value-of select="."/>
+			</note>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedSubject">
+		<xsl:for-each select="marc:subfield[@code='j']">
+			<subject>
+				<temporal encoding="iso8601">
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString" select="."/>
+					</xsl:call-template>
+				</temporal>
+			</subject>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedIdentifierISSN">
+		<xsl:for-each select="marc:subfield[@code='x']">
+			<identifier type="issn">
+				<xsl:value-of select="."/>
+			</identifier>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedIdentifierLocal">
+		<xsl:for-each select="marc:subfield[@code='w']">
+			<identifier type="local">
+				<xsl:value-of select="."/>
+			</identifier>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedIdentifier">
+		<xsl:for-each select="marc:subfield[@code='o']">
+			<identifier>
+				<xsl:value-of select="."/>
+			</identifier>
+		</xsl:for-each>
+	</xsl:template>
+
+	<!--tmee 1.40 510 isReferencedBy -->
+	<xsl:template name="relatedItem510">
+		<xsl:call-template name="displayLabel"/>
+		<xsl:call-template name="relatedTitle76X-78X"/>
+		<xsl:call-template name="relatedName"/>
+		<xsl:call-template name="relatedOriginInfo510"/>
+		<xsl:call-template name="relatedLanguage"/>
+		<xsl:call-template name="relatedExtent"/>
+		<xsl:call-template name="relatedNote"/>
+		<xsl:call-template name="relatedSubject"/>
+		<xsl:call-template name="relatedIdentifier"/>
+		<xsl:call-template name="relatedIdentifierISSN"/>
+		<xsl:call-template name="relatedIdentifierLocal"/>
+		<xsl:call-template name="relatedPart"/>
+	</xsl:template>
+	<xsl:template name="relatedItem76X-78X">
+		<xsl:call-template name="displayLabel"/>
+		<xsl:call-template name="relatedTitle76X-78X"/>
+		<xsl:call-template name="relatedName"/>
+		<xsl:call-template name="relatedOriginInfo"/>
+		<xsl:call-template name="relatedLanguage"/>
+		<xsl:call-template name="relatedExtent"/>
+		<xsl:call-template name="relatedNote"/>
+		<xsl:call-template name="relatedSubject"/>
+		<xsl:call-template name="relatedIdentifier"/>
+		<xsl:call-template name="relatedIdentifierISSN"/>
+		<xsl:call-template name="relatedIdentifierLocal"/>
+		<xsl:call-template name="relatedPart"/>
+	</xsl:template>
+	<xsl:template name="subjectGeographicZ">
+		<geographic>
+			<xsl:call-template name="chopPunctuation">
+				<xsl:with-param name="chopString" select="."/>
+			</xsl:call-template>
+		</geographic>
+	</xsl:template>
+	<xsl:template name="subjectTemporalY">
+		<temporal>
+			<xsl:call-template name="chopPunctuation">
+				<xsl:with-param name="chopString" select="."/>
+			</xsl:call-template>
+		</temporal>
+	</xsl:template>
+	<xsl:template name="subjectTopic">
+		<topic>
+			<xsl:call-template name="chopPunctuation">
+				<xsl:with-param name="chopString" select="."/>
+			</xsl:call-template>
+		</topic>
+	</xsl:template>
+	<!-- 3.2 change tmee 6xx $v genre -->
+	<xsl:template name="subjectGenre">
+		<genre>
+			<xsl:call-template name="chopPunctuation">
+				<xsl:with-param name="chopString" select="."/>
+			</xsl:call-template>
+		</genre>
+	</xsl:template>
+
+	<xsl:template name="nameABCDN">
+		<xsl:for-each select="marc:subfield[@code='a']">
+			<namePart>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString" select="."/>
+				</xsl:call-template>
+			</namePart>
+		</xsl:for-each>
+		<xsl:for-each select="marc:subfield[@code='b']">
+			<namePart>
+				<xsl:value-of select="."/>
+			</namePart>
+		</xsl:for-each>
+		<xsl:if
+			test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
+			<namePart>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">cdn</xsl:with-param>
+				</xsl:call-template>
+			</namePart>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="nameABCDQ">
+		<namePart>
+			<xsl:call-template name="chopPunctuation">
+				<xsl:with-param name="chopString">
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">aq</xsl:with-param>
+					</xsl:call-template>
+				</xsl:with-param>
+				<xsl:with-param name="punctuation">
+					<xsl:text>:,;/ </xsl:text>
+				</xsl:with-param>
+			</xsl:call-template>
+		</namePart>
+		<xsl:call-template name="termsOfAddress"/>
+		<xsl:call-template name="nameDate"/>
+	</xsl:template>
+	<xsl:template name="nameACDEQ">
+		<namePart>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">acdeq</xsl:with-param>
+			</xsl:call-template>
+		</namePart>
+	</xsl:template>
+	<xsl:template name="constituentOrRelatedType">
+		<xsl:if test="@ind2=2">
+			<xsl:attribute name="type">constituent</xsl:attribute>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="relatedTitle">
+		<xsl:for-each select="marc:subfield[@code='t']">
+			<titleInfo>
+				<title>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="."/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</title>
+			</titleInfo>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedTitle76X-78X">
+		<xsl:for-each select="marc:subfield[@code='t']">
+			<titleInfo>
+				<title>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="."/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</title>
+				<xsl:if test="marc:datafield[@tag!=773]and marc:subfield[@code='g']">
+					<xsl:call-template name="relatedPartNumName"/>
+				</xsl:if>
+			</titleInfo>
+		</xsl:for-each>
+		<xsl:for-each select="marc:subfield[@code='p']">
+			<titleInfo type="abbreviated">
+				<title>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="."/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</title>
+				<xsl:if test="marc:datafield[@tag!=773]and marc:subfield[@code='g']">
+					<xsl:call-template name="relatedPartNumName"/>
+				</xsl:if>
+			</titleInfo>
+		</xsl:for-each>
+		<xsl:for-each select="marc:subfield[@code='s']">
+			<titleInfo type="uniform">
+				<title>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="."/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</title>
+				<xsl:if test="marc:datafield[@tag!=773]and marc:subfield[@code='g']">
+					<xsl:call-template name="relatedPartNumName"/>
+				</xsl:if>
+			</titleInfo>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedOriginInfo">
+		<xsl:if test="marc:subfield[@code='b' or @code='d'] or marc:subfield[@code='f']">
+			<originInfo>
+				<xsl:if test="@tag=775">
+					<xsl:for-each select="marc:subfield[@code='f']">
+						<place>
+							<placeTerm>
+								<xsl:attribute name="type">code</xsl:attribute>
+								<xsl:attribute name="authority">marcgac</xsl:attribute>
+								<xsl:value-of select="."/>
+							</placeTerm>
+						</place>
+					</xsl:for-each>
+				</xsl:if>
+				<xsl:for-each select="marc:subfield[@code='d']">
+					<publisher>
+						<xsl:value-of select="."/>
+					</publisher>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='b']">
+					<edition>
+						<xsl:value-of select="."/>
+					</edition>
+				</xsl:for-each>
+			</originInfo>
+		</xsl:if>
+	</xsl:template>
+
+	<!-- tmee 1.40 -->
+
+	<xsl:template name="relatedOriginInfo510">
+		<xsl:for-each select="marc:subfield[@code='b']">
+			<originInfo>
+				<dateOther type="coverage">
+					<xsl:value-of select="."/>
+				</dateOther>
+			</originInfo>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="relatedLanguage">
+		<xsl:for-each select="marc:subfield[@code='e']">
+			<xsl:call-template name="getLanguage">
+				<xsl:with-param name="langString">
+					<xsl:value-of select="."/>
+				</xsl:with-param>
+			</xsl:call-template>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="nameDate">
+		<xsl:for-each select="marc:subfield[@code='d']">
+			<namePart type="date">
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString" select="."/>
+				</xsl:call-template>
+			</namePart>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="subjectAuthority">
+		<xsl:if test="@ind2!=4">
+			<xsl:if test="@ind2!=' '">
+				<xsl:if test="@ind2!=8">
+					<xsl:if test="@ind2!=9">
+						<xsl:attribute name="authority">
+							<xsl:choose>
+								<xsl:when test="@ind2=0">lcsh</xsl:when>
+								<xsl:when test="@ind2=1">lcshac</xsl:when>
+								<xsl:when test="@ind2=2">mesh</xsl:when>
+								<!-- 1/04 fix -->
+								<xsl:when test="@ind2=3">nal</xsl:when>
+								<xsl:when test="@ind2=5">csh</xsl:when>
+								<xsl:when test="@ind2=6">rvm</xsl:when>
+								<xsl:when test="@ind2=7">
+									<xsl:value-of select="marc:subfield[@code='2']"/>
+								</xsl:when>
+							</xsl:choose>
+						</xsl:attribute>
+					</xsl:if>
+				</xsl:if>
+			</xsl:if>
+		</xsl:if>
+	</xsl:template>
+	<!-- 1.75
+		fix -->
+	<xsl:template name="subject653Type">
+		<xsl:if test="@ind2!=' '">
+			<xsl:if test="@ind2!='0'">
+				<xsl:if test="@ind2!='4'">
+					<xsl:if test="@ind2!='5'">
+						<xsl:if test="@ind2!='6'">
+							<xsl:if test="@ind2!='7'">
+								<xsl:if test="@ind2!='8'">
+									<xsl:if test="@ind2!='9'">
+										<xsl:attribute name="type">
+											<xsl:choose>
+												<xsl:when test="@ind2=1">personal</xsl:when>
+												<xsl:when test="@ind2=2">corporate</xsl:when>
+												<xsl:when test="@ind2=3">conference</xsl:when>
+											</xsl:choose>
+										</xsl:attribute>
+									</xsl:if>
+								</xsl:if>
+							</xsl:if>
+						</xsl:if>
+					</xsl:if>
+				</xsl:if>
+			</xsl:if>
+		</xsl:if>
+
+
+	</xsl:template>
+	<xsl:template name="subjectAnyOrder">
+		<xsl:for-each select="marc:subfield[@code='v' or @code='x' or @code='y' or @code='z']">
+			<xsl:choose>
+				<xsl:when test="@code='v'">
+					<xsl:call-template name="subjectGenre"/>
+				</xsl:when>
+				<xsl:when test="@code='x'">
+					<xsl:call-template name="subjectTopic"/>
+				</xsl:when>
+				<xsl:when test="@code='y'">
+					<xsl:call-template name="subjectTemporalY"/>
+				</xsl:when>
+				<xsl:when test="@code='z'">
+					<xsl:call-template name="subjectGeographicZ"/>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="specialSubfieldSelect">
+		<xsl:param name="anyCodes"/>
+		<xsl:param name="axis"/>
+		<xsl:param name="beforeCodes"/>
+		<xsl:param name="afterCodes"/>
+		<xsl:variable name="str">
+			<xsl:for-each select="marc:subfield">
+				<xsl:if
+					test="contains($anyCodes, @code) or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
+					<xsl:value-of select="text()"/>
+					<xsl:text> </xsl:text>
+				</xsl:if>
+			</xsl:for-each>
+		</xsl:variable>
+		<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+	</xsl:template>
+
+
+	<xsl:template match="marc:datafield[@tag=656]">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:if test="marc:subfield[@code=2]">
+				<xsl:attribute name="authority">
+					<xsl:value-of select="marc:subfield[@code=2]"/>
+				</xsl:attribute>
+			</xsl:if>
+			<occupation>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:value-of select="marc:subfield[@code='a']"/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</occupation>
+		</subject>
+	</xsl:template>
+	<xsl:template name="termsOfAddress">
+		<xsl:if test="marc:subfield[@code='b' or @code='c']">
+			<namePart type="termsOfAddress">
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">bc</xsl:with-param>
+						</xsl:call-template>
+					</xsl:with-param>
+				</xsl:call-template>
+			</namePart>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="displayLabel">
+		<xsl:if test="marc:subfield[@code='i']">
+			<xsl:attribute name="displayLabel">
+				<xsl:value-of select="marc:subfield[@code='i']"/>
+			</xsl:attribute>
+		</xsl:if>
+		<xsl:if test="marc:subfield[@code='3']">
+			<xsl:attribute name="displayLabel">
+				<xsl:value-of select="marc:subfield[@code='3']"/>
+			</xsl:attribute>
+		</xsl:if>
+	</xsl:template>
+
+	<!-- isInvalid
+	<xsl:template name="isInvalid">
+		<xsl:param name="type"/>
+		<xsl:if
+			test="marc:subfield[@code='z'] or marc:subfield[@code='y'] or marc:subfield[@code='m']">
+			<identifier>
+				<xsl:attribute name="type">
+					<xsl:value-of select="$type"/>
+				</xsl:attribute>
+				<xsl:attribute name="invalid">
+					<xsl:text>yes</xsl:text>
+				</xsl:attribute>
+				<xsl:if test="marc:subfield[@code='z']">
+					<xsl:value-of select="marc:subfield[@code='z']"/>
+				</xsl:if>
+				<xsl:if test="marc:subfield[@code='y']">
+					<xsl:value-of select="marc:subfield[@code='y']"/>
+				</xsl:if>
+				<xsl:if test="marc:subfield[@code='m']">
+					<xsl:value-of select="marc:subfield[@code='m']"/>
+				</xsl:if>
+			</identifier>
+		</xsl:if>
+	</xsl:template>
+	-->
+	<xsl:template name="subtitle">
+		<xsl:if test="marc:subfield[@code='b']">
+			<subTitle>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:value-of select="marc:subfield[@code='b']"/>
+						<!--<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">b</xsl:with-param>
+						</xsl:call-template>-->
+					</xsl:with-param>
+				</xsl:call-template>
+			</subTitle>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="script">
+		<xsl:param name="scriptCode"/>
+		<xsl:attribute name="script">
+			<xsl:choose>
+				<!-- ISO 15924	and CJK is a local code	20101123-->
+				<xsl:when test="$scriptCode='(3'">Arab</xsl:when>
+				<xsl:when test="$scriptCode='(4'">Arab</xsl:when>
+				<xsl:when test="$scriptCode='(B'">Latn</xsl:when>
+				<xsl:when test="$scriptCode='!E'">Latn</xsl:when>
+				<xsl:when test="$scriptCode='$1'">CJK</xsl:when>
+				<xsl:when test="$scriptCode='(N'">Cyrl</xsl:when>
+				<xsl:when test="$scriptCode='(Q'">Cyrl</xsl:when>
+				<xsl:when test="$scriptCode='(2'">Hebr</xsl:when>
+				<xsl:when test="$scriptCode='(S'">Grek</xsl:when>
+			</xsl:choose>
+		</xsl:attribute>
+	</xsl:template>
+	<xsl:template name="parsePart">
+		<!-- assumes 773$q= 1:2:3<4
+		     with up to 3 levels and one optional start page
+		-->
+		<xsl:variable name="level1">
+			<xsl:choose>
+				<xsl:when test="contains(text(),':')">
+					<!-- 1:2 -->
+					<xsl:value-of select="substring-before(text(),':')"/>
+				</xsl:when>
+				<xsl:when test="not(contains(text(),':'))">
+					<!-- 1 or 1<3 -->
+					<xsl:if test="contains(text(),'&lt;')">
+						<!-- 1<3 -->
+						<xsl:value-of select="substring-before(text(),'&lt;')"/>
+					</xsl:if>
+					<xsl:if test="not(contains(text(),'&lt;'))">
+						<!-- 1 -->
+						<xsl:value-of select="text()"/>
+					</xsl:if>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="sici2">
+			<xsl:choose>
+				<xsl:when test="starts-with(substring-after(text(),$level1),':')">
+					<xsl:value-of select="substring(substring-after(text(),$level1),2)"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="substring-after(text(),$level1)"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="level2">
+			<xsl:choose>
+				<xsl:when test="contains($sici2,':')">
+					<!--  2:3<4  -->
+					<xsl:value-of select="substring-before($sici2,':')"/>
+				</xsl:when>
+				<xsl:when test="contains($sici2,'&lt;')">
+					<!-- 1: 2<4 -->
+					<xsl:value-of select="substring-before($sici2,'&lt;')"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="$sici2"/>
+					<!-- 1:2 -->
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="sici3">
+			<xsl:choose>
+				<xsl:when test="starts-with(substring-after($sici2,$level2),':')">
+					<xsl:value-of select="substring(substring-after($sici2,$level2),2)"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="substring-after($sici2,$level2)"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="level3">
+			<xsl:choose>
+				<xsl:when test="contains($sici3,'&lt;')">
+					<!-- 2<4 -->
+					<xsl:value-of select="substring-before($sici3,'&lt;')"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="$sici3"/>
+					<!-- 3 -->
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="page">
+			<xsl:if test="contains(text(),'&lt;')">
+				<xsl:value-of select="substring-after(text(),'&lt;')"/>
+			</xsl:if>
+		</xsl:variable>
+		<xsl:if test="$level1">
+			<detail level="1">
+				<number>
+					<xsl:value-of select="$level1"/>
+				</number>
+			</detail>
+		</xsl:if>
+		<xsl:if test="$level2">
+			<detail level="2">
+				<number>
+					<xsl:value-of select="$level2"/>
+				</number>
+			</detail>
+		</xsl:if>
+		<xsl:if test="$level3">
+			<detail level="3">
+				<number>
+					<xsl:value-of select="$level3"/>
+				</number>
+			</detail>
+		</xsl:if>
+		<xsl:if test="$page">
+			<extent unit="page">
+				<start>
+					<xsl:value-of select="$page"/>
+				</start>
+			</extent>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="getLanguage">
+		<xsl:param name="langString"/>
+		<xsl:param name="controlField008-35-37"/>
+		<xsl:variable name="length" select="string-length($langString)"/>
+		<xsl:choose>
+			<xsl:when test="$length=0"/>
+			<xsl:when test="$controlField008-35-37=substring($langString,1,3)">
+				<xsl:call-template name="getLanguage">
+					<xsl:with-param name="langString" select="substring($langString,4,$length)"/>
+					<xsl:with-param name="controlField008-35-37" select="$controlField008-35-37"/>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:otherwise>
+				<language>
+					<languageTerm authority="iso639-2b" type="code">
+						<xsl:value-of select="substring($langString,1,3)"/>
+					</languageTerm>
+				</language>
+				<xsl:call-template name="getLanguage">
+					<xsl:with-param name="langString" select="substring($langString,4,$length)"/>
+					<xsl:with-param name="controlField008-35-37" select="$controlField008-35-37"/>
+				</xsl:call-template>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+	<xsl:template name="isoLanguage">
+		<xsl:param name="currentLanguage"/>
+		<xsl:param name="usedLanguages"/>
+		<xsl:param name="remainingLanguages"/>
+		<xsl:choose>
+			<xsl:when test="string-length($currentLanguage)=0"/>
+			<xsl:when test="not(contains($usedLanguages, $currentLanguage))">
+				<language>
+					<xsl:if test="@code!='a'">
+						<xsl:attribute name="objectPart">
+							<xsl:choose>
+								<xsl:when test="@code='b'">summary or subtitle</xsl:when>
+								<xsl:when test="@code='d'">sung or spoken text</xsl:when>
+								<xsl:when test="@code='e'">libretto</xsl:when>
+								<xsl:when test="@code='f'">table of contents</xsl:when>
+								<xsl:when test="@code='g'">accompanying material</xsl:when>
+								<xsl:when test="@code='h'">translation</xsl:when>
+							</xsl:choose>
+						</xsl:attribute>
+					</xsl:if>
+					<languageTerm authority="iso639-2b" type="code">
+						<xsl:value-of select="$currentLanguage"/>
+					</languageTerm>
+				</language>
+				<xsl:call-template name="isoLanguage">
+					<xsl:with-param name="currentLanguage">
+						<xsl:value-of select="substring($remainingLanguages,1,3)"/>
+					</xsl:with-param>
+					<xsl:with-param name="usedLanguages">
+						<xsl:value-of select="concat($usedLanguages,$currentLanguage)"/>
+					</xsl:with-param>
+					<xsl:with-param name="remainingLanguages">
+						<xsl:value-of
+							select="substring($remainingLanguages,4,string-length($remainingLanguages))"
+						/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:call-template name="isoLanguage">
+					<xsl:with-param name="currentLanguage">
+						<xsl:value-of select="substring($remainingLanguages,1,3)"/>
+					</xsl:with-param>
+					<xsl:with-param name="usedLanguages">
+						<xsl:value-of select="concat($usedLanguages,$currentLanguage)"/>
+					</xsl:with-param>
+					<xsl:with-param name="remainingLanguages">
+						<xsl:value-of
+							select="substring($remainingLanguages,4,string-length($remainingLanguages))"
+						/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+	<xsl:template name="chopBrackets">
+		<xsl:param name="chopString"/>
+		<xsl:variable name="string">
+			<xsl:call-template name="chopPunctuation">
+				<xsl:with-param name="chopString" select="$chopString"/>
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:if test="substring($string, 1,1)='['">
+			<xsl:value-of select="substring($string,2, string-length($string)-2)"/>
+		</xsl:if>
+		<xsl:if test="substring($string, 1,1)!='['">
+			<xsl:value-of select="$string"/>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="rfcLanguages">
+		<xsl:param name="nodeNum"/>
+		<xsl:param name="usedLanguages"/>
+		<xsl:param name="controlField008-35-37"/>
+		<xsl:variable name="currentLanguage" select="."/>
+		<xsl:choose>
+			<xsl:when test="not($currentLanguage)"/>
+			<xsl:when
+				test="$currentLanguage!=$controlField008-35-37 and $currentLanguage!='rfc3066'">
+				<xsl:if test="not(contains($usedLanguages,$currentLanguage))">
+					<language>
+						<xsl:if test="@code!='a'">
+							<xsl:attribute name="objectPart">
+								<xsl:choose>
+									<xsl:when test="@code='b'">summary or subtitle</xsl:when>
+									<xsl:when test="@code='d'">sung or spoken text</xsl:when>
+									<xsl:when test="@code='e'">libretto</xsl:when>
+									<xsl:when test="@code='f'">table of contents</xsl:when>
+									<xsl:when test="@code='g'">accompanying material</xsl:when>
+									<xsl:when test="@code='h'">translation</xsl:when>
+								</xsl:choose>
+							</xsl:attribute>
+						</xsl:if>
+						<languageTerm authority="rfc3066" type="code">
+							<xsl:value-of select="$currentLanguage"/>
+						</languageTerm>
+					</language>
+				</xsl:if>
+			</xsl:when>
+			<xsl:otherwise> </xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- tmee added 20100106 for 045$b BC and CE date range info -->
+	<xsl:template name="dates045b">
+		<xsl:param name="str"/>
+		<xsl:variable name="first-char" select="substring($str,1,1)"/>
+		<xsl:choose>
+			<xsl:when test="$first-char ='c'">
+				<xsl:value-of select="concat ('-', substring($str, 2))"/>
+			</xsl:when>
+			<xsl:when test="$first-char ='d'">
+				<xsl:value-of select="substring($str, 2)"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$str"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template name="scriptCode">
+		<xsl:variable name="sf06" select="normalize-space(child::marc:subfield[@code='6'])"/>
+		<xsl:variable name="sf06a" select="substring($sf06, 1, 3)"/>
+		<xsl:variable name="sf06b" select="substring($sf06, 5, 2)"/>
+		<xsl:variable name="sf06c" select="substring($sf06, 7)"/>
+		<xsl:variable name="scriptCode" select="substring($sf06, 8, 2)"/>
+		<xsl:if test="//marc:datafield/marc:subfield[@code='6']">
+			<xsl:attribute name="script">
+				<xsl:choose>
+					<xsl:when test="$scriptCode=''">Latn</xsl:when>
+					<xsl:when test="$scriptCode='(3'">Arab</xsl:when>
+					<xsl:when test="$scriptCode='(4'">Arab</xsl:when>
+					<xsl:when test="$scriptCode='(B'">Latn</xsl:when>
+					<xsl:when test="$scriptCode='!E'">Latn</xsl:when>
+					<xsl:when test="$scriptCode='$1'">CJK</xsl:when>
+					<xsl:when test="$scriptCode='(N'">Cyrl</xsl:when>
+					<xsl:when test="$scriptCode='(Q'">Cyrl</xsl:when>
+					<xsl:when test="$scriptCode='(2'">Hebr</xsl:when>
+					<xsl:when test="$scriptCode='(S'">Grek</xsl:when>
+				</xsl:choose>
+			</xsl:attribute>
+		</xsl:if>
+	</xsl:template>
+
+	<!-- tmee 20100927 for 880s & corresponding fields  20101123 scriptCode -->
+
+	<xsl:template name="xxx880">
+		<xsl:if test="child::marc:subfield[@code='6']">
+			<xsl:variable name="sf06" select="normalize-space(child::marc:subfield[@code='6'])"/>
+			<xsl:variable name="sf06a" select="substring($sf06, 1, 3)"/>
+			<xsl:variable name="sf06b" select="substring($sf06, 5, 2)"/>
+			<xsl:variable name="sf06c" select="substring($sf06, 7)"/>
+			<xsl:variable name="scriptCode" select="substring($sf06, 8, 2)"/>
+			<xsl:if test="//marc:datafield/marc:subfield[@code='6']">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$sf06b"/>
+				</xsl:attribute>
+				<xsl:attribute name="script">
+					<xsl:choose>
+						<xsl:when test="$scriptCode=''">Latn</xsl:when>
+						<xsl:when test="$scriptCode='(3'">Arab</xsl:when>
+						<xsl:when test="$scriptCode='(4'">Arab</xsl:when>
+						<xsl:when test="$scriptCode='(B'">Latn</xsl:when>
+						<xsl:when test="$scriptCode='!E'">Latn</xsl:when>
+						<xsl:when test="$scriptCode='$1'">CJK</xsl:when>
+						<xsl:when test="$scriptCode='(N'">Cyrl</xsl:when>
+						<xsl:when test="$scriptCode='(Q'">Cyrl</xsl:when>
+						<xsl:when test="$scriptCode='(2'">Hebr</xsl:when>
+						<xsl:when test="$scriptCode='(S'">Grek</xsl:when>
+					</xsl:choose>
+				</xsl:attribute>
+			</xsl:if>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="yyy880">
+		<xsl:if test="preceding-sibling::marc:subfield[@code='6']">
+			<xsl:variable name="sf06"
+				select="normalize-space(preceding-sibling::marc:subfield[@code='6'])"/>
+			<xsl:variable name="sf06a" select="substring($sf06, 1, 3)"/>
+			<xsl:variable name="sf06b" select="substring($sf06, 5, 2)"/>
+			<xsl:variable name="sf06c" select="substring($sf06, 7)"/>
+			<xsl:if test="//marc:datafield/marc:subfield[@code='6']">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$sf06b"/>
+				</xsl:attribute>
+			</xsl:if>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="z2xx880">
+		<!-- Evaluating the 260 field -->
+		<xsl:variable name="x260">
+			<xsl:choose>
+				<xsl:when test="@tag='260' and marc:subfield[@code='6']">
+					<xsl:variable name="sf06260"
+						select="normalize-space(child::marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06260a" select="substring($sf06260, 1, 3)"/>
+					<xsl:variable name="sf06260b" select="substring($sf06260, 5, 2)"/>
+					<xsl:variable name="sf06260c" select="substring($sf06260, 7)"/>
+					<xsl:value-of select="$sf06260b"/>
+				</xsl:when>
+				<xsl:when
+					test="@tag='250' and ../marc:datafield[@tag='260']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06260"
+						select="normalize-space(../marc:datafield[@tag='260']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06260a" select="substring($sf06260, 1, 3)"/>
+					<xsl:variable name="sf06260b" select="substring($sf06260, 5, 2)"/>
+					<xsl:variable name="sf06260c" select="substring($sf06260, 7)"/>
+					<xsl:value-of select="$sf06260b"/>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:variable name="x250">
+			<xsl:choose>
+				<xsl:when test="@tag='250' and marc:subfield[@code='6']">
+					<xsl:variable name="sf06250"
+						select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06250a" select="substring($sf06250, 1, 3)"/>
+					<xsl:variable name="sf06250b" select="substring($sf06250, 5, 2)"/>
+					<xsl:variable name="sf06250c" select="substring($sf06250, 7)"/>
+					<xsl:value-of select="$sf06250b"/>
+				</xsl:when>
+				<xsl:when
+					test="@tag='260' and ../marc:datafield[@tag='250']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06250"
+						select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06250a" select="substring($sf06250, 1, 3)"/>
+					<xsl:variable name="sf06250b" select="substring($sf06250, 5, 2)"/>
+					<xsl:variable name="sf06250c" select="substring($sf06250, 7)"/>
+					<xsl:value-of select="$sf06250b"/>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:choose>
+			<xsl:when test="$x250!='' and $x260!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="concat($x250, $x260)"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$x250!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$x250"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$x260!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$x260"/>
+				</xsl:attribute>
+			</xsl:when>
+		</xsl:choose>
+		<xsl:if test="//marc:datafield/marc:subfield[@code='6']"> </xsl:if>
+	</xsl:template>
+
+	<xsl:template name="z3xx880">
+		<!-- Evaluating the 300 field -->
+		<xsl:variable name="x300">
+			<xsl:choose>
+				<xsl:when test="@tag='300' and marc:subfield[@code='6']">
+					<xsl:variable name="sf06300"
+						select="normalize-space(child::marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06300a" select="substring($sf06300, 1, 3)"/>
+					<xsl:variable name="sf06300b" select="substring($sf06300, 5, 2)"/>
+					<xsl:variable name="sf06300c" select="substring($sf06300, 7)"/>
+					<xsl:value-of select="$sf06300b"/>
+				</xsl:when>
+				<xsl:when
+					test="@tag='351' and ../marc:datafield[@tag='300']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06300"
+						select="normalize-space(../marc:datafield[@tag='300']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06300a" select="substring($sf06300, 1, 3)"/>
+					<xsl:variable name="sf06300b" select="substring($sf06300, 5, 2)"/>
+					<xsl:variable name="sf06300c" select="substring($sf06300, 7)"/>
+					<xsl:value-of select="$sf06300b"/>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:variable name="x351">
+			<xsl:choose>
+				<xsl:when test="@tag='351' and marc:subfield[@code='6']">
+					<xsl:variable name="sf06351"
+						select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06351a" select="substring($sf06351, 1, 3)"/>
+					<xsl:variable name="sf06351b" select="substring($sf06351, 5, 2)"/>
+					<xsl:variable name="sf06351c" select="substring($sf06351, 7)"/>
+					<xsl:value-of select="$sf06351b"/>
+				</xsl:when>
+				<xsl:when
+					test="@tag='300' and ../marc:datafield[@tag='351']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06351"
+						select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06351a" select="substring($sf06351, 1, 3)"/>
+					<xsl:variable name="sf06351b" select="substring($sf06351, 5, 2)"/>
+					<xsl:variable name="sf06351c" select="substring($sf06351, 7)"/>
+					<xsl:value-of select="$sf06351b"/>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:variable name="x337">
+			<xsl:if test="@tag='337' and marc:subfield[@code='6']">
+				<xsl:variable name="sf06337"
+					select="normalize-space(child::marc:subfield[@code='6'])"/>
+				<xsl:variable name="sf06337a" select="substring($sf06337, 1, 3)"/>
+				<xsl:variable name="sf06337b" select="substring($sf06337, 5, 2)"/>
+				<xsl:variable name="sf06337c" select="substring($sf06337, 7)"/>
+				<xsl:value-of select="$sf06337b"/>
+			</xsl:if>
+		</xsl:variable>
+		<xsl:variable name="x338">
+			<xsl:if test="@tag='338' and marc:subfield[@code='6']">
+				<xsl:variable name="sf06338"
+					select="normalize-space(child::marc:subfield[@code='6'])"/>
+				<xsl:variable name="sf06338a" select="substring($sf06338, 1, 3)"/>
+				<xsl:variable name="sf06338b" select="substring($sf06338, 5, 2)"/>
+				<xsl:variable name="sf06338c" select="substring($sf06338, 7)"/>
+				<xsl:value-of select="$sf06338b"/>
+			</xsl:if>
+		</xsl:variable>
+
+		<xsl:choose>
+			<xsl:when test="$x351!='' and $x300!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="concat($x351, $x300, $x337, $x338)"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$x351!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$x351"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$x300!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$x300"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$x337!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$x351"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$x338!=''">
+				<xsl:attribute name="altRepGroup">
+					<xsl:value-of select="$x300"/>
+				</xsl:attribute>
+			</xsl:when>
+		</xsl:choose>
+		<xsl:if test="//marc:datafield/marc:subfield[@code='6']"> </xsl:if>
+	</xsl:template>
+
+
+
+	<xsl:template name="true880">
+		<xsl:variable name="sf06" select="normalize-space(marc:subfield[@code='6'])"/>
+		<xsl:variable name="sf06a" select="substring($sf06, 1, 3)"/>
+		<xsl:variable name="sf06b" select="substring($sf06, 5, 2)"/>
+		<xsl:variable name="sf06c" select="substring($sf06, 7)"/>
+		<xsl:if test="//marc:datafield/marc:subfield[@code='6']">
+			<xsl:attribute name="altRepGroup">
+				<xsl:value-of select="$sf06b"/>
+			</xsl:attribute>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="marc:datafield" mode="trans880">
+		<xsl:variable name="dataField880" select="//marc:datafield"/>
+		<xsl:variable name="sf06" select="normalize-space(marc:subfield[@code='6'])"/>
+		<xsl:variable name="sf06a" select="substring($sf06, 1, 3)"/>
+		<xsl:variable name="sf06b" select="substring($sf06, 4)"/>
+		<xsl:choose>
+
+			<!--tranforms 880 equiv-->
+
+			<xsl:when test="$sf06a='047'">
+				<xsl:call-template name="createGenreFrom047"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='336'">
+				<xsl:call-template name="createGenreFrom336"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='655'">
+				<xsl:call-template name="createGenreFrom655"/>
+			</xsl:when>
+
+			<xsl:when test="$sf06a='050'">
+				<xsl:call-template name="createClassificationFrom050"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='060'">
+				<xsl:call-template name="createClassificationFrom060"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='080'">
+				<xsl:call-template name="createClassificationFrom080"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='082'">
+				<xsl:call-template name="createClassificationFrom082"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='084'">
+				<xsl:call-template name="createClassificationFrom080"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='086'">
+				<xsl:call-template name="createClassificationFrom082"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='100'">
+				<xsl:call-template name="createNameFrom100"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='110'">
+				<xsl:call-template name="createNameFrom110"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='111'">
+				<xsl:call-template name="createNameFrom110"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='700'">
+				<xsl:call-template name="createNameFrom700"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='710'">
+				<xsl:call-template name="createNameFrom710"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='711'">
+				<xsl:call-template name="createNameFrom710"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='210'">
+				<xsl:call-template name="createTitleInfoFrom210"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='245'">
+				<xsl:call-template name="createTitleInfoFrom245"/>
+				<xsl:call-template name="createNoteFrom245c"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='246'">
+				<xsl:call-template name="createTitleInfoFrom246"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='240'">
+				<xsl:call-template name="createTitleInfoFrom240"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='740'">
+				<xsl:call-template name="createTitleInfoFrom740"/>
+			</xsl:when>
+
+			<xsl:when test="$sf06a='130'">
+				<xsl:call-template name="createTitleInfoFrom130"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='730'">
+				<xsl:call-template name="createTitleInfoFrom730"/>
+			</xsl:when>
+
+			<xsl:when test="$sf06a='505'">
+				<xsl:call-template name="createTOCFrom505"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='520'">
+				<xsl:call-template name="createAbstractFrom520"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='521'">
+				<xsl:call-template name="createTargetAudienceFrom521"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='506'">
+				<xsl:call-template name="createAccessConditionFrom506"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='540'">
+				<xsl:call-template name="createAccessConditionFrom540"/>
+			</xsl:when>
+
+			<!-- note 245 362 etc	-->
+
+			<xsl:when test="$sf06a='245'">
+				<xsl:call-template name="createNoteFrom245c"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='362'">
+				<xsl:call-template name="createNoteFrom362"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='502'">
+				<xsl:call-template name="createNoteFrom502"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='504'">
+				<xsl:call-template name="createNoteFrom504"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='508'">
+				<xsl:call-template name="createNoteFrom508"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='511'">
+				<xsl:call-template name="createNoteFrom511"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='515'">
+				<xsl:call-template name="createNoteFrom515"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='518'">
+				<xsl:call-template name="createNoteFrom518"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='524'">
+				<xsl:call-template name="createNoteFrom524"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='530'">
+				<xsl:call-template name="createNoteFrom530"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='533'">
+				<xsl:call-template name="createNoteFrom533"/>
+			</xsl:when>
+			<!--
+			<xsl:when test="$sf06a='534'">
+				<xsl:call-template name="createNoteFrom534"/>
+			</xsl:when>
+-->
+			<xsl:when test="$sf06a='535'">
+				<xsl:call-template name="createNoteFrom535"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='536'">
+				<xsl:call-template name="createNoteFrom536"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='538'">
+				<xsl:call-template name="createNoteFrom538"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='541'">
+				<xsl:call-template name="createNoteFrom541"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='545'">
+				<xsl:call-template name="createNoteFrom545"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='546'">
+				<xsl:call-template name="createNoteFrom546"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='561'">
+				<xsl:call-template name="createNoteFrom561"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='562'">
+				<xsl:call-template name="createNoteFrom562"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='581'">
+				<xsl:call-template name="createNoteFrom581"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='583'">
+				<xsl:call-template name="createNoteFrom583"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='585'">
+				<xsl:call-template name="createNoteFrom585"/>
+			</xsl:when>
+
+			<!--	note 5XX	-->
+
+			<xsl:when test="$sf06a='501'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='507'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='513'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='514'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='516'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='522'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='525'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='526'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='544'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='552'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='555'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='556'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='565'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='567'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='580'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='584'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='586'">
+				<xsl:call-template name="createNoteFrom5XX"/>
+			</xsl:when>
+
+			<!--  subject 034 043 045 255 656 662 752 	-->
+
+			<xsl:when test="$sf06a='034'">
+				<xsl:call-template name="createSubGeoFrom034"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='043'">
+				<xsl:call-template name="createSubGeoFrom043"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='045'">
+				<xsl:call-template name="createSubTemFrom045"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='255'">
+				<xsl:call-template name="createSubGeoFrom255"/>
+			</xsl:when>
+
+			<xsl:when test="$sf06a='600'">
+				<xsl:call-template name="createSubNameFrom600"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='610'">
+				<xsl:call-template name="createSubNameFrom610"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='611'">
+				<xsl:call-template name="createSubNameFrom611"/>
+			</xsl:when>
+
+			<xsl:when test="$sf06a='630'">
+				<xsl:call-template name="createSubTitleFrom630"/>
+			</xsl:when>
+
+			<xsl:when test="$sf06a='648'">
+				<xsl:call-template name="createSubChronFrom648"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='650'">
+				<xsl:call-template name="createSubTopFrom650"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='651'">
+				<xsl:call-template name="createSubGeoFrom651"/>
+			</xsl:when>
+
+
+			<xsl:when test="$sf06a='653'">
+				<xsl:call-template name="createSubFrom653"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='656'">
+				<xsl:call-template name="createSubFrom656"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='662'">
+				<xsl:call-template name="createSubGeoFrom662752"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='752'">
+				<xsl:call-template name="createSubGeoFrom662752"/>
+			</xsl:when>
+
+			<!--  location  852 856 -->
+
+			<xsl:when test="$sf06a='852'">
+				<xsl:call-template name="createLocationFrom852"/>
+			</xsl:when>
+			<xsl:when test="$sf06a='856'">
+				<xsl:call-template name="createLocationFrom856"/>
+			</xsl:when>
+
+			<xsl:when test="$sf06a='490'">
+				<xsl:call-template name="createRelatedItemFrom490"/>
+			</xsl:when>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- titleInfo 130 730 245 246 240 740 210 -->
+
+	<!-- 130 -->
+	<xsl:template name="createTitleInfoFrom130">
+		<xsl:for-each select="marc:datafield[@tag='130'][@ind2!='2']">
+			<titleInfo type="uniform">
+				<title>
+					<xsl:variable name="str">
+						<xsl:for-each select="marc:subfield">
+							<xsl:if test="(contains('s',@code))">
+								<xsl:value-of select="text()"/>
+								<xsl:text> </xsl:text>
+							</xsl:if>
+							<xsl:if
+								test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+								<xsl:value-of select="text()"/>
+								<xsl:text> </xsl:text>
+							</xsl:if>
+						</xsl:for-each>
+					</xsl:variable>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+						</xsl:with-param>
+					</xsl:call-template>
+				</title>
+				<xsl:call-template name="part"/>
+			</titleInfo>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="createTitleInfoFrom730">
+		<titleInfo type="uniform">
+			<title>
+				<xsl:variable name="str">
+					<xsl:for-each select="marc:subfield">
+						<xsl:if test="(contains('s',@code))">
+							<xsl:value-of select="text()"/>
+							<xsl:text> </xsl:text>
+						</xsl:if>
+						<xsl:if
+							test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+							<xsl:value-of select="text()"/>
+							<xsl:text> </xsl:text>
+						</xsl:if>
+					</xsl:for-each>
+				</xsl:variable>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</title>
+			<xsl:call-template name="part"/>
+		</titleInfo>
+	</xsl:template>
+
+	<xsl:template name="createTitleInfoFrom210">
+		<titleInfo type="abbreviated">
+			<xsl:if test="marc:datafield[@tag='210'][@ind2='2']">
+				<xsl:attribute name="authority">
+					<xsl:value-of select="marc:subfield[@code='2']"/>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:call-template name="xxx880"/>
+			<title>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">a</xsl:with-param>
+						</xsl:call-template>
+					</xsl:with-param>
+				</xsl:call-template>
+			</title>
+			<xsl:call-template name="subtitle"/>
+		</titleInfo>
+	</xsl:template>
+	<!-- 1.79 -->
+	<xsl:template name="createTitleInfoFrom245">
+		<titleInfo>
+			<xsl:call-template name="xxx880"/>
+			<xsl:variable name="title">
+				<xsl:choose>
+					<xsl:when test="marc:subfield[@code='b']">
+						<xsl:call-template name="specialSubfieldSelect">
+							<xsl:with-param name="axis">b</xsl:with-param>
+							<xsl:with-param name="beforeCodes">afgks</xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">abfgks</xsl:with-param>
+						</xsl:call-template>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:variable>
+			<xsl:variable name="titleChop">
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:value-of select="$title"/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</xsl:variable>
+			<xsl:choose>
+				<xsl:when test="@ind2&gt;0">
+					<xsl:if test="@tag!='880'">
+						<nonSort>
+							<xsl:value-of select="substring($titleChop,1,@ind2)"/>
+						</nonSort>
+					</xsl:if>
+					<title>
+						<xsl:value-of select="substring($titleChop,@ind2+1)"/>
+					</title>
+				</xsl:when>
+				<xsl:otherwise>
+					<title>
+						<xsl:value-of select="$titleChop"/>
+					</title>
+				</xsl:otherwise>
+			</xsl:choose>
+			<xsl:if test="marc:subfield[@code='b']">
+				<subTitle>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:call-template name="specialSubfieldSelect">
+								<xsl:with-param name="axis">b</xsl:with-param>
+								<xsl:with-param name="anyCodes">b</xsl:with-param>
+								<xsl:with-param name="afterCodes">afgks</xsl:with-param>
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+				</subTitle>
+			</xsl:if>
+			<xsl:call-template name="part"/>
+		</titleInfo>
+	</xsl:template>
+
+	<xsl:template name="createTitleInfoFrom246">
+		<titleInfo type="alternative">
+			<xsl:call-template name="xxx880"/>
+			<xsl:for-each select="marc:subfield[@code='i']">
+				<xsl:attribute name="displayLabel">
+					<xsl:value-of select="text()"/>
+				</xsl:attribute>
+			</xsl:for-each>
+			<title>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:call-template name="subfieldSelect">
+							<!-- 1/04 removed $h, $b -->
+							<xsl:with-param name="codes">af</xsl:with-param>
+						</xsl:call-template>
+					</xsl:with-param>
+				</xsl:call-template>
+			</title>
+			<xsl:call-template name="subtitle"/>
+			<xsl:call-template name="part"/>
+		</titleInfo>
+	</xsl:template>
+
+	<!-- 240 nameTitleGroup-->
+
+	<xsl:template name="createTitleInfoFrom240">
+		<titleInfo type="uniform">
+			<xsl:if
+				test="//marc:datafield[@tag='100']|//marc:datafield[@tag='110']|//marc:datafield[@tag='111']">
+				<xsl:attribute name="nameTitleGroup">
+					<xsl:text>1</xsl:text>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:call-template name="xxx880"/>
+			<title>
+				<xsl:variable name="str">
+					<xsl:for-each select="marc:subfield">
+						<xsl:if test="(contains('s',@code))">
+							<xsl:value-of select="text()"/>
+							<xsl:text> </xsl:text>
+						</xsl:if>
+						<xsl:if
+							test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+							<xsl:value-of select="text()"/>
+							<xsl:text> </xsl:text>
+						</xsl:if>
+					</xsl:for-each>
+				</xsl:variable>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</title>
+			<xsl:call-template name="part"/>
+		</titleInfo>
+	</xsl:template>
+
+	<xsl:template name="createTitleInfoFrom740">
+		<titleInfo type="alternative">
+			<xsl:call-template name="xxx880"/>
+			<title>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">ah</xsl:with-param>
+						</xsl:call-template>
+					</xsl:with-param>
+				</xsl:call-template>
+			</title>
+			<xsl:call-template name="part"/>
+		</titleInfo>
+	</xsl:template>
+
+	<!-- name 100 110 111 1.93      -->
+
+	<xsl:template name="createNameFrom100">
+		<xsl:if test="@ind1='0' or @ind1='1'">
+			<name type="personal">
+				<xsl:attribute name="usage">
+					<xsl:text>primary</xsl:text>
+				</xsl:attribute>
+				<xsl:call-template name="xxx880"/>
+				<xsl:if test="//marc:datafield[@tag='240']">
+					<xsl:attribute name="nameTitleGroup">
+						<xsl:text>1</xsl:text>
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:call-template name="nameABCDQ"/>
+				<xsl:call-template name="affiliation"/>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:if>
+		<xsl:if test="@ind1='3'">
+			<name type="family">
+				<xsl:attribute name="usage">
+					<xsl:text>primary</xsl:text>
+				</xsl:attribute>
+				<xsl:call-template name="xxx880"/>
+				<xsl:if test="//marc:datafield[@tag='240']">
+					<xsl:attribute name="nameTitleGroup">
+						<xsl:text>1</xsl:text>
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:call-template name="nameABCDQ"/>
+				<xsl:call-template name="affiliation"/>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="createNameFrom110">
+		<name type="corporate">
+			<xsl:call-template name="xxx880"/>
+			<xsl:if test="//marc:datafield[@tag='240']">
+				<xsl:attribute name="nameTitleGroup">
+					<xsl:text>1</xsl:text>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:call-template name="nameABCDN"/>
+			<xsl:call-template name="role"/>
+		</name>
+	</xsl:template>
+
+	<xsl:template name="createNameFrom111">
+		<name type="conference">
+			<xsl:call-template name="xxx880"/>
+			<xsl:if test="//marc:datafield[@tag='240']">
+				<xsl:attribute name="nameTitleGroup">
+					<xsl:text>1</xsl:text>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:call-template name="nameACDEQ"/>
+			<xsl:call-template name="role"/>
+		</name>
+	</xsl:template>
+
+
+
+	<!-- name 700 710 711 720 -->
+
+	<xsl:template name="createNameFrom700">
+		<xsl:if test="@ind1='1'">
+			<name type="personal">
+				<xsl:call-template name="xxx880"/>
+				<xsl:call-template name="nameABCDQ"/>
+				<xsl:call-template name="affiliation"/>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:if>
+		<xsl:if test="@ind1='3'">
+			<name type="family">
+				<xsl:call-template name="xxx880"/>
+				<xsl:call-template name="nameABCDQ"/>
+				<xsl:call-template name="affiliation"/>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="createNameFrom710">
+		<name type="corporate">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="nameABCDN"/>
+			<xsl:call-template name="role"/>
+		</name>
+	</xsl:template>
+
+	<xsl:template name="createNameFrom711">
+		<name type="conference">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="nameACDEQ"/>
+			<xsl:call-template name="role"/>
+		</name>
+	</xsl:template>
+
+
+	<xsl:template name="createNameFrom720">
+		<!-- 1.91 FLVC correction: the original if test will fail because of xpath: the current node (from the for-each above) is already the 720 datafield -->
+		<!-- <xsl:if test="marc:datafield[@tag='720'][not(marc:subfield[@code='t'])]"> -->
+		<xsl:if test="not(marc:subfield[@code='t'])">
+			<name>
+				<xsl:if test="@ind1=1">
+					<xsl:attribute name="type">
+						<xsl:text>personal</xsl:text>
+					</xsl:attribute>
+				</xsl:if>
+				<namePart>
+					<xsl:value-of select="marc:subfield[@code='a']"/>
+				</namePart>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:if>
+	</xsl:template>
+
+
+
+	<!-- replced by above 1.91
+	<xsl:template name="createNameFrom720">
+		<xsl:if test="marc:datafield[@tag='720'][not(marc:subfield[@code='t'])]">
+			<name>
+				<xsl:if test="@ind1=1">
+					<xsl:attribute name="type">
+						<xsl:text>personal</xsl:text>
+					</xsl:attribute>
+				</xsl:if>
+				<namePart>
+					<xsl:value-of select="marc:subfield[@code='a']"/>
+				</namePart>
+				<xsl:call-template name="role"/>
+			</name>
+		</xsl:if>
+	</xsl:template>
+	-->
+
+
+	<!-- genre 047 336 655	-->
+
+	<xsl:template name="createGenreFrom047">
+		<genre authority="marcgt">
+			<xsl:attribute name="authority">
+				<xsl:value-of select="marc:subfield[@code='2']"/>
+			</xsl:attribute>
+			<!-- Template checks for altRepGroup - 880 $6 -->
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">abcdef</xsl:with-param>
+				<xsl:with-param name="delimeter">-</xsl:with-param>
+			</xsl:call-template>
+		</genre>
+	</xsl:template>
+
+	<xsl:template name="createGenreFrom336">
+		<genre>
+			<xsl:attribute name="authority">
+				<xsl:value-of select="marc:subfield[@code='2']"/>
+			</xsl:attribute>
+			<!-- Template checks for altRepGroup - 880 $6 -->
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">ab</xsl:with-param>
+				<xsl:with-param name="delimeter">-</xsl:with-param>
+			</xsl:call-template>
+		</genre>
+	</xsl:template>
+
+	<xsl:template name="createGenreFrom655">
+		<genre authority="marcgt">
+			<xsl:attribute name="authority">
+				<xsl:value-of select="marc:subfield[@code='2']"/>
+			</xsl:attribute>
+			<!-- Template checks for altRepGroup - 880 $6 -->
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">abvxyz</xsl:with-param>
+				<xsl:with-param name="delimeter">-</xsl:with-param>
+			</xsl:call-template>
+		</genre>
+	</xsl:template>
+
+	<!-- tOC 505 -->
+
+	<xsl:template name="createTOCFrom505">
+		<tableOfContents>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">agrt</xsl:with-param>
+			</xsl:call-template>
+		</tableOfContents>
+	</xsl:template>
+
+	<!-- abstract 520 -->
+
+	<xsl:template name="createAbstractFrom520">
+		<abstract>
+			<xsl:attribute name="type">
+				<xsl:choose>
+					<xsl:when test="@ind1=' '">Summary</xsl:when>
+					<xsl:when test="@ind1='0'">Subject</xsl:when>
+					<xsl:when test="@ind1='1'">Review</xsl:when>
+					<xsl:when test="@ind1='2'">Scope and content</xsl:when>
+					<xsl:when test="@ind1='3'">Abstract</xsl:when>
+					<xsl:when test="@ind1='4'">Content advice</xsl:when>
+				</xsl:choose>
+			</xsl:attribute>
+
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">ab</xsl:with-param>
+			</xsl:call-template>
+
+		</abstract>
+	</xsl:template>
+
+	<!-- targetAudience 521 -->
+
+	<xsl:template name="createTargetAudienceFrom521">
+		<targetAudience>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">ab</xsl:with-param>
+			</xsl:call-template>
+		</targetAudience>
+	</xsl:template>
+
+	<!-- note 245c thru 585 -->
+
+	<xsl:template name="createNoteFrom245c">
+
+				<note type="statement of responsibility">
+					<xsl:attribute name="altRepGroup">
+						<xsl:text>00</xsl:text>
+					</xsl:attribute>
+					<xsl:call-template name="scriptCode"/>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">c</xsl:with-param>
+					</xsl:call-template>
+				</note>
+
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom362">
+		<note type="date/sequential designation">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom500">
+		<note>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:value-of select="marc:subfield[@code='a']"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom502">
+		<note type="thesis">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom504">
+		<note type="bibliography">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom508">
+		<note type="creation/production credits">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each
+					select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom511">
+		<note type="performers">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom515">
+		<note type="numbering">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom518">
+		<note type="venue">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='3' and @code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom524">
+		<note type="preferred citation">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom530">
+		<note type="additional physical form">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each
+					select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom533">
+		<note type="reproduction">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<!-- tmee
+	<xsl:template name="createNoteFrom534">
+		<note type="original version">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+-->
+
+	<xsl:template name="createNoteFrom535">
+		<note type="original location">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom536">
+		<note type="funding">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom538">
+		<note type="system details">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom541">
+		<note type="acquisition">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom545">
+		<note type="biographical/historical">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom546">
+		<note type="language">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom561">
+		<note type="ownership">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom562">
+		<note type="version identification">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom581">
+		<note type="publications">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom583">
+		<note type="action">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom585">
+		<note type="exhibitions">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<xsl:template name="createNoteFrom5XX">
+		<note>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="uri"/>
+			<xsl:variable name="str">
+				<xsl:for-each select="marc:subfield[@code!='6' and @code!='8']">
+					<xsl:value-of select="."/>
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+		</note>
+	</xsl:template>
+
+	<!-- subject Geo 034 043 045 255 656 662 752 -->
+
+	<xsl:template name="createSubGeoFrom034">
+		<xsl:if
+			test="marc:datafield[@tag=034][marc:subfield[@code='d' or @code='e' or @code='f' or @code='g']]">
+			<subject>
+				<xsl:call-template name="xxx880"/>
+				<cartographics>
+					<coordinates>
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">defg</xsl:with-param>
+						</xsl:call-template>
+					</coordinates>
+				</cartographics>
+			</subject>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="createSubGeoFrom043">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:for-each select="marc:subfield[@code='a' or @code='b' or @code='c']">
+				<geographicCode>
+					<xsl:attribute name="authority">
+						<xsl:if test="@code='a'">
+							<xsl:text>marcgac</xsl:text>
+						</xsl:if>
+						<xsl:if test="@code='b'">
+							<xsl:value-of select="following-sibling::marc:subfield[@code=2]"/>
+						</xsl:if>
+						<xsl:if test="@code='c'">
+							<xsl:text>iso3166</xsl:text>
+						</xsl:if>
+					</xsl:attribute>
+					<xsl:value-of select="self::marc:subfield"/>
+				</geographicCode>
+			</xsl:for-each>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubGeoFrom255">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<cartographics>
+			<xsl:for-each select="marc:subfield[@code='a' or @code='b' or @code='c']">
+					<xsl:if test="@code='a'">
+						<scale>
+							<xsl:value-of select="."/>
+						</scale>
+					</xsl:if>
+					<xsl:if test="@code='b'">
+						<projection>
+							<xsl:value-of select="."/>
+						</projection>
+					</xsl:if>
+					<xsl:if test="@code='c'">
+						<coordinates>
+							<xsl:value-of select="."/>
+						</coordinates>
+					</xsl:if>
+			</xsl:for-each>
+			</cartographics>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubNameFrom600">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subjectAuthority"/>
+			<name type="personal">
+				<xsl:call-template name="termsOfAddress"/>
+				<namePart>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">aq</xsl:with-param>
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+				</namePart>
+				<xsl:call-template name="nameDate"/>
+				<xsl:call-template name="affiliation"/>
+				<xsl:call-template name="role"/>
+			</name>
+			<xsl:if test="marc:subfield[@code='t']">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">t</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+			</xsl:if>
+			<xsl:call-template name="subjectAnyOrder"/>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubNameFrom610">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subjectAuthority"/>
+			<name type="corporate">
+				<xsl:for-each select="marc:subfield[@code='a']">
+					<namePart>
+						<xsl:value-of select="."/>
+					</namePart>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='b']">
+					<namePart>
+						<xsl:value-of select="."/>
+					</namePart>
+				</xsl:for-each>
+				<xsl:if test="marc:subfield[@code='c' or @code='d' or @code='n' or @code='p']">
+					<namePart>
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">cdnp</xsl:with-param>
+						</xsl:call-template>
+					</namePart>
+				</xsl:if>
+				<xsl:call-template name="role"/>
+			</name>
+			<xsl:if test="marc:subfield[@code='t']">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">t</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+			</xsl:if>
+			<xsl:call-template name="subjectAnyOrder"/>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubNameFrom611">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subjectAuthority"/>
+			<name type="conference">
+				<namePart>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">abcdeqnp</xsl:with-param>
+					</xsl:call-template>
+				</namePart>
+				<xsl:for-each select="marc:subfield[@code='4']">
+					<role>
+						<roleTerm authority="marcrelator" type="code">
+							<xsl:value-of select="."/>
+						</roleTerm>
+					</role>
+				</xsl:for-each>
+			</name>
+			<xsl:if test="marc:subfield[@code='t']">
+				<titleInfo>
+					<title>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString">
+								<xsl:call-template name="subfieldSelect">
+									<xsl:with-param name="codes">tpn</xsl:with-param>
+								</xsl:call-template>
+							</xsl:with-param>
+						</xsl:call-template>
+					</title>
+					<xsl:call-template name="part"/>
+				</titleInfo>
+			</xsl:if>
+			<xsl:call-template name="subjectAnyOrder"/>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubTitleFrom630">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subjectAuthority"/>
+			<titleInfo>
+				<title>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">adfhklor</xsl:with-param>
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+				</title>
+				<xsl:call-template name="part"/>
+			</titleInfo>
+			<xsl:call-template name="subjectAnyOrder"/>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubChronFrom648">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:if test="marc:subfield[@code=2]">
+				<xsl:attribute name="authority">
+					<xsl:value-of select="marc:subfield[@code=2]"/>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:call-template name="uri"/>
+			<xsl:call-template name="subjectAuthority"/>
+			<temporal>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">abcd</xsl:with-param>
+						</xsl:call-template>
+					</xsl:with-param>
+				</xsl:call-template>
+			</temporal>
+			<xsl:call-template name="subjectAnyOrder"/>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubTopFrom650">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subjectAuthority"/>
+			<topic>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:call-template name="subfieldSelect">
+							<xsl:with-param name="codes">abcd</xsl:with-param>
+						</xsl:call-template>
+					</xsl:with-param>
+				</xsl:call-template>
+			</topic>
+			<xsl:call-template name="subjectAnyOrder"/>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubGeoFrom651">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subjectAuthority"/>
+			<xsl:for-each select="marc:subfield[@code='a']">
+				<geographic>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString" select="."/>
+					</xsl:call-template>
+				</geographic>
+			</xsl:for-each>
+			<xsl:call-template name="subjectAnyOrder"/>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubFrom653">
+
+		<xsl:if test="@ind2=' '">
+			<subject>
+				<topic>
+					<xsl:value-of select="."/>
+				</topic>
+			</subject>
+		</xsl:if>
+		<xsl:if test="@ind2='0'">
+			<subject>
+				<topic>
+					<xsl:value-of select="."/>
+				</topic>
+			</subject>
+		</xsl:if>
+<!-- tmee 1.93 20140130 -->
+		<xsl:if test="@ind=' ' or @ind1='0' or @ind1='1'">
+			<subject>
+				<name type="personal">
+					<namePart>
+						<xsl:value-of select="."/>
+					</namePart>
+				</name>
+			</subject>
+		</xsl:if>
+		<xsl:if test="@ind1='3'">
+			<subject>
+				<name type="family">
+					<namePart>
+						<xsl:value-of select="."/>
+					</namePart>
+				</name>
+			</subject>
+		</xsl:if>
+		<xsl:if test="@ind2='2'">
+			<subject>
+				<name type="corporate">
+					<namePart>
+						<xsl:value-of select="."/>
+					</namePart>
+				</name>
+			</subject>
+		</xsl:if>
+		<xsl:if test="@ind2='3'">
+			<subject>
+				<name type="conference">
+					<namePart>
+						<xsl:value-of select="."/>
+					</namePart>
+				</name>
+			</subject>
+		</xsl:if>
+		<xsl:if test="@ind2=4">
+			<subject>
+				<temporal>
+					<xsl:value-of select="."/>
+				</temporal>
+			</subject>
+		</xsl:if>
+		<xsl:if test="@ind2=5">
+			<subject>
+				<geographic>
+					<xsl:value-of select="."/>
+				</geographic>
+			</subject>
+		</xsl:if>
+
+		<xsl:if test="@ind2=6">
+			<subject>
+				<genre>
+					<xsl:value-of select="."/>
+				</genre>
+			</subject>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="createSubFrom656">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<xsl:if test="marc:subfield[@code=2]">
+				<xsl:attribute name="authority">
+					<xsl:value-of select="marc:subfield[@code=2]"/>
+				</xsl:attribute>
+			</xsl:if>
+			<occupation>
+				<xsl:call-template name="chopPunctuation">
+					<xsl:with-param name="chopString">
+						<xsl:value-of select="marc:subfield[@code='a']"/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</occupation>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubGeoFrom662752">
+		<subject>
+			<xsl:call-template name="xxx880"/>
+			<hierarchicalGeographic>
+				<xsl:for-each select="marc:subfield[@code='a']">
+					<country>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString" select="."/>
+						</xsl:call-template>
+					</country>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='b']">
+					<state>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString" select="."/>
+						</xsl:call-template>
+					</state>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='c']">
+					<county>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString" select="."/>
+						</xsl:call-template>
+					</county>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='d']">
+					<city>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString" select="."/>
+						</xsl:call-template>
+					</city>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='e']">
+					<citySection>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString" select="."/>
+						</xsl:call-template>
+					</citySection>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='g']">
+					<area>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString" select="."/>
+						</xsl:call-template>
+					</area>
+				</xsl:for-each>
+				<xsl:for-each select="marc:subfield[@code='h']">
+					<extraterrestrialArea>
+						<xsl:call-template name="chopPunctuation">
+							<xsl:with-param name="chopString" select="."/>
+						</xsl:call-template>
+					</extraterrestrialArea>
+				</xsl:for-each>
+			</hierarchicalGeographic>
+		</subject>
+	</xsl:template>
+
+	<xsl:template name="createSubTemFrom045">
+		<xsl:if
+			test="//marc:datafield[@tag=045 and @ind1='2'][marc:subfield[@code='b' or @code='c']]">
+			<subject>
+				<xsl:call-template name="xxx880"/>
+				<temporal encoding="iso8601" point="start">
+					<xsl:call-template name="dates045b">
+						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][1]"
+						/>
+					</xsl:call-template>
+				</temporal>
+				<temporal encoding="iso8601" point="end">
+					<xsl:call-template name="dates045b">
+						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][2]"
+						/>
+					</xsl:call-template>
+				</temporal>
+			</subject>
+		</xsl:if>
+	</xsl:template>
+
+	<!-- classification 050 060 080 082 084 086 -->
+
+	<xsl:template name="createClassificationFrom050">
+		<xsl:for-each select="marc:subfield[@code='b']">
+			<classification authority="lcc">
+				<xsl:call-template name="xxx880"/>
+				<xsl:if test="../marc:subfield[@code='3']">
+					<xsl:attribute name="displayLabel">
+						<xsl:value-of select="../marc:subfield[@code='3']"/>
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:value-of select="preceding-sibling::marc:subfield[@code='a'][1]"/>
+				<xsl:text> </xsl:text>
+				<xsl:value-of select="text()"/>
+			</classification>
+		</xsl:for-each>
+		<xsl:for-each
+			select="marc:subfield[@code='a'][not(following-sibling::marc:subfield[@code='b'])]">
+			<classification authority="lcc">
+				<xsl:call-template name="xxx880"/>
+				<xsl:if test="../marc:subfield[@code='3']">
+					<xsl:attribute name="displayLabel">
+						<xsl:value-of select="../marc:subfield[@code='3']"/>
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:value-of select="text()"/>
+			</classification>
+		</xsl:for-each>
+	</xsl:template>
+	<xsl:template name="createClassificationFrom060">
+		<classification authority="nlm">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">ab</xsl:with-param>
+			</xsl:call-template>
+		</classification>
+	</xsl:template>
+	<xsl:template name="createClassificationFrom080">
+		<classification authority="udc">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">abx</xsl:with-param>
+			</xsl:call-template>
+		</classification>
+	</xsl:template>
+	<xsl:template name="createClassificationFrom082">
+		<classification authority="ddc">
+			<xsl:call-template name="xxx880"/>
+			<xsl:if test="marc:subfield[@code='2']">
+				<xsl:attribute name="edition">
+					<xsl:value-of select="marc:subfield[@code='2']"/>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">ab</xsl:with-param>
+			</xsl:call-template>
+		</classification>
+	</xsl:template>
+	<xsl:template name="createClassificationFrom084">
+		<classification>
+			<xsl:attribute name="authority">
+				<xsl:value-of select="marc:subfield[@code='2']"/>
+			</xsl:attribute>
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">ab</xsl:with-param>
+			</xsl:call-template>
+		</classification>
+	</xsl:template>
+	<xsl:template name="createClassificationFrom086">
+		<xsl:for-each select="marc:datafield[@tag=086][@ind1=0]">
+			<classification authority="sudocs">
+				<xsl:call-template name="xxx880"/>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</classification>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=086][@ind1=1]">
+			<classification authority="candoc">
+				<xsl:call-template name="xxx880"/>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</classification>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=086][@ind1!=1 and @ind1!=0]">
+			<classification>
+				<xsl:call-template name="xxx880"/>
+				<xsl:attribute name="authority">
+					<xsl:value-of select="marc:subfield[@code='2']"/>
+				</xsl:attribute>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</classification>
+		</xsl:for-each>
+	</xsl:template>
+
+	<!-- identifier 020 024 022 028 010 037 UNDO Nov 23 2010 RG SM-->
+
+	<!-- createRelatedItemFrom490 <xsl:for-each select="marc:datafield[@tag=490][@ind1=0]"> -->
+
+	<xsl:template name="createRelatedItemFrom490">
+		<relatedItem type="series">
+			<xsl:call-template name="xxx880"/>
+			<titleInfo>
+				<title>
+					<xsl:call-template name="chopPunctuation">
+						<xsl:with-param name="chopString">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">av</xsl:with-param>
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+				</title>
+				<xsl:call-template name="part"/>
+			</titleInfo>
+		</relatedItem>
+	</xsl:template>
+
+
+	<!-- location 852 856 -->
+
+	<xsl:template name="createLocationFrom852">
+		<location>
+			<xsl:if test="marc:subfield[@code='a' or @code='b' or @code='e']">
+				<physicalLocation>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">abe</xsl:with-param>
+					</xsl:call-template>
+				</physicalLocation>
+			</xsl:if>
+			<xsl:if test="marc:subfield[@code='u']">
+				<physicalLocation>
+					<xsl:call-template name="uri"/>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">u</xsl:with-param>
+					</xsl:call-template>
+				</physicalLocation>
+			</xsl:if>
+			<!-- 1.78 -->
+			<xsl:if
+				test="marc:subfield[@code='h' or @code='i' or @code='j' or @code='k' or @code='l' or @code='m' or @code='t']">
+				<shelfLocator>
+					<xsl:call-template name="subfieldSelect">
+						<xsl:with-param name="codes">hijklmt</xsl:with-param>
+					</xsl:call-template>
+				</shelfLocator>
+			</xsl:if>
+		</location>
+	</xsl:template>
+
+	<xsl:template name="createLocationFrom856">
+		<xsl:if test="//marc:datafield[@tag=856][@ind2!=2][marc:subfield[@code='u']]">
+			<location>
+				<url displayLabel="electronic resource">
+					<!-- 1.41 tmee AQ1.9 added choice protocol for @usage="primary display" -->
+					<xsl:variable name="primary">
+						<xsl:choose>
+							<xsl:when
+								test="@ind2=0 and count(preceding-sibling::marc:datafield[@tag=856] [@ind2=0])=0"
+								>true</xsl:when>
+
+							<xsl:when
+								test="@ind2=1 and
+							count(ancestor::marc:record//marc:datafield[@tag=856][@ind2=0])=0 and
+							count(preceding-sibling::marc:datafield[@tag=856][@ind2=1])=0"
+								>true</xsl:when>
+
+							<xsl:when
+								test="@ind2!=1 and @ind2!=0 and
+							@ind2!=2 and count(ancestor::marc:record//marc:datafield[@tag=856 and
+							@ind2=0])=0 and count(ancestor::marc:record//marc:datafield[@tag=856 and
+							@ind2=1])=0 and
+							count(preceding-sibling::marc:datafield[@tag=856][@ind2])=0"
+								>true</xsl:when>
+							<xsl:otherwise>false</xsl:otherwise>
+						</xsl:choose>
+					</xsl:variable>
+					<xsl:if test="$primary='true'">
+						<xsl:attribute name="usage">primary display</xsl:attribute>
+					</xsl:if>
+
+					<xsl:if test="marc:subfield[@code='y' or @code='3']">
+						<xsl:attribute name="displayLabel">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">y3</xsl:with-param>
+							</xsl:call-template>
+						</xsl:attribute>
+					</xsl:if>
+					<xsl:if test="marc:subfield[@code='z']">
+						<xsl:attribute name="note">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">z</xsl:with-param>
+							</xsl:call-template>
+						</xsl:attribute>
+					</xsl:if>
+					<xsl:value-of select="marc:subfield[@code='u']"/>
+				</url>
+			</location>
+		</xsl:if>
+	</xsl:template>
+
+	<!-- accessCondition 506 540 1.87 20130829-->
+
+	<xsl:template name="createAccessConditionFrom506">
+		<accessCondition type="restriction on access">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">abcd35</xsl:with-param>
+			</xsl:call-template>
+		</accessCondition>
+	</xsl:template>
+
+	<xsl:template name="createAccessConditionFrom540">
+		<accessCondition type="use and reproduction">
+			<xsl:call-template name="xxx880"/>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">abcde35</xsl:with-param>
+			</xsl:call-template>
+		</accessCondition>
+	</xsl:template>
+
+	<!-- recordInfo 040 005 001 003 -->
+
+	<!-- 880 global copy template -->
+	<xsl:template match="* | @*" mode="global_copy">
+		<xsl:copy>
+			<xsl:apply-templates select="* | @* | text()" mode="global_copy"/>
+		</xsl:copy>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/Kitodo-XML-SchemaConverter/src/test/java/org/kitodo/xmlschemaconverter/XmlSchemaConverterTest.java
+++ b/Kitodo-XML-SchemaConverter/src/test/java/org/kitodo/xmlschemaconverter/XmlSchemaConverterTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -32,7 +31,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.kitodo.api.schemaconverter.DataRecord;
@@ -51,14 +49,6 @@ public class XmlSchemaConverterTest {
     private static final XMLSchemaConverter converter = new XMLSchemaConverter();
     private static final String MODS_TEST_FILE_PATH = "src/test/resources/modsXmlTestRecord.xml";
     private static final String MARC_TEST_FILE_PATH = "src/test/resources/marcXmlTestRecord.xml";
-
-    @AfterClass
-    public static void tearDown() {
-        File xslt = new File ("src/main/resources/xslt/marc21slim2mods.xsl");
-        if (xslt.exists()) {
-            xslt.delete();
-        }
-    }
 
     @Test
     public void shouldConvertModsToInternalFormat() throws IOException, ParserConfigurationException, SAXException,


### PR DESCRIPTION
Alternative solution to #5451 that also fixes #5449 

In contrast to #5451 this pull request does not add the Java files auto generated by the `mets.xsd` and `kitodo.xsd` schema definitions to the repository, but instead adds the METS and XLINK schema files and themselves.

Also adds the files `marc21slim2mods.xsl` and `MARC21slimUtils.xsl` to the repository which are required by a test case.

Both approaches - this pull request as well as #5451 - resolve the need to download resources from loc.gov during builds and therefor fix the linked issue.