### PR TITLE
Fix import of files from FTP servers

### DIFF
--- a/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
+++ b/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
@@ -213,7 +213,7 @@ public class QueryURLImport implements ExternalDataImportInterface {
         }
     }
 
-    private DataRecord performFTPQueryToRecord(DataImport dataImport, String identifier) {
+    private DataRecord performFTPQueryToRecord(DataImport dataImport, String filename) {
         if (StringUtils.isBlank(dataImport.getHost()) || StringUtils.isBlank(dataImport.getPath())) {
             throw new CatalogException("Missing host or path configuration for FTP import in OPAC configuration "
                     + "for import configuration '" + dataImport.getTitle() + "'");
@@ -224,12 +224,16 @@ public class QueryURLImport implements ExternalDataImportInterface {
         }
         try {
             ftpLogin(dataImport);
-            InputStream inputStream = ftpClient.retrieveFileStream(dataImport.getPath() + "/" + identifier);
+            String filepath = dataImport.getPath() + "/" + filename;
+            InputStream inputStream = ftpClient.retrieveFileStream(filepath);
+            if (Objects.isNull(inputStream)) {
+                throw new CatalogException("Unable to load file '" + filepath + "' from configured FTP source!");
+            }
             String stringContent = IOUtils.toString(inputStream, Charset.defaultCharset());
             inputStream.close();
             DataRecord dataRecord = createRecordFromXMLElement(dataImport, stringContent);
             if (!ftpClient.completePendingCommand()) {
-                throw new CatalogException("Unable to import '" + identifier + "'!");
+                throw new CatalogException("Unable to import '" + filename + "'!");
             }
             ftpLogout();
             return dataRecord;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -254,15 +254,17 @@ public class ImportService {
     /**
      * Check and return whether to skip hit list for given ImportConfiguration and search field or not.
      * Hit list is skipped either if SearchInterfaceType of given ImportConfiguration does not support
-     * hit lists (e.g. OAI and FTP interfaces) or if the provides search field equals the ID search field
-     * of the given ImportConfiguration.
+     * hit lists (e.g. OAI interfaces in their current implementation) or if the provided search field
+     * equals the ID search field of the given ImportConfiguration.
      * @param configuration ImportConfiguration to check
      * @param field value of SearchField to check
      * @return whether to skip hit list or not
      */
     public static boolean skipHitlist(ImportConfiguration configuration, String field) {
-        if (SearchInterfaceType.OAI.name().equals(configuration.getInterfaceType())
-                || SearchInterfaceType.FTP.name().equals(configuration.getInterfaceType())
+        if (SearchInterfaceType.FTP.name().equals(configuration.getInterfaceType())) {
+            return false;
+        }
+        else if (SearchInterfaceType.OAI.name().equals(configuration.getInterfaceType())
                 || field.equals(configuration.getIdSearchField().getLabel())) {
             return true;
         }

--- a/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/ImportServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/ImportServiceTest.java
@@ -21,23 +21,23 @@ import org.kitodo.production.services.data.ImportService;
 public class ImportServiceTest {
 
     /**
-     * Test whether hit list is properly skipped for FTP type import configurations.
+     * Test whether hit list is properly skipped for OAI type import configurations.
      */
     @Test
-    public void shouldSkipHitListForFtpImportConfiguration() {
-        ImportConfiguration ftpConfiguration = createFtpImportConfiguration();
-        Assert.assertTrue("'Skip hit list' should return 'true' for FTP configurations",
+    public void shouldSkipHitListForOaiImportConfiguration() {
+        ImportConfiguration ftpConfiguration = createOaiImportConfiguration();
+        Assert.assertTrue("'Skip hit list' should return 'true' for OAI configurations",
                 ImportService.skipHitlist(ftpConfiguration, null));
     }
 
     /**
-     * Create and return an ImportConfiguration with configuration type `OPAC_SEARCH` and search interface type 'FTP'.
+     * Create and return an ImportConfiguration with configuration type `OPAC_SEARCH` and search interface type 'OAI'.
      */
-    private ImportConfiguration createFtpImportConfiguration() {
+    private ImportConfiguration createOaiImportConfiguration() {
         ImportConfiguration genericFtpConfiguration = new ImportConfiguration();
-        genericFtpConfiguration.setTitle("FTP example configuration");
+        genericFtpConfiguration.setTitle("OAI example configuration");
         genericFtpConfiguration.setConfigurationType(ImportConfigurationType.OPAC_SEARCH.name());
-        genericFtpConfiguration.setInterfaceType(SearchInterfaceType.FTP.name());
+        genericFtpConfiguration.setInterfaceType(SearchInterfaceType.OAI.name());
         return genericFtpConfiguration;
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/ImportServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/ImportServiceTest.java
@@ -25,19 +25,32 @@ public class ImportServiceTest {
      */
     @Test
     public void shouldSkipHitListForOaiImportConfiguration() {
-        ImportConfiguration ftpConfiguration = createOaiImportConfiguration();
+        ImportConfiguration oaiConfiguration = createImportConfiguration(SearchInterfaceType.OAI);
         Assert.assertTrue("'Skip hit list' should return 'true' for OAI configurations",
+                ImportService.skipHitlist(oaiConfiguration, null));
+    }
+
+    /**
+     * Test whether hit list is not skipped for FTP type import configurations.
+     */
+    @Test
+    public void shouldNotSkipHitListForFtpImportConfiguration() {
+        ImportConfiguration ftpConfiguration = createImportConfiguration(SearchInterfaceType.FTP);
+        Assert.assertFalse("'Skip hit list' should return 'false' for FTP configurations",
                 ImportService.skipHitlist(ftpConfiguration, null));
     }
 
     /**
      * Create and return an ImportConfiguration with configuration type `OPAC_SEARCH` and search interface type 'OAI'.
+     *
+     * @param interfaceType as SearchInterfaceType
      */
-    private ImportConfiguration createOaiImportConfiguration() {
+    private ImportConfiguration createImportConfiguration(SearchInterfaceType interfaceType) {
+        String interfaceTypeName = interfaceType.name();
         ImportConfiguration genericFtpConfiguration = new ImportConfiguration();
-        genericFtpConfiguration.setTitle("OAI example configuration");
+        genericFtpConfiguration.setTitle(interfaceTypeName + " example configuration");
         genericFtpConfiguration.setConfigurationType(ImportConfigurationType.OPAC_SEARCH.name());
-        genericFtpConfiguration.setInterfaceType(SearchInterfaceType.OAI.name());
+        genericFtpConfiguration.setInterfaceType(interfaceTypeName);
         return genericFtpConfiguration;
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/ImportServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/ImportServiceTest.java
@@ -41,16 +41,17 @@ public class ImportServiceTest {
     }
 
     /**
-     * Create and return an ImportConfiguration with configuration type `OPAC_SEARCH` and search interface type 'OAI'.
+     * Create and return an ImportConfiguration with configuration type `OPAC_SEARCH` and given search interface type.
      *
      * @param interfaceType as SearchInterfaceType
+     * @return ImportConfiguration of given SearchInterfaceType
      */
     private ImportConfiguration createImportConfiguration(SearchInterfaceType interfaceType) {
         String interfaceTypeName = interfaceType.name();
-        ImportConfiguration genericFtpConfiguration = new ImportConfiguration();
-        genericFtpConfiguration.setTitle(interfaceTypeName + " example configuration");
-        genericFtpConfiguration.setConfigurationType(ImportConfigurationType.OPAC_SEARCH.name());
-        genericFtpConfiguration.setInterfaceType(interfaceTypeName);
-        return genericFtpConfiguration;
+        ImportConfiguration genericConfiguration = new ImportConfiguration();
+        genericConfiguration.setTitle(interfaceTypeName + " example configuration");
+        genericConfiguration.setConfigurationType(ImportConfigurationType.OPAC_SEARCH.name());
+        genericConfiguration.setInterfaceType(interfaceTypeName);
+        return genericConfiguration;
     }
 }


### PR DESCRIPTION
This PR fixes a bug where using a partial filename to retrieve files via an FTP interfaces did not work because hitlist generation and file filter by substring search were wrongly disabled for FTP interfaces.