### PR TITLE
Mark 'filterKeydownEvents' method as 'global' for JSHint

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please read the
  * GPL3-License.txt file that was distributed with this source code.
  */
-/* globals removeFilter, updateSuggestions, submitFilters */
+/* globals removeFilter, updateSuggestions, submitFilters, filterKeydownEvents */
 
 /* Define identifiers used to select elements */
 const LIST_WRAPPER = "#listWrapper";


### PR DESCRIPTION
Mark Javascript function `filterKeydownEvents` in `filter.js` as `global` to inform JSHint it is used somewhere outside of this file.