### PR TITLE
Hide 'parent id' search field for custom interfaces

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/searchFieldRows.xhtml
@@ -139,7 +139,8 @@
                 <p:tooltip for="defaultSearchFieldHelp"
                            value="#{msgs['tooltip.importConfig.defaultSearchFieldHelp']}"/>
             </div>
-            <div>
+            <h:panelGroup layout="block"
+                          rendered="#{importConfigurationEditView.importConfiguration.interfaceType ne 'CUSTOM'}">
                 <p:outputLabel for="parentIdSearchField" value="#{msgs['importConfig.searchFields.parentIdField']}"/>
                 <p:selectOneMenu id="parentIdSearchField"
                                  styleClass="input-with-button"
@@ -155,7 +156,7 @@
                                  styleClass="help-button" icon="fa fa-lg fa-question-circle-o"/>
                 <p:tooltip for="parentIdSearchFieldHelp"
                            value="#{msgs['tooltip.importConfig.parentIdSearchFieldHelp']}"/>
-            </div>
+            </h:panelGroup>
         </p:row>
     </f:view>
 </ui:composition>


### PR DESCRIPTION
Since CUSTOM search interfaces currently only support adding one search field for queries by record ID, the "Parent record ID" search field configuration should not be displayed for Import Configurations with search interface type "CUSTOM".