### PR TITLE
Activate 'Search' button when search field and term are not empty

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -242,6 +242,8 @@ public class ImportService {
             return Helper.getTranslation("recordId");
         } else if (Objects.nonNull(importConfiguration.getDefaultSearchField())) {
             return importConfiguration.getDefaultSearchField().getLabel();
+        } else if (!importConfiguration.getSearchFields().isEmpty()) {
+            return importConfiguration.getSearchFields().get(0).getLabel();
         }
         return "";
     }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
@@ -66,7 +66,8 @@
                                          required="#{not empty param['catalogSearchForm:performCatalogSearch']}"
                                          value="#{CreateProcessForm.catalogImportDialog.hitModel.selectedField}">
                             <f:selectItems value="#{CreateProcessForm.catalogImportDialog.searchFields}" var="field"/>
-                            <p:ajax update="catalogSearchForm:catalogSearchButton"/>
+                            <p:ajax update="catalogSearchForm:searchTerm
+                                            catalogSearchForm:catalogSearchButton"/>
                         </p:selectOneMenu>
                     </div>
                     <div>
@@ -94,7 +95,10 @@
                                      value="#{CreateProcessForm.catalogImportDialog.hitModel.searchTerm}"
                                      class="input"
                                      placeholder="#{msgs['newProcess.catalogueSearch.searchTerm']}"
-                                     required="#{not empty param['catalogSearchForm:performCatalogSearch']}"/>
+                                     required="#{not empty param['catalogSearchForm:performCatalogSearch']}">
+                            <p:ajax event="keyup"
+                                    update="catalogSearchForm:catalogSearchButton"/>
+                        </p:inputText>
                     </div>
                     <div>
                         <p:outputLabel id="importChildrenLabel"
@@ -111,7 +115,7 @@
             <h:panelGroup layout="block"
                           id="catalogSearchButton">
                 <p:commandButton id="performCatalogSearch"
-                                 disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration or empty CreateProcessForm.catalogImportDialog.hitModel.selectedField}"
+                                 disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration or empty CreateProcessForm.catalogImportDialog.hitModel.selectedField or empty CreateProcessForm.catalogImportDialog.hitModel.searchTerm}"
                                  action="#{CreateProcessForm.catalogImportDialog.search}"
                                  value="#{msgs.searchOPAC}"
                                  title="#{msgs.searchOPAC}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
@@ -98,6 +98,7 @@
                                      required="#{not empty param['catalogSearchForm:performCatalogSearch']}">
                             <p:ajax event="keyup"
                                     update="catalogSearchForm:catalogSearchButton"/>
+                            <p:ajax update="catalogSearchForm:catalogSearchButton"/>
                         </p:inputText>
                     </div>
                     <div>

--- a/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
@@ -11,9 +11,13 @@
 
 package org.kitodo.selenium;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
@@ -68,6 +72,24 @@ public class ImportingST extends BaseTestSelenium {
         Select searchFieldSelectMenu = new Select(importPage.getSearchFieldMenu());
         assertEquals("Wrong default search field selected", PPN,
                 searchFieldSelectMenu.getFirstSelectedOption().getAttribute("label"));
+    }
+
+    /**
+     * Checks whether 'Search' button is properly deactivated until import configuration, search field
+     * and search term have been selected/entered.
+     * @throws Exception when navigating to 'Create new process' page fails.
+     */
+    @Test
+    public void checkSearchButtonActivatedText() throws Exception {
+        projectsPage.createNewProcess();
+        assertFalse("'Search' button should be deactivated until import configuration, search field and " +
+                "search term have been selected", importPage.getSearchButton().isEnabled());
+        importPage.enterTestSearchValue();
+        await("Wait for 'Search' button to be enabled").pollDelay(700, TimeUnit.MILLISECONDS)
+                .atMost(30, TimeUnit.SECONDS).ignoreExceptions()
+                .until(() -> importPage.getSearchButton().isEnabled());
+        assertTrue("'Search' button should be activated when import configuration, search field and " +
+                "search term have been selected", importPage.getSearchButton().isEnabled());
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
@@ -82,14 +82,14 @@ public class ImportingST extends BaseTestSelenium {
     @Test
     public void checkSearchButtonActivatedText() throws Exception {
         projectsPage.createNewProcess();
-        assertFalse("'Search' button should be deactivated until import configuration, search field and " +
-                "search term have been selected", importPage.getSearchButton().isEnabled());
+        assertFalse("'Search' button should be deactivated until import configuration, search field and "
+                + "search term have been selected", importPage.getSearchButton().isEnabled());
         importPage.enterTestSearchValue();
         await("Wait for 'Search' button to be enabled").pollDelay(700, TimeUnit.MILLISECONDS)
                 .atMost(30, TimeUnit.SECONDS).ignoreExceptions()
                 .until(() -> importPage.getSearchButton().isEnabled());
-        assertTrue("'Search' button should be activated when import configuration, search field and " +
-                "search term have been selected", importPage.getSearchButton().isEnabled());
+        assertTrue("'Search' button should be activated when import configuration, search field and "
+                + "search term have been selected", importPage.getSearchButton().isEnabled());
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -122,6 +122,14 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
     }
 
     /**
+     * Get 'Search' button.
+     * @return 'Search' button as WebElement.
+     */
+    public WebElement getSearchButton() {
+        return Browser.getDriver().findElementById(OPAC_SEARCH_FORM + ":performCatalogSearch");
+    }
+
+    /**
      * Select GBV catalog.
      * @throws InterruptedException when thread is interrupted
      */
@@ -268,6 +276,13 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
         String generatedTitle = processTitleInput.getAttribute("value");
         save();
         return generatedTitle;
+    }
+
+    /**
+     * Enter test value into search term field.
+     */
+    public void enterTestSearchValue() {
+        searchTermInput.sendKeys("12345");
     }
 
     public ProcessesPage save() throws IllegalAccessException, InstantiationException {


### PR DESCRIPTION
Fixes #5485 

This was caused by removing the 'no selection option' in #5430 without preselcting a valid 'Search field' option for import configurations without default search field configured!