### PR TITLE
Add missing hashCode methods

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/Metadata.java
@@ -74,4 +74,15 @@ public class Metadata {
         return domain == metadata.domain
                 && Objects.equals(key, metadata.key);
     }
+
+    /**
+     * hashCode method of current class.
+     *
+     * @see java.lang.Object#hashCode()
+     * @return int
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(domain, key);
+    }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
@@ -853,4 +853,52 @@ public class ImportConfiguration extends BaseBean {
         }
         return false;
     }
+
+    /**
+     * hashCode method of current class.
+     *
+     * @see java.lang.Object#hashCode()
+     * @return int
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                title,
+                description,
+                configurationType,
+                prestructuredImport,
+                interfaceType,
+                returnFormat,
+                metadataFormat,
+                defaultImportDepth,
+                parentElementTrimMode,
+                host,
+                scheme,
+                path,
+                port,
+                anonymousAccess,
+                username,
+                password,
+                queryDelimiter,
+                itemFieldXpath,
+                itemFieldOwnerSubPath,
+                itemFieldOwnerMetadata,
+                itemFieldSignatureSubPath,
+                itemFieldSignatureMetadata,
+                idPrefix,
+                searchFields,
+                urlParameters,
+                defaultSearchField,
+                idSearchField,
+                parentSearchField,
+                defaultTemplateProcess,
+                mappingFiles,
+                parentMappingFile,
+                sruVersion,
+                sruRecordSchema,
+                oaiMetadataPrefix,
+                metadataRecordIdXPath,
+                metadataRecordTitleXPath
+        );
+    }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/MappingFile.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/MappingFile.java
@@ -12,6 +12,7 @@
 package org.kitodo.data.database.beans;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -160,5 +161,23 @@ public class MappingFile extends BaseBean {
             return mappingFile.getId().equals(this.getId());
         }
         return false;
+    }
+
+    /**
+     * hashCode method of current class.
+     *
+     * @see java.lang.Object#hashCode()
+     * @return int
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                title,
+                file,
+                inputMetadataFormat,
+                outputMetadataFormat,
+                prestructuredImport,
+                importConfigurations
+            );
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/filters/ParsedFilter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/ParsedFilter.java
@@ -83,4 +83,15 @@ public class ParsedFilter {
         }
         return plainFilter.equals(((ParsedFilter) o).getPlainFilter());
     }
+
+    /**
+     * hashCode method of current class.
+     *
+     * @see java.lang.Object#hashCode()
+     * @return int
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(plainFilter);
+    }
 }


### PR DESCRIPTION
In this classes are `equals()` methods implemented without necessary  ` hashCode()` method. `hashCode()` methods are needed by HashMap or similar classes on usage. `Objects.hashCode` is available since Java 6 and can create unique results instead of self-implementing.

Discovered by CodeQL.
