### PR TITLE
Update to latest chrome version

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -33,8 +33,6 @@ public class WebDriverProvider {
     private static final Logger logger = LogManager.getLogger(WebDriverProvider.class);
 
     // https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
-    // Please don't rely on the LATEST_RELEASE file without a version suffix.
-    // It exists for backward compatibility only, and will be removed in the near future.
     private static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE";
 
     private static UnArchiver zipUnArchiver = new ZipUnArchiver();

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -35,7 +35,7 @@ public class WebDriverProvider {
     // https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
     // Please don't rely on the LATEST_RELEASE file without a version suffix.
     // It exists for backward compatibility only, and will be removed in the near future.
-    private static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_108";
+    private static final String CHROME_DRIVER_LATEST_RELEASE_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE";
 
     private static UnArchiver zipUnArchiver = new ZipUnArchiver();
     private static UnArchiver tarGZipUnArchiver = new TarGZipUnArchiver();


### PR DESCRIPTION
This fix avoids the permanent adjustment of the Chrome version. The CI workflow always seems to use the latest version of the Chrome browser. 