### PR TITLE
Updating Bouncy Castle dependency (security fix)

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -87,7 +87,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.camunda.bpm.model</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -414,8 +414,8 @@ from system library in Java 11+ -->
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>1.70</version>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.77</version>
             </dependency>
             <dependency>
                 <groupId>org.camunda.bpm.model</groupId>


### PR DESCRIPTION
- Fix [CVE-2023-33201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-33201)
- Switching to different artefactId is necessary as new versions are released on new artefactId which depends at least on Java 8 instead of Java 5 