### PR TITLE
Do not try to load process table on other list pages

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/lists.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/lists.js
@@ -51,7 +51,7 @@ $(document).on("click", ".allSelectable .ui-chkbox-all .ui-chkbox-box", function
 
 $(window).on("load", function () {
     $.ready.then(function () {
-        if (typeof PF('processesTable').selection !== "undefined" && (PF('processesTable').selection[0] === '@all' || PF('processesTable').selection.length === PF('processesTable').cfg.paginator.rowCount )) {
+        if ($('#processesTabView\\:processesForm\\:processesTable').length && typeof PF('processesTable').selection !== "undefined" && (PF('processesTable').selection[0] === '@all' || PF('processesTable').selection.length === PF('processesTable').cfg.paginator.rowCount )) {
             PF('processesTable').selectAllRows();
             PF('processesTable').selection=new Array("@all");
             $(PF('processesTable').selectionHolder).val('@all');


### PR DESCRIPTION
Javascript file `lists.js` is loaded an all list pages ("UserList", "ProcessList", "ProjectList" etc.). Since it tries to access the element `processList` on every page it is included, it produces an Javascript error on all pages but the process list page:

![Bildschirmfoto 2024-01-05 um 14 23 44](https://github.com/kitodo/kitodo-production/assets/19183925/e7ffe219-cdc4-445f-89f4-bf9852f74d50)

This pull request prevents the Javascript error on other list pages like project list etc.