### PR TITLE
Update Chrome to latest stable version in workflow main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,13 @@ jobs:
     runs-on: ubuntu-20.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: update chrome to latest stable 
+        run: |
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+          sudo apt-get update
+          sudo apt-get --only-upgrade install google-chrome-stable
+    
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Update Chrome to latest stable version using the Google's sources. Chrome in the Ubuntu packages is not updated as fast and from time to time has an older version than the latest Chrome driver supports.

Updating chrome version of packages does not work cause latest stable version is 110.xxx atm.
```
Run sudo apt-get -y install google-chrome-stable
Reading package lists...
Building dependency tree...
Reading state information...
google-chrome-stable is already the newest version (109.0.5414.119-1).
0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
```

Updating using `browser-actions/setup-chrome@v1` action does not worked for me, cause selenium uses native chrome version which is not updated hereby.
