### PR TITLE
Make individual terms in process properties searchable

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -832,7 +832,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      */
     public QueryBuilder createPropertyQuery(String title, String value) {
         String titleSearchKey = ProcessTypeField.PROPERTIES + ".title.keyword";
-        String valueSearchKey = ProcessTypeField.PROPERTIES + ".value.keyword";
+        String valueSearchKey = ProcessTypeField.PROPERTIES + ".value";
 
         BoolQueryBuilder pairQuery = new BoolQueryBuilder();
         if (!WILDCARD.equals(title)) {


### PR DESCRIPTION
The long term concept for improving metadata search in Kitodo production is to use the metadata of a process (which seems to be already indexed) to search for a process by its metadata.

see: https://github.com/kitodo/kitodo-production/issues/3512

Right now the properties can be used for searching, but the current configuration of the search requires that the search query to exactly match the content of a property because it targets the `keyword` subfield of the property. It is therefor not possible to search e.g. for only a part of a title. There is also no normalization applied, so that the query must match exactly what's in the field. This makes the search not really useful in my opinion. 

In order to give a little better search experience i propose to enable searching also for parts of a property, e.g. parts of a title, by removing the "keyword"-setting.