### PR TITLE
Enable client side validation in Create Process form

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -55,7 +55,7 @@
                     <p:inputText id="inputText"
                                  value="#{item.value}"
                                  disabled="#{not item.editable or readOnly}"
-                                 required="#{request.requestURI.contains('metadataEditor') and item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                                 required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                  styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
                         <p:ajax event="change" oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
                     </p:inputText>
@@ -68,7 +68,7 @@
                                      value="#{item.value}"
                                      rows="2"
                                      disabled="#{not item.editable or readOnly}"
-                                     required="#{request.requestURI.contains('metadataEditor') and item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                                     required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                      styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
                         <p:ajax event="change" oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
                     </p:inputTextarea>
@@ -80,7 +80,7 @@
                     <p:spinner id="spinner"
                                value="#{item.value}"
                                disabled="#{not item.editable or readOnly}"
-                               required="#{request.requestURI.contains('metadataEditor') and item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                               required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
                         <p:ajax event="change" oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
                     </p:spinner>
@@ -93,7 +93,7 @@
                                 pattern="yyyy-MM-dd"
                                 styleClass="input-with-button #{not item.editable or readOnly ? 'read-only disabled' : ''}"
                                 showOn="button"
-                                required="#{request.requestURI.contains('metadataEditor') and item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                                required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                 disabled="#{not item.editable or readOnly}">
                         <p:ajax event="dateSelect" oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
                     </p:calendar>
@@ -106,7 +106,7 @@
                                       readonly="#{not item.editable}"
                                       styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
                                       disabled="#{not item.editable or readOnly}"
-                                      required="#{request.requestURI.contains('metadataEditor') and item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                                      required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                       showCheckbox="true">
                         <f:selectItems value="#{item.items}"/>
                         <p:ajax event="change" oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
@@ -121,7 +121,7 @@
                                      readonly="#{not item.editable}"
                                      autoWidth="false"
                                      disabled="#{not item.editable or readOnly}"
-                                     required="#{request.requestURI.contains('metadataEditor') and item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
+                                     required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                      styleClass="#{readOnly ? 'read-only' : ''}">
                         <f:selectItem itemValue="#{null}"
                                       itemDisabled="#{item.required}"


### PR DESCRIPTION
resolves https://github.com/kitodo/kitodo-production/issues/3403

As discussed in the linked issue: The current behavior does not seem correct since no client side checking is ever performed during process creation for most field types. Apart from that: the current settings are not consistent since there is validation performed on radio buttons but not on normal text inputs.

My proposal would be to enforce that the user enters required values during process creation, to ensure that only valid processes are created.

I would prefer an even stricter validation on process creation (e.g. checking if the pattern of the field values conforms with the ruleset), but this would require more logic. So it would be good to prevent at least empty values on required fields. 

The implemented logic ensures that the client validation is only triggered during process creation, since the element with id `editForm` exists only in the page layout used during process creation:
`item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])`

My implementation reflects my understanding of the issue: There should probably be no enforced client side validation in the editor since that might prevent people from saving whose task is just about structuring the document but not working on the metadata for example. But this could be discussed as well since actually enforcing values in required fields prevents errors earlier in the workflow (although metadata validation is always executed during export)

@andre-hohmann 