### PR TITLE
Make use of full page width on role edit details page

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/roleEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/roleEdit/details.xhtml
@@ -42,52 +42,53 @@
             </p:row>
             <p:row rendered="#{not SecurityAccessController.hasAuthorityGlobalToAddOrEditRole()}" />
         </p:panelGrid>
-            <div>
-                <p:panelGrid columns="2" layout="grid">
-                    <!--global authorities-->
+        <p:panelGrid columns="2" layout="grid">
+            <p:row>
+                <!--global authorities-->
+                <h:panelGroup>
+                    <h3 style="margin-bottom: 20px">
+                        <h:outputText value="#{msgs.globalAssignable}"/>
+                    </h3>
+                    <p:pickList id="authoritiesGlobalPick"
+                                showSourceFilter="true" showTargetFilter="true"
+                                filterMatchMode="contains"
+                                responsive="true"
+                                disabled="#{isViewMode}"
+                                value="#{RoleForm.globalAssignableAuthorities}"
+                                converter="#{authorityConverter}"
+                                var="authority"
+                                itemLabel="#{HelperForm.getTranslated(authority.getTitleWithoutSuffix())}"
+                                itemValue="#{authority}"
+                                onTransfer="toggleSave()">
+                        <f:facet name="sourceCaption">#{msgs.available}</f:facet>
+                        <f:facet name="targetCaption">#{msgs.assigned}</f:facet>
+                    </p:pickList>
+                </h:panelGroup>
+            </p:row>
 
-                    <h:panelGroup>
-                        <h3 style="margin-bottom: 20px">
-                            <h:outputText value="#{msgs.globalAssignable}"/>
-                        </h3>
-                        <p:pickList id="authoritiesGlobalPick"
-                                    showSourceFilter="true" showTargetFilter="true"
-                                    filterMatchMode="contains"
-                                    responsive="true"
-                                    disabled="#{isViewMode}"
-                                    value="#{RoleForm.globalAssignableAuthorities}"
-                                    converter="#{authorityConverter}"
-                                    var="authority"
-                                    itemLabel="#{HelperForm.getTranslated(authority.getTitleWithoutSuffix())}"
-                                    itemValue="#{authority}"
-                                    onTransfer="toggleSave()">
-                            <f:facet name="sourceCaption">#{msgs.available}</f:facet>
-                            <f:facet name="targetCaption">#{msgs.assigned}</f:facet>
-                        </p:pickList>
-                    </h:panelGroup>
-
-                    <!--client authorities-->
-                    <h:panelGroup>
-                        <h3 style="margin-bottom: 20px">
-                            <h:outputText value="#{msgs.clientAssignable}"/>
-                        </h3>
-                        <p:pickList id="authoritiesClientPick"
-                                    value="#{RoleForm.clientAssignableAuthorities}"
-                                    converter="#{authorityConverter}"
-                                    var="authority"
-                                    disabled="#{isViewMode}"
-                                    showSourceFilter="true" showTargetFilter="true"
-                                    filterMatchMode="contains"
-                                    responsive="true"
-                                    onTransfer="toggleSave()"
-                                    itemLabel="#{HelperForm.getTranslated(authority.getTitleWithoutSuffix())}"
-                                    itemValue="#{authority}">
-                            <f:facet name="sourceCaption">#{msgs.available}</f:facet>
-                            <f:facet name="targetCaption">#{msgs.assigned}</f:facet>
-                        </p:pickList>
-                    </h:panelGroup>
-                </p:panelGrid>
-            </div>
+            <p:row>
+                <!--client authorities-->
+                <h:panelGroup>
+                    <h3 style="margin-bottom: 20px">
+                        <h:outputText value="#{msgs.clientAssignable}"/>
+                    </h3>
+                    <p:pickList id="authoritiesClientPick"
+                                value="#{RoleForm.clientAssignableAuthorities}"
+                                converter="#{authorityConverter}"
+                                var="authority"
+                                disabled="#{isViewMode}"
+                                showSourceFilter="true" showTargetFilter="true"
+                                filterMatchMode="contains"
+                                responsive="true"
+                                onTransfer="toggleSave()"
+                                itemLabel="#{HelperForm.getTranslated(authority.getTitleWithoutSuffix())}"
+                                itemValue="#{authority}">
+                        <f:facet name="sourceCaption">#{msgs.available}</f:facet>
+                        <f:facet name="targetCaption">#{msgs.assigned}</f:facet>
+                    </p:pickList>
+                </h:panelGroup>
+            </p:row>
+        </p:panelGrid>
         <p:row/>
     </p:panelGrid>
 


### PR DESCRIPTION
The "Edit role" page currently only used two thirds of the available horizontal space for assigning global and client authorities/permissions to a role. This results in a slighty off look and waisted screen estate:

![Bildschirmfoto 2023-11-28 um 11 02 57](https://github.com/kitodo/kitodo-production/assets/19183925/88d66f10-640f-489c-8a73-f17e377c2a8c)

This PR changes the layout to utilize the horizontal space correctly:

![Bildschirmfoto 2023-11-28 um 11 02 24](https://github.com/kitodo/kitodo-production/assets/19183925/3038a646-b8f0-4609-b1b8-87b2f18f0824)
