### PR TITLE
Return import configurations sorted by title

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
@@ -139,8 +139,18 @@ public class ImportConfigurationService extends SearchDatabaseService<ImportConf
         return getAllImportConfigurations(ImportConfigurationType.FILE_UPLOAD);
     }
 
+    /**
+     * Load and return all ImportConfigurations sorted by title.
+     * @return list of all ImportConfigurations sorted by title
+     * @throws DAOException when ImportConfigurations could not be loaded
+     */
+    public List<ImportConfiguration> getAll() throws DAOException {
+        return super.getAll().stream().sorted(Comparator.comparing(ImportConfiguration::getTitle))
+                .collect(Collectors.toList());
+    }
+
     private List<ImportConfiguration> getAllImportConfigurations(ImportConfigurationType type) throws DAOException {
-        return getAll().stream()
+        return super.getAll().stream()
                 .filter(importConfiguration -> type.name()
                         .equals(importConfiguration.getConfigurationType()))
                 .sorted(Comparator.comparing(ImportConfiguration::getTitle))

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
@@ -11,6 +11,10 @@
 
 package org.kitodo.production.services.data;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -18,10 +22,6 @@ import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
-
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class ImportConfigurationIT {
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.ImportConfiguration;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.production.services.ServiceManager;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImportConfigurationIT {
+
+    /**
+     * Insert test mapping files and import configurations into database.
+     */
+    @BeforeClass
+    public static void prepareDatabase() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertMappingFiles();
+        MockDatabase.insertImportConfigurations();
+        MockDatabase.setUpAwaitility();
+    }
+
+    /**
+     * Verifies that ImportConfigurations are returned in alphabetical order by ImportConfigurationService.
+     * @throws DAOException when loading of ImportConfigurations fails
+     */
+    @Test
+    public void shouldGetAllImportConfigurationsSortedAlphabetically() throws DAOException {
+        List<ImportConfiguration> configs = ServiceManager.getImportConfigurationService().getAll();
+        assertEquals("Wrong number of import configurations", Long.valueOf(3), Long.valueOf(configs.size()));
+        assertEquals("Wrong first import configuration", "GBV", configs.get(0).getTitle());
+        assertEquals("Wrong last import configuration", "Kalliope", configs.get(2).getTitle());
+    }
+
+    /**
+     * Clean up test database.
+     */
+    @AfterClass
+    public static void cleanDatabase() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+    }
+
+}


### PR DESCRIPTION
Currently, the entries in the pulldown menu for default import configurations in the project edit page are unsorted:

<img width="881" alt="Bildschirmfoto 2023-05-02 um 10 34 49" src="https://user-images.githubusercontent.com/19183925/235618896-b6594ac8-f5d0-4864-83c4-f1e5442d2a34.png">

This PR adds a small change to return import configurations sorted alphabetically from service class in order to make user experience less confusing.