### PR TITLE
Create hashCode methods on class generation

### DIFF
--- a/Kitodo-DataFormat/pom.xml
+++ b/Kitodo-DataFormat/pom.xml
@@ -122,6 +122,7 @@
                             <generateDirectory>${project.build.directory}/generated-sources/xjc</generateDirectory>
                             <args>
                                 <arg>-Xequals</arg>
+                                <arg>-XhashCode</arg>
                                 <arg>-extension</arg>
                                 <arg>-Xnamespace-prefix</arg>
                             </args>


### PR DESCRIPTION
Generated classes in Kitodo-DataFormat module from the xsd files have `equals` but no `hashCode` methods. Let generate the missing `hashCode` methods too.

Discovered by CodeQL: severity "ERROR" and rule "Inconsistent equals and hashCode" .