### PR TITLE
Create newspaper processes in the correct year

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/IndividualIssue.java
@@ -53,16 +53,16 @@ public class IndividualIssue {
     private static final DateTimeFormatter MONTH = DateTimeFormatter.ofPattern("MM");
 
     /**
-     * The constant YEAR2 holds a DateTimeFormatter used to get the a four-digit
+     * The constant YEAR2 holds a DateTimeFormatter used to get the a two-digit
      * year of era (00—99, always positive) from the newspaper’s date.
      */
-    private static final DateTimeFormatter YEAR2 = DateTimeFormatter.ofPattern("YY");
+    private static final DateTimeFormatter YEAR2 = DateTimeFormatter.ofPattern("yy");
 
     /**
      * The constant YEAR4 holds a DateTimeFormatter used to get the a four-digit
      * year of era (0001—9999, always positive) from the newspaper’s date.
      */
-    private static final DateTimeFormatter YEAR4 = DateTimeFormatter.ofPattern("YYYY");
+    private static final DateTimeFormatter YEAR4 = DateTimeFormatter.ofPattern("yyyy");
 
     /**
      * Metadata key to store the sorting number.


### PR DESCRIPTION
Fixes #4824

Explanation: The constants _uppercase_ `YY` and `YYYY` generate the year of the associated **calendar week** in the [Java date formatter](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/time/format/DateTimeFormatter.java#L288-L295). Depending on how the calendar week falls (week 01/_nnnn_ may start in December, or week 52/_nnnn_ may end in January), issues from the last days of December slipped into the next year, or issues from the first days of January slipped into the previous year. The correct constants are _lowercase_ `yy` and `yyyy`, these generate the calendar year to which the day really belongs.