### PR TITLE
Prevent saving a broken METS file

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -428,6 +428,12 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
     private StructLink createStructLink(LinkedList<Pair<String, String>> smLinkData) {
         StructLink structLink = new StructLink();
         structLink.getSmLinkOrSmLinkGrp().addAll(smLinkData.parallelStream().map(entry -> {
+            if (Objects.isNull(entry.getLeft())) {
+                throw new IllegalArgumentException("smLinkData.entry[?].left must not be null");
+            }
+            if (Objects.isNull(entry.getRight())) {
+                throw new IllegalArgumentException("smLinkData.entry[?].right must not be null");
+            }
             SmLink smLink = new SmLink();
             smLink.setFrom(entry.getLeft());
             smLink.setTo(entry.getRight());


### PR DESCRIPTION
See #5880. This will not fix the underlying problem, but it will prevent the Metadata Editor from silently saving a broken METS file. Instead, an exception will occur, to rise awareness to a problem.

After PR #5756 has been  merged, those lines can be refactored to:
```java
Guard.isNotNull("smLinkData.entry[?].left", entry.getLeft());
Guard.isNotNull("smLinkData.entry[?].right", entry.getRight());
```