### PR TITLE
Filtering of single and multiple select fields

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataeditor/rulesetmanagement/SimpleMetadataViewInterface.java
@@ -118,6 +118,13 @@ public interface SimpleMetadataViewInterface extends MetadataViewInterface {
     boolean isEditable();
 
     /**
+     * Returns whether values under this key can be filtered in this view.
+     *
+     * @return whether values can be filtered
+     */
+    boolean isFilterable();
+
+    /**
      * Returns whether the value corresponds to the value range. The value range
      * can be determined in various ways. Integers or dates must parse, it may
      * be that the value must be in a list or is checked against a regular

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/KeyView.java
@@ -154,6 +154,15 @@ class KeyView extends AbstractKeyView<KeyDeclaration> implements DatesSimpleMeta
         return settings.isEditable(declaration.getId());
     }
 
+    @Override
+    public boolean isFilterable() {
+        InputType inputType = getInputType();
+        if (InputType.MULTIPLE_SELECTION.equals(inputType) || InputType.ONE_LINE_SINGLE_SELECTION.equals(inputType)) {
+            return settings.isFilterable(declaration.getId());
+        }
+        return false;
+    }
+
     /**
      * Checks if a URI is in the configured namespace, if one has been
      * specified. Typically, a namespace is used as a URL prefix. For namespaces

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Settings.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Settings.java
@@ -107,6 +107,22 @@ public class Settings {
     }
 
     /**
+     * Whether the key is filterable.
+     *
+     * @param keyId
+     *            key for which the query is
+     * @return whether the key is filterable
+     */
+    boolean isFilterable(String keyId) {
+        if (currentSettings.containsKey(keyId)) {
+            return currentSettings.get(keyId).isFilterable();
+        } else {
+            return true;
+        }
+    }
+
+
+    /**
      * Whether the key is excluded.
      *
      * @param keyId
@@ -176,6 +192,7 @@ public class Settings {
                         other.getAlwaysShowing() != null ? other.getAlwaysShowing() : current.getAlwaysShowing());
                     merged.setEditable(other.getEditable() != null ? other.getEditable() : current.getEditable());
                     merged.setExcluded(other.getExcluded() != null ? other.getExcluded() : current.getExcluded());
+                    merged.setFilterable(other.getFilterable() != null ? other.getFilterable() : current.getFilterable());
                     merged.setMultiline(other.getMultiline() != null ? other.getMultiline() : current.getMultiline());
                     merged.setReimport(other.getReimport() != null ? other.getReimport() : current.getReimport());
                     merged.setSettings(merge(current.getSettings(), other.getSettings()));

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Setting.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/xml/Setting.java
@@ -52,6 +52,9 @@ public class Setting {
     @XmlAttribute
     private Boolean editable;
 
+    @XmlAttribute
+    private Boolean filterable;
+
     /**
      * This will hide a field, even if a value has been entered for this field.
      * Normally, there are rules in the ruleset that say which fields are
@@ -121,6 +124,10 @@ public class Setting {
         return excluded;
     }
 
+    public Boolean getFilterable() {
+        return filterable;
+    }
+
     /**
      * Returns the key whose representation is influenced.
      * 
@@ -182,6 +189,10 @@ public class Setting {
         return editable != null ? editable : true;
     }
 
+    public boolean isFilterable() {
+        return filterable != null ? filterable : false;
+    }
+
     /**
      * Returns the “excluded” value or otherwise the default value if the
      * attribute is not set.
@@ -222,6 +233,11 @@ public class Setting {
      */
     public void setEditable(Boolean editable) {
         this.editable = editable;
+    }
+
+
+    public void setFilterable(Boolean filterable) {
+        this.filterable = filterable;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -12,12 +12,7 @@
 package org.kitodo.production.forms.createprocess;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.BiConsumer;
 
@@ -109,6 +104,10 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
             default:
                 return "";
         }
+    }
+
+    public boolean isFilterable() {
+        return Objects.isNull(settings) || settings.isFilterable();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -82,6 +82,10 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
         return Objects.isNull(settings) || settings.isEditable();
     }
 
+    public boolean isFilterable() {
+        return Objects.isNull(settings) || settings.isFilterable();
+    }
+
     @Override
     public boolean isUndefined() {
         return Objects.isNull(settings) || settings.isUndefined();

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2966,8 +2966,22 @@ Column content
 }
 
 #metadataAccordion\:metadata\:metadataTable_data .ui-inputfield.ui-selectmanymenu.read-only,
+#metadataAccordion\:metadata\:metadataTable_data .ui-selectlistbox-filter-container .ui-selectlistbox-filter,
 #metadataAccordion\:metadata\:metadataTable_data .ui-selectoneradio.read-only {
     max-width: unset;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-selectlistbox-filter-container .ui-icon-search {
+    top: 8px;
+    right: 6px;
+    text-indent: unset;
+    background: none;
+}
+
+#metadataAccordion\:metadata\:metadataTable_data .ui-selectlistbox-filter-container .ui-icon-search::after {
+    font-family: FontAwesome;
+    content: "\f002";
+    text-indent: unset;
 }
 
 #metadataAccordion\:metadata\:metadataTable_data .ui-selectoneradio {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -122,7 +122,8 @@
                                       styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
                                       disabled="#{not item.editable or readOnly}"
                                       required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
-                                      showCheckbox="true">
+                                      showCheckbox="true"
+                                      filter="#{item.filterable}">
                         <f:selectItems value="#{item.items}"/>
                         <p:ajax event="change"
                                 oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
@@ -139,7 +140,8 @@
                                      autoWidth="false"
                                      disabled="#{not item.editable or readOnly}"
                                      required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
-                                     styleClass="#{readOnly ? 'read-only' : ''}">
+                                     styleClass="#{readOnly ? 'read-only' : ''}"
+                                     filter="#{item.filterable}">
                         <f:selectItem itemValue="#{null}"
                                       itemDisabled="#{item.required}"
                                       itemLabel="#{msgs.notSelected}"


### PR DESCRIPTION
In the last conversation about a project, it was noted that the more options assigned to a key, the more cumbersome it becomes to find the right option.

PrimeFaces 8 already provides an implementation for making the select field searchable/filterable.
https://primefaces.github.io/primefaces/8_0/#/components/selectonemenu?id=filtering
https://primefaces.github.io/primefaces/8_0/#/components/selectmanymenu?id=filtering

I have made this configurable for select fields through the `filterable` attribute in the rule set. In the settings of a key, you can now set the attribute to `filterable="true"`. This will display the following filter:

![filter-select](https://github.com/kitodo/kitodo-production/assets/3832618/d1724dd1-5af3-4409-b8a3-a6c30f4b9fd3)

By default, the filter is not displayed and must be explicitly activated. After activation, the filter is displayed, and it searches for all entries that begin with the input.

There are also other Primeface filter modes that allow the entered search term to match not only at the beginning but also at the end or anywhere within the option being searched for. Additionally, you can set a custom filter mode.

If needed, these filter modes can also be made configurable, or the default filter mode of "only at the beginning" can be changed to "anywhere." It depends on which option is more prevalent.
