### PR TITLE
Improve layout of parsed filters

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -920,6 +920,13 @@ label.ui-outputlabel[for] {
 
 #parsedFiltersForm\:parsedFilters .ui-datalist-data {
     padding-right: var(--group-margin);
+    overflow-x: hidden;
+    overflow-y: hidden;
+    white-space: nowrap;
+}
+
+#parsedFiltersForm\:parsedFilters .ui-datalist-data:hover {
+    overflow-x: scroll;
 }
 
 #parsedFiltersForm\:parsedFilters .ui-datalist-empty-message {


### PR DESCRIPTION
Improves the layout of parsed filters when they are larger than the available space in the input field.
The parsed filters are now displayed in one horizontal line. A horizontal scrollbar is shown on hover.
![Bildschirmaufnahme 2023-07-06 um 16 59 14-2](https://github.com/kitodo/kitodo-production/assets/32509444/d0dd5bcd-780e-412e-930f-de0f31b737d0)

Resolves #5643