### PR TITLE
Fix the wrong ordering of the exported METS structLink section

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -23,7 +24,6 @@ import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.Comparator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -416,7 +417,11 @@ public class MetadataEditor {
         Collection<View> viewsToAdd = getViewsFromChildrenRecursive(structure);
         Collection<View> assignedViews = structure.getViews();
         viewsToAdd.removeAll(assignedViews);
-        assignedViews.addAll(viewsToAdd);
+        List<View> sortedViews = Stream.concat(assignedViews.stream(), viewsToAdd.stream())
+                .sorted(Comparator.comparing(view -> view.getPhysicalDivision().getOrder()))
+                .collect(Collectors.toList());
+        assignedViews.clear();
+        assignedViews.addAll(sortedViews);
     }
 
     private static Collection<View> getViewsFromChildrenRecursive(LogicalDivision structure) {


### PR DESCRIPTION
fixes https://github.com/kitodo/kitodo-production/issues/5554