### PR TITLE
Run Kitodo Script commands via Active MQ

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -621,6 +621,8 @@ public enum ParameterCore implements ParameterInterface {
 
     ACTIVE_MQ_FINALIZE_STEP_QUEUE(new Parameter<UndefinedParameter>("activeMQ.finalizeStep.queue")),
 
+    ACTIVE_MQ_KITODO_SCRIPT_ALLOW(new Parameter<UndefinedParameter>("activeMQ.kitodoScript.allow")),
+
     ACTIVE_MQ_KITODO_SCRIPT_QUEUE(new Parameter<UndefinedParameter>("activeMQ.kitodoScript.queue")),
 
     ACTIVE_MQ_TASK_ACTION_QUEUE(new Parameter<UndefinedParameter>("activeMQ.taskAction.queue")),

--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -621,6 +621,8 @@ public enum ParameterCore implements ParameterInterface {
 
     ACTIVE_MQ_FINALIZE_STEP_QUEUE(new Parameter<UndefinedParameter>("activeMQ.finalizeStep.queue")),
 
+    ACTIVE_MQ_KITODO_SCRIPT_QUEUE(new Parameter<UndefinedParameter>("activeMQ.kitodoScript.queue")),
+
     ACTIVE_MQ_TASK_ACTION_QUEUE(new Parameter<UndefinedParameter>("activeMQ.taskAction.queue")),
 
     ACTIVE_MQ_USER(new Parameter<UndefinedParameter>("activeMQ.user")),

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
@@ -57,7 +57,7 @@ public class ActiveMQDirector implements Runnable, ServletContextListener {
     private static Collection<? extends ActiveMQProcessor> services;
 
     static {
-        services = Arrays.asList(new FinalizeStepProcessor(), new TaskActionProcessor());
+        services = Arrays.asList(new FinalizeStepProcessor(), new TaskActionProcessor(), new KitodoScriptProcessor());
     }
 
     private static Connection connection = null;

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.interfaces.activemq;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.jms.JMSException;
+
+import org.kitodo.config.ConfigCore;
+import org.kitodo.config.enums.ParameterCore;
+import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.exceptions.InvalidImagesException;
+import org.kitodo.exceptions.MediaNotFoundException;
+import org.kitodo.exceptions.ProcessorException;
+import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.command.KitodoScriptService;
+import org.kitodo.production.services.data.ProcessService;
+
+/**
+ * Executes instructions to start a Kitodo Script command from the Active MQ
+ * interface. The MapMessage must contain the command statement in the
+ * {@code script} argument. You pass a list of the process IDs as
+ * {@code processes}.
+ */
+public class KitodoScriptProcessor extends ActiveMQProcessor {
+
+    private final KitodoScriptService kitodoScriptService = ServiceManager.getKitodoScriptService();
+    private final ProcessService processService = ServiceManager.getProcessService();
+
+    public KitodoScriptProcessor() {
+        super(ConfigCore.getOptionalString(ParameterCore.ACTIVE_MQ_KITODO_SCRIPT_QUEUE).orElse(null));
+    }
+
+    @Override
+    protected void process(MapMessageObjectReader ticket) throws ProcessorException, JMSException {
+        try {
+            String script = ticket.getMandatoryString("script");
+            Collection<Integer> processIds = ticket.getCollectionOfInteger("processes");
+            List<Process> processes = new ArrayList<>(processIds.size());
+            for (Integer id : processIds) {
+                processes.add(processService.getById(id));
+            }
+            kitodoScriptService.execute(processes, script);
+        } catch (DAOException | DataException | IOException | InvalidImagesException | MediaNotFoundException e) {
+            throw new ProcessorException(e);
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import javax.jms.JMSException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
@@ -48,12 +49,12 @@ public class KitodoScriptProcessor extends ActiveMQProcessor {
 
     @Override
     protected void process(MapMessageObjectReader ticket) throws ProcessorException, JMSException {
-        final List<String> allowedCommands = Arrays.asList(ConfigCore.getParameter(
-            ParameterCore.ACTIVE_MQ_KITODO_SCRIPT_ALLOW).split(","));
+        final String[] allowedCommands = ConfigCore.getStringArrayParameter(
+            ParameterCore.ACTIVE_MQ_KITODO_SCRIPT_ALLOW);
         try {
             String script = ticket.getMandatoryString("script");
             int space = script.indexOf(' ');
-            if (!allowedCommands.contains(script.substring(7, space >= 0 ? space : script.length()))) {
+            if (!ArrayUtils.contains(allowedCommands, script.substring(7, space >= 0 ? space : script.length()))) {
                 throw new IllegalArgumentException((space >= 0 ? script.substring(0, space) : script)
                         + " is not allowed");
             }

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
@@ -13,6 +13,7 @@ package org.kitodo.production.interfaces.activemq;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -47,8 +48,15 @@ public class KitodoScriptProcessor extends ActiveMQProcessor {
 
     @Override
     protected void process(MapMessageObjectReader ticket) throws ProcessorException, JMSException {
+        final List<String> allowedCommands = Arrays.asList(ConfigCore.getParameter(
+            ParameterCore.ACTIVE_MQ_KITODO_SCRIPT_ALLOW).split(","));
         try {
             String script = ticket.getMandatoryString("script");
+            int space = script.indexOf(' ');
+            if (!allowedCommands.contains(script.substring(7, space >= 0 ? space : script.length()))) {
+                throw new IllegalArgumentException((space >= 0 ? script.substring(0, space) : script)
+                        + " is not allowed");
+            }
             Collection<Integer> processIds = ticket.getCollectionOfInteger("processes");
             List<Process> processes = new ArrayList<>(processIds.size());
             for (Integer id : processIds) {

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -24,9 +25,9 @@ import java.util.stream.Collectors;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.util.Strings;
 import org.kitodo.utils.Guard;
 
 public class MapMessageObjectReader {
@@ -128,7 +129,7 @@ public class MapMessageObjectReader {
     public Collection<Integer> getCollectionOfInteger(String key) throws JMSException {
         Collection<String> collectionOfString = getCollectionOfString(key);
         List<Integer> collectionOfInteger = collectionOfString.stream()
-                .flatMap(string -> Arrays.stream(string.split("\\D+"))).filter(Strings::isNotBlank)
+                .flatMap(string -> Arrays.stream(string.split("\\D+"))).filter(StringUtils::isNumeric)
                 .map(Integer::valueOf).collect(Collectors.toList());
         return collectionOfInteger;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -127,11 +126,9 @@ public class MapMessageObjectReader {
      *             can be thrown by MapMessage.getObject(String)
      */
     public Collection<Integer> getCollectionOfInteger(String key) throws JMSException {
-        Collection<String> collectionOfString = getCollectionOfString(key);
-        List<Integer> collectionOfInteger = collectionOfString.stream()
+        return getCollectionOfString(key).stream()
                 .flatMap(string -> Arrays.stream(string.split("\\D+"))).filter(StringUtils::isNumeric)
                 .map(Integer::valueOf).collect(Collectors.toList());
-        return collectionOfInteger;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
@@ -27,6 +27,7 @@ import javax.jms.MapMessage;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 import org.kitodo.utils.Guard;
 
 public class MapMessageObjectReader {
@@ -128,8 +129,8 @@ public class MapMessageObjectReader {
     public Collection<Integer> getCollectionOfInteger(String key) throws JMSException {
         Collection<String> collectionOfString = getCollectionOfString(key);
         List<Integer> collectionOfInteger = collectionOfString.stream()
-                .flatMap(string -> Arrays.stream(string.split("\\D+"))).map(Integer::valueOf)
-                .collect(Collectors.toList());
+                .flatMap(string -> Arrays.stream(string.split("\\D+"))).filter(Strings::isNotBlank)
+                .map(Integer::valueOf).collect(Collectors.toList());
         return collectionOfInteger;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -86,7 +86,7 @@ public class KitodoScriptService {
     /**
      * Private constructor. Use {@link #getInstance()} to get the instance.
      */
-    private KitodoScriptService() {
+    protected KitodoScriptService() {
     }
 
     /**

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -642,6 +642,10 @@ activeMQ.user=testAdmin
 # You can provide a queue from which messages are read to run a Kitodo Script
 #activeMQ.kitodoScript.queue=KitodoProduction.KitodoScript.Queue
 
+# The Kitodo Script commands authorized to be executed must be named here:
+activeMQ.kitodoScript.allow=createFolders,export,searchForMedia
+
+
 # -----------------------------------
 # Elasticsearch properties
 # -----------------------------------

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -643,7 +643,7 @@ activeMQ.user=testAdmin
 #activeMQ.kitodoScript.queue=KitodoProduction.KitodoScript.Queue
 
 # The Kitodo Script commands authorized to be executed must be named here:
-activeMQ.kitodoScript.allow=createFolders,export,searchForMedia
+activeMQ.kitodoScript.allow=createFolders&export&searchForMedia
 
 
 # -----------------------------------

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -639,6 +639,9 @@ activeMQ.user=testAdmin
 # You can provide a queue from which messages are read to process task actions
 #activeMQ.taskAction.queue=KitodoProduction.TaskAction.Queue
 
+# You can provide a queue from which messages are read to run a Kitodo Script
+#activeMQ.kitodoScript.queue=KitodoProduction.KitodoScript.Queue
+
 # -----------------------------------
 # Elasticsearch properties
 # -----------------------------------

--- a/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessorIT.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.interfaces.activemq;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -98,5 +99,21 @@ public class KitodoScriptProcessorIT {
         assertEquals("action:test", scriptCaptor.getValue(), "should have passed the script to be executed");
         assertEquals(1, processCaptor.getAllValues().size(), "should have passed one process");
         assertEquals(1, processCaptor.getAllValues().get(0).get(0).getId(), "should have passed process 1");
+    }
+
+    @Test
+    public void shouldNotExecuteKitodoScript() throws Exception {
+        // test data
+        MapMessageObjectReader mockedMessage = mock(MapMessageObjectReader.class);
+        when(mockedMessage.getMandatoryString("script")).thenReturn("action:other");
+
+        // the object to be tested
+        KitodoScriptProcessor underTest = new KitodoScriptProcessor();
+
+        // carry out test
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> underTest
+                .process(mockedMessage));
+        assertEquals("action:other is not allowed", illegalArgumentException.getMessage(),
+            "should report that the action is not permitted");
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessorIT.java
@@ -1,0 +1,440 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+package org.kitodo.production.interfaces.activemq;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitodo.MockDatabase;
+import org.kitodo.SecurityTestUtils;
+import org.kitodo.data.database.beans.Process;
+import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.command.KitodoScriptService;
+
+public class KitodoScriptProcessorIT {
+    @Before
+    public void prepare() throws Exception {
+        MockDatabase.startNode();
+        MockDatabase.insertProcessesForWorkflowFull();
+        SecurityTestUtils.addUserDataToSecurityContext(ServiceManager.getUserService().getById(1), 1);
+    }
+
+    @After
+    public void clean() throws Exception {
+        MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
+        SecurityTestUtils.cleanSecurityContext();
+    }
+
+    @Test
+    public void shouldExecuteKitodoScript() throws Exception {
+
+        // define test data
+        MapMessageObjectReader testData = new MapMessageObjectReader(new MapMessage() {
+            @Override
+            public String getJMSMessageID() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public void setJMSMessageID(String id) throws JMSException {
+
+            }
+
+            @Override
+            public long getJMSTimestamp() throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public void setJMSTimestamp(long timestamp) throws JMSException {
+
+            }
+
+            @Override
+            public byte[] getJMSCorrelationIDAsBytes() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public void setJMSCorrelationIDAsBytes(byte[] correlationID) throws JMSException {
+
+            }
+
+            @Override
+            public void setJMSCorrelationID(String correlationID) throws JMSException {
+
+            }
+
+            @Override
+            public String getJMSCorrelationID() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public Destination getJMSReplyTo() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public void setJMSReplyTo(Destination replyTo) throws JMSException {
+
+            }
+
+            @Override
+            public Destination getJMSDestination() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public void setJMSDestination(Destination destination) throws JMSException {
+
+            }
+
+            @Override
+            public int getJMSDeliveryMode() throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public void setJMSDeliveryMode(int deliveryMode) throws JMSException {
+
+            }
+
+            @Override
+            public boolean getJMSRedelivered() throws JMSException {
+                return false;
+            }
+
+            @Override
+            public void setJMSRedelivered(boolean redelivered) throws JMSException {
+
+            }
+
+            @Override
+            public String getJMSType() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public void setJMSType(String type) throws JMSException {
+
+            }
+
+            @Override
+            public long getJMSExpiration() throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public void setJMSExpiration(long expiration) throws JMSException {
+
+            }
+
+            @Override
+            public int getJMSPriority() throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public void setJMSPriority(int priority) throws JMSException {
+
+            }
+
+            @Override
+            public void clearProperties() throws JMSException {
+
+            }
+
+            @Override
+            public boolean propertyExists(String name) throws JMSException {
+                return false;
+            }
+
+            @Override
+            public boolean getBooleanProperty(String name) throws JMSException {
+                return false;
+            }
+
+            @Override
+            public byte getByteProperty(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public short getShortProperty(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public int getIntProperty(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public long getLongProperty(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public float getFloatProperty(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public double getDoubleProperty(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public String getStringProperty(String name) throws JMSException {
+                return null;
+            }
+
+            @Override
+            public Object getObjectProperty(String name) throws JMSException {
+                return null;
+            }
+
+            @Override
+            public Enumeration getPropertyNames() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public void setBooleanProperty(String name, boolean value) throws JMSException {
+
+            }
+
+            @Override
+            public void setByteProperty(String name, byte value) throws JMSException {
+
+            }
+
+            @Override
+            public void setShortProperty(String name, short value) throws JMSException {
+
+            }
+
+            @Override
+            public void setIntProperty(String name, int value) throws JMSException {
+
+            }
+
+            @Override
+            public void setLongProperty(String name, long value) throws JMSException {
+
+            }
+
+            @Override
+            public void setFloatProperty(String name, float value) throws JMSException {
+
+            }
+
+            @Override
+            public void setDoubleProperty(String name, double value) throws JMSException {
+
+            }
+
+            @Override
+            public void setStringProperty(String name, String value) throws JMSException {
+
+            }
+
+            @Override
+            public void setObjectProperty(String name, Object value) throws JMSException {
+
+            }
+
+            @Override
+            public void acknowledge() throws JMSException {
+
+            }
+
+            @Override
+            public void clearBody() throws JMSException {
+
+            }
+
+            @Override
+            public boolean getBoolean(String name) throws JMSException {
+                return false;
+            }
+
+            @Override
+            public byte getByte(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public short getShort(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public char getChar(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public int getInt(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public long getLong(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public float getFloat(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public double getDouble(String name) throws JMSException {
+                return 0;
+            }
+
+            @Override
+            public String getString(String name) throws JMSException {
+                return null;
+            }
+
+            @Override
+            public byte[] getBytes(String name) throws JMSException {
+                return null;
+            }
+
+            @Override
+            public Object getObject(String name) throws JMSException {
+                return null;
+            }
+
+            @Override
+            public Enumeration getMapNames() throws JMSException {
+                return null;
+            }
+
+            @Override
+            public void setBoolean(String name, boolean value) throws JMSException {
+
+            }
+
+            @Override
+            public void setByte(String name, byte value) throws JMSException {
+
+            }
+
+            @Override
+            public void setShort(String name, short value) throws JMSException {
+
+            }
+
+            @Override
+            public void setChar(String name, char value) throws JMSException {
+
+            }
+
+            @Override
+            public void setInt(String name, int value) throws JMSException {
+
+            }
+
+            @Override
+            public void setLong(String name, long value) throws JMSException {
+
+            }
+
+            @Override
+            public void setFloat(String name, float value) throws JMSException {
+
+            }
+
+            @Override
+            public void setDouble(String name, double value) throws JMSException {
+
+            }
+
+            @Override
+            public void setString(String name, String value) throws JMSException {
+
+            }
+
+            @Override
+            public void setBytes(String name, byte[] value) throws JMSException {
+
+            }
+
+            @Override
+            public void setBytes(String name, byte[] value, int offset, int length) throws JMSException {
+
+            }
+
+            @Override
+            public void setObject(String name, Object value) throws JMSException {
+
+            }
+
+            @Override
+            public boolean itemExists(String name) throws JMSException {
+                return false;
+            }
+        }) {
+            @Override
+            public String getMandatoryString(String s) {
+                return "action:test";
+            }
+
+            @Override
+            public Collection<Integer> getCollectionOfInteger(String s) {
+                return Collections.singletonList(1);
+            }
+        };
+
+        // the object to be tested
+        KitodoScriptProcessor underTest = new KitodoScriptProcessor();
+
+        // organize return of results
+        List<String> scriptResult = new ArrayList<>();
+        List<Process> processesResult = new ArrayList<>();
+        Field serviceField = KitodoScriptProcessor.class.getDeclaredField("kitodoScriptService");
+        serviceField.setAccessible(true);
+        serviceField.set(underTest, new KitodoScriptService() {
+            @Override
+            public void execute(List<Process> processes, String script) {
+                scriptResult.add(script);
+                processesResult.addAll(processes);
+            }
+        });
+
+        // carry out test
+        underTest.process(testData);
+
+        // check results
+        assertEquals("should have passed the script to be executed", scriptResult.get(0), "action:test");
+        assertEquals("should have passed one process", processesResult.size(), 1);
+        assertEquals("should have passed process 1", processesResult.get(0).getId(), (Integer) 1);
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessorIT.java
@@ -10,7 +10,7 @@
  */
 package org.kitodo.production.interfaces.activemq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -23,9 +23,9 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.Process;
@@ -33,14 +33,14 @@ import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.command.KitodoScriptService;
 
 public class KitodoScriptProcessorIT {
-    @Before
+    @BeforeAll
     public void prepare() throws Exception {
         MockDatabase.startNode();
         MockDatabase.insertProcessesForWorkflowFull();
         SecurityTestUtils.addUserDataToSecurityContext(ServiceManager.getUserService().getById(1), 1);
     }
 
-    @After
+    @AfterAll
     public void clean() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
@@ -433,8 +433,8 @@ public class KitodoScriptProcessorIT {
         underTest.process(testData);
 
         // check results
-        assertEquals("should have passed the script to be executed", scriptResult.get(0), "action:test");
-        assertEquals("should have passed one process", processesResult.size(), 1);
-        assertEquals("should have passed process 1", processesResult.get(0).getId(), (Integer) 1);
+        assertEquals(scriptResult.get(0), "action:test", "should have passed the script to be executed");
+        assertEquals(processesResult.size(), 1, "should have passed one process");
+        assertEquals(processesResult.get(0).getId(), 1, "should have passed process 1");
     }
 }

--- a/Kitodo/src/test/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/kitodo_config.properties
@@ -54,7 +54,7 @@ metsEditor.lockingTime=2
 
 #copyData.onExport=/@GoobiIdentifier \= $process.id;
 
-activeMQ.kitodoScript.allow=test,test2
+activeMQ.kitodoScript.allow=test&test2
 
 LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
 LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR

--- a/Kitodo/src/test/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/kitodo_config.properties
@@ -54,6 +54,8 @@ metsEditor.lockingTime=2
 
 #copyData.onExport=/@GoobiIdentifier \= $process.id;
 
+activeMQ.kitodoScript.allow=test,test2
+
 LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
 LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
 LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR


### PR DESCRIPTION
This development allows to run Kitodo Script commands using the Active MQ interface.

For example, to export processes, you send a Map Message with the content:

    id        := "ID string used with Active MQ logging. Must be present, but is meaningless"
    script    := "action:export exportImages:true"
    processes := 4

`processes` can be a single integer, or string representing an integer, or a list of either, or string with several integers separated by non-digit character(s).

Resolves #5980

_This development is funded by the Municipality of The Hague—Construction Office._