### PR TITLE
Keep ID url parameter when reloading page after script execution

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -55,12 +55,12 @@
                     </h:panelGroup>
 
                     <!-- Script-button -->
-                    <h:commandLink id="executeScript"
+                    <p:commandLink id="executeScript"
                                    rendered="#{task.scriptPath != null and task.scriptPath != '' and task.process.blockedUser == null}"
                                    action="#{CurrentTaskForm.executeScript}" title="#{task.scriptName}">
                         <f:setPropertyActionListener target="#{CurrentTaskForm.scriptPath}" value="#{task.scriptPath}"/>
                         <h:outputText><i class="fa fa-cogs"/> #{msgs.scriptExecute}: #{task.scriptName}</h:outputText>
-                    </h:commandLink>
+                    </p:commandLink>
 
                     <!-- tiffHeaderDownload-button -->
                     <h:commandLink id="downloadTiffHeader" rendered="#{0==1 and process.blockedUser == null}"


### PR DESCRIPTION
URL parameters get lost when submitting a form and reloading the whole page without ajax. Since PrimeFaces command components use ajax by default, switching to the PrimeFaces variant of the `commandLink` used for script execution retains the current URL parameters including task ID and thus resolves the problem described in the linked issue.

Fixes #5552 