### PR TITLE
Fix WebDriverProvider for Windows

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -169,7 +169,7 @@ public class WebDriverProvider {
     private static File extractZipFileToFolder(File zipFile, File destinationFolder, String chromeDriverFilename,
                                                String chromeDriverVersion) {
         extractZipFileToFolder(zipFile, destinationFolder);
-        return new File(destinationFolder.toURI().resolve(chromeDriverVersion + File.separator)
+        return new File(destinationFolder.toURI().resolve(chromeDriverVersion + '/')
                 .resolve(chromeDriverFilename));
     }
 


### PR DESCRIPTION
Also on Windows, URIs use forward slashes.