### PR TITLE
Fix NullPointerException

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -757,7 +757,7 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
      * <p>Note: This method is called potentially thousands of times when rendering large galleries.</p>
      */
     public boolean consecutivePagesSelected() {
-        if (selectedMedia.isEmpty()) {
+        if (Objects.isNull(selectedMedia) || selectedMedia.isEmpty()) {
             return false;
         }
         int maxOrder = selectedMedia.stream().mapToInt(m -> m.getLeft().getOrder()).max().orElseThrow(NoSuchElementException::new);


### PR DESCRIPTION
Fixes a NullPointerException that can occur when opening Metadata Editor:

![Stacktrace](https://github.com/kitodo/kitodo-production/assets/3040657/e6acc1a7-a317-43ec-a14f-1f160b34a2b5)
