### PR TITLE
Add 'strict' mode to let metadata validation fail on warnings

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -375,6 +375,11 @@ public enum ParameterCore implements ParameterInterface {
     VALIDATE_IDENTIFIER_REGEX(new Parameter<>("validateIdentifierRegex", "[\\w|-]")),
 
     /**
+     * Flag to control whether metadata validation should fail on warnings or just on errors.
+     */
+    VALIDATION_FAIL_ON_WARNING(new Parameter<>("validationFailOnWarning", false)),
+
+    /**
      * Colours used to represent the issues in the calendar editor.
      */
     ISSUE_COLOURS(new Parameter<>("issue.colours",

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -179,13 +179,19 @@ public class WorkflowControllerService {
                 ConfigCore.getParameter(ParameterCore.DIR_RULESETS),
                 task.getProcess().getRuleset().getFile()).toString()));
         ValidationResult validationResult = ServiceManager.getMetadataValidationService().validate(workpiece, ruleset);
-        if (State.ERROR.equals(validationResult.getState())) {
+        boolean strictValidation = ConfigCore.getBooleanParameter(ParameterCore.VALIDATION_FAIL_ON_WARNING);
+        State state = validationResult.getState();
+        if (State.ERROR.equals(state) || (strictValidation && !State.SUCCESS.equals(state))) {
             Helper.setErrorMessage(Helper.getTranslation("dataEditor.validation.state.error"));
             for (String message : validationResult.getResultMessages()) {
                 Helper.setErrorMessage(message);
             }
         }
-        return !validationResult.getState().equals(State.ERROR);
+        if (strictValidation) {
+            return State.SUCCESS.equals(state);
+        } else {
+            return !State.ERROR.equals(state);
+        }
     }
 
     /**

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -728,6 +728,9 @@ LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
 LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
 LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING
 
+# Controls whether metadata validation should fail on warnings ("true") or just on errors ("false")
+validationFailOnWarning=true
+
 file.maxWaitMilliseconds=150000
 
 # Default client parameter to be returned if no session client could be determined by user service.


### PR DESCRIPTION
The changes in this PR are based on adjustments made by @henning-gerhardt to allow validation to fail not just on `ERROR`s, but also on `WARNING`s. It also adds a new boolean parameter `validationFailOnWarning` to the file `kitodo_config.properties` to make this behaviour configurable, thus introducing a `strict` validation made.