### PR TITLE
UI improvements

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -268,7 +268,9 @@ body.first-visit #portal-header {
     color: inherit;
 }
 
-#header-nav li:hover a {
+#dashboard-menu:hover,
+#user-menu:hover {
+    background: transparent;
     color: var(--carbon-blue);
 }
 

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1461,15 +1461,25 @@ Popup dialogs
 }
 
 #loadingScreen {
+    animation: overlay-delayed .3s .5s forwards;
     position: fixed;
     width: 100vw;
     height: 100vh;
-    background: rgba(255,255,255,.5);
+    background: rgba(255,255,255,0);
     top: 0;
     left: 0;
     z-index: 3;
     line-height: 100vh;
     text-align: center;
+}
+
+@keyframes overlay-delayed {
+    from {
+        background: rgba(255,255,255,0);
+    }
+    to {
+        background: rgba(255,255,255,.5);
+    }
 }
 
 #loadingScreen i.fa-spinner {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/header/navigation.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/header/navigation.xhtml
@@ -21,8 +21,11 @@
             <ul id="menu">
                 <li>
                     <!-- Dashboard menu -->
-                    <p:commandLink id="dashboard-menu" form="linkProcessesNavigationForm"><i class="fa fa-th fa-lg"/></p:commandLink>
-                    <p:overlayPanel for="dashboard-menu" my="right top" at="right bottom">
+                    <p:commandButton type="button"
+                                     icon="fa fa-th fa-lg"
+                                     id="dashboard-menu"
+                                     form="linkProcessesNavigationForm"/>
+                    <p:overlayPanel for="dashboard-menu" my="right top" at="right bottom" dynamic="false">
                         <ul>
                             <li id="dashboard-menu-header">
                                 <h3>#{msgs.dashboard}</h3>
@@ -83,7 +86,10 @@
                 </li>
                 <li>
                     <!-- User menu -->
-                    <p:commandLink id="user-menu" form="logout-form"><i class="fa fa-user-circle-o fa-lg"/></p:commandLink>
+                    <p:commandButton type="button"
+                                     icon="fa fa-user-circle-o fa-lg"
+                                     id="user-menu"
+                                     form="logout-form"/>
                     <p:overlayPanel for="user-menu">
                         <h:form id="logout-form">
                             <ul id="nav-user">


### PR DESCRIPTION
- Prevent submit when opening or closing the dashboard or user menu. This removes the loading screen from both menus.
- Delay the display of the loading screen background by 0.5 seconds. This removes most of the flickering on very short AJAX updates, e.g. selecting nodes in the metadata editor.