### PR TITLE
Remove spotbugs on automatic build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,6 @@ jobs:
             mvn --version
       - name: run build
         run:
-            mvn clean install -B '-Pall-tests,flyway,checkstyle,spotbugs,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
+            mvn clean install -B '-Pall-tests,flyway,checkstyle,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
 
 


### PR DESCRIPTION
Current execution of spotbugs on automatic build is useless as
- spotbugs messages got lost after build is done
- spotbugs reports more and more issues which not get fixed in time and increasing the log output to an level where the log out is not visible more on GitHub
- spotbugs is configured to only report issues but not break the build. Enabling this breaking on build even for a "high" threshold level would result first in fixing over 100 high level issues reported by spotbugs
- CodeQL integration did at least do the same with a lot better integration into GitHub

Deactivating spotbugs will result in
- (a little bit) faster automatic test execution
- less log output messages
