### PR TITLE
Generatorsource variable

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -323,11 +323,11 @@ public class VariableReplacer {
             return variableFinder.group(1);
         }
         if (Objects.isNull(process.getProject())) {
-            logger.warn("Cannot replace \"(" + match + ")\":process has no project assigned");
+            logger.warn("Cannot replace \"(" + match + ")\": process has no project assigned");
             return variableFinder.group(1);
         }
         if (Objects.isNull(process.getProject().getGeneratorSource())) {
-            logger.warn("Cannot replace \"(" + match + ")\":: process has no generator source assigned");
+            logger.warn("Cannot replace \"(" + match + ")\": process has no generator source assigned");
             return variableFinder.group(1);
         }
 

--- a/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertTrue;
 import java.net.URI;
 
 import org.junit.Test;
+import org.kitodo.config.KitodoConfig;
+import org.kitodo.data.database.beans.Folder;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Ruleset;
@@ -137,6 +139,26 @@ public class VariableReplacerTest {
                 variableReplacer.containsFiles(toBeMatched));
     }
 
+    @Test
+    public void shouldReplaceGeneratorSource() {
+        VariableReplacer variableReplacer = new VariableReplacer(null, prepareProcess(), null);
+
+        String replaced = variableReplacer.replace("-filename (generatorsource) -hardcoded test");
+        String expected = "-filename " + "images/Replacementscans" + " -hardcoded test";
+        assertEquals("String should not match as containing file variables!", expected,
+                replaced);
+    }
+
+    @Test
+    public void shouldReplaceGeneratorSourcePath() {
+        VariableReplacer variableReplacer = new VariableReplacer(null, prepareProcess(), null);
+
+        String replaced = variableReplacer.replace("-filename (generatorsourcepath) -hardcoded test");
+        String expected = "-filename " + KitodoConfig.getKitodoDataDirectory() + "2/" + "images/Replacementscans" + " -hardcoded test";
+        assertEquals("String should not match as containing file variables!", expected,
+                replaced);
+    }
+
     private Process prepareProcess() {
         Process process = new Process();
         process.setId(2);
@@ -146,9 +168,15 @@ public class VariableReplacerTest {
         ruleset.setFile("ruleset_test.xml");
         process.setRuleset(ruleset);
         process.setProcessBaseUri(URI.create("2"));
+        Folder scansFolder = new Folder();
+        scansFolder.setFileGroup("SOURCE");
+        scansFolder.setPath("images/(processtitle)scans");
         Project project = new Project();
         project.setId(projectId);
         process.setProject(project);
+        scansFolder.setProject(project);
+        project.getFolders().add(scansFolder);
+        project.setGeneratorSource(scansFolder);
 
         return process;
     }


### PR DESCRIPTION
This pull request fixes #5607 by adding two script variables `generatorsource` and `generatorsourcepath` which return the subfolder (`images/tifs`) and the full path (`/usr/local/kitodo/metadata/4/images/tifs`) respectively of the directory used for generating derivatives.