### PR TITLE
Add missing clone method to Course class

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
@@ -927,4 +927,14 @@ public class Course extends ArrayList<Block> {
     public void setYearStart(MonthDay yearStart) {
         this.yearStart = yearStart;
     }
+
+    /**
+     * Returns a shallow copy of this Course instance.
+     *
+     * @return a clone of this Course instance
+     */
+    @Override
+    public Course clone() {
+        return (Course) super.clone();
+    }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.model.bibliography.course;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.jupiter.api.Test;
+import org.kitodo.production.helper.XMLUtils;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+class CourseTest {
+
+    @Test
+    void testCloneMethod() throws IOException, ParserConfigurationException, SAXException {
+        String xmlString = new String(Files.readAllBytes(new File("src/test/resources/newspaper-course.xml").toPath()));
+        Document xmlDocument = XMLUtils.parseXMLString(xmlString);
+        Course course = new Course(xmlDocument);
+
+        // assert / check some data from the xml file
+        assertEquals(23L, course.getIndividualIssues().size());
+        assertEquals(23, course.countIndividualIssues());
+        assertEquals("", course.getYearName());
+
+        // clone course
+        Course clonedCourse = course.clone();
+        // courses should have same data
+        assertEquals(course.countIndividualIssues(), clonedCourse.countIndividualIssues());
+        assertEquals(course.getNumberOfProcesses(), clonedCourse.getNumberOfProcesses());
+        assertEquals(course.getYearName(), clonedCourse.getYearName());
+
+        // change year name of not cloned course
+        course.setYearName("Year 2024");
+        // year name should now differ
+        assertEquals("", clonedCourse.getYearName());
+        assertNotEquals(course.getYearName(), clonedCourse.getYearName());
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
@@ -25,10 +25,10 @@ import org.kitodo.production.helper.XMLUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-class CourseTest {
+public class CourseTest {
 
     @Test
-    void testCloneMethod() throws IOException, ParserConfigurationException, SAXException {
+    public void testCloneMethod() throws IOException, ParserConfigurationException, SAXException {
         String xmlString = new String(Files.readAllBytes(new File("src/test/resources/newspaper-course.xml").toPath()));
         Document xmlDocument = XMLUtils.parseXMLString(xmlString);
         Course course = new Course(xmlDocument);

--- a/Kitodo/src/test/resources/newspaper-course.xml
+++ b/Kitodo/src/test/resources/newspaper-course.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<course>
+   <description>Die Zeitung erschien vom 1. Januar 2024 bis zum 31. Januar 2024 regelmäßig an allen Montagen, Dienstagen, Mittwochen, Donnerstagen und Freitagen.</description>
+   <processes>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-01"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-02"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-03"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-04"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-05"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-08"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-09"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-10"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-11"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-12"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-15"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-16"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-17"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-18"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-19"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-22"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-23"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-24"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-25"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-26"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-29"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-30"/>
+         </title>
+      </process>
+      <process>
+         <title index="1">
+            <appeared date="2024-01-31"/>
+         </title>
+      </process>
+   </processes>
+</course>

--- a/Kitodo/src/test/resources/newspaper-course.xml
+++ b/Kitodo/src/test/resources/newspaper-course.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
 <course>
    <description>Die Zeitung erschien vom 1. Januar 2024 bis zum 31. Januar 2024 regelmäßig an allen Montagen, Dienstagen, Mittwochen, Donnerstagen und Freitagen.</description>
    <processes>


### PR DESCRIPTION
According to CodeQL the Course class is missing a `clone` method to extend the `ArrayList` base class complete.