### PR TITLE
Fix IllegalStateException: No logical node selected!

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
@@ -255,7 +255,7 @@ public class DataEditorService {
         TreeNode selectedLogicalNode = dataEditor.getStructurePanel().getSelectedLogicalNode();
 
         if (Objects.isNull(selectedLogicalNode)) {
-            throw new IllegalStateException("No logical node selected!");
+            return null;
         }
 
         if (!(selectedLogicalNode.getData() instanceof StructureTreeNode)) {


### PR DESCRIPTION
Exception occurs when opening Metadata Editor, because calling method expects `null` in no-data case, but receives IllegalStateException:

![Stacktrace](https://github.com/kitodo/kitodo-production/assets/3040657/7f4020b3-5bdb-4449-a513-30e3a473cfbd)
