### PR TITLE
Fix process selection st

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/ProcessesSelectingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ProcessesSelectingST.java
@@ -42,37 +42,9 @@ public class ProcessesSelectingST extends BaseTestSelenium {
     public static void setup() throws Exception {
 
         User user = ServiceManager.getUserService().getById(1);
-        user.setTableSize(2);
+        user.setTableSize(1);
         ServiceManager.getUserService().saveToDatabase(user);
-        addProcesses();
         processesPage = Pages.getProcessesPage();
-    }
-
-    private static void addProcesses() throws Exception {
-        Project projectOne = ServiceManager.getProjectService().getById(1);
-        Template template = ServiceManager.getTemplateService().getById(1);
-
-        Process forthProcess = new Process();
-        forthProcess.setTitle("Forth process");
-        LocalDate localDate = LocalDate.of(2020, 3, 20);
-        forthProcess.setCreationDate(Date.from(localDate.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()));
-        forthProcess.setWikiField("SelectionTest");
-        forthProcess.setDocket(ServiceManager.getDocketService().getById(1));
-        forthProcess.setProject(projectOne);
-        forthProcess.setRuleset(ServiceManager.getRulesetService().getById(1));
-        forthProcess.setTemplate(template);
-        ServiceManager.getProcessService().save(forthProcess);
-
-        Process fifthProcess = new Process();
-        fifthProcess.setTitle("Fifth process");
-        localDate = LocalDate.of(2020, 4, 20);
-        fifthProcess.setCreationDate(Date.from(localDate.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()));
-        fifthProcess.setWikiField("SelectionTest");
-        fifthProcess.setDocket(ServiceManager.getDocketService().getById(1));
-        fifthProcess.setProject(projectOne);
-        fifthProcess.setRuleset(ServiceManager.getRulesetService().getById(1));
-        fifthProcess.setTemplate(template);
-        ServiceManager.getProcessService().save(fifthProcess);
     }
 
     @Before
@@ -94,7 +66,7 @@ public class ProcessesSelectingST extends BaseTestSelenium {
         processesPage.goTo();
 
         processesPage.selectAllRowsOnPage();
-        assertEquals(processesPage.countListedSelectedProcesses(), 2);
+        assertEquals(processesPage.countListedSelectedProcesses(), 1);
 
         processesPage.goToNextPage();
         assertEquals(processesPage.countListedSelectedProcesses(), 0);
@@ -109,9 +81,9 @@ public class ProcessesSelectingST extends BaseTestSelenium {
         processesPage.goTo();
 
         processesPage.selectAllRows();
-        assertEquals(processesPage.countListedSelectedProcesses(), 2);
+        assertEquals(processesPage.countListedSelectedProcesses(), 1);
 
         processesPage.goToNextPage();
-        assertEquals(processesPage.countListedSelectedProcesses(), 2);
+        assertEquals(processesPage.countListedSelectedProcesses(), 1);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/ProcessesSelectingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ProcessesSelectingST.java
@@ -13,17 +13,10 @@ package org.kitodo.selenium;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.sql.Date;
-import java.time.LocalDate;
-import java.time.ZoneId;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kitodo.data.database.beans.Process;
-import org.kitodo.data.database.beans.Project;
-import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.selenium.testframework.BaseTestSelenium;


### PR DESCRIPTION
The Selenium test `ProcessesSelectingST` adds new test processes to the test database for testing the selection of processes over multiple pages. Unfortunately, the test environment of Kitodo.Production is currently set up in a very suboptimal way. The repository contains multiple test metadata folders and files with static process ids which are to be used in specific Selenium and integration tests, like for example `Kitodo/src/test/resources/metadata/2/meta.xml`

At the same time, some tests - like `ProcessSelectingST` - add their own tests for local usage. Depending on the order in which the tests are executed then, these new test processes are sometimes assigned process ids by the database that interfere with those processes with static ids mentioned above. When a test cleans up its own (presumably) test ressources  after execution, this can also lead to unintentionally removing wrong data and files required for other tests. 

Ideally, all data and files required for individually tests should be created/copied and cleaned up in the individual tests (as is done in `MetadataST`, for example), so that all tests always start with the same environment and can be executed independently in any order without interfering with each others resources. This means the repository should not contain any test resources in folders with specific IDs anymore.

This PR changes the test `ProcessesSelectionST` so that it does not add new processes to the database but instead uses those that are already added. This should improve the chances for builds to succeed because fewer test execution orders will result in wrong test resource handling. 

There are many other tests with similar configuration issues, though, which will still lead to undeterministic build failures until fixed. These will probably be addressed during https://github.com/orgs/kitodo/projects/8.