### PR TITLE
Renames variables ending in "interface" because they hold an instance

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Rule.java
@@ -206,15 +206,15 @@ public class Rule {
         return result;
     }
 
-    private static void getConditionalPermits(ConditionsMapInterface conditionsMapInterface,
+    private static void getConditionalPermits(ConditionsMapInterface conditionsMap,
             Map<String, Optional<MetadataEntry>> metadataCache, List<Map<MetadataEntry, Boolean>> metadata,
             Collection<RestrictivePermit> result) {
 
-        for (String conditionKey : conditionsMapInterface.getConditionKeys()) {
+        for (String conditionKey : conditionsMap.getConditionKeys()) {
             Optional<MetadataEntry> possibleMetadata = metadataCache.computeIfAbsent(conditionKey,
                 key -> getMetadataEntryForKey(key, metadata));
             if (possibleMetadata.isPresent()) {
-                Condition condition = conditionsMapInterface.getCondition(conditionKey, possibleMetadata.get().getValue());
+                Condition condition = conditionsMap.getCondition(conditionKey, possibleMetadata.get().getValue());
                 if (Objects.nonNull(condition)) {
                     result.addAll(condition.getPermits());
                     getConditionalPermits(condition, metadataCache, metadata, result); // recursive

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -152,11 +152,11 @@ public class AddDocStrucTypeDialog {
         Optional<LogicalDivision> selectedStructure = dataEditor.getSelectedStructure();
         if (selectedStructure.isPresent()) {
             if (selectedMetadata != "") {
-                MetadataViewInterface metadataViewInterface = getMetadataViewFromKey(
+                MetadataViewInterface metadataView = getMetadataViewFromKey(
                     docStructAddTypeSelectionSelectedItem, selectedMetadata);
                 MetadataEditor.addMultipleStructuresWithMetadata(elementsToAddSpinnerValue,
                     docStructAddTypeSelectionSelectedItem, dataEditor.getWorkpiece(), selectedStructure.get(),
-                    selectedDocStructPosition, metadataViewInterface, inputMetaDataValue);
+                    selectedDocStructPosition, metadataView, inputMetaDataValue);
             } else {
                 MetadataEditor.addMultipleStructures(elementsToAddSpinnerValue, docStructAddTypeSelectionSelectedItem,
                     dataEditor.getWorkpiece(), selectedStructure.get(), selectedDocStructPosition);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -54,9 +54,8 @@ public class ProcessHelper {
      * @param tempProcess
      *            the TempProcess for which the List of ProcessDetail objects is
      *            created
-     * @param managementInterface
-     *            RulesetManagementInterface used to create the metadata of the
-     *            process
+     * @param rulesetManagement
+     *            Ruleset management used to create the metadata of the process
      * @param acquisitionStage
      *            String containing the acquisitionStage
      * @param priorityList
@@ -68,11 +67,11 @@ public class ProcessHelper {
      *             thrown if TempProcess contains undefined metadata
      */
     public static List<ProcessDetail> transformToProcessDetails(TempProcess tempProcess,
-            RulesetManagementInterface managementInterface, String acquisitionStage,
+            RulesetManagementInterface rulesetManagement, String acquisitionStage,
             List<Locale.LanguageRange> priorityList)
             throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         ProcessFieldedMetadata metadata = initializeProcessDetails(tempProcess.getWorkpiece().getLogicalStructure(),
-            managementInterface, acquisitionStage, priorityList);
+            rulesetManagement, acquisitionStage, priorityList);
         metadata.preserve();
         return metadata.getRows();
     }
@@ -85,8 +84,8 @@ public class ProcessHelper {
      *
      * @param structure
      *            LogicalDivision for which to create a ProcessFieldedMetadata
-     * @param managementInterface
-     *            RulesetManagementInterface used to create ProcessFieldedMetadata
+     * @param rulesetManagement
+     *            Ruleset management used to create ProcessFieldedMetadata
      * @param stage
      *            String containing acquisition stage used to create
      *            ProcessFieldedMetadata
@@ -96,8 +95,8 @@ public class ProcessHelper {
      * @return the created ProcessFieldedMetadata
      */
     public static ProcessFieldedMetadata initializeProcessDetails(LogicalDivision structure,
-            RulesetManagementInterface managementInterface, String stage, List<Locale.LanguageRange> priorityList) {
-        StructuralElementViewInterface divisionView = managementInterface.getStructuralElementView(structure.getType(),
+            RulesetManagementInterface rulesetManagement, String stage, List<Locale.LanguageRange> priorityList) {
+        StructuralElementViewInterface divisionView = rulesetManagement.getStructuralElementView(structure.getType(),
                 stage, priorityList);
         return new ProcessFieldedMetadata(structure, divisionView);
     }
@@ -113,8 +112,8 @@ public class ProcessHelper {
      *         the parent temp processes
      * @param docType
      *         current division
-     * @param rulesetManagementInterface
-     *         interface that provides access to the ruleset
+     * @param rulesetManagement
+     *         current ruleset management
      * @param acquisitionStage
      *         current acquisition level
      * @param priorityList
@@ -124,9 +123,9 @@ public class ProcessHelper {
      */
     public static void generateAtstslFields(TempProcess tempProcess, List<ProcessDetail> processDetails,
             List<TempProcess> parentTempProcesses, String docType,
-            RulesetManagementInterface rulesetManagementInterface, String acquisitionStage,
+            RulesetManagementInterface rulesetManagement, String acquisitionStage,
             List<Locale.LanguageRange> priorityList) throws ProcessGenerationException {
-        generateAtstslFields(tempProcess, processDetails, parentTempProcesses, docType, rulesetManagementInterface, acquisitionStage,
+        generateAtstslFields(tempProcess, processDetails, parentTempProcesses, docType, rulesetManagement, acquisitionStage,
                 priorityList, null, false);
     }
 
@@ -154,13 +153,13 @@ public class ProcessHelper {
             String acquisitionStage, boolean force)
             throws ProcessGenerationException, InvalidMetadataValueException, NoSuchMetadataFieldException,
             IOException {
-        RulesetManagementInterface rulesetManagementInterface = ServiceManager.getRulesetService()
+        RulesetManagementInterface rulesetManagement = ServiceManager.getRulesetService()
                 .openRuleset(tempProcess.getProcess().getRuleset());
         List<Locale.LanguageRange> priorityList = ServiceManager.getUserService().getCurrentMetadataLanguage();
         String docType = tempProcess.getWorkpiece().getLogicalStructure().getType();
-        List<ProcessDetail> processDetails = transformToProcessDetails(tempProcess, rulesetManagementInterface,
+        List<ProcessDetail> processDetails = transformToProcessDetails(tempProcess, rulesetManagement,
                 acquisitionStage, priorityList);
-        generateAtstslFields(tempProcess, processDetails, parentTempProcesses, docType, rulesetManagementInterface,
+        generateAtstslFields(tempProcess, processDetails, parentTempProcesses, docType, rulesetManagement,
                 acquisitionStage, priorityList, null, force);
     }
 
@@ -175,8 +174,8 @@ public class ProcessHelper {
      *            the parent temp processes of temp process
      * @param docType
      *            current division or docType to get the title definition from
-     * @param rulesetManagementInterface
-     *            interface that provides access to the ruleset
+     * @param rulesetManagement
+     *            the ruleset management
      * @param acquisitionStage
      *            current acquisition level
      * @param priorityList
@@ -190,14 +189,14 @@ public class ProcessHelper {
      */
     public static void generateAtstslFields(TempProcess tempProcess, List<ProcessDetail> processDetails,
             List<TempProcess> parentTempProcesses, String docType,
-            RulesetManagementInterface rulesetManagementInterface, String acquisitionStage,
+            RulesetManagementInterface rulesetManagement, String acquisitionStage,
             List<Locale.LanguageRange> priorityList, Process parentProcess, boolean force)
             throws ProcessGenerationException {
         if (!shouldGenerateAtstslFields(tempProcess) && !force) {
             return;
         }
 
-        String titleDefinition = getTitleDefinition(rulesetManagementInterface, docType, acquisitionStage,
+        String titleDefinition = getTitleDefinition(rulesetManagement, docType, acquisitionStage,
                 priorityList);
         String currentTitle = TitleGenerator.getValueOfMetadataID(TitleGenerator.TITLE_DOC_MAIN, processDetails);
         if (StringUtils.isBlank(currentTitle)) {
@@ -207,7 +206,7 @@ public class ProcessHelper {
                 }
                 currentTitle = getTitleFromWorkpiece(parentProcess);
             } else if (Objects.nonNull(parentTempProcesses)) {
-                currentTitle = getTitleFromParents(parentTempProcesses, rulesetManagementInterface, acquisitionStage,
+                currentTitle = getTitleFromParents(parentTempProcesses, rulesetManagement, acquisitionStage,
                         priorityList);
             }
         }
@@ -227,8 +226,8 @@ public class ProcessHelper {
     /**
      * Get the title definition of doc type view.
      *
-     * @param rulesetManagementInterface
-     *         interface that provides access to the ruleset
+     * @param rulesetManagement
+     *         the ruleset management
      * @param docType
      *         current division
      * @param acquisitionStage
@@ -237,9 +236,9 @@ public class ProcessHelper {
      *         weighted list of user-preferred display languages
      * @return the process title of doc type view
      */
-    public static String getTitleDefinition(RulesetManagementInterface rulesetManagementInterface, String docType,
+    public static String getTitleDefinition(RulesetManagementInterface rulesetManagement, String docType,
             String acquisitionStage, List<Locale.LanguageRange> priorityList) {
-        StructuralElementViewInterface docTypeView = rulesetManagementInterface.getStructuralElementView(docType,
+        StructuralElementViewInterface docTypeView = rulesetManagement.getStructuralElementView(docType,
                 acquisitionStage, priorityList);
         return docTypeView.getProcessTitle().orElse("");
     }
@@ -328,7 +327,7 @@ public class ProcessHelper {
     }
 
     private static String getTitleFromParents(List<TempProcess> parentTempProcesses,
-            RulesetManagementInterface rulesetManagementInterface, String acquisitionStage,
+            RulesetManagementInterface rulesetManagement, String acquisitionStage,
             List<Locale.LanguageRange> priorityList) {
         if (parentTempProcesses.size() == 0) {
             return StringUtils.EMPTY;
@@ -338,7 +337,7 @@ public class ProcessHelper {
             String title;
             if (Objects.nonNull(tempProcess.getMetadataNodes())) {
                 ProcessFieldedMetadata processFieldedMetadata = initializeTempProcessDetails(tempProcess,
-                        rulesetManagementInterface, acquisitionStage, priorityList);
+                        rulesetManagement, acquisitionStage, priorityList);
                 title = getTitleFromMetadata(processFieldedMetadata.getChildMetadata());
             } else {
                 title = getTitleFromWorkpiece(tempProcess.getProcess());
@@ -352,10 +351,10 @@ public class ProcessHelper {
     }
 
     private static ProcessFieldedMetadata initializeTempProcessDetails(TempProcess tempProcess,
-            RulesetManagementInterface rulesetManagementInterface, String acquisitionStage,
+            RulesetManagementInterface rulesetManagement, String acquisitionStage,
             List<Locale.LanguageRange> priorityList) {
         ProcessFieldedMetadata metadata = initializeProcessDetails(tempProcess.getWorkpiece().getLogicalStructure(),
-                rulesetManagementInterface, acquisitionStage, priorityList);
+                rulesetManagement, acquisitionStage, priorityList);
         metadata.setMetadata(convertMetadata(tempProcess.getMetadataNodes(), MdSec.DMD_SEC));
         return metadata;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetadataHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetadataHelper.java
@@ -35,7 +35,7 @@ public class LegacyMetadataHelper {
      */
     private LegacyInnerPhysicalDocStructHelper legacyInnerPhysicalDocStructHelper;
 
-    private BindingSaveInterface bindingSaveInterface;
+    private BindingSaveInterface bindingSaver;
 
     private MetadataEntry binding;
 
@@ -78,7 +78,7 @@ public class LegacyMetadataHelper {
      * This allows the metadata to be saved.
      */
     public void saveToBinding() {
-        bindingSaveInterface.saveMetadata(this);
+        bindingSaver.saveMetadata(this);
     }
 
     /**
@@ -88,7 +88,7 @@ public class LegacyMetadataHelper {
      * the value may be, aside from the value of a metadata entry, the value of
      * a field of the container, which makes the matter a bit unwieldy.
      *
-     * @param bsi
+     * @param bindingSaver
      *            thee binding save interface via which the metadata can
      *            automatically save itself afterwards
      * @param binding
@@ -97,8 +97,8 @@ public class LegacyMetadataHelper {
      * @param domain
      *            the domain where the metadata entry is stored
      */
-    public void setBinding(BindingSaveInterface bsi, MetadataEntry binding, Domain domain) {
-        this.bindingSaveInterface = bsi;
+    public void setBinding(BindingSaveInterface bindingSaver, MetadataEntry binding, Domain domain) {
+        this.bindingSaver = bindingSaver;
         this.binding = binding;
         this.domain = domain;
     }
@@ -124,7 +124,7 @@ public class LegacyMetadataHelper {
     @Deprecated
     public void setStringValue(String value) {
         this.value = value;
-        if (bindingSaveInterface != null) {
+        if (bindingSaver != null) {
             saveToBinding();
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -224,17 +224,17 @@ public class MetadataEditor {
      *            inserted
      * @param position
      *            relative insertion position
-     * @param metadataViewInterface
-     *            interface of the metadata to be added
+     * @param metadataView
+     *            view on the metadata to be added
      * @param metadataValue
      *            value of the first metadata entry
      */
     public static void addMultipleStructuresWithMetadata(int number, String type, Workpiece workpiece, LogicalDivision structure,
-            InsertionPosition position, MetadataViewInterface metadataViewInterface, String metadataValue) {
+            InsertionPosition position, MetadataViewInterface metadataView, String metadataValue) {
 
-        String metadataKey = metadataViewInterface.getId();
+        String metadataKey = metadataView.getId();
         
-        if (metadataViewInterface.isComplex()) {
+        if (metadataView.isComplex()) {
             addMultipleStructuresWithMetadataGroup(number, type, workpiece, structure, position, metadataKey);
         } else {
             addMultipleStructuresWithMetadataEntry(number, type, workpiece, structure, position, metadataKey, metadataValue);

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -109,11 +109,8 @@ public class CommandService {
      */
     public void runCommandAsync(String script) {
         if (Objects.nonNull(script)) {
-            KitodoServiceLoader<CommandInterface> serviceLoader = new KitodoServiceLoader<>(CommandInterface.class);
-            CommandInterface commandInterface = serviceLoader.loadModule();
-
             Flowable<CommandResult> source = Flowable.fromCallable(() ->
-                commandInterface.runCommand(random.nextInt(), script)
+                commandModule.runCommand(random.nextInt(), script)
             );
 
             Flowable<CommandResult> commandBackgroundWorker = source.subscribeOn(Schedulers.io());

--- a/Kitodo/src/test/java/org/kitodo/production/helper/ProcessHelperIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/ProcessHelperIT.java
@@ -80,28 +80,28 @@ public class ProcessHelperIT {
         process.setProject(ServiceManager.getProjectService().getById(1));
         process.setRuleset(ServiceManager.getRulesetService().getById(1));
         TempProcess tempProcess = new TempProcess(process, new Workpiece());
-        RulesetManagementInterface rulesetManagementInterface = ServiceManager.getRulesetService()
+        RulesetManagementInterface rulesetManagement = ServiceManager.getRulesetService()
                 .openRuleset(tempProcess.getProcess().getRuleset());
 
-        testGenerationOfAtstslByCurrentTempProcess(tempProcess, rulesetManagementInterface);
+        testGenerationOfAtstslByCurrentTempProcess(tempProcess, rulesetManagement);
 
-        testForceRegenerationOfAtstsl(tempProcess, rulesetManagementInterface);
+        testForceRegenerationOfAtstsl(tempProcess, rulesetManagement);
 
-        testForceRegenerationByTempProcessParents(tempProcess, rulesetManagementInterface);
+        testForceRegenerationByTempProcessParents(tempProcess, rulesetManagement);
 
-        testForceRegenerationByParentProcess(tempProcess, rulesetManagementInterface);
+        testForceRegenerationByParentProcess(tempProcess, rulesetManagement);
     }
 
     private void testForceRegenerationByParentProcess(TempProcess tempProcess,
-            RulesetManagementInterface rulesetManagementInterface) throws ProcessGenerationException, DAOException {
+            RulesetManagementInterface rulesetManagement) throws ProcessGenerationException, DAOException {
         ProcessHelper.generateAtstslFields(tempProcess, tempProcess.getProcessMetadata().getProcessDetailsElements(),
-                null, DOCTYPE, rulesetManagementInterface, ACQUISITION_STAGE_CREATE, priorityList,
+                null, DOCTYPE, rulesetManagement, ACQUISITION_STAGE_CREATE, priorityList,
                 ServiceManager.getProcessService().getById(2), true);
         assertEquals("Secopr", tempProcess.getAtstsl());
     }
 
     private void testForceRegenerationByTempProcessParents(TempProcess tempProcess,
-            RulesetManagementInterface rulesetManagementInterface) throws DAOException, ProcessGenerationException {
+            RulesetManagementInterface rulesetManagement) throws DAOException, ProcessGenerationException {
         TempProcess tempProcessParent = new TempProcess(ServiceManager.getProcessService().getById(2), new Workpiece());
         tempProcess.getProcessMetadata().setProcessDetails(new ProcessFieldedMetadata() {
             {
@@ -110,23 +110,23 @@ public class ProcessHelperIT {
             }
         });
         ProcessHelper.generateAtstslFields(tempProcess, tempProcess.getProcessMetadata().getProcessDetailsElements(),
-                Collections.singletonList(tempProcessParent), DOCTYPE, rulesetManagementInterface,
+                Collections.singletonList(tempProcessParent), DOCTYPE, rulesetManagement,
                 ACQUISITION_STAGE_CREATE, priorityList, null, true);
         assertEquals("Secopr", tempProcess.getAtstsl());
     }
 
     private void testForceRegenerationOfAtstsl(TempProcess tempProcess,
-            RulesetManagementInterface rulesetManagementInterface) throws ProcessGenerationException {
+            RulesetManagementInterface rulesetManagement) throws ProcessGenerationException {
         ProcessHelper.generateAtstslFields(tempProcess, tempProcess.getProcessMetadata().getProcessDetailsElements(),
-                null, DOCTYPE, rulesetManagementInterface, ACQUISITION_STAGE_CREATE, priorityList, null, false);
+                null, DOCTYPE, rulesetManagement, ACQUISITION_STAGE_CREATE, priorityList, null, false);
         assertEquals("test", tempProcess.getAtstsl());
         ProcessHelper.generateAtstslFields(tempProcess, tempProcess.getProcessMetadata().getProcessDetailsElements(),
-                null, DOCTYPE, rulesetManagementInterface, ACQUISITION_STAGE_CREATE, priorityList, null, true);
+                null, DOCTYPE, rulesetManagement, ACQUISITION_STAGE_CREATE, priorityList, null, true);
         assertEquals("test2", tempProcess.getAtstsl());
     }
 
     private void testGenerationOfAtstslByCurrentTempProcess(TempProcess tempProcess,
-            RulesetManagementInterface rulesetManagementInterface) throws ProcessGenerationException {
+            RulesetManagementInterface rulesetManagement) throws ProcessGenerationException {
         tempProcess.getProcessMetadata().setProcessDetails(new ProcessFieldedMetadata() {
             {
                 treeNode.getChildren()
@@ -135,7 +135,7 @@ public class ProcessHelperIT {
         });
         assertNull(tempProcess.getAtstsl());
         ProcessHelper.generateAtstslFields(tempProcess, tempProcess.getProcessMetadata().getProcessDetailsElements(),
-                null, DOCTYPE, rulesetManagementInterface, ACQUISITION_STAGE_CREATE, priorityList, null, false);
+                null, DOCTYPE, rulesetManagement, ACQUISITION_STAGE_CREATE, priorityList, null, false);
         assertEquals("test", tempProcess.getAtstsl());
         tempProcess.getProcessMetadata().setProcessDetails(new ProcessFieldedMetadata() {
             {

--- a/Kitodo/src/test/java/org/kitodo/production/process/ProcessValidatorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/ProcessValidatorIT.java
@@ -110,9 +110,9 @@ public class ProcessValidatorIT {
     private List<ProcessDetail> createProcessDetailsList() throws IOException {
         Workpiece workpiece = new Workpiece();
         workpiece.getLogicalStructure().setType("Monograph");
-        RulesetManagementInterface rulesetManagementInterface = ServiceManager.getRulesetManagementService().getRulesetManagement();
-        rulesetManagementInterface.load(new File("src/test/resources/rulesets/monograph.xml"));
-        StructuralElementViewInterface monograph = rulesetManagementInterface.getStructuralElementView(
+        RulesetManagementInterface rulesetManagement = ServiceManager.getRulesetManagementService().getRulesetManagement();
+        rulesetManagement.load(new File("src/test/resources/rulesets/monograph.xml"));
+        StructuralElementViewInterface monograph = rulesetManagement.getStructuralElementView(
                 "Monograph", "", Locale.LanguageRange.parse("en"));
         ProcessFieldedMetadata processDetails = new ProcessFieldedMetadata(workpiece.getLogicalStructure(), monograph);
         for (ProcessDetail detail : processDetails.getRows()) {

--- a/Kitodo/src/test/java/org/kitodo/production/process/TitleGeneratorTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/TitleGeneratorTest.java
@@ -102,9 +102,9 @@ public class TitleGeneratorTest {
     static List<ProcessDetail> createProcessDetailsList() throws IOException {
         Workpiece workpiece = new Workpiece();
         workpiece.getLogicalStructure().setType("Monograph");
-        RulesetManagementInterface rulesetManagementInterface = ServiceManager.getRulesetManagementService().getRulesetManagement();
-        rulesetManagementInterface.load(new File("src/test/resources/rulesets/monograph.xml"));
-        StructuralElementViewInterface monograph = rulesetManagementInterface.getStructuralElementView(
+        RulesetManagementInterface rulesetManagement = ServiceManager.getRulesetManagementService().getRulesetManagement();
+        rulesetManagement.load(new File("src/test/resources/rulesets/monograph.xml"));
+        StructuralElementViewInterface monograph = rulesetManagement.getStructuralElementView(
                 "Monograph", "", Locale.LanguageRange.parse("en"));
         ProcessFieldedMetadata processDetails = new ProcessFieldedMetadata(workpiece.getLogicalStructure(), monograph);
         for (ProcessDetail detail : processDetails.getRows()) {

--- a/Kitodo/src/test/java/org/kitodo/utils/ProcessTestUtils.java
+++ b/Kitodo/src/test/java/org/kitodo/utils/ProcessTestUtils.java
@@ -42,9 +42,9 @@ public class ProcessTestUtils {
     }
 
     private static SimpleMetadataViewInterface getSimpleMetadataView(String metadataId) {
-        SimpleMetadataViewInterface simpleMetadataViewInterface = mock(SimpleMetadataViewInterface.class);
-        when(simpleMetadataViewInterface.getId()).thenReturn(metadataId);
-        return simpleMetadataViewInterface;
+        SimpleMetadataViewInterface simpleMetadataView = mock(SimpleMetadataViewInterface.class);
+        when(simpleMetadataView.getId()).thenReturn(metadataId);
+        return simpleMetadataView;
     }
 
 }


### PR DESCRIPTION
Renames variables ending in "interface" because they hold an instance of a class that implements an interface. Even if an object implements an interface, it's still an object and not an interface, so this naming is misleading. It fixes a bit of Javadoc as well, and eliminates an unnecessary call to the module loader every time a script is run, since the module was loaded when the class was instantiated.