### PR TITLE
Fix order of logical and physical divisions

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -136,8 +136,6 @@ public class AddDocStrucTypeDialog {
             dataEditor.getGalleryPanel().setGalleryViewMode(LIST_MODE);
         }
         try {
-            dataEditor.getStructurePanel().preserve();
-            dataEditor.refreshStructurePanel();
             dataEditor.getPaginationPanel().show();
         } catch (UnknownTreeNodeDataException e) {
             Helper.setErrorMessage(e.getMessage());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1488,6 +1488,14 @@ public class StructurePanel implements Serializable {
                 }
             }
         }
+        /*
+            PhysicalDivisions assigned to multiple LogicalDivisions may lead to wrong order value. The order will be
+            incremented for each occurrence and not just the last one. The LogicalDivisions containing those
+            PhysicalDivisions must be set to the order value of their first PhysicalDivision.
+         */
+        if (!structure.getViews().isEmpty()) {
+            structure.setOrder(structure.getViews().getFirst().getPhysicalDivision().getOrder());
+        }
         return structure;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/MetadataEditor.java
@@ -329,8 +329,8 @@ public class MetadataEditor {
                     List<Integer> siblingOrderValues = Stream.concat(logicalDivision.getChildren().stream()
                             .map(Division::getOrder), Stream.of(structureOrder)).sorted().collect(Collectors.toList());
 
-                    // new order must be set at correction location between existing siblings
-                    logicalDivision.getChildren().add(siblingOrderValues.indexOf(structureOrder), newStructure);
+                    // new order must be set at correct location between existing siblings
+                    logicalDivision.getChildren().add(siblingOrderValues.lastIndexOf(structureOrder), newStructure);
                 }
                 break;
             case FIRST_CHILD_OF_CURRENT_ELEMENT:


### PR DESCRIPTION
Fixes two bugs:
- When assigning a physical division to two (or more) logical divisions the order value did not consider the multiple assignments.
- When assigning a physical division to two (or more) logical divisions and adding another logical division with assigned physical divisions behind the multiple assignments the last element could be sorted in the wrong place between the multiple assignments.

Resolves #5464.