### PR TITLE
Fix maven warning by deleting doubled entry

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -278,10 +278,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
fixes: #5568 