### PR TITLE
Fix retrieval of Chrome driver for Selenium tests

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
@@ -81,11 +81,7 @@ public class Browser {
     }
 
     private static void provideChromeDriver() throws IOException {
-        String driverFileName = "chromedriver";
-        if (SystemUtils.IS_OS_WINDOWS) {
-            driverFileName = driverFileName.concat(".exe");
-        }
-        File driverFile = new File(DRIVER_DIR + driverFileName);
+        File driverFile = getDriverFile();
 
         if (!driverFile.exists()) {
             logger.debug("{} does not exist, providing chrome driver now", driverFile.getAbsolutePath());
@@ -104,6 +100,18 @@ public class Browser {
         options.setExperimentalOption("prefs", chromePrefs);
 
         webDriver = new ChromeDriver(service, options);
+    }
+
+    private static File getDriverFile() {
+        String driver = WebDriverProvider.CHROME_DRIVER;
+        if (SystemUtils.IS_OS_WINDOWS) {
+            driver = WebDriverProvider.CHROME_DRIVER_WIN_SUBDIR + "/" + driver.concat(WebDriverProvider.EXE);
+        } else if (SystemUtils.IS_OS_MAC_OSX) {
+            driver = WebDriverProvider.CHROME_DRIVER_MAC_SUBDIR + "/" + driver;
+        } else {
+            driver = WebDriverProvider.CHROME_DRIVER_LINUX_SUBDIR + "/" + driver;
+        }
+        return new File(DRIVER_DIR + driver);
     }
 
     private static void provideGeckoDriver() throws IOException {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -122,19 +122,19 @@ public class WebDriverProvider {
     public static void provideChromeDriver(String downloadFolder, String extractFolder)
             throws IOException {
         String chromeDriverVersion = fetchLatestStableChromeDriverVersion();
-        String chromeDriverUrl = CHROME_FOR_TESTING_URL + chromeDriverVersion + "/";
+        String chromeDriverUrl = CHROME_FOR_TESTING_URL + chromeDriverVersion + File.separator;
         String driverFilename = CHROME_DRIVER;
         File chromeDriverFile;
         if (SystemUtils.IS_OS_WINDOWS) {
             driverFilename = driverFilename + EXE;
-            File chromeDriverZipFile = new File(downloadFolder + CHROME_DRIVER_WIN_SUBDIR + "/" + ZIP_FILE);
-            FileUtils.copyURLToFile(new URL(chromeDriverUrl + CHROME_DRIVER_WIN_PREFIX + "/"
+            File chromeDriverZipFile = new File(downloadFolder + CHROME_DRIVER_WIN_SUBDIR + File.separator + ZIP_FILE);
+            FileUtils.copyURLToFile(new URL(chromeDriverUrl + CHROME_DRIVER_WIN_PREFIX + File.separator
                     + CHROME_DRIVER_WIN_SUBDIR + ZIP), chromeDriverZipFile);
             chromeDriverFile = extractZipFileToFolder(chromeDriverZipFile, new File(extractFolder), driverFilename,
                     CHROME_DRIVER_WIN_SUBDIR);
         } else if (SystemUtils.IS_OS_MAC_OSX) {
-            File chromeDriverZipFile = new File(downloadFolder + CHROME_DRIVER_MAC_SUBDIR + "/" + ZIP_FILE);
-            FileUtils.copyURLToFile(new URL(chromeDriverUrl + CHROME_DRIVER_MAC_PREFIX + "/"
+            File chromeDriverZipFile = new File(downloadFolder + CHROME_DRIVER_MAC_SUBDIR + File.separator + ZIP_FILE);
+            FileUtils.copyURLToFile(new URL(chromeDriverUrl + CHROME_DRIVER_MAC_PREFIX + File.separator
                     + CHROME_DRIVER_MAC_SUBDIR + ZIP), chromeDriverZipFile);
             File theDir = new File(extractFolder);
             if (!theDir.exists()) {
@@ -145,8 +145,8 @@ public class WebDriverProvider {
             chromeDriverFile = extractZipFileToFolder(chromeDriverZipFile, new File(extractFolder), driverFilename,
                     CHROME_DRIVER_MAC_SUBDIR);
         } else {
-            File chromeDriverZipFile = new File(downloadFolder + CHROME_DRIVER_LINUX_SUBDIR + "/" + ZIP_FILE);
-            FileUtils.copyURLToFile(new URL(chromeDriverUrl + CHROME_DRIVER_LINUX_PREFIX + "/"
+            File chromeDriverZipFile = new File(downloadFolder + CHROME_DRIVER_LINUX_SUBDIR + File.separator + ZIP_FILE);
+            FileUtils.copyURLToFile(new URL(chromeDriverUrl + CHROME_DRIVER_LINUX_PREFIX + File.separator
                     + CHROME_DRIVER_LINUX_SUBDIR + ZIP), chromeDriverZipFile);
             chromeDriverFile = extractZipFileToFolder(chromeDriverZipFile, new File(extractFolder), driverFilename,
                     CHROME_DRIVER_LINUX_SUBDIR);

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -20,6 +20,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -29,10 +33,6 @@ import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.tar.TarGZipUnArchiver;
 import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
 import org.kitodo.ExecutionPermission;
-
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
 
 public class WebDriverProvider {
 


### PR DESCRIPTION
Current builds fail because the Selenium tests are set up to use the newest Chrome version available and the way to retrieve this newest version has changed (see https://chromedriver.chromium.org/downloads). 

This PR refactors the `WebDriverProvider` class to take advantage of the new JSON endpoint https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json to retrieve the most recent version of the Chrome driver instead of the old link https://chromedriver.storage.googleapis.com/LATEST_RELEASE which does not seem to get updated anymore after version 114 (currently 116 is the newest version of Chrome available)

@Erikmitk would you mind reviewing this pull request?