### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of Kitodo.Production are currently being supported with ongoing feature development and/or security updates.
+
+| Version | Active Development       |      Security Fixes      |
+|-----| :----------------------: |:------------------------:|
+| 3.7 | :heavy_check_mark:       |    :heavy_check_mark:    |
+| 3.6 | :heavy_multiplication_x: |    :heavy_check_mark:    |
+| 3.5 | :heavy_multiplication_x: | :heavy_multiplication_x: |
+| 3.3 | :heavy_multiplication_x: | :heavy_multiplication_x: |
+| 3.2 | :heavy_multiplication_x: | :heavy_multiplication_x: |
+| 3.1 | :heavy_multiplication_x: | :heavy_multiplication_x: |
+| 3.0 | :heavy_multiplication_x: | :heavy_multiplication_x: |
+| 2.x | :heavy_multiplication_x: | :heavy_multiplication_x: |
+| 1.x | :heavy_multiplication_x: | :heavy_multiplication_x: |
+
+## Reporting a Vulnerability
+
+If you find a vulnerability please consider immediately reporting it to our [release management team](https://github.com/orgs/kitodo/teams/kitodo-production-maintainers) or by sending an [email](mailto:security@kitodo.org).


### PR DESCRIPTION
Add security policy with information about supported versions of Kitodo.Production. 

As discussed with @kitodo/kitodo-board only the version which is currently in development - 3.7 right now - will receive active development while the last release (3.6 at the moment of this writing) will get security fixes.