### PR TITLE
Improve status color

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
@@ -38,7 +38,7 @@
                               style="background-color:
                                 #{item.processingStatus.title == 'statusDone' ? 'var(--green)' : ''}
                                 #{item.processingStatus.title == 'statusInProcessing' ? 'var(--light-green)' : ''}
-                                #{item.processingStatus.title == 'statusOpen' ? 'var(--light-orange)' : ''}
+                                #{item.processingStatus.title == 'statusOpen' ? 'var(--blue)' : ''}
                                 #{item.processingStatus.title == 'statusLocked' ? 'var(--orange)' : ''};"
                 />
                 <p:panel rendered="#{SecurityAccessController.hasAuthorityToEditTask()}">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/progressColumn.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/progressColumn.xhtml
@@ -27,8 +27,8 @@
                     var(--green) #{process.progressClosed}%,
                     var(--light-green) #{process.progressClosed}%,
                     var(--light-green) #{process.progressInProcessing + process.progressClosed}%,
-                    var(--light-orange) #{process.progressInProcessing + process.progressClosed}%,
-                    var(--light-orange) #{process.progressOpen + process.progressClosed + process.progressInProcessing}%,
+                    var(--blue) #{process.progressInProcessing + process.progressClosed}%,
+                    var(--blue) #{process.progressOpen + process.progressClosed + process.progressInProcessing}%,
                     var(--orange) #{process.progressOpen + process.progressClosed + process.progressInProcessing}%);"
     />
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -84,7 +84,7 @@
                               style="margin-right:10px; background-color:
                                 #{item.processingStatus.title == 'statusDone' ? 'var(--green)' : ''}
                                 #{item.processingStatus.title == 'statusInProcessing' ? 'var(--light-green)' : ''}
-                                #{item.processingStatus.title == 'statusOpen' ? 'var(--light-orange)' : ''}
+                                #{item.processingStatus.title == 'statusOpen' ? 'var(--blue)' : ''}
                                 #{item.processingStatus.title == 'statusLocked' ? 'var(--orange)' : ''};"
                 />
             </p:column>


### PR DESCRIPTION
Improve color for task status "open". To make the colors easier to distinguish, the statuses have now the colors:
- Locked: Orange
- **Open: Light Blue**
- In Processing: Light Green
- Done: Green
![Bildschirmfoto 2023-08-10 um 16 12 30](https://github.com/kitodo/kitodo-production/assets/32509444/8c2c87e1-6fbb-4c46-9b5f-861e7d8fdf59)

