### PR TITLE
Relocate dependencies

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -91,8 +91,8 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/Kitodo-DataEditor/pom.xml
+++ b/Kitodo-DataEditor/pom.xml
@@ -38,8 +38,8 @@
             <artifactId>kitodo-data-format</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/Kitodo-DataFormat/pom.xml
+++ b/Kitodo-DataFormat/pom.xml
@@ -99,9 +99,9 @@
             </plugin>
             <!--generate classes-->
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.15.3</version>
+                <groupId>org.jvnet.jaxb</groupId>
+                <artifactId>jaxb-maven-plugin</artifactId>
+                <version>2.0.9</version>
                 <executions>
                     <execution>
                         <phase>process-sources</phase>
@@ -125,16 +125,15 @@
                             </bindingIncludes>
                             <generateDirectory>${project.build.directory}/generated-sources/xjc</generateDirectory>
                             <args>
-                                <arg>-Xequals</arg>
-                                <arg>-XhashCode</arg>
+                                <arg>-Xcommons-lang</arg>
                                 <arg>-extension</arg>
                                 <arg>-Xnamespace-prefix</arg>
                             </args>
                             <plugins>
                                 <plugin>
-                                    <groupId>org.jvnet.jaxb2_commons</groupId>
+                                    <groupId>org.jvnet.jaxb</groupId>
                                     <artifactId>jaxb2-basics</artifactId>
-                                    <version>${jaxb2-basics-runtime.version}</version>
+                                    <version>2.0.9</version>
                                 </plugin>
                             </plugins>
                         </configuration>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -81,6 +81,10 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-c3p0</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,18 @@ from system library in Java 11+ -->
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hibernate.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- can be removed with Hibernate 6.x -->
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-c3p0</artifactId>
                 <version>${hibernate.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <hamcrest.version>2.2-rc1</hamcrest.version>
         <hibernate.version>5.6.10.Final</hibernate.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
-        <jaxb.glassfish-runtime.version>2.3.6</jaxb.glassfish-runtime.version>
+        <jaxb.glassfish-runtime.version>2.3.9</jaxb.glassfish-runtime.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.2.0</jaxen.version>
         <jhove.version>1.20.1</jhove.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <org.apache.avalon.framework.version>4.3.1</org.apache.avalon.framework.version>
         <hamcrest.version>2.2-rc1</hamcrest.version>
         <hibernate.version>5.6.10.Final</hibernate.version>
-        <jaxb.api.version>2.3.1</jaxb.api.version>
+        <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.glassfish-runtime.version>2.3.6</jaxb.glassfish-runtime.version>
         <jaxb2-basics-runtime.version>1.11.1</jaxb2-basics-runtime.version>
         <jaxen.version>1.2.0</jaxen.version>
@@ -226,8 +226,8 @@
             <!-- Include jaxb runtime dependencies which have been removed
 from system library in Java 11+ -->
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${jaxb.api.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -485,8 +485,8 @@ from system library in Java 11+ -->
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.json</artifactId>
-                <version>1.1.4</version>
+                <artifactId>jakarta.json</artifactId>
+                <version>1.1.6</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>


### PR DESCRIPTION
Relocate some XML based dependencies as needed for switch to Java 17 and Jakarta support without changing existing code.