### PR TITLE
Create SecureRandom only once per class

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -53,6 +53,7 @@ public class Helper {
     private static final Logger logger = LogManager.getLogger(Helper.class);
     private static Map<Locale, ResourceBundle> commonMessages = null;
     private static Map<Locale, ResourceBundle> errorMessages = null;
+    private static final SecureRandom secureRandom = new SecureRandom();
 
     /**
      * Determine a specific parameter of the request.
@@ -542,11 +543,10 @@ public class Helper {
      */
     public static String generateRandomString(int length) {
         final String AB = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-        SecureRandom random = new SecureRandom();
 
         StringBuilder sb = new StringBuilder(length);
         for (int i = 0; i < length; i++) {
-            sb.append(AB.charAt(random.nextInt(AB.length())));
+            sb.append(AB.charAt(secureRandom.nextInt(AB.length())));
         }
         return sb.toString();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/security/AESUtil.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/AESUtil.java
@@ -39,6 +39,8 @@ public class AESUtil {
 
     private static final Logger logger = LogManager.getLogger(AESUtil.class);
 
+    private static final SecureRandom secureRandom = new SecureRandom();
+
     /*
      * DO NOT CHANGE! Identifier for is encryption check and secret key generation.
      * If changed are made, encrypted data cannot be restored.
@@ -78,12 +80,12 @@ public class AESUtil {
 
         // generate salt
         byte[] salt = new byte[SALT_LENGTH];
-        new SecureRandom().nextBytes(salt);
+        secureRandom.nextBytes(salt);
         System.arraycopy(SALT_PREFIX.getBytes(), 0, salt, 0, SALT_PREFIX.getBytes().length);
 
         // generate iv
         byte[] iv = new byte[IV_LENGTH];
-        new SecureRandom().nextBytes(iv);
+        secureRandom.nextBytes(iv);
 
         Cipher cipher = Cipher.getInstance(ALGORITHM);
         cipher.init(Cipher.ENCRYPT_MODE, getSecretKey(secret, salt), new IvParameterSpec(iv));


### PR DESCRIPTION
Fixes [CWE-335](https://cwe.mitre.org/data/definitions/335.html) as only one random generator per class is used. This can maybe extend to one random generator per module in a following change.