### PR TITLE
Remove unneccessary null-checks

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -77,12 +77,12 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
      * @return whether the field is editable
      */
     public boolean isEditable() {
-        return Objects.isNull(settings) || settings.isEditable();
+        return settings.isEditable();
     }
 
     @Override
     public boolean isUndefined() {
-        return Objects.isNull(settings) || settings.isUndefined();
+        return settings.isUndefined();
     }
 
     public boolean isRequired() {


### PR DESCRIPTION
It seems that 'settings' can never be null, as other parts of the code rely on it not being null, without checking for it. The commit doesn’t touch `public boolean isRequired()` as it is already handled in PR #5609.