### PR TITLE
Make 'DocType' label configurable

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -384,6 +384,7 @@ docstructAnAndereStelleSchieben=Strukturelement an andere Stelle schieben
 docstructNachObenSchieben=Strukturelement nach oben schieben
 docstructNachUntenSchieben=Strukturelement nach unten schieben
 docstructs=Strukturelemente
+documentType=Dokumenttyp
 down=unter
 download=Images herunterladen
 doYouWantToProceed=Wollen Sie fortfahren?

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -385,6 +385,7 @@ docstructAnAndereStelleSchieben=Move docstruct to other location
 docstructNachObenSchieben=Move docstruct up
 docstructNachUntenSchieben=Move docstruct down
 docstructs=Docstructs
+documentType=Document type
 down=down
 download=Download images
 doYouWantToProceed=Do you want to proceed?

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
@@ -86,7 +86,7 @@
 
                     <div>
                         <!-- DocType -->
-                        <p:outputLabel value="DocType"/>
+                        <p:outputLabel value="#{msgs.documentType}"/>
                         <p:selectOneMenu id="docType" value="#{CreateProcessForm.processDataTab.docType}">
                             <f:selectItems value="#{CreateProcessForm.processDataTab.allDoctypes}"
                                            var="step"


### PR DESCRIPTION
The label of the "DocType" input field in the "Create new process" form is currently not configurable. This pull request adds and uses a corresponding key to the German and English message files.

<img width="709" alt="doctype" src="https://github.com/kitodo/kitodo-production/assets/19183925/20eb1baf-309d-45a6-b6db-ab3a217095cd">
