### PR TITLE
Create title for new processes from uploaded files without parent pro…

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -80,9 +80,14 @@ public abstract class MetadataImportDialog {
             }
         }
 
-        if (StringUtils.isBlank(tempProcess.getAtstsl()) && Objects.nonNull(parentTempProcess)) {
-            ProcessHelper.generateAtstslFields(tempProcess, Collections.singletonList(parentTempProcess),
-                    ImportService.ACQUISITION_STAGE_CREATE, true);
+        if (StringUtils.isBlank(tempProcess.getAtstsl())) {
+            if (Objects.nonNull(parentTempProcess)) {
+                ProcessHelper.generateAtstslFields(tempProcess, Collections.singletonList(parentTempProcess),
+                        ImportService.ACQUISITION_STAGE_CREATE, true);
+            } else {
+                ProcessHelper.generateAtstslFields(tempProcess, null,
+                        ImportService.ACQUISITION_STAGE_CREATE, true);
+            }
         }
     }
 
@@ -126,7 +131,7 @@ public abstract class MetadataImportDialog {
             throws InvalidMetadataValueException, NoSuchMetadataFieldException {
 
         int countOfAddedMetadata = 0;
-        if (processes.size() > 0) {
+        if (!processes.isEmpty()) {
             TempProcess process = processes.getFirst();
             if (process.getMetadataNodes().getLength() > 0) {
                 if (createProcessForm.getProcessDataTab().getDocType()


### PR DESCRIPTION
…cess automatically

Titles for processes created from uploaded files are currently only generated automatically when the uploaded XML file also contains the parent record of the process. For processes created from files _without_ parent record the title generation has to be triggered manually by clicking gear symbol next to the title input field.

The change in this pull request ensures that process title generating rules from the ruleset are also applied automatically when the uploaded XML contains only one record without its parent. 