### PR TITLE
Print comments onto docket

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/docket/DocketData.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/docket/DocketData.java
@@ -39,8 +39,8 @@ public class DocketData {
     /** The creation Date of the process. */
     private String creationDate;
 
-    /** A comment. */
-    private String comment;
+    /** The comments. */
+    private List<String> comments = new ArrayList<>();
 
     /** The template properties. */
     private List<Property> templateProperties;
@@ -185,22 +185,22 @@ public class DocketData {
     }
 
     /**
-     * Gets the comment.
+     * Gets the comments.
      * 
-     * @return The comment.
+     * @return The comments.
      */
-    public String getComment() {
-        return comment;
+    public List<String> getComments() {
+        return comments;
     }
 
     /**
-     * Sets the comment.
+     * Sets the comments.
      * 
-     * @param comment
-     *            The comment.
+     * @param comments
+     *            The comments.
      */
-    public void setComment(String comment) {
-        this.comment = comment;
+    public void setComments(List<String> comments) {
+        this.comments = comments;
     }
 
     /**

--- a/Kitodo-Docket/src/main/java/org/kitodo/docket/ExportXmlLog.java
+++ b/Kitodo-Docket/src/main/java/org/kitodo/docket/ExportXmlLog.java
@@ -300,9 +300,15 @@ public class ExportXmlLog implements Consumer<OutputStream> {
         ruleset.setText(docketData.getRulesetName());
         processElements.add(ruleset);
 
-        Element comment = new Element("comment", xmlns);
-        comment.setText(docketData.getComment());
-        processElements.add(comment);
+        Element comments = new Element("comments", xmlns);
+        List<Element> commentList = new ArrayList<>();
+        for (String commentString : docketData.getComments()) {
+            Element comment = new Element("comment", xmlns);
+            comment.setText(commentString);
+            commentList.add(comment);
+        }
+        comments.addContent(commentList);
+        processElements.add(comments);
 
         List<Element> processProperties = prepareProperties(docketData.getProcessProperties(), xmlns);
 

--- a/Kitodo-Docket/src/test/java/org/kitodo/docket/DocketDataGenerator.java
+++ b/Kitodo-Docket/src/test/java/org/kitodo/docket/DocketDataGenerator.java
@@ -14,6 +14,7 @@ package org.kitodo.docket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.kitodo.api.docket.DocketData;
@@ -32,7 +33,7 @@ public class DocketDataGenerator {
         docketdata.setProcessName("ProcessTitle");
         docketdata.setProjectName("projectTitle");
         docketdata.setRulesetName("RulesetTitle");
-        docketdata.setComment("A comment");
+        docketdata.setComments(Collections.singletonList("A comment"));
 
         List<Property> templateProperties = new ArrayList<>();
         Property propertyForDocket = new Property();

--- a/Kitodo-Docket/src/test/resources/docket_multipage.xsl
+++ b/Kitodo-Docket/src/test/resources/docket_multipage.xsl
@@ -334,13 +334,15 @@
                     <fo:table line-height="14pt">
                         <fo:table-column column-width="12.8cm"/>
                         <fo:table-body>
-                            <fo:table-row height="2cm" border-width="1pt" border-style="solid">
-                                <fo:table-cell>
-                                    <fo:block>
-                                        <xsl:value-of select="kitodo:comment"/>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </fo:table-row>
+                            <xsl:for-each select="kitodo:comments/kitodo:comment">
+                                <fo:table-row border-width="1pt" border-style="solid">
+                                    <fo:table-cell>
+                                        <fo:block>
+                                            <xsl:value-of select="text()"/>
+                                        </fo:block>
+                                    </fo:table-cell>
+                                </fo:table-row>
+                            </xsl:for-each>
                         </fo:table-body>
                     </fo:table>
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -37,6 +37,8 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -2036,7 +2038,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         docketdata.setProcessName(process.getTitle());
         docketdata.setProjectName(process.getProject().getTitle());
         docketdata.setRulesetName(process.getRuleset().getTitle());
-        docketdata.setComment(process.getWikiField());
+        docketdata.setComments(getDocketDataForComments(process.getComments()));
 
         if (!process.getTemplates().isEmpty()) {
             docketdata.setTemplateProperties(getDocketDataForProperties(process.getTemplates()));
@@ -2062,6 +2064,17 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         }
 
         return propertiesForDocket;
+    }
+
+    private static List<String> getDocketDataForComments(List<Comment> comments) {
+        List<String> commentsForDocket = new ArrayList<>();
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        for (Comment comment : comments) {
+            String commentString = dateFormat.format(comment.getCreationDate()) + " "
+                    + comment.getAuthor().getFullName() + ": " + comment.getMessage();
+            commentsForDocket.add(commentString);
+        }
+        return commentsForDocket;
     }
 
     private List<Map<String, Object>> getMetadataForIndex(Process process) {

--- a/Kitodo/src/main/resources/docket.xsl
+++ b/Kitodo/src/main/resources/docket.xsl
@@ -333,13 +333,15 @@
                         <fo:table line-height="14pt">
                             <fo:table-column column-width="12.8cm"/>
                             <fo:table-body>
-                                <fo:table-row height="2cm" border-width="1pt" border-style="solid">
-                                    <fo:table-cell>
-                                        <fo:block>
-                                            <xsl:value-of select="kitodo:comment"/>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </fo:table-row>
+                                <xsl:for-each select="kitodo:comments/kitodo:comment">
+                                    <fo:table-row border-width="1pt" border-style="solid">
+                                        <fo:table-cell>
+                                            <fo:block>
+                                                <xsl:value-of select="text()"/>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                    </fo:table-row>
+                                </xsl:for-each>
                             </fo:table-body>
                         </fo:table>
 

--- a/Kitodo/src/main/resources/docket_multipage.xsl
+++ b/Kitodo/src/main/resources/docket_multipage.xsl
@@ -334,13 +334,15 @@
                     <fo:table line-height="14pt">
                         <fo:table-column column-width="12.8cm"/>
                         <fo:table-body>
-                            <fo:table-row height="2cm" border-width="1pt" border-style="solid">
-                                <fo:table-cell>
-                                    <fo:block>
-                                        <xsl:value-of select="kitodo:comment"/>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </fo:table-row>
+                            <xsl:for-each select="kitodo:comments/kitodo:comment">
+                                <fo:table-row border-width="1pt" border-style="solid">
+                                    <fo:table-cell>
+                                        <fo:block>
+                                            <xsl:value-of select="text()"/>
+                                        </fo:block>
+                                    </fo:table-cell>
+                                </fo:table-row>
+                            </xsl:for-each>
                         </fo:table-body>
                     </fo:table>
 


### PR DESCRIPTION
Print comments onto the docket instead of the old, unused 'wikifield'.

To test this, make sure you have the updated docket.xsl in your local directory. Then use the "print docket" button (printer icon) in the process list on any process with at least one comment.