### PR TITLE
Kitodo-API: Replace Junit4 with Junit5 calls

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -83,10 +83,6 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/Kitodo-API/src/test/java/org/kitodo/api/dataformat/DivisionTest.java
+++ b/Kitodo-API/src/test/java/org/kitodo/api/dataformat/DivisionTest.java
@@ -11,13 +11,13 @@
 
 package org.kitodo.api.dataformat;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DivisionTest {
 

--- a/Kitodo-API/src/test/java/org/kitodo/config/ConfigTest.java
+++ b/Kitodo-API/src/test/java/org/kitodo/config/ConfigTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
 

--- a/Kitodo-API/src/test/java/org/kitodo/config/KitodoConfigTest.java
+++ b/Kitodo-API/src/test/java/org/kitodo/config/KitodoConfigTest.java
@@ -11,10 +11,10 @@
 
 package org.kitodo.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.NoSuchElementException;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.kitodo.config.enums.ParameterAPI;
 
 public class KitodoConfigTest {
@@ -35,7 +35,7 @@ public class KitodoConfigTest {
      *
      * @throws Exception the exceptions thrown by method
      */
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         NONE = mock(ParameterAPI.class);
         doReturn(3).when(NONE).ordinal();
@@ -49,13 +49,13 @@ public class KitodoConfigTest {
     @Test
     public void shouldGetStringParameterWithoutDefault() {
         String param = KitodoConfig.getParameter(ParameterAPI.DIR_XML_CONFIG);
-        assertEquals("Incorrect param!", "String", param);
+        assertEquals("String", param, "Incorrect param!");
     }
 
     @Test
     public void shouldGetStringParameterWithDefault() {
         String param = KitodoConfig.getParameter(ParameterAPI.DIR_XML_CONFIG, "test");
-        assertEquals("Incorrect param!", "String", param);
+        assertEquals("String", param, "Incorrect param!");
     }
 
     @Test
@@ -64,52 +64,51 @@ public class KitodoConfigTest {
             () -> KitodoConfig.getParameter(ParameterAPI.DIR_PROCESSES),
             "Expected NoSuchElementException to be thrown, but it didn't");
 
-        assertEquals("No configuration found in kitodo_config.properties for key directory.metadata!",
-            thrown.getMessage());
+        assertEquals("No configuration found in kitodo_config.properties for key directory.metadata!", thrown.getMessage());
     }
 
     @Test
     public void shouldGetStringParameterForNonexistentWithDefault() {
         String param = KitodoConfig.getParameter(ParameterAPI.DIR_PROCESSES, "Default");
-        assertEquals("Incorrect param!", "Default", param);
+        assertEquals("Default", param, "Incorrect param!");
     }
 
     @Test
     public void shouldGetBooleanParameter() {
-        assertTrue("Incorrect param!", KitodoConfig.getBooleanParameter(ParameterAPI.DIR_MODULES));
+        assertTrue(KitodoConfig.getBooleanParameter(ParameterAPI.DIR_MODULES), "Incorrect param!");
     }
 
     @Test
     public void shouldGetBooleanParameterForNonexistentWithoutDefault() {
-        assertFalse("Incorrect param!", KitodoConfig.getBooleanParameter(ParameterAPI.DIR_PROCESSES));
+        assertFalse(KitodoConfig.getBooleanParameter(ParameterAPI.DIR_PROCESSES), "Incorrect param!");
     }
 
     @Test
     public void shouldGetBooleanParameterForNonexistentWithDefault() {
-        assertTrue("Incorrect param!", KitodoConfig.getBooleanParameter(ParameterAPI.DIR_PROCESSES, true));
+        assertTrue(KitodoConfig.getBooleanParameter(ParameterAPI.DIR_PROCESSES, true), "Incorrect param!");
     }
 
     @Test
     public void shouldGetIntParameterWithoutDefault() {
         int param = KitodoConfig.getIntParameter(NONE);
-        assertEquals("Incorrect param for non existing enum without default value!", 0, param);
+        assertEquals(0, param, "Incorrect param for non existing enum without default value!");
     }
 
     @Test
     public void shouldGetIntParameterWithDefault() {
         int param = KitodoConfig.getIntParameter(NONE, 3);
-        assertEquals("Incorrect param for non existing enum with default value!", 3, param);
+        assertEquals(3, param, "Incorrect param for non existing enum with default value!");
     }
 
     @Test
     public void shouldGetIntParameterForNonexistentWithoutDefault() {
         int param = KitodoConfig.getIntParameter(ParameterAPI.DIR_PROCESSES);
-        assertEquals("Incorrect param!", 0, param);
+        assertEquals(0, param, "Incorrect param!");
     }
 
     @Test
     public void shouldGetIntParameterForNonexistentWithDefault() {
         int param = KitodoConfig.getIntParameter(ParameterAPI.DIR_PROCESSES, 3);
-        assertEquals("Incorrect param!", 3, param);
+        assertEquals(3, param, "Incorrect param!");
     }
 }

--- a/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
+++ b/Kitodo-API/src/test/java/org/kitodo/utils/MediaUtilTest.java
@@ -11,11 +11,11 @@
 
 package org.kitodo.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kitodo.api.dataformat.PhysicalDivision;
 
 public class MediaUtilTest {


### PR DESCRIPTION
First pull request of a few others following: replacing the used Junit4 with Junit5 calls including adjustments for Junit5 usage. This can be done step by step or module by module and in the last module the dependency for Junit4 can be removed.