### PR TITLE
Remove unused class variable

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -93,8 +93,6 @@ public class GalleryPanel {
     private GalleryViewMode galleryViewMode = GalleryViewMode.LIST;
     private List<GalleryMediaContent> medias = Collections.emptyList();
 
-    private Map<String, GalleryMediaContent> previewImageResolver = new HashMap<>();
-
     private Map<MediaContentType, Map<GalleryViewMode, MediaVariant>> mediaContentTypeVariants = new HashMap<>();
 
     private Map<MediaContentType, Subfolder> mediaContentTypePreviewFolder = new HashMap<>();


### PR DESCRIPTION
Class variable `previewImageResolver` is never used so removing it.

Discovered by CodeQL.