### PR TITLE
Do not reset media resolver on metadata editor page reload

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -384,7 +384,9 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
         ruleset = null;
         currentChildren.clear();
         selectedMedia.clear();
-        mediaProvider.resetMediaResolverForProcess(process.getId());
+        if (!FacesContext.getCurrentInstance().isPostback()) {
+            mediaProvider.resetMediaResolverForProcess(process.getId());
+        }
         // do not unlock process if this locked process was opened by a different user opening editor
         // directly via URL bookmark and 'preDestroy' method was being triggered redirecting him to desktop page
         if (this.user.equals(MetadataLock.getLockUser(process.getId()))) {


### PR DESCRIPTION
Fixes #5566 

Solution details: since the Metadata editor is now `ViewScoped`, the `DataEditorForm` bean is destroyed and recreated when reloading the editor page. This triggers the `@preDestroy` annotated `close` method of the editor. This resets the media resolver for the current process, which is meant for when the user _exits_  the metadata editor, but not for when he _reloads_ it. 

Thus, this solution skips resetting the media resolver for the current process when a postback request is detected (which corresponds to page reloads). This might also improve performance of reloading processes with large amounts of images, though I have not verified this.