### PR TITLE
Prevent NPE when creating unknown metadata group and metadata

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -578,16 +578,18 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
         assert division == null;
         MetadataGroup result = new MetadataGroup();
         result.setKey(metadataKey);
-        result.setDomain(DOMAIN_TO_MDSEC.get(metadataView.getDomain().orElse(Domain.DESCRIPTION)));
-        try {
-            this.preserve();
-        } catch (NoSuchMetadataFieldException e) {
-            throw new IllegalStateException("never happening exception");
-        }
-        if (skipEmpty) {
-            result.setMetadata(metadata instanceof List ? metadata : new HashSet<>(metadata));
-        } else {
-            result.setMetadata(new HashSet<>(DataEditorService.getExistingMetadataRows(treeNode.getChildren())));
+        if (Objects.nonNull(metadataView)) {
+            result.setDomain(DOMAIN_TO_MDSEC.get(metadataView.getDomain().orElse(Domain.DESCRIPTION)));
+            try {
+                this.preserve();
+            } catch (NoSuchMetadataFieldException e) {
+                throw new IllegalStateException("never happening exception");
+            }
+            if (skipEmpty) {
+                result.setMetadata(metadata instanceof List ? metadata : new HashSet<>(metadata));
+            } else {
+                result.setMetadata(new HashSet<>(DataEditorService.getExistingMetadataRows(treeNode.getChildren())));
+            }
         }
         return result.getMetadata().isEmpty() ? Collections.emptyList() : Collections.singletonList(result);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -43,7 +43,7 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
     }
 
     private String addLeadingZeros(String value) {
-        if (Objects.equals(super.settings.getInputType(), InputType.INTEGER)) {
+        if (Objects.nonNull(super.settings) && InputType.INTEGER.equals(super.settings.getInputType())) {
             int valueLength = value.length();
             int minDigits = super.settings.getMinDigits();
             return valueLength >= minDigits ? value : "0".repeat(minDigits - valueLength).concat(value);

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
@@ -139,13 +139,15 @@ public class DataEditorService {
         ProcessFieldedMetadata fieldedMetadata = ((ProcessFieldedMetadata) metadataNode.getData());
         ComplexMetadataViewInterface metadataView = fieldedMetadata.getMetadataView();
         List<SelectItem> addableMetadata = new ArrayList<>();
-        for (MetadataViewInterface keyView : metadataView.getAddableMetadata(fieldedMetadata.getChildMetadata(),
-                fieldedMetadata.getAdditionallySelectedFields())) {
-            addableMetadata.add(
-                    new SelectItem(keyView.getId(), keyView.getLabel(),
-                            keyView instanceof SimpleMetadataViewInterface
-                                    ? ((SimpleMetadataViewInterface) keyView).getInputType().toString()
-                                    : "dataTable"));
+        if (Objects.nonNull(metadataView)) {
+            for (MetadataViewInterface keyView : metadataView.getAddableMetadata(fieldedMetadata.getChildMetadata(),
+                    fieldedMetadata.getAdditionallySelectedFields())) {
+                addableMetadata.add(
+                        new SelectItem(keyView.getId(), keyView.getLabel(),
+                                keyView instanceof SimpleMetadataViewInterface
+                                        ? ((SimpleMetadataViewInterface) keyView).getInputType().toString()
+                                        : "dataTable"));
+            }
         }
         return sortMetadataList(addableMetadata, ruleset);
     }


### PR DESCRIPTION
This PR fixes #5217 by preventing the NullPointerException that is currently being displayed to the user when the import mapping xslt file creates a metadata group that is undefined in the used ruleset.