### PR TITLE
Handle potential ConfigException during catalogue configuration import

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationListView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationListView.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.kitodo.config.OPACConfig;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.exceptions.ConfigException;
 import org.kitodo.exceptions.ImportConfigurationInUseException;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
@@ -96,6 +97,8 @@ public class ImportConfigurationListView extends BaseForm {
             PrimeFaces.current().executeScript("PF('importCatalogConfigurationsDialog').show();");
         } catch (ConfigurationException e) {
             Helper.setErrorMessage(e.getMessage() + ": " + e.getCause().getMessage());
+        } catch (ConfigException e) {
+            Helper.setErrorMessage(e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Fixes #5862 by handling `ConfigException` in addition to `ConfigurationException`.

The reason for both exception being handled in separate `catch` blocks is that the `ConfigurationException` is thrown when syntactical errors in the XML file are encountered and this "cause" is then also displayed (in addition to the exception message itself): 
<img width="1472" alt="Bildschirmfoto 2023-12-22 um 16 04 56" src="https://github.com/kitodo/kitodo-production/assets/19183925/cf9dc38e-3b2b-4a5c-abe7-928c876bac71">

The `ConfigException` on the other hand is thrown when the whole XML file is missing. In this case, the "cause" of the exception is identical to the exception message itself, so there is no need to show both of them:
<img width="1479" alt="Bildschirmfoto 2023-12-22 um 16 03 53" src="https://github.com/kitodo/kitodo-production/assets/19183925/abad35e4-8245-4870-842a-65ac78ed2e67">


