### PR TITLE
[3.6.x] Catch Exceptions in indexing processes, log warning and continue

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -71,6 +71,7 @@ import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.join.ScoreMode;
@@ -350,11 +351,16 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         if (!fileService.fileExist(metadataFilePath)) {
             logger.info("No metadata file for indexing: {}", metadataFilePath);
         } else {
-            Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metadataFilePath);
-            process.setNumberOfImages(getNumberOfImagesForIndex(workpiece));
-            process.setNumberOfMetadata(getNumberOfMetadata(workpiece));
-            process.setNumberOfStructures(getNumberOfStructures(workpiece));
-            process.setBaseType(getBaseType(workpiece));
+            try {
+                Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(metadataFilePath);
+                process.setNumberOfImages(getNumberOfImagesForIndex(workpiece));
+                process.setNumberOfMetadata(getNumberOfMetadata(workpiece));
+                process.setNumberOfStructures(getNumberOfStructures(workpiece));
+                process.setBaseType(getBaseType(workpiece));
+            } catch (IllegalArgumentException | IOException e) {
+                logger.warn("Cannot read metadata file for indexing: {}", metadataFilePath);
+                logger.catching(Level.DEBUG, e);
+            }
         }
     }
 


### PR DESCRIPTION
If the indexing has a problem reading a METS file, you will get a condition like depicted below, and there is nothing you can do. There is also no additional information displayed as to what is causing this:

![Screenshot](https://github.com/kitodo/kitodo-production/assets/3040657/7a16f20c-23e6-48d3-94b9-e1b7586562e7)

Cases in which the index becomes corrupt in a productive environment have become rare, fortunately! But having to rebuild the index, for whatever reason, is associated with downtime in the production environment during which colleagues cannot work. Therefore, I have followed the procedure here when the METS file is missing: An error is now logged and indexing continues for this process without METS data. The error is logged at `WARN` level, and you can take care of this process manually later.