### PR TITLE
Use type track for audio and video MIME types instead of type page for physical division type

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Workpiece.java
@@ -12,7 +12,7 @@
 package org.kitodo.api.dataformat;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -180,15 +180,16 @@ public class Workpiece {
 
     /**
      * Returns all child physical divisions of the physical division of the workpiece with
-     * type "page" sorted by their {@code order} as a flat list. The root media
+     * type "page" or "track" sorted by their {@code order} as a flat list. The root media
      * unit is not contained. The list isn’t backed by the physical divisions, which
      * means that insertions and deletions in the list would not change the
      * physical divisions. Therefore, a list that cannot be modified is returned.
      *
-     * @return all physical divisions with type "page", sorted by their {@code order}
+     * @return all physical divisions with type "page" or "track", sorted by their {@code order}
      */
-    public List<PhysicalDivision> getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted() {
-        return getAllPhysicalDivisionChildrenFilteredByTypes(Collections.singletonList(PhysicalDivision.TYPE_PAGE));
+    public List<PhysicalDivision> getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack() {
+        return getAllPhysicalDivisionChildrenFilteredByTypes(
+                Arrays.asList(PhysicalDivision.TYPE_PAGE, PhysicalDivision.TYPE_TRACK));
     }
 
     /**

--- a/Kitodo-API/src/main/java/org/kitodo/utils/MediaUtil.java
+++ b/Kitodo-API/src/main/java/org/kitodo/utils/MediaUtil.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.utils;
+
+import java.util.Objects;
+
+import org.kitodo.api.dataformat.PhysicalDivision;
+
+public class MediaUtil {
+
+    public static final String MIME_TYPE_AUDIO_PREFIX = "audio";
+    public static final String MIME_TYPE_IMAGE_PREFIX = "image";
+    public static final String MIME_TYPE_VIDEO_PREFIX = "video";
+
+    /**
+     * Private constructor to hide the implicit public one.
+     */
+    private MediaUtil() {
+
+    }
+
+    /**
+     * Check if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_AUDIO_PREFIX} or
+     * {@link org.kitodo.utils.MediaUtil#MIME_TYPE_VIDEO_PREFIX}.
+     *
+     * @param mimeType
+     *         The mime type to check
+     * @return True if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_AUDIO_PREFIX} or
+     *         {@link org.kitodo.utils.MediaUtil#MIME_TYPE_VIDEO_PREFIX}.
+     */
+    public static boolean isAudioOrVideo(String mimeType) {
+        return isAudio(mimeType) || isVideo(mimeType);
+    }
+
+    /**
+     * Check if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_AUDIO_PREFIX}.
+     *
+     * @param mimeType
+     *         The mime type to check
+     * @return True if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_AUDIO_PREFIX}
+     */
+    public static boolean isAudio(String mimeType) {
+        return Objects.nonNull(mimeType) && mimeType.startsWith(MIME_TYPE_AUDIO_PREFIX);
+    }
+
+    /**
+     * Check if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_IMAGE_PREFIX}.
+     *
+     * @param mimeType
+     *         The mime type to check
+     * @return True if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_IMAGE_PREFIX}
+     */
+    public static boolean isImage(String mimeType) {
+        return Objects.nonNull(mimeType) && mimeType.startsWith(MIME_TYPE_IMAGE_PREFIX);
+    }
+
+    /**
+     * Check if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_VIDEO_PREFIX}.
+     *
+     * @param mimeType
+     *         The mime type to check
+     * @return True if mime type starts with {@link org.kitodo.utils.MediaUtil#MIME_TYPE_VIDEO_PREFIX}
+     */
+    public static boolean isVideo(String mimeType) {
+        return Objects.nonNull(mimeType) && mimeType.startsWith(MIME_TYPE_VIDEO_PREFIX);
+    }
+
+    /**
+     * Get the type of {@link org.kitodo.api.dataformat.PhysicalDivision} by mime type.
+     *
+     * @param mimeType
+     *         The mime type to get the physical division type for
+     * @return The type of the {@link org.kitodo.api.dataformat.PhysicalDivision}
+     */
+    public static String getPhysicalDivisionTypeOfMimeType(String mimeType) {
+        if (isImage(mimeType)) {
+            return PhysicalDivision.TYPE_PAGE;
+        }
+        if (isAudioOrVideo(mimeType)) {
+            return PhysicalDivision.TYPE_TRACK;
+        }
+        return PhysicalDivision.TYPE_OTHER;
+    }
+
+}

--- a/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
+++ b/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.utils;
+
+import org.junit.Test;
+import org.kitodo.api.dataformat.PhysicalDivision;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MediaUtilTest {
+
+    /**
+     * Test detection of mime type.
+     */
+    @Test
+    public void testMimeTypeDetection() {
+        assertTrue(MediaUtil.isAudio("audio/mp3"));
+        assertFalse(MediaUtil.isVideo("image/jpeg"));
+
+        assertTrue(MediaUtil.isImage("image/jpeg"));
+        assertFalse(MediaUtil.isImage("video/mp4"));
+
+        assertTrue(MediaUtil.isVideo("video/mp4"));
+        assertFalse(MediaUtil.isVideo("image/jpeg"));
+
+        assertTrue(MediaUtil.isAudioOrVideo("audio/mp3"));
+        assertTrue(MediaUtil.isAudioOrVideo("video/mp4"));
+        assertFalse(MediaUtil.isAudioOrVideo("image/jpeg"));
+    }
+
+    /**
+     * Test getting the type of the {@link org.kitodo.api.dataformat.PhysicalDivision}.
+     */
+    @Test
+    public void testGettingPhysicalDivisionTypeByMimeType() {
+        assertEquals(PhysicalDivision.TYPE_PAGE, MediaUtil.getPhysicalDivisionTypeOfMimeType("image/jpeg"));
+        assertEquals(PhysicalDivision.TYPE_TRACK, MediaUtil.getPhysicalDivisionTypeOfMimeType("audio/mp3"));
+        assertEquals(PhysicalDivision.TYPE_TRACK, MediaUtil.getPhysicalDivisionTypeOfMimeType("video/mp4"));
+        assertEquals(PhysicalDivision.TYPE_OTHER, MediaUtil.getPhysicalDivisionTypeOfMimeType("application/pdf"));
+    }
+}

--- a/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
+++ b/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
@@ -12,11 +12,12 @@
 package org.kitodo.utils;
 
 import org.junit.Test;
-import org.kitodo.api.dataformat.PhysicalDivision;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.kitodo.api.dataformat.PhysicalDivision;
 
 public class MediaUtilTest {
 

--- a/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
+++ b/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
@@ -11,12 +11,11 @@
 
 package org.kitodo.utils;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.kitodo.api.dataformat.PhysicalDivision;
 
 public class MediaUtilTest {

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/entities/PhysicalStructMapType.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/entities/PhysicalStructMapType.java
@@ -17,13 +17,13 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-import org.kitodo.api.dataformat.PhysicalDivision;
 import org.kitodo.config.KitodoConfig;
 import org.kitodo.config.enums.ParameterDataEditor;
 import org.kitodo.dataeditor.MetsKitodoObjectFactory;
 import org.kitodo.dataformat.metskitodo.DivType;
 import org.kitodo.dataformat.metskitodo.FileType;
 import org.kitodo.dataformat.metskitodo.StructMapType;
+import org.kitodo.utils.MediaUtil;
 
 public class PhysicalStructMapType extends StructMapType {
 
@@ -63,7 +63,7 @@ public class PhysicalStructMapType extends StructMapType {
             div.setID("PHYS_" + String.format("%04d", counter));
             div.setORDER(BigInteger.valueOf(counter));
             div.setORDERLABEL(KitodoConfig.getParameter(ParameterDataEditor.METS_EDITOR_DEFAULT_PAGINATION));
-            div.setTYPE(getPhysicalDivTypeByFileType(file));
+            div.setTYPE(MediaUtil.getPhysicalDivisionTypeOfMimeType(file.getMIMETYPE()));
             DivType.Fptr divTypeFptr = objectFactory.createDivTypeFptr();
             divTypeFptr.setFILEID(file);
             div.getFptr().add(divTypeFptr);
@@ -73,16 +73,6 @@ public class PhysicalStructMapType extends StructMapType {
             counter++;
         }
         return divTypes;
-    }
-
-    private String getPhysicalDivTypeByFileType(FileType file) {
-        if (file.getMIMETYPE().contains("image")) {
-            return PhysicalDivision.TYPE_PAGE;
-        }
-        if (file.getMIMETYPE().contains("audio")) {
-            return PhysicalDivision.TYPE_TRACK;
-        }
-        return PhysicalDivision.TYPE_OTHER;
     }
 
     private DivType getDivById(String id) {

--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/MetsKitodoWrapperTest.java
@@ -36,6 +36,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.kitodo.api.dataformat.PhysicalDivision;
 import org.kitodo.dataeditor.enums.FileLocationType;
 import org.kitodo.dataeditor.enums.PositionOfNewDiv;
 import org.kitodo.dataformat.metskitodo.DivType;
@@ -202,22 +203,22 @@ public class MetsKitodoWrapperTest {
     }
 
     @Test
-    public void shouldInsertFileGroup() throws IOException, DatatypeConfigurationException {
+    public void shouldInsertFileGroup() throws DatatypeConfigurationException, IOException {
         Path path = Paths.get("images");
         int numberOfFiles = 5;
         List<MediaFile> mediaFiles = new ArrayList<>();
         for (int i = 1; i <= numberOfFiles; i++) {
             mediaFiles.add(
-                new MediaFile(Paths.get(path + "/0000" + i + ".tif").toUri(), FileLocationType.URL, "image/tiff"));
+                    new MediaFile(Paths.get(path + "/0000" + i + ".tif").toUri(), FileLocationType.URL, "image/tiff"));
         }
 
         MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper("Manuscript");
         metsKitodoWrapper.insertMediaFiles(mediaFiles);
 
         Assert.assertEquals("Wrong number of divs in physical structMap", numberOfFiles,
-            metsKitodoWrapper.getPhysicalStructMap().getDiv().getDiv().size());
-        Assert.assertEquals("Wrong number of fils in fileSec", numberOfFiles,
-            metsKitodoWrapper.getMets().getFileSec().getFileGrp().get(0).getFile().size());
+                metsKitodoWrapper.getPhysicalStructMap().getDiv().getDiv().size());
+        Assert.assertEquals("Wrong number of files in fileSec", numberOfFiles,
+                metsKitodoWrapper.getMets().getFileSec().getFileGrp().get(0).getFile().size());
 
         DivType divType = metsKitodoWrapper.getPhysicalStructMap().getDiv().getDiv().get(1);
 
@@ -229,6 +230,28 @@ public class MetsKitodoWrapperTest {
         FileType fileType = (FileType) divType.getFptr().get(0).getFILEID();
         Assert.assertEquals("Wrong file id at second div", "FILE_0002", fileType.getID());
 
+    }
+
+
+    @Test
+    public void testPhysicalDivisionType() throws IOException, DatatypeConfigurationException {
+        List<MediaFile> mediaFiles = new ArrayList<>();
+        mediaFiles.add(new MediaFile(Paths.get("image/jpeg/0001.jpeg").toUri(), FileLocationType.URL, "image/jpeg"));
+        mediaFiles.add(new MediaFile(Paths.get("audio/mpeg/0002.jpeg").toUri(), FileLocationType.URL, "audio/mpeg"));
+        mediaFiles.add(new MediaFile(Paths.get("video/mp4/0003.jpeg").toUri(), FileLocationType.URL, "video/mp4"));
+
+        MetsKitodoWrapper metsKitodoWrapper = new MetsKitodoWrapper("MultiMedia");
+        metsKitodoWrapper.insertMediaFiles(mediaFiles);
+
+        Assert.assertEquals("Wrong number of divs in physical structMap", 3,
+                metsKitodoWrapper.getPhysicalStructMap().getDiv().getDiv().size());
+        Assert.assertEquals("Wrong number of files in fileSec", 3,
+                metsKitodoWrapper.getMets().getFileSec().getFileGrp().get(0).getFile().size());
+
+        List<DivType> divTypes = metsKitodoWrapper.getPhysicalStructMap().getDiv().getDiv();
+        Assert.assertEquals(PhysicalDivision.TYPE_PAGE, divTypes.get(0).getTYPE());
+        Assert.assertEquals(PhysicalDivision.TYPE_TRACK, divTypes.get(1).getTYPE());
+        Assert.assertEquals(PhysicalDivision.TYPE_TRACK, divTypes.get(2).getTYPE());
     }
 
     @Rule

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -553,7 +553,7 @@ public class AddDocStrucTypeDialog {
     }
 
     private void prepareSelectPageOnAddNodeItems() {
-        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
         selectPageOnAddNodeItems = new ArrayList<>(physicalDivisions.size());
         for (int i = 0; i < physicalDivisions.size(); i++) {
             View view = View.of(physicalDivisions.get(i));

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/EditPagesDialog.java
@@ -206,7 +206,7 @@ public class EditPagesDialog {
 
     private List<View> getViewsToAdd(List<Integer> pages) {
         return pages.parallelStream()
-                .map(dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted()::get)
+                .map(dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack()::get)
                 .map(MetadataEditor::getFirstViewForPhysicalDivision)
                 .collect(Collectors.toList());
     }
@@ -232,7 +232,7 @@ public class EditPagesDialog {
         paginationSubSelectionItems = new ArrayList<>();
         paginationSelectionItems = new ArrayList<>();
 
-        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
         int capacity = (int) Math.ceil(physicalDivisions.size() / .75);
         Set<Integer> assigneds = new HashSet<>(capacity);
         Set<Integer> unassigneds = new HashSet<>(capacity);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -50,6 +50,7 @@ import org.kitodo.production.helper.Helper;
 import org.kitodo.production.model.Subfolder;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.file.FileService;
+import org.kitodo.utils.MediaUtil;
 import org.primefaces.PrimeFaces;
 
 /**
@@ -356,7 +357,7 @@ public class GalleryPanel {
         Process process = dataEditor.getProcess();
         Project project = process.getProject();
         List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece()
-                .getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+                .getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
 
         mediaContentTypeVariants.clear();
         mediaContentTypePreviewFolder.clear();
@@ -400,7 +401,7 @@ public class GalleryPanel {
      */
     private void updateMedia() {
         List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece()
-                .getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+                .getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
         medias = new ArrayList<>(physicalDivisions.size());
         dataEditor.getMediaProvider().resetMediaResolverForProcess(dataEditor.getProcess().getId());
         for (PhysicalDivision physicalDivision : physicalDivisions) {
@@ -806,7 +807,7 @@ public class GalleryPanel {
     private void selectMedia(String physicalDivisionOrder, String stripeIndex, String selectionType) {
         PhysicalDivision selectedPhysicalDivision = null;
         for (PhysicalDivision physicalDivision : this.dataEditor.getWorkpiece()
-                .getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted()) {
+                .getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack()) {
             if (Objects.equals(physicalDivision.getOrder(), Integer.parseInt(physicalDivisionOrder))) {
                 selectedPhysicalDivision = physicalDivision;
                 break;
@@ -984,4 +985,32 @@ public class GalleryPanel {
     public String getCachingUUID() {
         return cachingUUID;
     }
+
+    /**
+     * Check if media view has mime type prefix.
+     *
+     * @param mimeTypePrefix
+     *         The mime type prefix
+     * @return True if media view has mime type prefix
+     */
+    public boolean hasMediaViewMimeTypePrefix(String mimeTypePrefix) {
+        Pair<PhysicalDivision, LogicalDivision> lastSelection = getLastSelection();
+        if (Objects.nonNull(lastSelection)) {
+            GalleryMediaContent galleryMediaContent = getGalleryMediaContent(lastSelection.getKey());
+            if (Objects.nonNull(galleryMediaContent)) {
+                String mediaViewMimeType = galleryMediaContent.getMediaViewMimeType();
+                switch (mimeTypePrefix) {
+                    case MediaUtil.MIME_TYPE_AUDIO_PREFIX:
+                        return MediaUtil.isAudio(mediaViewMimeType);
+                    case MediaUtil.MIME_TYPE_VIDEO_PREFIX:
+                        return MediaUtil.isVideo(mediaViewMimeType);
+                    case MediaUtil.MIME_TYPE_IMAGE_PREFIX:
+                        return MediaUtil.isImage(mediaViewMimeType);
+                    default:
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
@@ -84,7 +84,7 @@ public class PaginationPanel {
             Helper.setWarnMessage(e.getMessage());
         }
         dataEditor.setMediaUpdated(mediaReferencesChanged);
-        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
         for (int i = 1; i < physicalDivisions.size(); i++) {
             PhysicalDivision physicalDivision = physicalDivisions.get(i - 1);
             physicalDivision.setOrder(i);
@@ -112,7 +112,7 @@ public class PaginationPanel {
      *            selected items to set
      */
     public void setPaginationSelectionSelectedItems(List<Integer> selectedItems) {
-        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
         if (!selectedItems.isEmpty()) {
             int lastItemIndex = selectedItems.get(selectedItems.size() - 1);
             if (this.paginationSelectionSelectedItems.isEmpty()
@@ -266,7 +266,7 @@ public class PaginationPanel {
     }
 
     private void preparePaginationSelectionItems() {
-        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
         paginationSelectionItems = new ArrayList<>(physicalDivisions.size());
         for (int i = 0; i < physicalDivisions.size(); i++) {
             View view = View.of(physicalDivisions.get(i));
@@ -280,7 +280,7 @@ public class PaginationPanel {
      */
     public void preparePaginationSelectionSelectedItems() {
         paginationSelectionSelectedItems = new ArrayList<>();
-        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+        List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
         for (Pair<PhysicalDivision, LogicalDivision> selectedElement : dataEditor.getSelectedMedia()) {
             for (int i = 0; i < physicalDivisions.size(); i++) {
                 PhysicalDivision physicalDivision = physicalDivisions.get(i);
@@ -342,7 +342,7 @@ public class PaginationPanel {
                 paginationStartValue, fictitiousCheckboxChecked, pageSeparators.get(0).getSeparatorString());
             Paginator paginator = new Paginator(initializer);
             List<PhysicalDivision> physicalDivisions = dataEditor.getWorkpiece()
-                    .getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted();
+                    .getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack();
             if (selectPaginationScopeSelectedItem) {
                 for (int i = paginationSelectionSelectedItems.get(0); i < physicalDivisions.size(); i++) {
                     physicalDivisions.get(i).setOrderlabel(paginator.next());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -239,7 +239,7 @@ public class StructurePanel implements Serializable {
             }
         }
         int i = 1;
-        for (PhysicalDivision physicalDivision : dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenFilteredByTypePageAndSorted()) {
+        for (PhysicalDivision physicalDivision : dataEditor.getWorkpiece().getAllPhysicalDivisionChildrenSortedFilteredByPageAndTrack()) {
             physicalDivision.setOrder(i);
             i++;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/UploadFileDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/UploadFileDialog.java
@@ -55,6 +55,7 @@ import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.file.SubfolderFactoryService;
 import org.kitodo.production.services.image.ImageGenerator;
 import org.kitodo.production.thread.TaskImageGeneratorThread;
+import org.kitodo.utils.MediaUtil;
 import org.primefaces.PrimeFaces;
 import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.TreeNode;
@@ -213,16 +214,6 @@ public class UploadFileDialog {
         return mediaVariant;
     }
 
-    private String getPhysicalDivType() {
-        if (mimeType.contains("image")) {
-            return PhysicalDivision.TYPE_PAGE;
-        }
-        if (mimeType.contains("audio")) {
-            return PhysicalDivision.TYPE_TRACK;
-        }
-        return PhysicalDivision.TYPE_OTHER;
-    }
-
     private boolean setUpFolders() {
         VariableReplacer variableReplacer = new VariableReplacer(null, dataEditor.getProcess(), null);
         sourceFolder = dataEditor.getProcess().getProject().getGeneratorSource();
@@ -336,7 +327,7 @@ public class UploadFileDialog {
     public void uploadMedia(FileUploadEvent event) {
         if (event.getFile() != null) {
 
-            PhysicalDivision physicalDivision = MetadataEditor.addPhysicalDivision(getPhysicalDivType(),
+            PhysicalDivision physicalDivision = MetadataEditor.addPhysicalDivision(MediaUtil.getPhysicalDivisionTypeOfMimeType(mimeType),
                     dataEditor.getWorkpiece(), dataEditor.getWorkpiece().getPhysicalStructure(),
                     InsertionPosition.LAST_CHILD_OF_CURRENT_ELEMENT);
             uploadFileUri = new File(sourceFolderURI.getPath().concat(event.getFile().getFileName())).toURI();

--- a/Kitodo/src/main/resources/kitodo_fileFormats.xml
+++ b/Kitodo/src/main/resources/kitodo_fileFormats.xml
@@ -70,4 +70,10 @@
     <fileFormat extension="bmp" formatName="bmp" imageFileFormat="BMP" mimeType="image/bmp">
         <label>Windows Bitmap (image/bmp, *.bmp)</label>
     </fileFormat>
+    <fileFormat extension="mp4" formatName="mp4" mimeType="video/mp4">
+        <label>MP4 (video/mp4, *.mp4)</label>
+    </fileFormat>
+    <fileFormat extension="mp3" formatName="mp3" mimeType="audio/mpeg">
+        <label>MP3 (audio/mpeg, *.mp3)</label>
+    </fileFormat>
 </kitodo_fileFormats>

--- a/Kitodo/src/main/resources/kitodo_fileFormats.xml
+++ b/Kitodo/src/main/resources/kitodo_fileFormats.xml
@@ -73,7 +73,19 @@
     <fileFormat extension="mp4" formatName="mp4" mimeType="video/mp4">
         <label>MP4 (video/mp4, *.mp4)</label>
     </fileFormat>
+    <fileFormat extension="ogv" formatName="ogv" mimeType="video/ogg">
+        <label>OGG (video/ogg, *.ogv)</label>
+    </fileFormat>
+    <fileFormat extension="webm" formatName="webm" mimeType="video/webm">
+        <label>WEBM (video/webm, *.webm)</label>
+    </fileFormat>
     <fileFormat extension="mp3" formatName="mp3" mimeType="audio/mpeg">
         <label>MP3 (audio/mpeg, *.mp3)</label>
+    </fileFormat>
+    <fileFormat extension="oga" formatName="oga" mimeType="audio/ogg">
+        <label>OGG (audio/ogg, *.oga)</label>
+    </fileFormat>
+    <fileFormat extension="weba" formatName="weba" mimeType="audio/webm">
+        <label>WEBM (audio/webm, *.weba)</label>
     </fileFormat>
 </kitodo_fileFormats>

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -207,11 +207,15 @@
                                 </ui:fragment>
                                 <ui:fragment rendered="#{DataEditorForm.galleryPanel.galleryViewMode eq 'preview'}">
                                     <h:outputText styleClass="columnHeading"
-                                                  rendered="#{DataEditorForm.galleryPanel.lastSelection ne null and DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).mediaViewMimeType eq 'video/mp4'}"
+                                                  rendered="#{DataEditorForm.galleryPanel.hasMediaViewMimeTypePrefix('audio')}"
+                                                  value="#{msgs.audio}
+                                                  #{DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).shortId}"/>
+                                    <h:outputText styleClass="columnHeading"
+                                                  rendered="#{DataEditorForm.galleryPanel.hasMediaViewMimeTypePrefix('video')}"
                                                   value="#{msgs.video}
                                                   #{DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).shortId}"/>
                                     <h:outputText styleClass="columnHeading"
-                                                  rendered="#{DataEditorForm.galleryPanel.lastSelection ne null and DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).mediaViewMimeType ne 'video/mp4'}"
+                                                  rendered="#{DataEditorForm.galleryPanel.hasMediaViewMimeTypePrefix('image')}"
                                                   value="#{msgs.image}
                                                  #{DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key).shortId},
                                                  #{msgs.page}


### PR DESCRIPTION
- Use track type for audio and video MIME types
- Add MediaUtils class to handle media specific functionalities
- Tests for these functionalities
- Add supported video and audio formats to `kitodo_fileFormats.xml`