### PR TITLE
Fix async export

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -263,8 +263,7 @@ public class ExportDms extends ExportMets {
         }
 
         // export the file to the import folder
-        asyncExportWithImport(process, gdzfile, destination);
-        return true;
+        return asyncExportWithImport(process, gdzfile, destination);
     }
 
     private boolean executeDataCopierProcess(LegacyMetsModsDigitalDocumentHelper gdzfile, Process process) {
@@ -312,18 +311,20 @@ public class ExportDms extends ExportMets {
         }
     }
 
-    private void asyncExportWithImport(Process process, LegacyMetsModsDigitalDocumentHelper gdzfile, URI userHome)
+    private boolean asyncExportWithImport(Process process, LegacyMetsModsDigitalDocumentHelper gdzfile, URI userHome)
             throws IOException, DAOException {
 
         String atsPpnBand = Helper.getNormalizedTitle(process.getTitle());
         if (Objects.nonNull(exportDmsTask)) {
             exportDmsTask.setWorkDetail(atsPpnBand + ".xml");
         }
-        writeMetsFile(process, fileService.createResource(userHome, File.separator + atsPpnBand + ".xml"), gdzfile);
+        boolean metsFileWrittenSuccesful = writeMetsFile(process, fileService.createResource(userHome,
+                File.separator + atsPpnBand + ".xml"), gdzfile);
 
         if (Objects.nonNull(exportDmsTask)) {
             exportDmsTask.setProgress(100);
         }
+        return metsFileWrittenSuccesful;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -63,11 +63,17 @@ public class ExportDms extends ExportMets {
 
     private boolean exportWithImages = true;
 
+    private Task workFlowTask;
+
     public ExportDms() {
     }
 
     public ExportDms(boolean exportImages) {
         this.exportWithImages = exportImages;
+    }
+
+    public ExportDms(Task workFlowTask) {
+        this.workFlowTask = workFlowTask;
     }
 
     /**
@@ -130,7 +136,7 @@ public class ExportDms extends ExportMets {
             TaskManager.addTask(new ExportDmsTask(this, process));
             Helper.setMessage(TaskSitter.isAutoRunningThreads() ? "DMSExportByThread" : "DMSExportThreadCreated",
                 process.getTitle());
-            return true;
+            return false;
         } else {
             return startExport(process, (ExportDmsTask) null);
         }
@@ -328,6 +334,26 @@ public class ExportDms extends ExportMets {
     public EmptyTask getExportDmsTask() {
         return exportDmsTask;
     }
+
+    /**
+     * Get workflowTask.
+     *
+     * @return value of workFlowTask
+     */
+    public Task getWorkflowTask() {
+        return workFlowTask;
+    }
+
+    /**
+     * Set workflowTask.
+     *
+     * @param workFlowTask
+     *              the workflow stask associated with the export
+     */
+    public void setWorkflowTask(Task workFlowTask) {
+       this.workFlowTask = workFlowTask;
+    }
+
 
     /**
      * Setter method to pass in a task thread to whom progress and error messages

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -352,7 +352,7 @@ public class ExportDms extends ExportMets {
      *              the workflow stask associated with the export
      */
     public void setWorkflowTask(Task workFlowTask) {
-       this.workFlowTask = workFlowTask;
+        this.workFlowTask = workFlowTask;
     }
 
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
@@ -162,7 +162,6 @@ public class DesktopForm extends BaseForm {
     public void exportMets(int processId) {
         try {
             ProcessService.exportMets(processId);
-            Helper.setMessage(EXPORT_FINISHED);
         } catch (DAOException | DataException | IOException e) {
             Helper.setErrorMessage("An error occurred while trying to export METS file for process "
                     + processId, logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
@@ -369,7 +369,6 @@ public class ProcessListBaseView extends BaseForm {
             try {
 
                 export.startExport(processToExport);
-                Helper.setMessage(EXPORT_FINISHED);
             } catch (DataException e) {
                 Helper.setErrorMessage(ERROR_EXPORTING,
                         new Object[] {ObjectType.PROCESS.getTranslationSingular(), processToExport.getId() }, logger, e);
@@ -441,7 +440,6 @@ public class ProcessListBaseView extends BaseForm {
     public void exportMets(int processId) {
         try {
             ProcessService.exportMets(processId);
-            Helper.setMessage(EXPORT_FINISHED);
         } catch (DAOException | DataException | IOException e) {
             Helper.setErrorMessage("An error occurred while trying to export METS file for process "
                     + processId, logger, e);
@@ -455,7 +453,6 @@ public class ProcessListBaseView extends BaseForm {
         ExportDms export = new ExportDms();
         try {
             export.startExport(ServiceManager.getProcessService().getById(id));
-            Helper.setMessage(EXPORT_FINISHED);
         } catch (DataException e) {
             Helper.setErrorMessage(ERROR_EXPORTING,
                     new Object[] {ObjectType.PROCESS.getTranslationSingular(), id }, logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
@@ -11,8 +11,14 @@
 
 package org.kitodo.production.helper.tasks;
 
+import java.io.IOException;
+import java.util.Objects;
+
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
 import org.kitodo.export.ExportDms;
+import org.kitodo.production.services.workflow.WorkflowControllerService;
 
 /**
  * The class ExportDmsTask accepts an {@link org.kitodo.export.ExportDms} for a
@@ -62,9 +68,12 @@ public class ExportDmsTask extends EmptyTask {
     @Override
     public void run() {
         try {
-            exportDms.startExport(process, this);
+            boolean exportSuccessful = exportDms.startExport(process, this);
             setProgress(100);
-        } catch (RuntimeException e) {
+            if (Objects.nonNull(exportDms.getWorkflowTask()) && exportSuccessful) {
+                new WorkflowControllerService().close(exportDms.getWorkflowTask());
+            }
+        } catch (RuntimeException | DataException | IOException | DAOException e) {
             setException(e);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
@@ -69,8 +69,8 @@ public class ExportDmsTask extends EmptyTask {
     public void run() {
         try {
             boolean exportSuccessful = exportDms.startExport(process, this);
-            setProgress(100);
             if (Objects.nonNull(exportDms.getWorkflowTask()) && exportSuccessful) {
+                setProgress(100);
                 new WorkflowControllerService().close(exportDms.getWorkflowTask());
             }
         } catch (RuntimeException | DataException | IOException | DAOException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -613,7 +613,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
      *            as Task object
      */
     public void executeDmsExport(Task task) throws DataException, IOException, DAOException {
-        new ExportDms().startExport(task);
+        new ExportDms(task).startExport(task);
     }
 
     /**


### PR DESCRIPTION
resolves https://github.com/kitodo/kitodo-production/issues/5481
resolves https://github.com/kitodo/kitodo-production/issues/5008

This pull request tries to adress the problems outlined in the above issue by
- not immediatly indicating a succesful export in case of an asynchronous export and prevent closing a workflow step  after a failed automatic export
- ensuring that the export status is correctly propagated through all the method calls involved
- removing the static "export finished" message from the Desktop and Process list form to ensure that a success message is only displayed in case of an actual succesful export