### PR TITLE
Don't complain required fields from an altogether empty metadata group

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
+import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
 import org.kitodo.api.dataformat.Division;
@@ -86,7 +87,10 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
     }
 
     public boolean isRequired() {
-		if (container != null && container.getChildMetadata().isEmpty()) return false;
+		if (container != null && container.getChildMetadata().isEmpty()) {
+			ComplexMetadataViewInterface containerInterface = container.getMetadataView();
+			if (containerInterface == null || containerInterface.getMinOccurs() == 0) return false;
+		}
         return Objects.nonNull(settings) && settings.getMinOccurs() > 0;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -21,6 +21,7 @@ import java.util.function.BiConsumer;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
+import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.Division;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.PhysicalDivision;
@@ -87,13 +88,12 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
     }
 
     public boolean isRequired() {
-        if (container != null && container.getChildMetadata().isEmpty()) {
-            ComplexMetadataViewInterface containerSettings = container.getMetadataView();
-            if (containerSettings == null || containerSettings.getMinOccurs() == 0) {
-                return false;
-            }
+        ComplexMetadataViewInterface containerSettings = container.getMetadataView();
+        if (!(containerSettings instanceof StructuralElementViewInterface) && container.getChildMetadata().isEmpty()
+                && containerSettings.getMinOccurs() == 0) {
+            return false;
         }
-        return Objects.nonNull(settings) && settings.getMinOccurs() > 0;
+        return settings.getMinOccurs() > 0;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -86,6 +86,7 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
     }
 
     public boolean isRequired() {
+		if (container != null && container.getChildMetadata().isEmpty()) return false;
         return Objects.nonNull(settings) && settings.getMinOccurs() > 0;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -89,7 +89,9 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
     public boolean isRequired() {
         if (container != null && container.getChildMetadata().isEmpty()) {
             ComplexMetadataViewInterface containerSettings = container.getMetadataView();
-            if (containerSettings == null || containerSettings.getMinOccurs() == 0) return false;
+            if (containerSettings == null || containerSettings.getMinOccurs() == 0) {
+                return false;
+            }
         }
         return Objects.nonNull(settings) && settings.getMinOccurs() > 0;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -87,10 +87,10 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
     }
 
     public boolean isRequired() {
-		if (container != null && container.getChildMetadata().isEmpty()) {
-			ComplexMetadataViewInterface containerInterface = container.getMetadataView();
-			if (containerInterface == null || containerInterface.getMinOccurs() == 0) return false;
-		}
+        if (container != null && container.getChildMetadata().isEmpty()) {
+            ComplexMetadataViewInterface containerInterface = container.getMetadataView();
+            if (containerInterface == null || containerInterface.getMinOccurs() == 0) return false;
+        }
         return Objects.nonNull(settings) && settings.getMinOccurs() > 0;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -88,8 +88,8 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
 
     public boolean isRequired() {
         if (container != null && container.getChildMetadata().isEmpty()) {
-            ComplexMetadataViewInterface containerInterface = container.getMetadataView();
-            if (containerInterface == null || containerInterface.getMinOccurs() == 0) return false;
+            ComplexMetadataViewInterface containerSettings = container.getMetadataView();
+            if (containerSettings == null || containerSettings.getMinOccurs() == 0) return false;
         }
         return Objects.nonNull(settings) && settings.getMinOccurs() > 0;
     }


### PR DESCRIPTION
If for a metadata group, all children are empty, then the whole group is empty, and then, ignore 'minOccurs' from the child.

Fixes #5297