### PR TITLE
Prevent NPE

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -490,6 +490,7 @@ public class Helper {
         StringBuilder messageBuilder = new StringBuilder(message);
         for (String insertion : insertions) {
             String separator = ": ";
+            insertion = Objects.toString(insertion);
             if (!messageBuilder.toString().contains(insertion)) {
                 messageBuilder.append(separator).append(insertion);
             }


### PR DESCRIPTION
Do not crash the building of error messages it an argument is `null`.

The message building checks the result string, if all `insertion`s have been inserted in the string. If not, they are appended. Example:
“Metadata entry {0} not allowed for division {1}” ["TitleDocMain", "ephemera", "ruleset_default", "IOException: Cannot read ruleset_default.xml"] → “Metadata TitleDocMain not allowed for division ephemera: ruleset_default: IOException: Cannot read ruleset_default.xml”.

If an `insertion` is `null`, the test `if (!messageBuilder.toString().contains(insertion))` (next line) will throw a `NullPointerException`. Error message building shouldn’t throw an exception by itself.