### PR TITLE
Use efficient isEmpty call over inefficient empty string comparison

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameBeginsAndEndsWithFilter.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameBeginsAndEndsWithFilter.java
@@ -34,7 +34,7 @@ public class FileNameBeginsAndEndsWithFilter implements FilenameFilter {
      *             Strings
      */
     public FileNameBeginsAndEndsWithFilter(String begin, String end) {
-        if (begin == null || begin.equals("") || end == null || end.equals("")) {
+        if (begin == null || begin.isEmpty() || end == null || end.isEmpty()) {
             throw new IllegalArgumentException("No filter or empty filter for file begin or end is given.");
         }
         this.begin = begin;

--- a/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameEndsAndDoesNotBeginWithFilter.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameEndsAndDoesNotBeginWithFilter.java
@@ -34,7 +34,7 @@ public class FileNameEndsAndDoesNotBeginWithFilter implements FilenameFilter {
      *             Strings
      */
     public FileNameEndsAndDoesNotBeginWithFilter(String notBegin, String end) {
-        if (notBegin == null || notBegin.equals("") || end == null || end.equals("")) {
+        if (notBegin == null || notBegin.isEmpty() || end == null || end.isEmpty()) {
             throw new IllegalArgumentException("No filter or empty filter for file begin or end is given.");
         }
         this.notBegin = notBegin;

--- a/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameEndsWithFilter.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameEndsWithFilter.java
@@ -30,7 +30,7 @@ public class FileNameEndsWithFilter implements FilenameFilter {
      *             it is thrown in case parameter is null or empty String
      */
     public FileNameEndsWithFilter(String end) {
-        if (end == null || end.equals("")) {
+        if (end == null || end.isEmpty()) {
             throw new IllegalArgumentException("No filter or empty filter for file end is given.");
         }
         this.end = end;

--- a/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameMatchesFilter.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/filemanagement/filters/FileNameMatchesFilter.java
@@ -27,7 +27,7 @@ public class FileNameMatchesFilter implements FilenameFilter {
      *             it is thrown in case parameter is null or empty String
      */
     public FileNameMatchesFilter(String name) {
-        if (name == null || name.equals("")) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("No filter or empty name is given.");
         }
         this.name = name;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -149,7 +149,7 @@ public class AddDocStrucTypeDialog {
     private void addMultiDocStruc() {
         Optional<LogicalDivision> selectedStructure = dataEditor.getSelectedStructure();
         if (selectedStructure.isPresent()) {
-            if (selectedMetadata != "") {
+            if (!selectedMetadata.isEmpty()) {
                 MetadataViewInterface metadataView = getMetadataViewFromKey(
                     docStructAddTypeSelectionSelectedItem, selectedMetadata);
                 MetadataEditor.addMultipleStructuresWithMetadata(elementsToAddSpinnerValue,

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -412,7 +412,7 @@ public class Helper {
      * @return the date or null if it can not be parsed
      */
     public static Date parseDateFromFormattedString(String date) {
-        if (Objects.isNull(date) || date.equals("")) {
+        if (Objects.isNull(date) || date.isEmpty()) {
             return null;
         }
         try {

--- a/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
+++ b/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
@@ -278,7 +278,7 @@ public class LdapUser implements DirContext {
 
     @Override
     public Attributes getAttributes(String name) throws NamingException {
-        if (!name.equals("")) {
+        if (!name.isEmpty()) {
             throw new NameNotFoundException();
         }
         return (Attributes) this.attributes.clone();

--- a/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
+++ b/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
@@ -44,6 +44,7 @@ import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.digests.MD4Digest;
@@ -278,7 +279,7 @@ public class LdapUser implements DirContext {
 
     @Override
     public Attributes getAttributes(String name) throws NamingException {
-        if (!name.isEmpty()) {
+        if (StringUtils.isBlank(name)) {
             throw new NameNotFoundException();
         }
         return (Attributes) this.attributes.clone();
@@ -291,7 +292,7 @@ public class LdapUser implements DirContext {
 
     @Override
     public Attributes getAttributes(String name, String[] ids) throws NamingException {
-        if (!name.isEmpty()) {
+        if (StringUtils.isBlank(name)) {
             throw new NameNotFoundException();
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/process/field/AdditionalField.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/field/AdditionalField.java
@@ -329,16 +329,16 @@ public class AdditionalField {
      */
     public boolean showDependingOnDoctype() {
         // if nothing was specified, then show
-        if (this.isDocType.equals("") && this.isNotDoctype.equals("")) {
+        if (this.isDocType.isEmpty() && this.isNotDoctype.isEmpty()) {
             return true;
         }
 
         // if obligatory was specified
-        if (!this.isDocType.equals("") && !StringUtils.containsIgnoreCase(this.isDocType, this.docType)) {
+        if (!this.isDocType.isEmpty() && !StringUtils.containsIgnoreCase(this.isDocType, this.docType)) {
             return false;
         }
 
         // if only "may not" was specified
-        return !(!this.isNotDoctype.equals("") && StringUtils.containsIgnoreCase(this.isNotDoctype, this.docType));
+        return !(!this.isNotDoctype.isEmpty() && StringUtils.containsIgnoreCase(this.isNotDoctype, this.docType));
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1183,14 +1183,14 @@ public class FileService {
                     physicalDivision.getMediaFiles().put(entry.getKey(), mediaFile);
                 }
                 String fileCanonical = subfolder.getCanonical(mediaFile);
-                if ("".equals(unitCanonical)) {
+                if (unitCanonical.isEmpty()) {
                     unitCanonical = fileCanonical;
                 } else if (!unitCanonical.equals(fileCanonical)) {
                     throw new InvalidImagesException("Ambiguous canonical file name part in the same physical division: \""
                             + unitCanonical + "\" and \"" + fileCanonical + "\"!");
                 }
             }
-            if (physicalDivision.getMediaFiles().size() > 0 && "".equals(unitCanonical)) {
+            if (!physicalDivision.getMediaFiles().isEmpty() && unitCanonical.isEmpty()) {
                 throw new InvalidImagesException("Missing canonical file name part in physical division " + physicalDivision);
             }
             canonicals.add(unitCanonical);

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1183,14 +1183,14 @@ public class FileService {
                     physicalDivision.getMediaFiles().put(entry.getKey(), mediaFile);
                 }
                 String fileCanonical = subfolder.getCanonical(mediaFile);
-                if (unitCanonical.isEmpty()) {
+                if (StringUtils.isBlank(unitCanonical)) {
                     unitCanonical = fileCanonical;
                 } else if (!unitCanonical.equals(fileCanonical)) {
                     throw new InvalidImagesException("Ambiguous canonical file name part in the same physical division: \""
                             + unitCanonical + "\" and \"" + fileCanonical + "\"!");
                 }
             }
-            if (!physicalDivision.getMediaFiles().isEmpty() && unitCanonical.isEmpty()) {
+            if (!physicalDivision.getMediaFiles().isEmpty() && StringUtils.isBlank(unitCanonical)) {
                 throw new InvalidImagesException("Missing canonical file name part in physical division " + physicalDivision);
             }
             canonicals.add(unitCanonical);

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -33,6 +33,7 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.ConfigCore;
@@ -426,7 +427,7 @@ public class IndexingService {
     public String createMapping() throws IOException, CustomResponseException {
         for (String mappingType : KitodoRestClient.MAPPING_TYPES) {
             String mapping = readMapping(mappingType);
-            if (mapping.isEmpty()) {
+            if (StringUtils.isBlank(mapping)) {
                 if (indexRestClient.createIndex(null, mappingType)) {
                     currentState = IndexStates.CREATING_MAPPING_SUCCESSFUL;
                 } else {

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -426,7 +426,7 @@ public class IndexingService {
     public String createMapping() throws IOException, CustomResponseException {
         for (String mappingType : KitodoRestClient.MAPPING_TYPES) {
             String mapping = readMapping(mappingType);
-            if ("".equals(mapping)) {
+            if (mapping.isEmpty()) {
                 if (indexRestClient.createIndex(null, mappingType)) {
                     currentState = IndexStates.CREATING_MAPPING_SUCCESSFUL;
                 } else {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/Page.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/Page.java
@@ -238,7 +238,7 @@ public abstract class Page<T> {
     };
 
     Predicate<WebElement> isInputValueNotEmpty = (webElement) -> {
-        return !webElement.getAttribute("value").equals("");
+        return !webElement.getAttribute("value").isEmpty();
     };
 
     Predicate<File> isFileDownloaded = (file) -> {


### PR DESCRIPTION
`isEmpty` call is more efficient than a complex `equals` call on strings if only comparison is on empty or not empty string.

Discovered by CodeQL scan.
