### PR TITLE
Change log level to "info" for KitodoRestClient class on automatic test execution

### DIFF
--- a/Kitodo/src/test/resources/log4j2.xml
+++ b/Kitodo/src/test/resources/log4j2.xml
@@ -27,6 +27,11 @@
         <Logger name="org.kitodo" level="debug" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </Logger>
+        <!-- KitodoRestClient log level set to info to reduce log output on automatic execution -->
+        <!-- in case of errors with elastic search set it to debug or trace -->
+        <Logger name="org.kitodo.data.elasticsearch.KitodoRestClient" level="info" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
         <Root level="error">
             <AppenderRef ref="STDOUT"/>
         </Root>

--- a/Kitodo/src/test/resources/selenium/resources/log4j2.xml
+++ b/Kitodo/src/test/resources/selenium/resources/log4j2.xml
@@ -27,6 +27,11 @@
         <Logger name="org.kitodo" level="debug" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </Logger>
+        <!-- KitodoRestClient log level set to info to reduce log output on automatic execution -->
+        <!-- in case of errors with elastic search set it to debug or trace -->
+        <Logger name="org.kitodo.data.elasticsearch.KitodoRestClient" level="info" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
         <Root level="error">
             <AppenderRef ref="STDOUT"/>
         </Root>


### PR DESCRIPTION
With PR #5908 a lot of log messages are created while automatic test execution. This is not needed as long as the ElasticSearch connection on the executing GitHub action is working and there are no connection issues to the local ElasticSearch server in the last couple of months. 

If there are any connection issues the log value can be changed from "info" to "debug" or "trace" to get more information but with even more log messages.