### PR TITLE
Remove unsupported context params

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -23,18 +23,8 @@
     </context-param>
 
     <context-param>
-        <param-name>org.apache.myfaces.ALLOW_JAVASCRIPT</param-name>
-        <param-value>true</param-value>
-    </context-param>
-
-    <context-param>
         <param-name>org.apache.myfaces.DETECT_JAVASCRIPT</param-name>
         <param-value>false</param-value>
-    </context-param>
-
-    <context-param>
-        <param-name>org.apache.myfaces.PRETTY_HTML</param-name>
-        <param-value>true</param-value>
     </context-param>
 
     <context-param>


### PR DESCRIPTION
The configured MyFaces context parameters "ALLOW_JAVASCRIPT" and "PRETTY_HTML" was removed with at least MyFaces 2.3.x and causing severe / crit log messages in catalina.out like

```
[crit] 'org.apache.myfaces.ALLOW_JAVASCRIPT' is not supported anymore.
[crit] 'org.apache.myfaces.PRETTY_HTML' is not supported anymore. 
```

This pull request remove the unsupported params.

Edit: Support long removed and warning was added by https://github.com/apache/myfaces/pull/81