### PR TITLE
Fix creation of query URL for custom interfaces without url parameters

### DIFF
--- a/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
+++ b/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
@@ -248,7 +248,10 @@ public class QueryURLImport implements ExternalDataImportInterface {
 
     private DataRecord performQueryToRecord(DataImport dataImport, String queryURL, String identifier)
             throws NoRecordFoundException {
-        String fullUrl = queryURL + AND;
+        String fullUrl = queryURL;
+        if (!dataImport.getUrlParameters().isEmpty()) {
+            fullUrl = fullUrl + AND;
+        }
         SearchInterfaceType interfaceType = dataImport.getSearchInterfaceType();
         if (Objects.nonNull(interfaceType)) {
             if (Objects.nonNull(interfaceType.getMaxRecordsString())) {


### PR DESCRIPTION
This PR contains a small fix that ensures search queries created using import configurations with search interfaces type CUSTOM generate URLs with correct syntax. Prevsiously, if CUSOM interfaces did not contain custom URL parameters, a superflous "`&`" character would be added right after the "`?`" character of the query, resulting in wrong URL syntax like this:

http://localhost:8080/path?&id=1234

The change in this PR fixes this by adding the `&` conditionally only when custom url parameters have been defined, thus fixing the URL above where no such url parameters are defined like this:

http://localhost:8080/path?id=1234

See https://github.com/kitodo/kitodo-production/discussions/5508#discussioncomment-4789776 for more details.