### PR TITLE
Assign ID to logical divisions in imported METS files which don't have one

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -80,9 +80,14 @@ public class DivXmlElementAccess extends LogicalDivision {
      */
     DivXmlElementAccess(LogicalDivision logicalDivision) {
         super(logicalDivision);
-        metsReferrerId = logicalDivision instanceof DivXmlElementAccess
-                ? ((DivXmlElementAccess) logicalDivision).metsReferrerId
-                : KitodoUUID.randomUUID();
+        String obtainedReferrerId = null;
+        if (logicalDivision instanceof DivXmlElementAccess) {
+            obtainedReferrerId = ((DivXmlElementAccess) logicalDivision).metsReferrerId;
+        }
+        if (Objects.isNull(obtainedReferrerId)) {
+            obtainedReferrerId = KitodoUUID.randomUUID();
+        }
+        metsReferrerId = obtainedReferrerId;
     }
 
     /**


### PR DESCRIPTION
In imported data, logical `<div>`s may not yet have an ID, in which case they cannot be linked. As by now Production did assume that itself was the only source METS files, this error never showed up because Production always assigned IDs in the first place.