### PR TITLE
Remove redundant filter and task status menus

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -277,40 +277,4 @@
             </p:rowExpansion>
         </p:dataTable>
     </h:form>
-
-    <div id="dropDownMenus">
-        <h:form id="filterForm"
-                styleClass="filter-form"
-                style="display: inline-block;">
-            <p:selectCheckboxMenu id="taskFilters"
-                                  panelStyleClass="filter-panel"
-                                  value="#{CurrentTaskForm.selectedTaskFilters}"
-                                  styleClass="secondary"
-                                  label="#{msgs.filter}">
-                <f:selectItems value="#{CurrentTaskForm.taskFilters}"
-                               var="taskFilter"
-                               itemLabel="#{msgs[taskFilter]}"/>
-                <p:ajax event="change"
-                        onstart="PF('taskTable').getPaginator().setPage(0);"
-                        listener="#{CurrentTaskForm.taskFiltersChanged}"
-                        update="tasksTabView:tasksForm:taskTable"/>
-            </p:selectCheckboxMenu>
-        </h:form>
-        <h:form id="statusForm"
-                style="display: inline-block;">
-            <p:selectCheckboxMenu id="taskStatus"
-                                  panelStyleClass="filter-panel"
-                                  value="#{CurrentTaskForm.selectedTaskStatus}"
-                                  styleClass="secondary"
-                                  label="#{msgs.processingStatus}">
-                <f:selectItems value="#{CurrentTaskForm.taskStatus}"
-                               var="taskStatus"
-                               itemLabel="#{msgs[taskStatus.title]}"/>
-                <p:ajax event="change"
-                        onstart="PF('taskTable').getPaginator().setPage(0);"
-                        listener="#{CurrentTaskForm.taskStatusChanged}"
-                        update="tasksTabView:tasksForm:taskTable"/>
-            </p:selectCheckboxMenu>
-        </h:form>
-    </div>
 </ui:composition>


### PR DESCRIPTION
#5523 introduced a new filter menu with modern look and feel for the task and process lists in Kitodo.Production, replacing the old UI elements in the footer:

<img width="475" alt="Bildschirmfoto 2024-01-02 um 12 50 32" src="https://github.com/kitodo/kitodo-production/assets/19183925/aba865ad-0a62-4617-bbf8-d0392b682829">

The task list however still contains these old footer filter menus, which I think it redundant and unnecessarily complicates usage.

<img width="521" alt="Bildschirmfoto 2024-01-02 um 12 51 51" src="https://github.com/kitodo/kitodo-production/assets/19183925/edc61bd0-4a3a-4483-84a1-ff2881e22b1e">

Additionally, the status of a specific filter in one of both UI components is not updated when changed in the other component, leading to contradicting UI states:

<img width="1504" alt="Bildschirmfoto 2024-01-02 um 12 55 15" src="https://github.com/kitodo/kitodo-production/assets/19183925/207022fc-81b2-4e55-b1a6-b8a33856d439">

This pull request resolves this issue by removing the now redundant filters in the footer menu.