### PR TITLE
Use correct spellings of database table names

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/AuthorityDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/AuthorityDAO.java
@@ -35,7 +35,7 @@ public class AuthorityDAO extends BaseDAO<Authority> {
 
     @Override
     public List<Authority> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Authority ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM authority ORDER BY id ASC", offset, size);
     }
 
     @Override
@@ -56,7 +56,7 @@ public class AuthorityDAO extends BaseDAO<Authority> {
      * @return matching authority
      */
     public Authority getByTitle(String title) throws DAOException {
-        List<Authority> authorities = getByQuery("FROM Authority WHERE title = :title", Collections.singletonMap("title", title));
+        List<Authority> authorities = getByQuery("FROM authority WHERE title = :title", Collections.singletonMap("title", title));
 
         if (!authorities.isEmpty()) {
             return authorities.get(0);

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BatchDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BatchDAO.java
@@ -40,12 +40,12 @@ public class BatchDAO extends BaseDAO<Batch> {
 
     @Override
     public List<Batch> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Batch ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM batch ORDER BY id ASC", offset, size);
     }
 
     @Override
     public List<Batch> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Batch WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC", offset,
+        return retrieveObjects("FROM batch WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC", offset,
             size);
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ClientDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ClientDAO.java
@@ -34,7 +34,7 @@ public class ClientDAO extends BaseDAO<Client> {
 
     @Override
     public List<Client> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Client ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM client ORDER BY id ASC", offset, size);
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/CommentDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/CommentDAO.java
@@ -36,7 +36,7 @@ public class CommentDAO extends BaseDAO<Comment> {
 
     @Override
     public List<Comment> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Comment ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM comment ORDER BY id ASC", offset, size);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class CommentDAO extends BaseDAO<Comment> {
     }
 
     public List<Comment> getAllByProcess(Process process) {
-        return getByQuery("FROM Comment WHERE process_id = :processId ORDER BY id ASC",
+        return getByQuery("FROM comment WHERE process_id = :processId ORDER BY id ASC",
                 Collections.singletonMap("processId", process.getId()));
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DataEditorSettingDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DataEditorSettingDAO.java
@@ -34,7 +34,7 @@ public class DataEditorSettingDAO extends BaseDAO<DataEditorSetting> {
 
     @Override
     public List<DataEditorSetting> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM DataEditorSetting ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM dataeditor_setting ORDER BY id ASC", offset, size);
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DocketDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/DocketDAO.java
@@ -34,12 +34,12 @@ public class DocketDAO extends BaseDAO<Docket> {
 
     @Override
     public List<Docket> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Docket ORDER BY id", offset, size);
+        return retrieveObjects("FROM docket ORDER BY id", offset, size);
     }
 
     @Override
     public List<Docket> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Docket WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC", offset,
+        return retrieveObjects("FROM docket WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC", offset,
                 size);
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FilterDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FilterDAO.java
@@ -37,12 +37,12 @@ public class FilterDAO extends BaseDAO<Filter> {
 
     @Override
     public List<Filter> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Filter ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM filter ORDER BY id ASC", offset, size);
     }
 
     @Override
     public List<Filter> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Filter WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC", offset,
+        return retrieveObjects("FROM filter WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC", offset,
                 size);
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FolderDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/FolderDAO.java
@@ -34,7 +34,7 @@ public class FolderDAO extends BaseDAO<Folder> {
 
     @Override
     public List<Folder> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Folder ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM folder ORDER BY id ASC", offset, size);
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapGroupDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapGroupDAO.java
@@ -39,7 +39,7 @@ public class LdapGroupDAO extends BaseDAO<LdapGroup> {
 
     @Override
     public List<LdapGroup> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM LdapGroup ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM ldapgroup ORDER BY id ASC", offset, size);
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapServerDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/LdapServerDAO.java
@@ -39,7 +39,7 @@ public class LdapServerDAO extends BaseDAO<LdapServer> {
 
     @Override
     public List<LdapServer> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM LdapServer ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM ldapserver ORDER BY id ASC", offset, size);
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ListColumnDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ListColumnDAO.java
@@ -34,7 +34,7 @@ public class ListColumnDAO extends BaseDAO<ListColumn> {
 
     @Override
     public List<ListColumn> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM ListColumn ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM listcolumn ORDER BY id ASC", offset, size);
     }
 
     /**
@@ -43,7 +43,7 @@ public class ListColumnDAO extends BaseDAO<ListColumn> {
      * @return list of standard list columns
      */
     public List<ListColumn> getAllStandard() {
-        return getByQuery("FROM ListColumn WHERE custom = 0");
+        return getByQuery("FROM listcolumn WHERE custom = 0");
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProcessDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProcessDAO.java
@@ -34,13 +34,13 @@ public class ProcessDAO extends BaseDAO<Process> {
 
     @Override
     public List<Process> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Process WHERE " + getDateFilter("creationDate") + " ORDER BY id ASC", offset,
+        return retrieveObjects("FROM process WHERE " + getDateFilter("creationDate") + " ORDER BY id ASC", offset,
             size);
     }
 
     @Override
     public List<Process> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Process WHERE " + getDateFilter("creationDate")
+        return retrieveObjects("FROM process WHERE " + getDateFilter("creationDate")
                 + " AND (indexAction = 'INDEX' OR indexAction IS NULL) ORDER BY id ASC",
             offset, size);
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProjectDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProjectDAO.java
@@ -34,12 +34,12 @@ public class ProjectDAO extends BaseDAO<Project> {
 
     @Override
     public List<Project> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Project ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM project ORDER BY id ASC", offset, size);
     }
 
     @Override
     public List<Project> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Project WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
+        return retrieveObjects("FROM project WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
             offset, size);
     }
 
@@ -54,7 +54,7 @@ public class ProjectDAO extends BaseDAO<Project> {
      * @return all projects sorted by title as Project objects
      */
     public List<Project> getAllProjectsSortedByTitle() {
-        return getByQuery("FROM Project ORDER BY title ASC");
+        return getByQuery("FROM project ORDER BY title ASC");
     }
 
     /**
@@ -63,6 +63,6 @@ public class ProjectDAO extends BaseDAO<Project> {
      * @return all active projects sorted by title as Project objects
      */
     public List<Project> getAllActiveProjectsSortedByTitle() {
-        return getByQuery("FROM Project WHERE active = 1 ORDER BY title ASC");
+        return getByQuery("FROM project WHERE active = 1 ORDER BY title ASC");
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/PropertyDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/PropertyDAO.java
@@ -39,12 +39,12 @@ public class PropertyDAO extends BaseDAO<Property> {
 
     @Override
     public List<Property> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Property ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM property ORDER BY id ASC", offset, size);
     }
 
     @Override
     public List<Property> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Property WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
+        return retrieveObjects("FROM property WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
             offset, size);
     }
 
@@ -60,7 +60,7 @@ public class PropertyDAO extends BaseDAO<Property> {
      */
     public List<String> retrieveDistinctTitles() {
         try (Session session = HibernateUtil.getSession()) {
-            List<?> titles = session.createQuery("SELECT DISTINCT title FROM Property").list();
+            List<?> titles = session.createQuery("SELECT DISTINCT title FROM property").list();
             return titles.stream().map(Object::toString).sorted().collect(Collectors.toList());
         } catch (PersistenceException e) {
             return Collections.emptyList();

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RoleDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RoleDAO.java
@@ -38,7 +38,7 @@ public class RoleDAO extends BaseDAO<Role> {
 
     @Override
     public List<Role> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Role ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM role ORDER BY id ASC", offset, size);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class RoleDAO extends BaseDAO<Role> {
     public List<Role> getAllRolesByClientId(int clientId) {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("clientId", clientId);
-        return getByQuery("SELECT r FROM Role AS r JOIN r.client AS c WHERE c.id = :clientId GROUP BY r.id",
+        return getByQuery("SELECT r FROM role AS r JOIN r.client AS c WHERE c.id = :clientId GROUP BY r.id",
             parameters);
     }
 
@@ -82,7 +82,7 @@ public class RoleDAO extends BaseDAO<Role> {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("clientIds", clientIds);
-        return getByQuery("SELECT r FROM Role AS r JOIN r.client AS c WITH c.id IN :clientIds",
+        return getByQuery("SELECT r FROM role AS r JOIN r.client AS c WITH c.id IN :clientIds",
                 parameters);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RulesetDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/RulesetDAO.java
@@ -34,12 +34,12 @@ public class RulesetDAO extends BaseDAO<Ruleset> {
 
     @Override
     public List<Ruleset> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Ruleset ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM ruleset ORDER BY id ASC", offset, size);
     }
 
     @Override
     public List<Ruleset> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Ruleset WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
+        return retrieveObjects("FROM ruleset WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
             offset, size);
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TaskDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TaskDAO.java
@@ -46,13 +46,13 @@ public class TaskDAO extends BaseDAO<Task> {
 
     @Override
     public List<Task> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Task WHERE " + getDateFilter("processingBegin") + " ORDER BY id ASC", offset,
+        return retrieveObjects("FROM task WHERE " + getDateFilter("processingBegin") + " ORDER BY id ASC", offset,
             size);
     }
 
     @Override
     public List<Task> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Task WHERE " + getDateFilter("processingBegin")
+        return retrieveObjects("FROM task WHERE " + getDateFilter("processingBegin")
                 + " AND (indexAction = 'INDEX' OR indexAction IS NULL) ORDER BY id ASC",
             offset,
             size);
@@ -80,7 +80,7 @@ public class TaskDAO extends BaseDAO<Task> {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("title", title);
         parameters.put("batchId", batchId);
-        return getByQuery("SELECT t FROM Task AS t INNER JOIN t.process AS p INNER JOIN p.batches AS b WHERE t.title = "
+        return getByQuery("SELECT t FROM task AS t INNER JOIN t.process AS p INNER JOIN p.batches AS b WHERE t.title = "
                 + ":title AND batchStep = 1 AND b.id = :batchId",
             parameters);
     }
@@ -101,7 +101,7 @@ public class TaskDAO extends BaseDAO<Task> {
         parameters.put("orderingMax", orderingMax);
         parameters.put("orderingMin", orderingMin);
         parameters.put(KEY_PROCESS_ID, processId);
-        return getByQuery("FROM Task WHERE process_id = :processId AND ordering < :orderingMin"
+        return getByQuery("FROM task WHERE process_id = :processId AND ordering < :orderingMin"
                 + " AND ordering > :orderingMax ORDER BY ordering ASC",
             parameters);
     }
@@ -119,7 +119,7 @@ public class TaskDAO extends BaseDAO<Task> {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("ordering", ordering);
         parameters.put(KEY_PROCESS_ID, processId);
-        return getByQuery("FROM Task WHERE process_id = :processId AND ordering > :ordering AND repeatOnCorrection = 1",
+        return getByQuery("FROM task WHERE process_id = :processId AND ordering > :ordering AND repeatOnCorrection = 1",
             parameters);
     }
 
@@ -137,7 +137,7 @@ public class TaskDAO extends BaseDAO<Task> {
         parameters.put("ordering", ordering);
         parameters.put(KEY_PROCESS_ID, processId);
         return getByQuery(
-            "FROM Task WHERE process_id = :processId AND ordering < :ordering" + " ORDER BY ordering DESC", parameters);
+            "FROM task WHERE process_id = :processId AND ordering < :ordering" + " ORDER BY ordering DESC", parameters);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TemplateDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/TemplateDAO.java
@@ -36,12 +36,12 @@ public class TemplateDAO extends BaseDAO<Template> {
 
     @Override
     public List<Template> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Template ORDER BY title ASC", offset, size);
+        return retrieveObjects("FROM template ORDER BY title ASC", offset, size);
     }
 
     @Override
     public List<Template> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Template WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
+        return retrieveObjects("FROM template WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
             offset, size);
     }
 
@@ -81,7 +81,7 @@ public class TemplateDAO extends BaseDAO<Template> {
     public List<Template> getTemplatesWithTitle(String title) {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("title", title);
-        return getByQuery("FROM Template WHERE title LIKE :title ORDER BY title ASC", parameters);
+        return getByQuery("FROM template WHERE title LIKE :title ORDER BY title ASC", parameters);
     }
 
     /**
@@ -92,7 +92,7 @@ public class TemplateDAO extends BaseDAO<Template> {
     public List<Template> getActiveTemplates(int clientId) {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("clientId", clientId);
-        return getByQuery("SELECT t FROM Template AS t WHERE active = 1 AND client_id = :clientId",
+        return getByQuery("SELECT t FROM template AS t WHERE active = 1 AND client_id = :clientId",
             parameters);
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UrlParameterDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UrlParameterDAO.java
@@ -52,7 +52,7 @@ public class UrlParameterDAO extends BaseDAO<UrlParameter> {
      */
     @Override
     public List<UrlParameter> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM UrlParameter ORDER BY ID ASC", offset, size);
+        return retrieveObjects("FROM urlparameter ORDER BY ID ASC", offset, size);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/UserDAO.java
@@ -32,12 +32,12 @@ public class UserDAO extends BaseDAO<User> {
 
     @Override
     public List<User> getAll() {
-        return getByQuery("FROM User WHERE deleted = 0");
+        return getByQuery("FROM user WHERE deleted = 0");
     }
 
     @Override
     public List<User> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM User WHERE deleted = 0 ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM user WHERE deleted = 0 ORDER BY id ASC", offset, size);
     }
 
     @Override
@@ -73,12 +73,12 @@ public class UserDAO extends BaseDAO<User> {
         if (Objects.nonNull(id)) {
             parameters.put("id", id);
             parameters.put("login", login);
-            return count("SELECT COUNT(*) FROM User WHERE id != :id AND login = :login",
+            return count("SELECT COUNT(*) FROM user WHERE id != :id AND login = :login",
                     parameters);
         }
 
         parameters.put("login", login);
-        return count("SELECT COUNT(*) FROM User WHERE login = :login", parameters);
+        return count("SELECT COUNT(*) FROM user WHERE login = :login", parameters);
     }
 
     /**
@@ -87,6 +87,6 @@ public class UserDAO extends BaseDAO<User> {
      * @return sorted list of all active users as User objects
      */
     public List<User> getAllActiveUsersSortedByNameAndSurname() {
-        return getByQuery("FROM User WHERE active = 1 AND deleted = 0 ORDER BY surname ASC, name ASC");
+        return getByQuery("FROM user WHERE active = 1 AND deleted = 0 ORDER BY surname ASC, name ASC");
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkflowConditionDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkflowConditionDAO.java
@@ -34,7 +34,7 @@ public class WorkflowConditionDAO extends BaseDAO<WorkflowCondition> {
 
     @Override
     public List<WorkflowCondition> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM WorkflowCondition ORDER BY id ASC", offset, size);
+        return retrieveObjects("FROM workflowcondition ORDER BY id ASC", offset, size);
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkflowDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/WorkflowDAO.java
@@ -35,12 +35,12 @@ public class WorkflowDAO extends BaseDAO<Workflow> {
 
     @Override
     public List<Workflow> getAll(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Workflow ORDER BY id", offset, size);
+        return retrieveObjects("FROM workflow ORDER BY id", offset, size);
     }
 
     @Override
     public List<Workflow> getAllNotIndexed(int offset, int size) throws DAOException {
-        return retrieveObjects("FROM Workflow WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
+        return retrieveObjects("FROM workflow WHERE indexAction = 'INDEX' OR indexAction IS NULL ORDER BY id ASC",
             offset, size);
     }
 
@@ -59,7 +59,7 @@ public class WorkflowDAO extends BaseDAO<Workflow> {
      */
     public List<Workflow> getAvailableWorkflows(int clientId) {
         return getByQuery(
-            "SELECT w FROM Workflow AS w INNER JOIN w.client AS c WITH c.id = :clientId WHERE w.status = 'ACTIVE'",
+            "SELECT w FROM workflow AS w INNER JOIN w.client AS c WITH c.id = :clientId WHERE w.status = 'ACTIVE'",
             Collections.singletonMap("clientId", clientId));
     }
 
@@ -68,6 +68,6 @@ public class WorkflowDAO extends BaseDAO<Workflow> {
      * @return A list of workflows with status "active"
      */
     public List<Workflow> getAllActive() {
-        return getByQuery("FROM Workflow WHERE status = 'ACTIVE'");
+        return getByQuery("FROM workflow WHERE status = 'ACTIVE'");
     }
 }


### PR DESCRIPTION
Database table names are case-sensitive on Linux. So, I wonder why this ever worked …