### PR TITLE
Avoid duplication of metadata groups while adding new metadata fields

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -238,6 +238,8 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
         Collection<Metadata> entered = addLabels(new HashSet<>(metadata));
         if (Objects.nonNull(treeNode) && !treeNode.getChildren().isEmpty()) {
             try {
+                entered = entered.stream().filter(metadataElem -> !(metadataElem instanceof MetadataGroup))
+                        .collect(Collectors.toSet());
                 entered.addAll(DataEditorService.getExistingMetadataRows(treeNode.getChildren()));
             } catch (InvalidMetadataValueException e) {
                 logger.error(e.getLocalizedMessage());


### PR DESCRIPTION
Resolves [5484](https://github.com/kitodo/kitodo-production/issues/5484)

As outlined in the issue: existing metadata groups are added twice to the list of metadata elements when new elements are added to the list. This PR addresses this by explicitely removing the metadata groups which have the empty elements filtered out before the existing groups are reconstructed from the tree (including their empty values).