### PR TITLE
Improve correction icon

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -227,7 +227,6 @@ copyRolesToClient=Rollen zum Mandanten hinzuf\u00FCgen
 copyTemplates=Projekt inkl. Templates kopieren
 correction=Korrektur
 correctionFor=Korrektur f\u00FCr Schritt
-correctionK=K
 correctionMessage=Korrekturmeldung
 correctionMessageSend=Korrekturmeldung senden
 correctionMessageSendAllTasks=Korrekturmeldung f\u00FCr alle Schritte senden

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -227,7 +227,6 @@ copyRolesToClient=Copy roles to client
 copyTemplates=Copy Project including Templates
 correction=Correction
 correctionFor=Correction for step
-correctionK=C
 correctionMessage=Correction message
 correctionMessageSend=Send correction message
 correctionMessageSendAllTasks=send correction message to all tasks

--- a/Kitodo/src/main/resources/messages/messages_es.properties
+++ b/Kitodo/src/main/resources/messages/messages_es.properties
@@ -229,7 +229,6 @@ copyRolesToClient=Añadir funciones al cliente
 copyTemplates=Copiar el proyecto incluyendo las plantillas
 correction=Corrección
 correctionFor=Corrección del paso
-correctionK=C
 correctionMessage=Mensaje de corrección
 correctionMessageSend=Enviar mensaje de corrección
 correctionMessageSendAllTasks=Enviar mensaje de corrección para todos los pasos

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1779,15 +1779,8 @@ Mass import
     color: var(--medium-gray);
 }
 
-.correction-marker {
-    color: var(--focused-orange);
-    font-size: var(--input-height);
-    font-weight: bold;
-}
-
 .correction {
     color: var(--focused-orange);
-    font-weight: bold;
 }
 
 .corrected {
@@ -2270,6 +2263,10 @@ form#metadata div label,
 
 #commentsBox\:commentsGrid_head {
     display: none;
+}
+
+.comment-correction {
+    margin-right: var(--group-margin);
 }
 
 .comment-author {
@@ -3885,7 +3882,7 @@ footer {
     width: 1em;
 }
 
-.ui-tooltip.comments .icon .correction-marker {
+.ui-tooltip.comments .icon .correction {
     font-size: inherit;
 }
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/base/commentTooltip.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/base/commentTooltip.xhtml
@@ -22,9 +22,8 @@
         <p:dataViewListItem>
             <h:panelGrid columns="4" columnClasses="icon,date,name,message">
                 <h:panelGroup>
-                    <h:outputText value="#{msgs.correctionK}"
-                                  id="commentIcon"
-                                  styleClass="correction-marker #{comment.isCorrected() ? 'corrected' : ''}"
+                    <h:outputText id="commentIcon"
+                                  styleClass="fa fa-exclamation-circle correction #{comment.isCorrected() ? 'corrected' : ''}"
                                   rendered="#{comment.getType() eq 'ERROR'}"/>
                 </h:panelGroup>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/comments.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/comments.xhtml
@@ -21,9 +21,8 @@
             <!-- Existing comments -->
             <p:dataTable id="commentsGrid" value="#{CommentForm.getAllComments()}" var="item">
                 <p:column style="width: 100%;">
-                    <p:outputLabel value="#{msgs.correctionK} "
-                                   styleClass="#{(item.corrected) ? 'correction corrected' : 'correction'}"
-                                   rendered="#{item.type eq 'ERROR'}"/>
+                    <h:outputText styleClass="comment-correction fa fa-exclamation-circle #{(item.corrected) ? 'correction corrected' : 'correction'}"
+                                  rendered="#{item.type eq 'ERROR'}"/>
 
                     <h:outputText value="#{item.author ne null ? item.author.fullName : 'System'}"
                                   styleClass="comment-author"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/newCommentDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/comments/newCommentDialog.xhtml
@@ -65,7 +65,9 @@
                 <!-- Switch between normal and correction comment -->
                 <p:panelGrid columns="1">
                     <p:column>
-                        <p:outputLabel value="#{msgs.correctionMessage}" for="correctionMessageSwitch"/>
+                        <p:outputLabel for="correctionMessageSwitch">
+                            #{msgs.correctionMessage} <i class="fa fa-exclamation-circle"></i>
+                        </p:outputLabel>
                         <p:selectBooleanCheckbox id="correctionMessageSwitch"
                                                  value="#{CommentForm.correctionComment}"
                                                  disabled="#{!CommentForm.correctionCommentAllowed}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxActivities.xhtml
@@ -124,7 +124,7 @@
                                    oncomplete="PF('newCommentDialog').show()"
                                    rendered="#{CommentForm.correctionCommentAllowed}"
                                    update=":newCommentForm">
-                        <h:outputText><i class="fa fa-commenting" /> #{msgs.correctionMessageWrite}</h:outputText>
+                        <h:outputText><i class="fa fa-exclamation-circle" /> #{msgs.correctionMessageWrite}</h:outputText>
                     </p:commandLink>
 
                     <!-- Edit Cancel-buttons -->

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
@@ -39,8 +39,8 @@
                   width="85"
                   headerText="#{msgs.comments}">
             <h:panelGroup id="commentIcon">
-                <h:panelGroup styleClass="fa fa-comment
-                    #{DesktopForm.hasCorrectionTask(process.id) gt 0 ? 'fa-exclamation-circle' : 'fa-comment'}
+                <h:panelGroup styleClass="fa
+                    #{DesktopForm.hasCorrectionTask(process.id) gt 0 ? 'fa-exclamation-circle correction' : 'fa-comment'}
                     #{DesktopForm.hasCorrectionTask(process.id) eq 1 ? 'corrected' : ''}"
                               rendered="#{process.hasComments()}"/>
             </h:panelGroup>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/processesWidget.xhtml
@@ -39,11 +39,10 @@
                   width="85"
                   headerText="#{msgs.comments}">
             <h:panelGroup id="commentIcon">
-                <h:panelGroup styleClass="fa fa-comment"
-                              rendered="#{process.hasComments() and DesktopForm.hasCorrectionTask(process.id) eq 0}"/>
-                <h:outputText value="#{msgs.correctionK}"
-                              styleClass="correction-marker #{DesktopForm.hasCorrectionTask(process.id) eq 1 ? 'corrected' : ''}"
-                              rendered="#{DesktopForm.hasCorrectionTask(process.id) gt 0}"/>
+                <h:panelGroup styleClass="fa fa-comment
+                    #{DesktopForm.hasCorrectionTask(process.id) gt 0 ? 'fa-exclamation-circle' : 'fa-comment'}
+                    #{DesktopForm.hasCorrectionTask(process.id) eq 1 ? 'corrected' : ''}"
+                              rendered="#{process.hasComments()}"/>
             </h:panelGroup>
             <p:tooltip for="commentIcon" styleClass="comments" trackMouse="true">
                 <ui:include src="/WEB-INF/templates/includes/base/commentTooltip.xhtml">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -112,11 +112,10 @@
                       rendered="#{ProcessForm.showColumn('process.comments')}"
                       headerText="#{msgs.comments}">
                 <h:panelGroup id="commentIcon">
-                    <h:panelGroup styleClass="fa fa-comment"
-                                  rendered="#{process.hasComments() and process.correctionCommentStatus eq 0}"/>
-                    <h:outputText value="#{msgs.correctionK}"
-                                  styleClass="correction-marker #{process.correctionCommentStatus eq 1 ? 'corrected' : ''}"
-                                  rendered="#{process.correctionCommentStatus gt 0}"/>
+                    <h:panelGroup styleClass="fa
+                        #{process.correctionCommentStatus gt 0 ? 'fa-exclamation-circle correction' : 'fa-comment'}
+                        #{process.correctionCommentStatus eq 1 ? 'corrected' : ''}"
+                                  rendered="#{process.hasComments()}"/>
                 </h:panelGroup>
                 <p:tooltip for="commentIcon" styleClass="comments" trackMouse="true" rendered="#{process.hasComments()}">
                     <ui:include src="/WEB-INF/templates/includes/base/commentTooltip.xhtml">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditActions.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/taskBatchEdit/taskEditActions.xhtml
@@ -119,9 +119,8 @@
                                         <p:dataTable id="commentsGrid" value="#{CommentForm.getAllComments()}"
                                                      var="item">
                                             <p:column style="width: 100%;">
-                                                <p:outputLabel value="#{msgs.correctionK}"
-                                                               styleClass="#{(item.corrected) ? 'correction corrected' : 'correction'}"
-                                                               rendered="#{item.type eq 'ERROR'}"/>
+                                                <h:outputText styleClass="fa fa-exclamation-circle correction #{(item.corrected) ? 'corrected' : ''}"
+                                                              rendered="#{item.type eq 'ERROR'}"/>
 
                                                 <h:outputText
                                                         value="#{item.author.name} #{item.author.surname}: #{item.message}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -119,11 +119,10 @@
                       sortBy="#{item.correctionCommentStatus}"
                       headerText="#{msgs.comments}">
                 <h:panelGroup id="commentIcon">
-                    <h:panelGroup styleClass="fa fa-comment"
-                                  rendered="#{item.getProcess().hasComments() and item.correctionCommentStatus eq 0}"/>
-                    <h:outputText value="#{msgs.correctionK}"
-                                  styleClass="correction-marker #{item.correctionCommentStatus eq 1 ? 'corrected' : ''}"
-                                  rendered="#{item.correctionCommentStatus gt 0}"/>
+                    <h:panelGroup styleClass="fa
+                        #{item.correctionCommentStatus gt 0 ? 'fa-exclamation-circle correction' : 'fa-comment'}
+                        #{item.correctionCommentStatus eq 1 ? 'corrected' : ''}"
+                                  rendered="#{item.getProcess().hasComments()}"/>
                 </h:panelGroup>
                 <p:tooltip for="commentIcon" styleClass="comments" trackMouse="true">
                     <ui:include src="/WEB-INF/templates/includes/base/commentTooltip.xhtml">


### PR DESCRIPTION
Replace the correction "C"/"K" with a more universal icon independent of the user language. The new icon matches the style of the other icons used in Kitodo and has the same size as the other icons, thus not breaking the list layout.
The character is replaced by an exclamation icon in a circle:
![Bildschirmfoto 2023-06-01 um 17 06 52](https://github.com/kitodo/kitodo-production/assets/32509444/2582f357-c591-4592-80ad-d263853eb66b)
The color scheme (red/gray) for active/resolved correction comments is kept.