### PR TITLE
Scroll 'record identifier missing' dialog on vertical overflow

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1713,6 +1713,11 @@ Import form
     color: var(--pure-white);
 }
 
+#recordIdentifierMissingDialog .select-note {
+    max-height: 480px;
+    overflow-y: auto;
+}
+
 .error-item {
     margin-top: var(--default-half-size);
 }


### PR DESCRIPTION
The system does not handle the content of the "Record identifier missing" dialog correctly (the whole dialog scrolls instead of just the content):

<img width="1037" alt="Bildschirmfoto 2023-09-08 um 10 56 48" src="https://github.com/kitodo/kitodo-production/assets/19183925/9c07e4df-24db-488a-91ad-a27be0c8ef1b">

This PR moves the vertical scroll bar from the dialog to the message when required:

<img width="1121" alt="Bildschirmfoto 2023-09-08 um 10 50 31" src="https://github.com/kitodo/kitodo-production/assets/19183925/cd0fae6b-fb95-41b5-b8b4-2f14fd8a28ad">



