### PR TITLE
Prevent saved filters menu from overflowing page on page load

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -965,8 +965,9 @@ label.ui-outputlabel[for] {
 }
 
 #savedFilters\:savedFiltersOverlay {
-    width: 430px;
     border-radius: var(--default-border-radius);
+    margin-left: -430px; /* Make sure the overlay does not overflow the page when invisible. Gets repositioned when being displayed. */
+    width: 430px;
 }
 
 #savedFilters\:savedFiltersOverlay .ui-overlaypanel-content {


### PR DESCRIPTION
The overlay is hidden on page load but already rendered. It is place right of its anchor element, making it overflow the right edge of the page and creating a horizontal scroll bar.
By defining a large `margin-left` we can make sure it does not overflow the page when being hidden.
By default it is repositioned by PrimeFaces' javascript when it gets displayed, thus the `margin-left` has no visible impact on the overlay.