### PR TITLE
Fix Tomcat start with Eclipse broken, local-config ignored

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <elasticsearch.version>7.17.10</elasticsearch.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 
-        <!-- maven-resources-plugin version > 3.2.0 introduces changes that
+        <!-- maven-resources-plugin versions greater 3.2.0 introduce changes that
              stop the build in Eclipse on Windows from using "config-local" -->
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,11 @@
         <junit.version>5.9.2</junit.version>
         <elasticsearch.version>7.17.10</elasticsearch.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
-        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+
+        <!-- maven-resources-plugin version > 3.2.0 introduces changes that
+             stop the build in Eclipse on Windows from using "config-local" -->
+        <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <mockito.version>5.0.0</mockito.version>


### PR DESCRIPTION
Fixes #5999. ~Does undo commit 8062b8caa66b08aee2d428b03e1f77235a005fe4 which was merged in PR #5851 and was intended as a fix for #5850. As a consequence, issue #5850 must be reopened.~