### PR TITLE
Catch import configuration errors during mass import

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
@@ -30,6 +30,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.exceptions.ConfigException;
 import org.kitodo.exceptions.ImportException;
 import org.kitodo.production.forms.BaseForm;
 import org.kitodo.production.forms.CsvRecord;
@@ -62,6 +63,7 @@ public class MassImportForm extends BaseForm {
     private HashMap<String, String> importSuccessMap = new HashMap<>();
     private Integer progress = 0;
     private Boolean rulesetConfigurationForOpacImportComplete = null;
+    private String configurationError = null;
 
     /**
      * Prepare mass import.
@@ -157,6 +159,11 @@ public class MassImportForm extends BaseForm {
             PrimeFaces.current().ajax().update("massImportResultDialog");
         } catch (ImportException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
+        } catch (ConfigException e) {
+            configurationError = e.getLocalizedMessage();
+            PrimeFaces.current().executeScript("PF('massImportProgressBar').cancel();");
+            PrimeFaces.current().executeScript("PF('configErrorDialog').show();");
+            PrimeFaces.current().ajax().update("configErrorDialog");
         }
     }
 
@@ -442,5 +449,13 @@ public class MassImportForm extends BaseForm {
      */
     public Boolean getRulesetConfigurationForOpacImportComplete() {
         return rulesetConfigurationForOpacImportComplete;
+    }
+
+    /**
+     * Get ConfigurationError value.
+     * @return configuration error value
+     */
+    public String getConfigurationError() {
+        return configurationError;
     }
 }

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -25,6 +25,7 @@ calendar.upload.missingMandatoryElement=Ein erforderliches XML-Element konnte ni
 calendar.upload.missingMandatoryValue=Ein erforderlicher Wert konnte nicht gefunden werden.
 calendar.upload.overlappingDateRanges=Der Erscheinungsverlauf konnte nicht importiert werden, da sich Datumsbereiche von Bl\u00F6cken \u00FCberlappen\:
 catalogError=Fehler bei Abfrage von Katalog \u201E{0}\u201C
+configurationError=Konfigurationsfehler
 copyDataError=Fehler beim Kopieren der Daten
 createProcessForm.createNewProcess.noInsertionPositionSelected=Es wurde keine Position f\u00FCr die Titelsatzverkn\u00FCpfung ausgew\u00E4hlt.
 createProcessForm.createNewProcess.recordIdentifierMissing.caption='recordIdentifier'-Metadaten nicht gefunden

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -25,6 +25,7 @@ calendar.upload.missingMandatoryElement=A mandatory XML element could not be fou
 calendar.upload.missingMandatoryValue=A mandatory value could not be found.
 calendar.upload.overlappingDateRanges=Due to overlapping date ranges of blocks, the course of appearance could not be imported\:
 catalogError=Error querying OPAC \u201E{0}\u201C
+configurationError=Configuration error
 copyDataError=Error while copying the data
 createProcessForm.createNewProcess.noInsertionPositionSelected=No title record linking position was selected.
 createProcessForm.createNewProcess.recordIdentifierMissing.caption='recordIdentifier' metadata missing

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/configError.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/configError.xhtml
@@ -1,0 +1,58 @@
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:f="http://java.sun.com/jsf/core"
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+    <p:dialog id="configErrorDialog"
+              widgetVar="configErrorDialog"
+              showHeader="false"
+              modal="true"
+              width="680px"
+              appendTo="@(body)"
+              resizable="false"
+              closable="false">
+        <h:panelGroup id="configErrorWrapper">
+            <h3>#{err['configurationError']} - #{MassImportForm.importConfigurationId.title}</h3>
+            <div class="select-note ui-messages-error">
+                <h:outputText value="#{MassImportForm.configurationError}"/>
+            </div>
+        </h:panelGroup>
+
+        <p:panelGrid>
+            <h:panelGroup layout="block"
+                          styleClass="dialogButtonWrapper right">
+                <p:commandButton value="#{msgs.close}"
+                                 type="button"
+                                 widgetVar="closeButton"
+                                 onclick="PF('configErrorDialog').hide();"
+                                 icon="fa fa-times fa-lg"
+                                 iconPos="right"
+                                 styleClass="secondary right"/>
+                <p:button id="editImportConfiguration"
+                          outcome="importConfigurationEdit"
+                          title="#{msgs.editImportConfiguration}"
+                          value="#{msgs.editImportConfiguration}"
+                          icon="fa fa-pencil-square fa-lg"
+                          iconPos="right"
+                          styleClass="secondary-button secondary right"
+                          rendered="#{SecurityAccessController.hasAuthorityToEditImportConfiguration()}">
+                    <f:param name="id" value="#{MassImportForm.importConfigurationId.id}"/>
+                </p:button>
+            </h:panelGroup>
+        </p:panelGrid>
+    </p:dialog>
+</ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/configError.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/configError.xhtml
@@ -41,7 +41,7 @@
                                  onclick="PF('configErrorDialog').hide();"
                                  icon="fa fa-times fa-lg"
                                  iconPos="right"
-                                 styleClass="secondary right"/>
+                                 styleClass="primary right"/>
                 <p:button id="editImportConfiguration"
                           outcome="importConfigurationEdit"
                           title="#{msgs.editImportConfiguration}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/configError.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/configError.xhtml
@@ -46,7 +46,7 @@
                           outcome="importConfigurationEdit"
                           title="#{msgs.editImportConfiguration}"
                           value="#{msgs.editImportConfiguration}"
-                          icon="fa fa-pencil-square fa-lg"
+                          icon="fa fa-pencil-square-o fa-lg"
                           iconPos="right"
                           styleClass="secondary-button secondary right"
                           rendered="#{SecurityAccessController.hasAuthorityToEditImportConfiguration()}">

--- a/Kitodo/src/main/webapp/pages/massImport.xhtml
+++ b/Kitodo/src/main/webapp/pages/massImport.xhtml
@@ -70,6 +70,7 @@
         <ui:include src="/WEB-INF/templates/includes/massImport/dialogs/addMetadata.xhtml"/>
         <ui:include src="/WEB-INF/templates/includes/massImport/dialogs/massImportProgress.xhtml"/>
         <ui:include src="/WEB-INF/templates/includes/massImport/dialogs/massImportResults.xhtml"/>
+        <ui:include src="/WEB-INF/templates/includes/massImport/dialogs/configError.xhtml"/>
         <ui:include src="/WEB-INF/templates/includes/recordIdentifierMissingDialog.xhtml"/>
     </ui:define>
 


### PR DESCRIPTION
Fixes #5584 
<img width="1501" alt="Bildschirmfoto 2024-01-10 um 11 14 17" src="https://github.com/kitodo/kitodo-production/assets/19183925/2540d811-22f2-4d10-a0bf-83c2630b1e93">

If the user has the corresponding permission, an additional button to edit and (hopefully) fix the import configuration is displayed:
<img width="1498" alt="Bildschirmfoto 2024-01-10 um 11 13 25" src="https://github.com/kitodo/kitodo-production/assets/19183925/e42f7e62-2850-4ccd-aa1e-6906aae64dfc">



