### PR TITLE
Prevent wrong error message when deleting process

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -2331,7 +2331,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      * @param task Task for which symlinks are removed
      */
     public static void deleteSymlinksFromUserHomes(Task task) {
-        if (task.isTypeImagesRead() || task.isTypeImagesWrite()) {
+        if (Objects.nonNull(task.getProcessingUser()) && (task.isTypeImagesRead() || task.isTypeImagesWrite())) {
             WebDav webDav = new WebDav();
             try {
                 webDav.uploadFromHome(task.getProcessingUser(), task.getProcess());


### PR DESCRIPTION
Fixes #5120 by checking whether a task is currently assigned to a user before passing the user object to the `uploadFromHome` method (which resulted in an NPE and produced the documented error message when no user was assigned)