### PR TITLE
Fix permission denied messages while running tests

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/TaskActionProcessorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/TaskActionProcessorIT.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,8 +26,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.kitodo.ExecutionPermission;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
+import org.kitodo.config.ConfigCore;
+import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Comment;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.enums.TaskStatus;
@@ -37,6 +41,11 @@ import org.kitodo.production.services.data.TaskService;
 public class TaskActionProcessorIT {
 
     private static final TaskService taskService = ServiceManager.getTaskService();
+
+    private static final File scriptDeleteSymLink = new File(
+            ConfigCore.getParameter(ParameterCore.SCRIPT_DELETE_SYMLINK));
+    private static final File scriptCreateDirMeta = new File(
+            ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_DIR_USER_HOME));
 
     /**
      * Prepare the data for every test.
@@ -49,6 +58,8 @@ public class TaskActionProcessorIT {
         MockDatabase.startNode();
         MockDatabase.insertProcessesForWorkflowFull();
         SecurityTestUtils.addUserDataToSecurityContext(ServiceManager.getUserService().getById(1), 1);
+        ExecutionPermission.setExecutePermission(scriptCreateDirMeta);
+        ExecutionPermission.setExecutePermission(scriptDeleteSymLink);
     }
 
     /**
@@ -62,6 +73,8 @@ public class TaskActionProcessorIT {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
         SecurityTestUtils.cleanSecurityContext();
+        ExecutionPermission.setNoExecutePermission(scriptCreateDirMeta);
+        ExecutionPermission.setNoExecutePermission(scriptDeleteSymLink);
     }
 
     @Test(expected = ProcessorException.class)

--- a/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
@@ -53,6 +53,8 @@ public class WorkflowControllerServiceIT {
             ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_DIR_USER_HOME));
     private static final File scriptCreateSymLink = new File(
             ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_SYMLINK));
+    private static final File scriptDeleteSymLink = new File(
+            ConfigCore.getParameter(ParameterCore.SCRIPT_DELETE_SYMLINK));
     private static final File scriptNotWorking = new File("src/test/resources/scripts/not_working_script.sh");
     private static final File scriptWorking = new File("src/test/resources/scripts/working_script.sh");
     private static final File usersDirectory = new File("src/test/resources/users");
@@ -79,6 +81,7 @@ public class WorkflowControllerServiceIT {
         if (!SystemUtils.IS_OS_WINDOWS) {
             ExecutionPermission.setExecutePermission(scriptCreateDirUserHome);
             ExecutionPermission.setExecutePermission(scriptCreateSymLink);
+            ExecutionPermission.setExecutePermission(scriptDeleteSymLink);
             ExecutionPermission.setExecutePermission(scriptNotWorking);
             ExecutionPermission.setExecutePermission(scriptWorking);
         }
@@ -95,6 +98,7 @@ public class WorkflowControllerServiceIT {
         if (!SystemUtils.IS_OS_WINDOWS) {
             ExecutionPermission.setNoExecutePermission(scriptCreateDirUserHome);
             ExecutionPermission.setNoExecutePermission(scriptCreateSymLink);
+            ExecutionPermission.setNoExecutePermission(scriptDeleteSymLink);
             ExecutionPermission.setNoExecutePermission(scriptNotWorking);
             ExecutionPermission.setNoExecutePermission(scriptWorking);
         }


### PR DESCRIPTION
While running the (integration) tests messages like

```
[ERROR] 2024-04-04 11:58:09.897 [main] Command - Execution of Command /home/gerhardt/git/kitodo/kitodo-production/Kitodo/src/test/resources/scripts/script_deleteSymLink.sh /home/gerhardt/git/kitodo/kitodo-production/Kitodo/src/test/resources/users/kowal/First__process__[1] failed!: [java.io.IOException: error=13, Permission denied, Cannot run program "/home/gerhardt/git/kitodo/kitodo-production/Kitodo/src/test/resources/scripts/script_deleteSymLink.sh": error=13, Permission denied]
[ERROR] 2024-04-04 11:58:09.897 [main] FileManagement - IOException in deleteSymLink
java.io.IOException: Cannot run program "/home/gerhardt/git/kitodo/kitodo-production/Kitodo/src/test/resources/scripts/script_deleteSymLink.sh": error=13, Permission denied
	at org.kitodo.filemanagement.CommandService.runCommand(CommandService.java:42) ~[?:?]
	at org.kitodo.filemanagement.CommandService.runCommand(CommandService.java:61) ~[?:?]
	at org.kitodo.filemanagement.FileManagement.deleteSymLink(FileManagement.java:543) ~[?:?]
	at org.kitodo.production.services.file.FileService.deleteSymLink(FileService.java:1426) ~[classes/:?]
	at org.kitodo.production.helper.WebDav.uploadFromHome(WebDav.java:145) ~[classes/:?]
...
```

appear and may hide some real issues. This pull request is fixing this for currently used shell script executions. It will be nice to look in the test execution output while running the tests to prevent this kind of messages in future.

