### PR TITLE
Filter client, role and project information in user list

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/constants/StringConstants.java
+++ b/Kitodo/src/main/java/org/kitodo/constants/StringConstants.java
@@ -1,0 +1,18 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.constants;
+
+public class StringConstants {
+
+    public static String COMMA_DELIMITER = ", ";
+
+}

--- a/Kitodo/src/main/java/org/kitodo/production/forms/BaseForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/BaseForm.java
@@ -27,12 +27,12 @@ import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Role;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.model.LazyDTOModel;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ClientService;
-import org.kitodo.production.services.data.ProjectService;
 import org.kitodo.production.services.data.RoleService;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.event.TabChangeEvent;
@@ -397,7 +397,12 @@ public class BaseForm implements Serializable {
      * @return String containing project titles
      */
     public String getProjectTitles(List<Project> projects) {
-        return ProjectService.getProjectTitles(projects);
+        try {
+            return ServiceManager.getProjectService().getProjectTitles(projects);
+        } catch (DataException e) {
+            Helper.setErrorMessage(e);
+            return "";
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.production.services.data;
 
+import static org.kitodo.constants.StringConstants.COMMA_DELIMITER;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -112,10 +114,10 @@ public class ClientService extends SearchDatabaseService<Client, ClientDAO> {
      */
     public static String getClientNames(List<Client> clients) {
         if (ServiceManager.getSecurityAccessService().hasAuthorityToViewClientList()) {
-            return clients.stream().map(Client::getName).collect(Collectors.joining(", "));
+            return clients.stream().map(Client::getName).collect(Collectors.joining(COMMA_DELIMITER));
         } else {
             return clients.stream().filter(client -> ServiceManager.getUserService().getAuthenticatedUser().getClients()
-                    .contains(client)).map(Client::getName).collect(Collectors.joining(", "));
+                    .contains(client)).map(Client::getName).collect(Collectors.joining(COMMA_DELIMITER));
         }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
@@ -111,6 +111,11 @@ public class ClientService extends SearchDatabaseService<Client, ClientDAO> {
      * @return String containing client names
      */
     public static String getClientNames(List<Client> clients) {
-        return clients.stream().map(Client::getName).collect(Collectors.joining(", "));
+        if (ServiceManager.getSecurityAccessService().hasAuthorityToViewClientList()) {
+            return clients.stream().map(Client::getName).collect(Collectors.joining(", "));
+        } else {
+            return clients.stream().filter(client -> ServiceManager.getUserService().getAuthenticatedUser().getClients()
+                    .contains(client)).map(Client::getName).collect(Collectors.joining(", "));
+        }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.production.services.data;
 
+import static org.kitodo.constants.StringConstants.COMMA_DELIMITER;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -353,12 +355,12 @@ public class ProjectService extends ClientSearchService<Project, ProjectDTO, Pro
     public String getProjectTitles(List<Project> projects) throws DataException {
         if (ServiceManager.getSecurityAccessService().hasAuthorityToViewProjectList()
                 && ServiceManager.getSecurityAccessService().hasAuthorityToViewClientList()) {
-            return projects.stream().map(Project::getTitle).collect(Collectors.joining());
+            return projects.stream().map(Project::getTitle).collect(Collectors.joining(COMMA_DELIMITER));
         } else {
             List<Integer> userProjectIds = findAllProjectsForCurrentUser().stream().map(ProjectDTO::getId)
                     .collect(Collectors.toList());
             return projects.stream().filter(project -> userProjectIds.contains(project.getId())).map(Project::getTitle)
-                    .collect(Collectors.joining(", "));
+                    .collect(Collectors.joining(COMMA_DELIMITER));
         }
     }
 
@@ -369,7 +371,7 @@ public class ProjectService extends ClientSearchService<Project, ProjectDTO, Pro
      */
     public static void delete(int projectID) throws DAOException, DataException, ProjectDeletionException {
         Project project = ServiceManager.getProjectService().getById(projectID);
-        if (project.getProcesses().size() > 0) {
+        if (!project.getProcesses().isEmpty()) {
             throw new ProjectDeletionException("cannotDeleteProject");
         }
         for (User user : project.getUsers()) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
@@ -350,8 +350,16 @@ public class ProjectService extends ClientSearchService<Project, ProjectDTO, Pro
      * @param projects list of roles
      * @return String containing project titles
      */
-    public static String getProjectTitles(List<Project> projects) {
-        return projects.stream().map(Project::getTitle).collect(Collectors.joining(", "));
+    public String getProjectTitles(List<Project> projects) throws DataException {
+        if (ServiceManager.getSecurityAccessService().hasAuthorityToViewProjectList()
+                && ServiceManager.getSecurityAccessService().hasAuthorityToViewClientList()) {
+            return projects.stream().map(Project::getTitle).collect(Collectors.joining());
+        } else {
+            List<Integer> userProjectIds = findAllProjectsForCurrentUser().stream().map(ProjectDTO::getId)
+                    .collect(Collectors.toList());
+            return projects.stream().filter(project -> userProjectIds.contains(project.getId())).map(Project::getTitle)
+                    .collect(Collectors.joining(", "));
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.production.services.data;
 
+import static org.kitodo.constants.StringConstants.COMMA_DELIMITER;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -162,11 +164,11 @@ public class RoleService extends ClientSearchDatabaseService<Role, RoleDAO> {
      */
     public static String getRoleTitles(List<Role> roles) {
         if (ServiceManager.getSecurityAccessService().hasAuthorityGlobalToViewRoleList()) {
-            return roles.stream().map(Role::getTitle).collect(Collectors.joining(", "));
+            return roles.stream().map(Role::getTitle).collect(Collectors.joining(COMMA_DELIMITER));
         } else {
             Client currentClient = ServiceManager.getUserService().getSessionClientOfAuthenticatedUser();
             return roles.stream().filter(role -> role.getClient().equals(currentClient)).map(Role::getTitle)
-                    .collect(Collectors.joining(", "));
+                    .collect(Collectors.joining(COMMA_DELIMITER));
         }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RoleService.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.kitodo.data.database.beans.Authority;
+import org.kitodo.data.database.beans.Client;
 import org.kitodo.data.database.beans.Role;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
@@ -160,6 +161,12 @@ public class RoleService extends ClientSearchDatabaseService<Role, RoleDAO> {
      * @return String containing role titles
      */
     public static String getRoleTitles(List<Role> roles) {
-        return roles.stream().map(Role::getTitle).collect(Collectors.joining(", "));
+        if (ServiceManager.getSecurityAccessService().hasAuthorityGlobalToViewRoleList()) {
+            return roles.stream().map(Role::getTitle).collect(Collectors.joining(", "));
+        } else {
+            Client currentClient = ServiceManager.getUserService().getSessionClientOfAuthenticatedUser();
+            return roles.stream().filter(role -> role.getClient().equals(currentClient)).map(Role::getTitle)
+                    .collect(Collectors.joining(", "));
+        }
     }
 }


### PR DESCRIPTION
Most pages and lists in Kitodo.Production are currently filtered by the current client of the the current user. The only exception to this are the client, role and project columns in the user list, which currently show _all_ assigned clients, roles and projects, no matter which information should actually be visible to the user according to his own clients and permissions. This undermines the client system and potentially even poses a security issue.

This pull request filters the columns accordingly so that only those information are displayed in the columns mentioned above to which the user has access via the clients and roles assigned to him.