### PR TITLE
Make mass import more resilient by skipping empty lines

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/MassImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/MassImportService.java
@@ -100,10 +100,12 @@ public class MassImportService {
         List<CsvRecord> records = new LinkedList<>();
         for (String line : lines) {
             List<CsvCell> cells = new LinkedList<>();
-            for (String value : line.split(separator, -1)) {
-                cells.add(new CsvCell(value));
+            if (!Objects.isNull(line) && !line.isBlank()) {
+                for (String value : line.split(separator, -1)) {
+                    cells.add(new CsvCell(value));
+                }
+                records.add(new CsvRecord(cells));
             }
-            records.add(new CsvRecord(cells));
         }
         return records;
     }


### PR DESCRIPTION
When importing a csv file with an empty line at the end (or anywhere in between)

![image](https://github.com/kitodo/kitodo-production/assets/7516499/348379ff-ae03-4abf-95f9-b345321f97b2)

an exception is thrown. 
```
java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
	at java.base/java.util.LinkedList.checkElementIndex(LinkedList.java:559)
	at java.base/java.util.LinkedList.get(LinkedList.java:480)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor1459.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```
This PR prevents that by ignoring empty lines in the `parseLine`-function