### PR TITLE
Swap arguments to prevent NPE

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -263,8 +263,8 @@ public class WorkflowControllerService {
         if (!process.getChildren().isEmpty()) {
             boolean allChildrenClosed = true;
             for (Process child : process.getChildren()) {
-                allChildrenClosed &= child.getSortHelperStatus().equals("100000000")
-                        || child.getSortHelperStatus().equals("100000000000");
+                allChildrenClosed &= "100000000".equals(child.getSortHelperStatus())
+                        || "100000000000".equals(child.getSortHelperStatus());
             }
             return allChildrenClosed;
         }


### PR DESCRIPTION
Fixes #5641.

Swap arguments of equal method call to prevent null pointer exception as data from the database can contain `null` values.