### PR TITLE
Replace old with new value for sortHelperStatus

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_123__Replace_old_sorthelperstatus_value.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_123__Replace_old_sorthelperstatus_value.sql
@@ -1,0 +1,21 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+-- 1. Disable safe updates
+--
+SET SQL_SAFE_UPDATES = 0;
+
+-- 2. Replace old sortHelperStatus from "100000000" to "100000000000"
+UPDATE process SET sortHelperStatus = "100000000000" WHERE sortHelperStatus = "100000000";
+
+-- 3. Enable safe updates
+--
+SET SQL_SAFE_UPDATES = 1;

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -35,6 +35,7 @@ import org.kitodo.data.elasticsearch.index.converter.ProcessConverter;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.ExportException;
 import org.kitodo.exceptions.MetadataException;
+import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.VariableReplacer;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyDocStructHelperInterface;
@@ -54,7 +55,6 @@ import org.kitodo.production.services.workflow.WorkflowControllerService;
 
 public class ExportDms extends ExportMets {
     private static final Logger logger = LogManager.getLogger(ExportDms.class);
-    private static final String COMPLETED = "100000000000";
     private static final String EXPORT_DIR_DELETE = "errorDirectoryDeleting";
     private static final String ERROR_EXPORT = "errorExport";
 
@@ -210,7 +210,8 @@ public class ExportDms extends ExportMets {
 
     private boolean exportCompletedChildren(List<Process> children) throws DataException {
         for (Process child:children) {
-            if (ProcessConverter.getCombinedProgressAsString(child, false).equals(COMPLETED) && !child.isExported()) {
+            if (ProcessConverter.getCombinedProgressAsString(child, false).equals(ProcessState.COMPLETED.getValue())
+                    && !child.isExported()) {
                 if (!startExport(child)) {
                     return false;
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/enums/ProcessState.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/ProcessState.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.enums;
+
+public enum ProcessState {
+
+    /**
+     * Use this enum for completed processes.
+     */
+    COMPLETED("100000000000"),
+
+    /**
+     * Do not use this enum except you need to stay compatible with Kitodo.Production 2.x values.
+     */
+    COMPLETED20("100000000");
+
+    private final String value;
+
+    private ProcessState(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the value of used enum entry.
+     *
+     * @return value of used enum entry
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/HierarchyMigrationTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/HierarchyMigrationTask.java
@@ -35,6 +35,7 @@ import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.ProcessGenerationException;
+import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.process.ProcessGenerator;
@@ -272,7 +273,7 @@ public class HierarchyMigrationTask extends EmptyTask {
         workpiece.setId(parentProcess.getId().toString());
         ServiceManager.getMetsService().saveWorkpiece(workpiece,parentMetadataFilePath);
         if (WorkflowControllerService.allChildrenClosed(parentProcess)) {
-            parentProcess.setSortHelperStatus("100000000");
+            parentProcess.setSortHelperStatus(ProcessState.COMPLETED.getValue());
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/migration/NewspaperProcessesMigrator.java
@@ -54,6 +54,7 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.ProcessGenerationException;
+import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.tasks.NewspaperMigrationTask;
 import org.kitodo.production.helper.tasks.TaskManager;
 import org.kitodo.production.metadata.MetadataEditor;
@@ -658,7 +659,7 @@ public class NewspaperProcessesMigrator {
             processService.saveToDatabase(child);
         }
         if (WorkflowControllerService.allChildrenClosed(yearProcess)) {
-            yearProcess.setSortHelperStatus("100000000");
+            yearProcess.setSortHelperStatus(ProcessState.COMPLETED.getValue());
         }
         processService.saveToDatabase(yearProcess);
         addToBatch(yearProcess);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -137,6 +137,7 @@ import org.kitodo.production.dto.ProjectDTO;
 import org.kitodo.production.dto.PropertyDTO;
 import org.kitodo.production.dto.TaskDTO;
 import org.kitodo.production.enums.ObjectType;
+import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.SearchResultGeneration;
 import org.kitodo.production.helper.WebDav;
@@ -856,8 +857,10 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      */
     public QueryBuilder getQueryForClosedProcesses() {
         BoolQueryBuilder query = new BoolQueryBuilder();
-        query.should(createSimpleQuery(ProcessTypeField.SORT_HELPER_STATUS.getKey(), "100000000", true));
-        query.should(createSimpleQuery(ProcessTypeField.SORT_HELPER_STATUS.getKey(), "100000000000", true));
+        query.should(createSimpleQuery(
+            ProcessTypeField.SORT_HELPER_STATUS.getKey(), ProcessState.COMPLETED20.getValue(), true));
+        query.should(createSimpleQuery(
+            ProcessTypeField.SORT_HELPER_STATUS.getKey(), ProcessState.COMPLETED.getValue(), true));
         return query;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -43,6 +43,7 @@ import org.kitodo.data.database.enums.WorkflowConditionType;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.elasticsearch.index.converter.ProcessConverter;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.VariableReplacer;
 import org.kitodo.production.helper.WebDav;
@@ -263,8 +264,8 @@ public class WorkflowControllerService {
         if (!process.getChildren().isEmpty()) {
             boolean allChildrenClosed = true;
             for (Process child : process.getChildren()) {
-                allChildrenClosed &= "100000000".equals(child.getSortHelperStatus())
-                        || "100000000000".equals(child.getSortHelperStatus());
+                allChildrenClosed &= ProcessState.COMPLETED20.getValue().equals(child.getSortHelperStatus())
+                        || ProcessState.COMPLETED.getValue().equals(child.getSortHelperStatus());
             }
             return allChildrenClosed;
         }
@@ -455,7 +456,7 @@ public class WorkflowControllerService {
 
     private void closeParent(Process process) throws DataException {
         if (Objects.nonNull(process.getParent()) && allChildrenClosed(process.getParent())) {
-            process.getParent().setSortHelperStatus("100000000");
+            process.getParent().setSortHelperStatus(ProcessState.COMPLETED.getValue());
             ServiceManager.getProcessService().save(process.getParent());
             closeParent(process.getParent());
         }

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -96,6 +96,7 @@ import org.kitodo.data.elasticsearch.index.IndexRestClient;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.WorkflowException;
 import org.kitodo.production.enums.ObjectType;
+import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.process.ProcessGenerator;
 import org.kitodo.production.security.password.SecurityPasswordEncoder;
@@ -618,7 +619,7 @@ public class MockDatabase {
         Project projectTwo = ServiceManager.getProjectService().getById(2);
         Process thirdProcess = new Process();
         thirdProcess.setTitle("DBConnectionTest");
-        thirdProcess.setSortHelperStatus("100000000");
+        thirdProcess.setSortHelperStatus(ProcessState.COMPLETED.getValue());
         thirdProcess.setProject(projectTwo);
         ServiceManager.getProcessService().save(thirdProcess);
     }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.elasticsearch.index.query.Operator;
@@ -58,6 +57,7 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.elasticsearch.index.converter.ProcessConverter;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.metadata.MetadataLock;
@@ -451,7 +451,7 @@ public class ProcessServiceIT {
         ProcessService processService = ServiceManager.getProcessService();
         Process secondProcess = processService.getById(2);
         final String sortHelperStatusOld = secondProcess.getSortHelperStatus();
-        secondProcess.setSortHelperStatus("100000000");
+        secondProcess.setSortHelperStatus(ProcessState.COMPLETED.getValue());
         processService.save(secondProcess);
 
         QueryBuilder querySortHelperStatusTrue = processService.getQueryForClosedProcesses();


### PR DESCRIPTION
Fixes: #5661 

- replacing old value `100000000` with new value `100000000000` on all needed places
- replacing the magic numbers with enumeration entries
- changing the values in the database

It is not necessary to reindex all processes after this change is live but I would recommend it. 

Searches in database and elastic search are still using both values to determinate completed processes. This can maybe changed in later versions.