### PR TITLE
[hibernate search] Introduce interfaces for the database- and search-related functions of the services

### DIFF
--- a/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
+++ b/Kitodo-DataEditor/src/test/java/org/kitodo/dataeditor/ruleset/RulesetManagementIT.java
@@ -1206,8 +1206,8 @@ public class RulesetManagementIT {
             List<MetadataViewWithValuesInterface> metadataViewWithValuesInterfaceList, String keyId) {
         return (ComplexMetadataViewInterface) metadataViewWithValuesInterfaceList.stream()
                 .filter(mvwvi -> mvwvi.getMetadata().isPresent())
-                .filter(metadataViewWithValuesInterface -> keyId
-                        .equals(metadataViewWithValuesInterface.getMetadata().get().getId()))
+                .filter(metadataViewWithValues -> keyId
+                        .equals(metadataViewWithValues.getMetadata().get().getId()))
                 .findAny().get().getMetadata().get();
     }
 
@@ -1235,8 +1235,8 @@ public class RulesetManagementIT {
      */
     private List<String> ids(List<MetadataViewWithValuesInterface> metadataViewWithValuesInterfaceList) {
         return metadataViewWithValuesInterfaceList.stream()
-                .filter(metadataViewWithValuesInterface -> metadataViewWithValuesInterface.getMetadata().isPresent())
-                .map(metadataViewWithValuesInterface -> metadataViewWithValuesInterface.getMetadata().get().getId())
+                .filter(metadataViewWithValues -> metadataViewWithValues.getMetadata().isPresent())
+                .map(metadataViewWithValues -> metadataViewWithValues.getMetadata().get().getId())
                 .collect(Collectors.toList());
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/BaseBean.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/BaseBean.java
@@ -23,22 +23,25 @@ import javax.persistence.MappedSuperclass;
 
 import org.hibernate.Hibernate;
 import org.kitodo.data.database.persistence.BaseDAO;
+import org.kitodo.data.interfaces.DataInterface;
 
 /**
  * Base bean class.
  */
 @MappedSuperclass
-public abstract class BaseBean implements Serializable {
+public abstract class BaseBean implements DataInterface, Serializable {
 
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected Integer id;
 
+    @Override
     public Integer getId() {
         return id;
     }
 
+    @Override
     public void setId(Integer id) {
         this.id = id;
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Batch.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Batch.java
@@ -29,6 +29,8 @@ import javax.persistence.Table;
 
 import org.kitodo.data.database.enums.BatchType;
 import org.kitodo.data.database.persistence.BatchDAO;
+import org.kitodo.data.interfaces.BatchInterface;
+import org.kitodo.data.interfaces.ProcessInterface;
 
 /**
  * A user-definable, unordered collection of processes whose batch-type tasks
@@ -39,7 +41,7 @@ import org.kitodo.data.database.persistence.BatchDAO;
  */
 @Entity
 @Table(name = "batch")
-public class Batch extends BaseIndexedBean {
+public class Batch extends BaseIndexedBean implements BatchInterface {
 
     /**
      * The batch title. Using titles for batches is optional, the field may be
@@ -105,22 +107,12 @@ public class Batch extends BaseIndexedBean {
         this.processes = new ArrayList<>(processes);
     }
 
-    /**
-     * Returns the batch title. Using titles for batches is optional, the field
-     * may be {@code null}. If so, the function returns null.
-     *
-     * @return the batch title
-     */
+    @Override
     public String getTitle() {
         return title;
     }
 
-    /**
-     * Sets a batch title.
-     *
-     * @param title
-     *            title of the batch
-     */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
@@ -134,11 +126,7 @@ public class Batch extends BaseIndexedBean {
         return type;
     }
 
-    /**
-     * Return the processes that belong to the batch.
-     *
-     * @return the processes of the batch
-     */
+    @Override
     public List<Process> getProcesses() {
         initialize(new BatchDAO(), this.processes);
         if (Objects.isNull(this.processes)) {
@@ -147,18 +135,14 @@ public class Batch extends BaseIndexedBean {
         return this.processes;
     }
 
-    /**
-     * Sets the processes that belong to the batch.
-     *
-     * @param processes
-     *            processes of the batch
-     */
-    public void setProcesses(List<Process> processes) {
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setProcesses(List<? extends ProcessInterface> processes) {
         if (this.processes == null) {
-            this.processes = processes;
+            this.processes = (List<Process>) processes;
         } else {
             this.processes.clear();
-            this.processes.addAll(processes);
+            this.processes.addAll((List<? extends Process>) processes);
         }
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Client.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Client.java
@@ -22,13 +22,17 @@ import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.kitodo.data.database.persistence.ClientDAO;
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.UserInterface;
 
 @Entity
 @Table(name = "client")
-public class Client extends BaseBean {
+public class Client extends BaseBean implements ClientInterface {
 
     @Column(name = "name")
     private String name;
@@ -40,21 +44,18 @@ public class Client extends BaseBean {
                     foreignKey = @ForeignKey(name = "FK_column_id"))})
     private List<ListColumn> listColumns;
 
-    /**
-     * Gets name.
-     *
-     * @return The name.
-     */
+    @ManyToMany(mappedBy = "clients", cascade = CascadeType.PERSIST)
+    private List<User> users;
+
+    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Project> projects;
+
+    @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * Sets name.
-     *
-     * @param name
-     *            The name.
-     */
+    @Override
     public void setName(String name) {
         this.name = name;
     }
@@ -98,5 +99,27 @@ public class Client extends BaseBean {
      */
     public void setListColumns(List<ListColumn> columns) {
         this.listColumns = columns;
+    }
+
+    @Override
+    public List<User> getUsers() {
+        return users;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setUsers(List<? extends UserInterface> users) {
+        this.users = (List<User>) users;
+    }
+
+    @Override
+    public List<Project> getProjects() {
+        return projects;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setProjects(List<? extends ProjectInterface> projects) {
+        this.projects = (List<Project>) projects;
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Docket.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Docket.java
@@ -20,9 +20,12 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.DocketInterface;
+
 @Entity
 @Table(name = "docket")
-public class Docket extends BaseIndexedBean {
+public class Docket extends BaseIndexedBean implements DocketInterface {
 
     @Column(name = "title")
     private String title;
@@ -37,18 +40,22 @@ public class Docket extends BaseIndexedBean {
     @JoinColumn(name = "client_id", foreignKey = @ForeignKey(name = "FK_docket_client_id"))
     private Client client;
 
+    @Override
     public String getTitle() {
         return title;
     }
 
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
 
+    @Override
     public String getFile() {
         return file;
     }
 
+    @Override
     public void setFile(String file) {
         this.file = file;
     }
@@ -74,23 +81,14 @@ public class Docket extends BaseIndexedBean {
         this.active = active;
     }
 
-    /**
-     * Get client.
-     *
-     * @return Client object
-     */
+    @Override
     public Client getClient() {
         return this.client;
     }
 
-    /**
-     * Set client.
-     *
-     * @param client
-     *            as Client object
-     */
-    public void setClient(Client client) {
-        this.client = client;
+    @Override
+    public void setClient(ClientInterface client) {
+        this.client = (Client) client;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Filter.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Filter.java
@@ -21,12 +21,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.kitodo.data.interfaces.FilterInterface;
+
 /**
  * Filter bean.
  */
 @Entity
 @Table(name = "filter")
-public class Filter extends BaseIndexedBean {
+public class Filter extends BaseIndexedBean implements FilterInterface {
 
     @Column(name = "value", columnDefinition = "longtext")
     private String value;
@@ -38,21 +40,12 @@ public class Filter extends BaseIndexedBean {
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "FK_filter_user_id"))
     private User user;
 
-    /**
-     * Get filter value.
-     *
-     * @return filter value
-     */
+    @Override
     public String getValue() {
         return value;
     }
 
-    /**
-     * Set filter value.
-     *
-     * @param value
-     *            filter
-     */
+    @Override
     public void setValue(String value) {
         this.value = value;
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -139,13 +139,13 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
     private List<Map<String, Object>> metadata;
 
     @Transient
-    private Integer numberOfMetadata;
+    private int numberOfMetadata;
 
     @Transient
-    private Integer numberOfImages;
+    private int numberOfImages;
 
     @Transient
-    private Integer numberOfStructures;
+    private int numberOfStructures;
 
     @Transient
     private String baseType;
@@ -622,6 +622,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
      * Get OCR-D workflow identifier.
      *
      * @return The OCR-D workflow identifier
+     * @see <a href="https://ocr-d.de/en/workflows">OCR-D Workflow Guide</a>
      */
     public String getOcrdWorkflowId() {
         return ocrdWorkflowId;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -430,7 +430,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
     }
 
     /*
-     * If list is empty just set, if not first clear and next set.
+     * Set batches, if list is empty just set, if not first clear and next set.
      */
     @Override
     @SuppressWarnings("unchecked")
@@ -459,8 +459,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
     /**
      * Set comments.
      *
-     * @param comments
-     *            as List of Comment objects
+     * @param comments as List of Comment objects
      */
     public void setComments(List<Comment> comments) {
         this.comments = comments;
@@ -493,8 +492,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
     /**
      * Set exported.
      *
-     * @param exported
-     *            as boolean
+     * @param exported as boolean
      */
     public void setExported(boolean exported) {
         this.exported = exported;
@@ -512,8 +510,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
     /**
      * Set metadata.
      *
-     * @param metadata
-     *            as Map
+     * @param metadata as Map
      */
     public void setMetadata(List<Map<String, Object>> metadata) {
         this.metadata = metadata;
@@ -551,8 +548,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
     /**
      * Set inChoiceListShown.
      *
-     * @param inChoiceListShown
-     *            as java.lang.Boolean
+     * @param inChoiceListShown as java.lang.Boolean
      */
     public void setInChoiceListShown(Boolean inChoiceListShown) {
         this.inChoiceListShown = inChoiceListShown;
@@ -560,9 +556,8 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
 
     /**
      * Determines whether or not two processes are equal. Two instances of
-     * {@code Process} are equal if the values of their {@code Id},
-     * {@code Title}, {@code OutputName} and {@code CreationDate} member fields
-     * are the same.
+     * {@code Process} are equal if the values of their {@code Id}, {@code Title},
+     * {@code OutputName} and {@code CreationDate} member fields are the same.
      *
      * @param object
      *            An object to be compared with this {@code Process}.
@@ -622,7 +617,6 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
      * Get OCR-D workflow identifier.
      *
      * @return The OCR-D workflow identifier
-     * @see <a href="https://ocr-d.de/en/workflows">OCR-D Workflow Guide</a>
      */
     public String getOcrdWorkflowId() {
         return ocrdWorkflowId;
@@ -632,7 +626,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
      * Set the OCR-D workflow identifier.
      *
      * @param ocrdWorkflowId
-     *            The identifier of the OCR-D workflow
+     *         The identifier of the OCR-D workflow
      */
     public void setOcrdWorkflowId(String ocrdWorkflowId) {
         this.ocrdWorkflowId = ocrdWorkflowId;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -126,13 +126,13 @@ public class Process extends BaseTemplateBean {
     private List<Map<String, Object>> metadata;
 
     @Transient
-    private int numberOfMetadata;
+    private Integer numberOfMetadata;
 
     @Transient
-    private int numberOfImages;
+    private Integer numberOfImages;
 
     @Transient
-    private int numberOfStructures;
+    private Integer numberOfStructures;
 
     @Transient
     private String baseType;
@@ -606,7 +606,7 @@ public class Process extends BaseTemplateBean {
      *
      * @return Amount of structure elements
      */
-    public int getNumberOfStructures() {
+    public Integer getNumberOfStructures() {
         return numberOfStructures;
     }
 
@@ -615,7 +615,7 @@ public class Process extends BaseTemplateBean {
      *
      * @return Amount of meta data elements
      */
-    public int getNumberOfMetadata() {
+    public Integer getNumberOfMetadata() {
         return numberOfMetadata;
     }
 
@@ -624,7 +624,7 @@ public class Process extends BaseTemplateBean {
      *
      * @param numberOfMetadata Integer value of amount of meta data elements
      */
-    public void setNumberOfMetadata(int numberOfMetadata) {
+    public void setNumberOfMetadata(Integer numberOfMetadata) {
         this.numberOfMetadata = numberOfMetadata;
     }
 
@@ -633,7 +633,7 @@ public class Process extends BaseTemplateBean {
      *
      * @return Integer value of amount of images
      */
-    public int getNumberOfImages() {
+    public Integer getNumberOfImages() {
         return numberOfImages;
     }
 
@@ -642,7 +642,7 @@ public class Process extends BaseTemplateBean {
      *
      * @param numberOfImages Integer value of amount of images
      */
-    public void setNumberOfImages(int numberOfImages) {
+    public void setNumberOfImages(Integer numberOfImages) {
         this.numberOfImages = numberOfImages;
     }
 
@@ -651,7 +651,7 @@ public class Process extends BaseTemplateBean {
      *
      * @param numberOfStructures Integer value of amount of structure elements
      */
-    public void setNumberOfStructures(int numberOfStructures) {
+    public void setNumberOfStructures(Integer numberOfStructures) {
         this.numberOfStructures = numberOfStructures;
     }
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import javax.el.PropertyNotWritableException;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -38,6 +39,7 @@ import org.kitodo.data.database.persistence.HibernateUtil;
 import org.kitodo.data.database.persistence.ProcessDAO;
 import org.kitodo.data.elasticsearch.index.converter.ProcessConverter;
 import org.kitodo.data.interfaces.BatchInterface;
+import org.kitodo.data.interfaces.ClientInterface;
 import org.kitodo.data.interfaces.DocketInterface;
 import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.data.interfaces.ProjectInterface;
@@ -277,6 +279,23 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
         this.project = (Project) project;
     }
 
+    /**
+     * Specifies the project to which the process belongs.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function exists because Faces does not recognize the more generic
+     * function {@link #setProject(ProjectInterface)} as a setter for the
+     * property {@code project} and otherwise throws a
+     * {@link PropertyNotWritableException}.
+     *
+     * @param project
+     *            project to which the process should belong
+     */
+    public void setProject(Project project) {
+        this.project = project;
+    }
+
     @Override
     public Ruleset getRuleset() {
         return this.ruleset;
@@ -287,6 +306,23 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
         this.ruleset = (Ruleset) ruleset;
     }
 
+    /**
+     * Sets the business domain specification this process is using.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function exists because Faces does not recognize the more generic
+     * function {@link #setRuleset(RulesetInterface)} as a setter for the
+     * property {@code ruleset} and otherwise throws a
+     * {@link PropertyNotWritableException}.
+     *
+     * @param ruleset
+     *            the business domain specification
+     */
+    public void setRuleset(Ruleset ruleset) {
+        this.ruleset = ruleset;
+    }
+
     @Override
     public Docket getDocket() {
         return docket;
@@ -295,6 +331,24 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
     @Override
     public void setDocket(DocketInterface docket) {
         this.docket = (Docket) docket;
+    }
+
+    /**
+     * Sets the docket generation statement to use when creating a docket for
+     * this process.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function exists because Faces does not recognize the more generic
+     * function {@link #setDocket(DocketInterface)} as a setter for the property
+     * {@code docket} and otherwise throws a
+     * {@link PropertyNotWritableException}.
+     *
+     * @param docket
+     *            the docket generation statement
+     */
+    public void setDocket(Docket docket) {
+        this.docket = docket;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import javax.el.PropertyNotWritableException;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -287,7 +286,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
      * This function exists because Faces does not recognize the more generic
      * function {@link #setProject(ProjectInterface)} as a setter for the
      * property {@code project} and otherwise throws a
-     * {@link PropertyNotWritableException}.
+     * {@code PropertyNotWritableException}.
      *
      * @param project
      *            project to which the process should belong
@@ -314,7 +313,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
      * This function exists because Faces does not recognize the more generic
      * function {@link #setRuleset(RulesetInterface)} as a setter for the
      * property {@code ruleset} and otherwise throws a
-     * {@link PropertyNotWritableException}.
+     * {@code PropertyNotWritableException}.
      *
      * @param ruleset
      *            the business domain specification
@@ -342,7 +341,7 @@ public class Process extends BaseTemplateBean implements ProcessInterface {
      * This function exists because Faces does not recognize the more generic
      * function {@link #setDocket(DocketInterface)} as a setter for the property
      * {@code docket} and otherwise throws a
-     * {@link PropertyNotWritableException}.
+     * {@code PropertyNotWritableException}.
      *
      * @param docket
      *            the docket generation statement

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -31,11 +32,23 @@ import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.kitodo.data.database.enums.TaskStatus;
+import org.kitodo.data.database.persistence.HibernateUtil;
 import org.kitodo.data.database.persistence.ProcessDAO;
+import org.kitodo.data.elasticsearch.index.converter.ProcessConverter;
+import org.kitodo.data.interfaces.BatchInterface;
+import org.kitodo.data.interfaces.DocketInterface;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.PropertyInterface;
+import org.kitodo.data.interfaces.RulesetInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.UserInterface;
 
 @Entity
 @Table(name = "process")
-public class Process extends BaseTemplateBean {
+public class Process extends BaseTemplateBean implements ProcessInterface {
 
     @Column(name = "sortHelperImages")
     private Integer sortHelperImages;
@@ -120,7 +133,7 @@ public class Process extends BaseTemplateBean {
     private String ocrdWorkflowId;
 
     @Transient
-    private User blockedUser;
+    private UserInterface blockedUser;
 
     @Transient
     private List<Map<String, Object>> metadata;
@@ -152,10 +165,9 @@ public class Process extends BaseTemplateBean {
     }
 
     /**
-     * Get sorting helper for images.
-     *
-     * @return sorting helper as Integer, in case of null it returns 0
+     * {@inheritDoc} In case of {@code null}, it returns 0.
      */
+    @Override
     public Integer getSortHelperImages() {
         if (this.sortHelperImages == null) {
             this.sortHelperImages = 0;
@@ -163,15 +175,15 @@ public class Process extends BaseTemplateBean {
         return this.sortHelperImages;
     }
 
+    @Override
     public void setSortHelperImages(Integer sortHelperImages) {
         this.sortHelperImages = sortHelperImages;
     }
 
     /**
-     * Get sorting helper for articles.
-     *
-     * @return sorting helper as Integer, in case of null it returns 0
+     * {@inheritDoc} In case of {@code null}, it returns 0.
      */
+    @Override
     public Integer getSortHelperArticles() {
         if (this.sortHelperArticles == null) {
             this.sortHelperArticles = 0;
@@ -179,15 +191,15 @@ public class Process extends BaseTemplateBean {
         return this.sortHelperArticles;
     }
 
+    @Override
     public void setSortHelperArticles(Integer sortHelperArticles) {
         this.sortHelperArticles = sortHelperArticles;
     }
 
     /**
-     * Get sorting helper for document structure.
-     *
-     * @return sorting helper as Integer, in case of null it returns 0
+     * {@inheritDoc} In case of {@code null}, it returns 0.
      */
+    @Override
     public Integer getSortHelperDocstructs() {
         if (this.sortHelperDocstructs == null) {
             this.sortHelperDocstructs = 0;
@@ -195,15 +207,15 @@ public class Process extends BaseTemplateBean {
         return this.sortHelperDocstructs;
     }
 
+    @Override
     public void setSortHelperDocstructs(Integer sortHelperDocstructs) {
         this.sortHelperDocstructs = sortHelperDocstructs;
     }
 
     /**
-     * Get sorting helper for metadata.
-     *
-     * @return sorting helper as Integer, in case of null it returns 0
+     * {@inheritDoc} In case of {@code null}, it returns 0.
      */
+    @Override
     public Integer getSortHelperMetadata() {
         if (this.sortHelperMetadata == null) {
             this.sortHelperMetadata = 0;
@@ -211,41 +223,27 @@ public class Process extends BaseTemplateBean {
         return this.sortHelperMetadata;
     }
 
+    @Override
     public void setSortHelperMetadata(Integer sortHelperMetadata) {
         this.sortHelperMetadata = sortHelperMetadata;
     }
 
-    /**
-     * Get wikiField.
-     *
-     * @return value of wikiField
-     */
+    @Override
     public String getWikiField() {
         return this.wikiField;
     }
 
-    /**
-     * Set wikiField.
-     *
-     * @param wikiField as java.lang.String
-     */
+    @Override
     public void setWikiField(String wikiField) {
         this.wikiField = wikiField;
     }
 
-    /**
-     * Gets the process base URI.
-     */
+    @Override
     public URI getProcessBaseUri() {
         return Objects.isNull(processBaseUri) ? null : URI.create(processBaseUri);
     }
 
-    /**
-     * Sets the process base URI.
-     *
-     * @param processBaseUri
-     *            the given process base URI
-     */
+    @Override
     public void setProcessBaseUri(URI processBaseUri) {
         this.processBaseUri = Objects.isNull(processBaseUri) ? null : processBaseUri.toString();
     }
@@ -262,34 +260,41 @@ public class Process extends BaseTemplateBean {
     /**
      * Set ordering.
      *
-     * @param ordering as java.lang.Integer
+     * @param ordering
+     *            as java.lang.Integer
      */
     public void setOrdering(Integer ordering) {
         this.ordering = ordering;
     }
 
+    @Override
     public Project getProject() {
         return this.project;
     }
 
-    public void setProject(Project project) {
-        this.project = project;
+    @Override
+    public void setProject(ProjectInterface project) {
+        this.project = (Project) project;
     }
 
+    @Override
     public Ruleset getRuleset() {
         return this.ruleset;
     }
 
-    public void setRuleset(Ruleset ruleset) {
-        this.ruleset = ruleset;
+    @Override
+    public void setRuleset(RulesetInterface ruleset) {
+        this.ruleset = (Ruleset) ruleset;
     }
 
+    @Override
     public Docket getDocket() {
         return docket;
     }
 
-    public void setDocket(Docket docket) {
-        this.docket = docket;
+    @Override
+    public void setDocket(DocketInterface docket) {
+        this.docket = (Docket) docket;
     }
 
     /**
@@ -304,7 +309,8 @@ public class Process extends BaseTemplateBean {
     /**
      * Set template.
      *
-     * @param template as Template object
+     * @param template
+     *            as Template object
      */
     public void setTemplate(Template template) {
         this.template = template;
@@ -322,7 +328,8 @@ public class Process extends BaseTemplateBean {
     /**
      * Set parent.
      *
-     * @param parent as org.kitodo.data.database.beans.Process
+     * @param parent
+     *            as org.kitodo.data.database.beans.Process
      */
     public void setParent(Process parent) {
         this.parent = parent;
@@ -344,17 +351,14 @@ public class Process extends BaseTemplateBean {
     /**
      * Set children.
      *
-     * @param children as List of Process objects
+     * @param children
+     *            as List of Process objects
      */
     public void setChildren(List<Process> children) {
         this.children = children;
     }
 
-    /**
-     * Get list of task.
-     *
-     * @return list of Task objects or empty list
-     */
+    @Override
     public List<Task> getTasks() {
         initialize(new ProcessDAO(), this.tasks);
         if (Objects.isNull(this.tasks)) {
@@ -363,8 +367,10 @@ public class Process extends BaseTemplateBean {
         return this.tasks;
     }
 
-    public void setTasks(List<Task> tasks) {
-        this.tasks = tasks;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setTasks(List<? extends TaskInterface> tasks) {
+        this.tasks = (List<Task>) tasks;
     }
 
     /**
@@ -414,11 +420,7 @@ public class Process extends BaseTemplateBean {
         this.workpieces = workpieces;
     }
 
-    /**
-     * Get list of batches or empty list.
-     *
-     * @return list of batches or empty list
-     */
+    @Override
     public List<Batch> getBatches() {
         initialize(new ProcessDAO(), this.batches);
         if (Objects.isNull(this.batches)) {
@@ -427,18 +429,17 @@ public class Process extends BaseTemplateBean {
         return this.batches;
     }
 
-    /**
-     * Set batches, if list is empty just set, if not first clear and next set.
-     *
-     * @param batches
-     *            list
+    /*
+     * If list is empty just set, if not first clear and next set.
      */
-    public void setBatches(List<Batch> batches) {
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setBatches(List<? extends BatchInterface> batches) {
         if (this.batches == null) {
-            this.batches = batches;
+            this.batches = (List<Batch>) batches;
         } else {
             this.batches.clear();
-            this.batches.addAll(batches);
+            this.batches.addAll((List<? extends Batch>) batches);
         }
     }
 
@@ -458,17 +459,14 @@ public class Process extends BaseTemplateBean {
     /**
      * Set comments.
      *
-     * @param comments as List of Comment objects
+     * @param comments
+     *            as List of Comment objects
      */
     public void setComments(List<Comment> comments) {
         this.comments = comments;
     }
 
-    /**
-     * Get list of properties.
-     *
-     * @return list of Property objects or empty list
-     */
+    @Override
     public List<Property> getProperties() {
         initialize(new ProcessDAO(), this.properties);
         if (Objects.isNull(this.properties)) {
@@ -477,8 +475,10 @@ public class Process extends BaseTemplateBean {
         return this.properties;
     }
 
-    public void setProperties(List<Property> properties) {
-        this.properties = properties;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setProperties(List<? extends PropertyInterface> properties) {
+        this.properties = (List<Property>) properties;
     }
 
     /**
@@ -493,7 +493,8 @@ public class Process extends BaseTemplateBean {
     /**
      * Set exported.
      *
-     * @param exported as boolean
+     * @param exported
+     *            as boolean
      */
     public void setExported(boolean exported) {
         this.exported = exported;
@@ -511,45 +512,29 @@ public class Process extends BaseTemplateBean {
     /**
      * Set metadata.
      *
-     * @param metadata as Map
+     * @param metadata
+     *            as Map
      */
     public void setMetadata(List<Map<String, Object>> metadata) {
         this.metadata = metadata;
     }
 
-    /**
-     * Get blocked user.
-     *
-     * @return User object if this user is blocked
-     */
-    public User getBlockedUser() {
+    @Override
+    public UserInterface getBlockedUser() {
         return blockedUser;
     }
 
-    /**
-     * Set blocked user.
-     *
-     * @param blockedUser
-     *            User object
-     */
-    public void setBlockedUser(User blockedUser) {
+    @Override
+    public void setBlockedUser(UserInterface blockedUser) {
         this.blockedUser = blockedUser;
     }
 
-    /**
-     * Get baseType.
-     *
-     * @return value of baseType
-     */
+    @Override
     public String getBaseType() {
         return baseType;
     }
 
-    /**
-     * Set baseType.
-     *
-     * @param baseType as java.lang.String
-     */
+    @Override
     public void setBaseType(String baseType) {
         this.baseType = baseType;
     }
@@ -566,7 +551,8 @@ public class Process extends BaseTemplateBean {
     /**
      * Set inChoiceListShown.
      *
-     * @param inChoiceListShown as java.lang.Boolean
+     * @param inChoiceListShown
+     *            as java.lang.Boolean
      */
     public void setInChoiceListShown(Boolean inChoiceListShown) {
         this.inChoiceListShown = inChoiceListShown;
@@ -574,8 +560,9 @@ public class Process extends BaseTemplateBean {
 
     /**
      * Determines whether or not two processes are equal. Two instances of
-     * {@code Process} are equal if the values of their {@code Id}, {@code Title},
-     * {@code OutputName} and {@code CreationDate} member fields are the same.
+     * {@code Process} are equal if the values of their {@code Id},
+     * {@code Title}, {@code OutputName} and {@code CreationDate} member fields
+     * are the same.
      *
      * @param object
      *            An object to be compared with this {@code Process}.
@@ -601,56 +588,32 @@ public class Process extends BaseTemplateBean {
         return Objects.hash(this.getId());
     }
 
-    /**
-     * Get amount of structure elements.
-     *
-     * @return Amount of structure elements
-     */
+    @Override
     public Integer getNumberOfStructures() {
         return numberOfStructures;
     }
 
-    /**
-     * Get amount of meta data elements.
-     *
-     * @return Amount of meta data elements
-     */
+    @Override
     public Integer getNumberOfMetadata() {
         return numberOfMetadata;
     }
 
-    /**
-     * Set amount of meta data elements.
-     *
-     * @param numberOfMetadata Integer value of amount of meta data elements
-     */
+    @Override
     public void setNumberOfMetadata(Integer numberOfMetadata) {
         this.numberOfMetadata = numberOfMetadata;
     }
 
-    /**
-     * Get amount of images.
-     *
-     * @return Integer value of amount of images
-     */
+    @Override
     public Integer getNumberOfImages() {
         return numberOfImages;
     }
 
-    /**
-     * Set amount of images.
-     *
-     * @param numberOfImages Integer value of amount of images
-     */
+    @Override
     public void setNumberOfImages(Integer numberOfImages) {
         this.numberOfImages = numberOfImages;
     }
 
-    /**
-     * Set amount of structure elements.
-     *
-     * @param numberOfStructures Integer value of amount of structure elements
-     */
+    @Override
     public void setNumberOfStructures(Integer numberOfStructures) {
         this.numberOfStructures = numberOfStructures;
     }
@@ -668,9 +631,118 @@ public class Process extends BaseTemplateBean {
      * Set the OCR-D workflow identifier.
      *
      * @param ocrdWorkflowId
-     *         The identifier of the OCR-D workflow
+     *            The identifier of the OCR-D workflow
      */
     public void setOcrdWorkflowId(String ocrdWorkflowId) {
         this.ocrdWorkflowId = ocrdWorkflowId;
+    }
+
+    @Override
+    public Double getProgressClosed() {
+        if (CollectionUtils.isEmpty(tasks)) {
+            return 0.0;
+        }
+        return getProgressPercentageExact(TaskStatus.DONE);
+    }
+
+    @Override
+    public Double getProgressInProcessing() {
+        if (CollectionUtils.isEmpty(tasks)) {
+            return 0.0;
+        }
+        return getProgressPercentageExact(TaskStatus.INWORK);
+    }
+
+    @Override
+    public Double getProgressLocked() {
+        if (CollectionUtils.isEmpty(tasks)) {
+            return 100.0;
+        }
+        return getProgressPercentageExact(TaskStatus.LOCKED);
+
+    }
+
+    @Override
+    public Double getProgressOpen() {
+        if (CollectionUtils.isEmpty(tasks)) {
+            return 0.0;
+        }
+        return getProgressPercentageExact(TaskStatus.OPEN);
+    }
+
+    private Double getProgressPercentageExact(TaskStatus status) {
+        Map<TaskStatus, Double> taskProgress = ProcessConverter.getTaskProgressPercentageOfProcess(this, true);
+        return taskProgress.get(status);
+    }
+
+    @Override
+    public String getProgressCombined() {
+        Map<TaskStatus, Double> taskProgress = ProcessConverter.getTaskProgressPercentageOfProcess(this, true);
+        return ProcessConverter.getCombinedProgressFromTaskPercentages(taskProgress);
+    }
+
+    @Override
+    public String getBatchID() {
+        return batches.stream().map(Batch::getTitle).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public Integer getParentID() {
+        return Objects.nonNull(parent) ? parent.getId() : null;
+    }
+
+    @Override
+    public void setParentID(Integer parentID) {
+        this.parent = HibernateUtil.getSession().get(Process.class, parentID);
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return CollectionUtils.isNotEmpty(children);
+    }
+
+    @Override
+    public void setHasChildren(boolean hasChildren) {
+        if (!hasChildren && Objects.nonNull(children)) {
+            children.forEach(child -> child.setParent(null));
+            children.clear();
+        } else if (hasChildren && CollectionUtils.isEmpty(children)) {
+            throw new UnsupportedOperationException("cannot insert child processes");
+        }
+    }
+
+    @Override
+    public String getLastEditingUser() {
+        return ProcessConverter.getLastEditingUser(this);
+    }
+
+    @Override
+    public Date getProcessingBeginLastTask() {
+        return ProcessConverter.getLastProcessingBegin(this);
+    }
+
+    @Override
+    public Date getProcessingEndLastTask() {
+        return ProcessConverter.getLastProcessingEnd(this);
+    }
+
+    @Override
+    public Integer getCorrectionCommentStatus() {
+        return ProcessConverter.getCorrectionCommentStatus(this).getValue();
+    }
+
+    @Override
+    public boolean hasComments() {
+        return CollectionUtils.isNotEmpty(comments);
+    }
+
+    @Override
+    public void setHasComments(boolean hasComments) {
+        if (!hasComments && Objects.nonNull(comments)) {
+            comments.forEach(comment -> comment.setProcess(null));
+            comments.clear();
+        } else if (hasComments && CollectionUtils.isEmpty(comments)) {
+            throw new UnsupportedOperationException("cannot insert comments");
+        }
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Project.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Project.java
@@ -33,6 +33,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.kitodo.data.database.enums.PreviewHoverMode;
 import org.kitodo.data.database.persistence.ProjectDAO;
 import org.kitodo.data.interfaces.ClientInterface;
@@ -98,6 +100,7 @@ public class Project extends BaseIndexedBean implements ProjectInterface, Compar
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Process> processes;
 
+    @LazyCollection(LazyCollectionOption.FALSE)
     @ManyToMany(mappedBy = "projects", cascade = CascadeType.PERSIST)
     private List<Template> templates;
 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Property.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Property.java
@@ -26,10 +26,11 @@ import javax.persistence.Table;
 import org.kitodo.data.database.converter.PropertyTypeConverter;
 import org.kitodo.data.database.enums.PropertyType;
 import org.kitodo.data.database.persistence.PropertyDAO;
+import org.kitodo.data.interfaces.PropertyInterface;
 
 @Entity
 @Table(name = "property")
-public class Property extends BaseIndexedBean implements Comparable<Property> {
+public class Property extends BaseIndexedBean implements PropertyInterface, Comparable<Property> {
 
     @Column(name = "title")
     private String title;
@@ -68,40 +69,22 @@ public class Property extends BaseIndexedBean implements Comparable<Property> {
         this.creationDate = new Date();
     }
 
-    /**
-     * Get title.
-     *
-     * @return title as String
-     */
+    @Override
     public String getTitle() {
         return this.title;
     }
 
-    /**
-     * Set title.
-     *
-     * @param title
-     *            as String
-     */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
 
-    /**
-     * Get value.
-     *
-     * @return value as String
-     */
+    @Override
     public String getValue() {
         return this.value;
     }
 
-    /**
-     * Set value.
-     *
-     * @param value
-     *            as String
-     */
+    @Override
     public void setValue(String value) {
         this.value = value;
     }
@@ -147,21 +130,12 @@ public class Property extends BaseIndexedBean implements Comparable<Property> {
         this.obligatory = obligatory;
     }
 
-    /**
-     * Get creation date.
-     *
-     * @return creation date as Date
-     */
+    @Override
     public Date getCreationDate() {
         return this.creationDate;
     }
 
-    /**
-     * Set creation date.
-     *
-     * @param creationDate
-     *            as Date
-     */
+    @Override
     public void setCreationDate(Date creationDate) {
         this.creationDate = creationDate;
     }
@@ -264,6 +238,7 @@ public class Property extends BaseIndexedBean implements Comparable<Property> {
      *            object
      * @return int
      */
+    @Override
     public int compareTo(Property property) {
         int titleMatch = this.getTitle().toLowerCase().compareTo(property.getTitle().toLowerCase());
         int valueMatch = this.getValue().toLowerCase().compareTo(property.getValue().toLowerCase());

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Role.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Role.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.el.PropertyNotWritableException;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -146,6 +147,23 @@ public class Role extends BaseBean implements RoleInterface, Comparable<Role> {
     @Override
     public void setClient(ClientInterface client) {
         this.client = (Client) client;
+    }
+
+    /**
+     * Sets the client in whose realm this role grants permissions.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function exists because Faces does not recognize the more generic
+     * function {@link #setClient(ClientInterface)} as a setter for the property
+     * {@code client} and otherwise throws a
+     * {@link PropertyNotWritableException}.
+     *
+     * @param client
+     *            client in whose realm this role grants permissions to set.
+     */
+    public void setClient(Client client) {
+        this.client = client;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Role.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Role.java
@@ -26,10 +26,13 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.kitodo.data.database.persistence.RoleDAO;
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.RoleInterface;
+import org.kitodo.data.interfaces.UserInterface;
 
 @Entity
 @Table(name = "role")
-public class Role extends BaseBean implements Comparable<Role> {
+public class Role extends BaseBean implements RoleInterface, Comparable<Role> {
 
     @Column(name = "title", nullable = false)
     private String title;
@@ -60,11 +63,7 @@ public class Role extends BaseBean implements Comparable<Role> {
         this.authorities = new ArrayList<>();
     }
 
-    /**
-     * Gets title.
-     *
-     * @return The title.
-     */
+    @Override
     public String getTitle() {
         if (this.title == null) {
             return "";
@@ -73,12 +72,7 @@ public class Role extends BaseBean implements Comparable<Role> {
         }
     }
 
-    /**
-     * Sets title.
-     *
-     * @param title
-     *            The title.
-     */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
@@ -106,11 +100,7 @@ public class Role extends BaseBean implements Comparable<Role> {
         this.authorities = authorities;
     }
 
-    /**
-     * Gets users.
-     *
-     * @return The users.
-     */
+    @Override
     public List<User> getUsers() {
         initialize(new RoleDAO(), this.users);
         if (Objects.isNull(this.users)) {
@@ -119,14 +109,10 @@ public class Role extends BaseBean implements Comparable<Role> {
         return this.users;
     }
 
-    /**
-     * Sets users.
-     *
-     * @param users
-     *            The users.
-     */
-    public void setUsers(List<User> users) {
-        this.users = users;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setUsers(List<? extends UserInterface> users) {
+        this.users = (List<User>) users;
     }
 
     /**
@@ -152,23 +138,14 @@ public class Role extends BaseBean implements Comparable<Role> {
         this.tasks = tasks;
     }
 
-    /**
-     * Get client.
-     *
-     * @return the client bean
-     */
+    @Override
     public Client getClient() {
         return client;
     }
 
-    /**
-     * Set client.
-     *
-     * @param client
-     *            bean
-     */
-    public void setClient(Client client) {
-        this.client = client;
+    @Override
+    public void setClient(ClientInterface client) {
+        this.client = (Client) client;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Role.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Role.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.el.PropertyNotWritableException;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -157,7 +156,7 @@ public class Role extends BaseBean implements RoleInterface, Comparable<Role> {
      * This function exists because Faces does not recognize the more generic
      * function {@link #setClient(ClientInterface)} as a setter for the property
      * {@code client} and otherwise throws a
-     * {@link PropertyNotWritableException}.
+     * {@code PropertyNotWritableException}.
      *
      * @param client
      *            client in whose realm this role grants permissions to set.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Ruleset.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Ruleset.java
@@ -20,9 +20,12 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.RulesetInterface;
+
 @Entity
 @Table(name = "ruleset")
-public class Ruleset extends BaseIndexedBean {
+public class Ruleset extends BaseIndexedBean implements RulesetInterface {
 
     @Column(name = "title")
     private String title;
@@ -40,27 +43,27 @@ public class Ruleset extends BaseIndexedBean {
     @JoinColumn(name = "client_id", foreignKey = @ForeignKey(name = "FK_ruleset_client_id"))
     private Client client;
 
+    @Override
     public String getTitle() {
         return this.title;
     }
 
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
 
+    @Override
     public String getFile() {
         return this.file;
     }
 
+    @Override
     public void setFile(String file) {
         this.file = file;
     }
 
-    /**
-     * Check if metadata should be ordered by ruleset.
-     *
-     * @return true or false
-     */
+    @Override
     public boolean isOrderMetadataByRuleset() {
         if (this.orderMetadataByRuleset == null) {
             this.orderMetadataByRuleset = false;
@@ -68,21 +71,12 @@ public class Ruleset extends BaseIndexedBean {
         return this.orderMetadataByRuleset;
     }
 
-    /**
-     * Set if metadata should be ordered by ruleset.
-     *
-     * @param orderMetadataByRuleset
-     *            true or false
-     */
+    @Override
     public void setOrderMetadataByRuleset(boolean orderMetadataByRuleset) {
         this.orderMetadataByRuleset = orderMetadataByRuleset;
     }
 
-    /**
-     * Check if ruleset is active.
-     *
-     * @return true or false
-     */
+    @Override
     public Boolean isActive() {
         if (Objects.isNull(this.active)) {
             this.active = true;
@@ -90,32 +84,19 @@ public class Ruleset extends BaseIndexedBean {
         return this.active;
     }
 
-    /**
-     * Set ruleset as active.
-     *
-     * @param active as boolean
-     */
+    @Override
     public void setActive(boolean active) {
         this.active = active;
     }
 
-    /**
-     * Get client.
-     *
-     * @return Client object
-     */
+    @Override
     public Client getClient() {
         return this.client;
     }
 
-    /**
-     * Set client.
-     *
-     * @param client
-     *            as Client object
-     */
-    public void setClient(Client client) {
-        this.client = client;
+    @Override
+    public void setClient(ClientInterface client) {
+        this.client = (Client) client;
     }
 
     @Override

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Task.java
@@ -35,10 +35,15 @@ import org.kitodo.data.database.converter.TaskStatusConverter;
 import org.kitodo.data.database.enums.TaskEditType;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.persistence.TaskDAO;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.RoleInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
+import org.kitodo.data.interfaces.UserInterface;
 
 @Entity
 @Table(name = "task")
-public class Task extends BaseIndexedBean {
+public class Task extends BaseIndexedBean implements TaskInterface {
 
     @Column(name = "title")
     private String title;
@@ -149,6 +154,12 @@ public class Task extends BaseIndexedBean {
     @Transient
     private String localizedTitle;
 
+    @Transient
+    private String processingStatusTitle;
+
+    @Transient
+    private String editTypeTitle;
+
     /**
      * Constructor.
      */
@@ -191,80 +202,72 @@ public class Task extends BaseIndexedBean {
         this.roles = new ArrayList<>(templateTask.getRoles());
     }
 
+    @Override
     public String getTitle() {
         return this.title;
     }
 
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
 
+    @Override
     public Integer getOrdering() {
         return this.ordering;
     }
 
+    @Override
     public void setOrdering(Integer ordering) {
         this.ordering = ordering;
     }
 
-    /**
-     * Get editType as {@link TaskEditType}.
-     *
-     * @return current edit type
-     */
+    @Override
     public TaskEditType getEditType() {
         return this.editType;
     }
 
-    /**
-     * Set editType to specific value from {@link TaskEditType}.
-     *
-     * @param inputType
-     *            as {@link TaskEditType}
-     */
+    @Override
     public void setEditType(TaskEditType inputType) {
         this.editType = inputType;
     }
 
-    /**
-     * Set processing status to specific value from {@link TaskStatus}.
-     *
-     * @param inputStatus
-     *            as {@link TaskStatus}
-     */
+    @Override
     public void setProcessingStatus(TaskStatus inputStatus) {
         this.processingStatus = inputStatus;
     }
 
-    /**
-     * Get processing status as {@link TaskStatus}.
-     *
-     * @return current processing status
-     */
+    @Override
     public TaskStatus getProcessingStatus() {
         return this.processingStatus;
     }
 
+    @Override
     public Date getProcessingTime() {
         return this.processingTime;
     }
 
+    @Override
     public void setProcessingTime(Date processingTime) {
         this.processingTime = processingTime;
     }
 
+    @Override
     public Date getProcessingBegin() {
         return this.processingBegin;
     }
 
+    @Override
     public void setProcessingBegin(Date processingBegin) {
         this.processingBegin = processingBegin;
     }
 
+    @Override
     public Date getProcessingEnd() {
         return this.processingEnd;
     }
 
+    @Override
     public void setProcessingEnd(Date processingEnd) {
         this.processingEnd = processingEnd;
     }
@@ -315,57 +318,44 @@ public class Task extends BaseIndexedBean {
         this.last = last;
     }
 
-    /**
-     * Get correction.
-     *
-     * @return value of correction
-     */
+    @Override
     public boolean isCorrection() {
         return correction;
     }
 
-    /**
-     * Set correction.
-     *
-     * @param correction as boolean
-     */
+    @Override
     public void setCorrection(boolean correction) {
         this.correction = correction;
     }
 
+    @Override
     public User getProcessingUser() {
         return this.processingUser;
     }
 
-    public void setProcessingUser(User processingUser) {
-        this.processingUser = processingUser;
+    @Override
+    public void setProcessingUser(UserInterface processingUser) {
+        this.processingUser = (User) processingUser;
     }
 
+    @Override
     public Process getProcess() {
         return this.process;
     }
 
-    public void setProcess(Process process) {
-        this.process = process;
+    @Override
+    public void setProcess(ProcessInterface process) {
+        this.process = (Process) process;
     }
 
-    /**
-     * Get template.
-     *
-     * @return value of template
-     */
+    @Override
     public Template getTemplate() {
         return this.template;
     }
 
-    /**
-     * Set template.
-     *
-     * @param template
-     *            as Template
-     */
-    public void setTemplate(Template template) {
-        this.template = template;
+    @Override
+    public void setTemplate(TemplateInterface template) {
+        this.template = (Template) template;
     }
 
     /**
@@ -420,25 +410,25 @@ public class Task extends BaseIndexedBean {
         return validationFolders;
     }
 
+    @Override
     public boolean isTypeImagesRead() {
         return this.typeImagesRead;
     }
 
+    @Override
     public void setTypeImagesRead(boolean typeImagesRead) {
         this.typeImagesRead = typeImagesRead;
     }
 
+    @Override
     public boolean isTypeImagesWrite() {
         return this.typeImagesWrite;
     }
 
     /**
-     * Set task type images. If types is true, it also sets type images read to
-     * true.
-     *
-     * @param typeImagesWrite
-     *            true or false
+     * {@inheritDoc} If true, the user is also given file system access.
      */
+    @Override
     public void setTypeImagesWrite(boolean typeImagesWrite) {
         this.typeImagesWrite = typeImagesWrite;
         if (typeImagesWrite) {
@@ -490,10 +480,12 @@ public class Task extends BaseIndexedBean {
         this.typeExportDMS = typeExportDMS;
     }
 
+    @Override
     public boolean isTypeMetadata() {
         return this.typeMetadata;
     }
 
+    @Override
     public void setTypeMetadata(boolean typeMetadata) {
         this.typeMetadata = typeMetadata;
     }
@@ -506,10 +498,12 @@ public class Task extends BaseIndexedBean {
         this.typeAcceptClose = typeAcceptClose;
     }
 
+    @Override
     public boolean isTypeAutomatic() {
         return this.typeAutomatic;
     }
 
+    @Override
     public void setTypeAutomatic(boolean typeAutomatic) {
         this.typeAutomatic = typeAutomatic;
     }
@@ -578,10 +572,12 @@ public class Task extends BaseIndexedBean {
         this.workflowCondition = workflowCondition;
     }
 
+    @Override
     public boolean isBatchStep() {
         return this.batchStep;
     }
 
+    @Override
     public void setBatchStep(boolean batchStep) {
         this.batchStep = batchStep;
     }
@@ -604,21 +600,12 @@ public class Task extends BaseIndexedBean {
         this.repeatOnCorrection = repeatOnCorrection;
     }
 
-    /**
-     * Get localized title.
-     *
-     * @return localized title as String
-     */
+    @Override
     public String getLocalizedTitle() {
         return this.localizedTitle;
     }
 
-    /**
-     * Set localized titles as String.
-     *
-     * @param localizedTitle
-     *            as String
-     */
+    @Override
     public void setLocalizedTitle(String localizedTitle) {
         this.localizedTitle = localizedTitle;
     }
@@ -656,5 +643,33 @@ public class Task extends BaseIndexedBean {
     @Override
     public int hashCode() {
         return Objects.hash(title, processingTime, processingBegin, processingEnd, process, template);
+    }
+
+    @Override
+    public String getProcessingStatusTitle() {
+        return processingStatusTitle;
+    }
+
+    @Override
+    public void setProcessingStatusTitle(String processingStatusTitle) {
+        this.processingStatusTitle = processingStatusTitle;
+    }
+
+    @Override
+    public String getEditTypeTitle() {
+        return editTypeTitle;
+    }
+
+    @Override
+    public void setEditTypeTitle(String editTypeTitle) {
+        this.editTypeTitle = editTypeTitle;
+    }
+
+    @Override
+    public List<Integer> getRoleIds() {
+        if (Objects.isNull(roles)) {
+            return null;
+        }
+        return roles.stream().map(RoleInterface::getId).collect(Collectors.toList());
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
+import javax.el.PropertyNotWritableException;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -29,6 +30,7 @@ import javax.persistence.Table;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.kitodo.data.database.persistence.TemplateDAO;
+import org.kitodo.data.interfaces.ClientInterface;
 import org.kitodo.data.interfaces.DocketInterface;
 import org.kitodo.data.interfaces.ProjectInterface;
 import org.kitodo.data.interfaces.RulesetInterface;
@@ -126,6 +128,24 @@ public class Template extends BaseTemplateBean implements TemplateInterface {
         this.docket = (Docket) docket;
     }
 
+    /**
+     * Sets the docket generation statement to use when creating dockets for
+     * processes derived from this process template.
+     *
+     * <p>
+     * <b>API Note:</b><br>
+     * This function exists because Faces does not recognize the more generic
+     * function {@link #setDocket(DocketInterface)} as a setter for the property
+     * {@code docket} and otherwise throws a
+     * {@link PropertyNotWritableException}.
+     *
+     * @param docket
+     *            the docket generation statement
+     */
+    public void setDocket(Docket docket) {
+        this.docket = docket;
+    }
+
     @Override
     public Ruleset getRuleset() {
         return this.ruleset;
@@ -136,6 +156,24 @@ public class Template extends BaseTemplateBean implements TemplateInterface {
         this.ruleset = (Ruleset) ruleset;
     }
 
+    /**
+     * Sets the business domain specification derived from this process template
+     * template shall be using.
+     *
+     * <p>
+     * <b>API Note:</b><br>
+     * This function exists because Faces does not recognize the more generic
+     * function {@link #setRuleset(RulesetInterface)} as a setter for the
+     * property {@code ruleset} and otherwise throws a
+     * {@link PropertyNotWritableException}.
+     *
+     * @param ruleset
+     *            the business domain specification
+     */
+    public void setRuleset(Ruleset ruleset) {
+        this.ruleset = ruleset;
+    }
+    
     @Override
     public Workflow getWorkflow() {
         return workflow;
@@ -146,6 +184,22 @@ public class Template extends BaseTemplateBean implements TemplateInterface {
         this.workflow = (Workflow) workflow;
     }
 
+    /**
+     * Sets the workflow from which the production template was created.
+     *
+     * <p>
+     * <b>API Note:</b><br>
+     * This function exists because Faces does not recognize the more generic
+     * function {@link #setWorkflow(WorkflowInterface)} as a setter for the
+     * property {@code workflow} and otherwise throws a
+     * {@link PropertyNotWritableException}.
+     *
+     * @param workflow
+     *            workflow to set
+     */
+    public void setWorkflow(Workflow workflow) {
+        this.workflow = workflow;
+    }
 
     /**
      * Get OCR-D workflow identifier.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
@@ -29,7 +29,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.kitodo.data.database.persistence.TemplateDAO;
-import org.kitodo.data.interfaces.ClientInterface;
 import org.kitodo.data.interfaces.DocketInterface;
 import org.kitodo.data.interfaces.ProjectInterface;
 import org.kitodo.data.interfaces.RulesetInterface;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
@@ -27,11 +27,18 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.kitodo.data.database.persistence.TemplateDAO;
+import org.kitodo.data.interfaces.DocketInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.RulesetInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
+import org.kitodo.data.interfaces.WorkflowInterface;
 
 @Entity
 @Table(name = "template")
-public class Template extends BaseTemplateBean {
+public class Template extends BaseTemplateBean implements TemplateInterface {
 
     @Column(name = "active")
     private Boolean active = true;
@@ -77,11 +84,7 @@ public class Template extends BaseTemplateBean {
         this.creationDate = new Date();
     }
 
-    /**
-     * Check if template is active.
-     *
-     * @return true or false
-     */
+    @Override
     public boolean isActive() {
         if (Objects.isNull(this.active)) {
             this.active = true;
@@ -89,11 +92,7 @@ public class Template extends BaseTemplateBean {
         return this.active;
     }
 
-    /**
-     * Set workflow as active.
-     *
-     * @param active as Boolean
-     */
+    @Override
     public void setActive(boolean active) {
         this.active = active;
     }
@@ -117,58 +116,34 @@ public class Template extends BaseTemplateBean {
         this.client = client;
     }
 
-    /**
-     * Get docket.
-     *
-     * @return value of docket
-     */
+    @Override
     public Docket getDocket() {
         return docket;
     }
 
-    /**
-     * Set docket.
-     *
-     * @param docket as Docket object
-     */
-    public void setDocket(Docket docket) {
-        this.docket = docket;
+    @Override
+    public void setDocket(DocketInterface docket) {
+        this.docket = (Docket) docket;
     }
 
-    /**
-     * Get ruleset.
-     *
-     * @return value of ruleset
-     */
+    @Override
     public Ruleset getRuleset() {
         return this.ruleset;
     }
 
-    /**
-     * Set ruleset.
-     *
-     * @param ruleset as Ruleset object
-     */
-    public void setRuleset(Ruleset ruleset) {
-        this.ruleset = ruleset;
+    @Override
+    public void setRuleset(RulesetInterface ruleset) {
+        this.ruleset = (Ruleset) ruleset;
     }
 
-    /**
-     * Get workflow.
-     *
-     * @return value of workflow
-     */
+    @Override
     public Workflow getWorkflow() {
         return workflow;
     }
 
-    /**
-     * Set workflow.
-     *
-     * @param workflow as Workflow object
-     */
-    public void setWorkflow(Workflow workflow) {
-        this.workflow = workflow;
+    @Override
+    public void setWorkflow(WorkflowInterface workflow) {
+        this.workflow = (Workflow) workflow;
     }
 
 
@@ -191,11 +166,7 @@ public class Template extends BaseTemplateBean {
         this.ocrdWorkflowId = ocrdWorkflowId;
     }
 
-    /**
-     * Get projects list.
-     *
-     * @return list of projects
-     */
+    @Override
     public List<Project> getProjects() {
         initialize(new TemplateDAO(), this.projects);
         if (Objects.isNull(this.projects)) {
@@ -204,13 +175,10 @@ public class Template extends BaseTemplateBean {
         return this.projects;
     }
 
-    /**
-     * Set list of projects.
-     *
-     * @param projects as Project list
-     */
-    public void setProjects(List<Project> projects) {
-        this.projects = projects;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setProjects(List<? extends ProjectInterface> projects) {
+        this.projects = (List<Project>) projects;
     }
 
     /**
@@ -235,11 +203,7 @@ public class Template extends BaseTemplateBean {
         this.processes = processes;
     }
 
-    /**
-     * Get list of task.
-     *
-     * @return list of Task objects or empty list
-     */
+    @Override
     public List<Task> getTasks() {
         initialize(new TemplateDAO(), this.tasks);
         if (Objects.isNull(this.tasks)) {
@@ -248,13 +212,10 @@ public class Template extends BaseTemplateBean {
         return this.tasks;
     }
 
-    /**
-     * Set tasks.
-     *
-     * @param tasks as list of task
-     */
-    public void setTasks(List<Task> tasks) {
-        this.tasks = tasks;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setTasks(List<? extends TaskInterface> tasks) {
+        this.tasks = (List<Task>) tasks;
     }
 
     /**
@@ -283,5 +244,13 @@ public class Template extends BaseTemplateBean {
     @Override
     public int hashCode() {
         return Objects.hash(client, docket, ruleset, workflow);
+    }
+
+    @Override
+    public boolean isCanBeUsedForProcess() {
+        if (Objects.isNull(tasks)) {
+            return false;
+        }
+        return tasks.stream().allMatch(task -> CollectionUtils.isNotEmpty(task.getRoles()));
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
@@ -16,7 +16,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import javax.el.PropertyNotWritableException;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -137,7 +136,7 @@ public class Template extends BaseTemplateBean implements TemplateInterface {
      * This function exists because Faces does not recognize the more generic
      * function {@link #setDocket(DocketInterface)} as a setter for the property
      * {@code docket} and otherwise throws a
-     * {@link PropertyNotWritableException}.
+     * {@code PropertyNotWritableException}.
      *
      * @param docket
      *            the docket generation statement
@@ -165,7 +164,7 @@ public class Template extends BaseTemplateBean implements TemplateInterface {
      * This function exists because Faces does not recognize the more generic
      * function {@link #setRuleset(RulesetInterface)} as a setter for the
      * property {@code ruleset} and otherwise throws a
-     * {@link PropertyNotWritableException}.
+     * {@code PropertyNotWritableException}.
      *
      * @param ruleset
      *            the business domain specification
@@ -192,7 +191,7 @@ public class Template extends BaseTemplateBean implements TemplateInterface {
      * This function exists because Faces does not recognize the more generic
      * function {@link #setWorkflow(WorkflowInterface)} as a setter for the
      * property {@code workflow} and otherwise throws a
-     * {@link PropertyNotWritableException}.
+     * {@code PropertyNotWritableException}.
      *
      * @param workflow
      *            workflow to set

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
@@ -27,10 +27,16 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.kitodo.data.database.persistence.UserDAO;
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.FilterInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.RoleInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.UserInterface;
 
 @Entity
 @Table(name = "user")
-public class User extends BaseBean {
+public class User extends BaseBean implements UserInterface {
 
     @Column(name = "name")
     private String name;
@@ -181,26 +187,32 @@ public class User extends BaseBean {
         }
     }
 
+    @Override
     public String getLogin() {
         return this.login;
     }
 
+    @Override
     public void setLogin(String login) {
         this.login = login;
     }
 
+    @Override
     public String getName() {
         return this.name;
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getSurname() {
         return this.surname;
     }
 
+    @Override
     public void setSurname(String surname) {
         this.surname = surname;
     }
@@ -213,10 +225,12 @@ public class User extends BaseBean {
         this.password = inputPassword;
     }
 
+    @Override
     public boolean isActive() {
         return this.active;
     }
 
+    @Override
     public void setActive(boolean active) {
         this.active = active;
     }
@@ -229,10 +243,12 @@ public class User extends BaseBean {
         this.deleted = deleted;
     }
 
+    @Override
     public String getLocation() {
         return this.location;
     }
 
+    @Override
     public void setLocation(String location) {
         this.location = location;
     }
@@ -287,11 +303,7 @@ public class User extends BaseBean {
         this.ldapGroup = ldapGroup;
     }
 
-    /**
-     * Get roles.
-     *
-     * @return list of Role objects
-     */
+    @Override
     public List<Role> getRoles() {
         initialize(new UserDAO(), this.roles);
         if (Objects.isNull(this.roles)) {
@@ -300,21 +312,13 @@ public class User extends BaseBean {
         return this.roles;
     }
 
-    /**
-     * Set roles.
-     *
-     * @param roles
-     *            list of Role objects
-     */
-    public void setRoles(List<Role> roles) {
-        this.roles = roles;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setRoles(List<? extends RoleInterface> roles) {
+        this.roles = (List<Role>) roles;
     }
 
-    /**
-     * Get tasks processed by this user.
-     *
-     * @return tasks processed by this user
-     */
+    @Override
     public List<Task> getProcessingTasks() {
         initialize(new UserDAO(), this.processingTasks);
         if (Objects.isNull(this.processingTasks)) {
@@ -323,15 +327,13 @@ public class User extends BaseBean {
         return this.processingTasks;
     }
 
-    public void setProcessingTasks(List<Task> processingTasks) {
-        this.processingTasks = processingTasks;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setProcessingTasks(List<? extends TaskInterface> processingTasks) {
+        this.processingTasks = (List<Task>) processingTasks;
     }
 
-    /**
-     * Get projects to which user is assigned.
-     *
-     * @return projects to which user is assigned
-     */
+    @Override
     public List<Project> getProjects() {
         initialize(new UserDAO(), this.projects);
         if (Objects.isNull(this.projects)) {
@@ -340,15 +342,13 @@ public class User extends BaseBean {
         return this.projects;
     }
 
-    public void setProjects(List<Project> projects) {
-        this.projects = projects;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setProjects(List<? extends ProjectInterface> projects) {
+        this.projects = (List<Project>) projects;
     }
 
-    /**
-     * Gets clients.
-     *
-     * @return The clients.
-     */
+    @Override
     public List<Client> getClients() {
         initialize(new UserDAO(), this.clients);
         if (Objects.isNull(this.clients)) {
@@ -357,14 +357,10 @@ public class User extends BaseBean {
         return this.clients;
     }
 
-    /**
-     * Sets clients.
-     *
-     * @param clients
-     *            The clients.
-     */
-    public void setClients(List<Client> clients) {
-        this.clients = clients;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setClients(List<? extends ClientInterface> clients) {
+        this.clients = (List<Client>) clients;
     }
 
     public boolean isConfigProductionDateShow() {
@@ -411,19 +407,17 @@ public class User extends BaseBean {
         this.language = language;
     }
 
+    @Override
     public String getLdapLogin() {
         return this.ldapLogin;
     }
 
+    @Override
     public void setLdapLogin(String ldapLogin) {
         this.ldapLogin = ldapLogin;
     }
 
-    /**
-     * Get user filters.
-     *
-     * @return list of user filters
-     */
+    @Override
     public List<Filter> getFilters() {
         initialize(new UserDAO(), this.filters);
         if (Objects.isNull(this.filters)) {
@@ -432,14 +426,10 @@ public class User extends BaseBean {
         return this.filters;
     }
 
-    /**
-     * Set user filters.
-     *
-     * @param filters
-     *            list of user filters
-     */
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setFilters(List<? extends FilterInterface> filters) {
+        this.filters = (List<Filter>) filters;
     }
 
     /**
@@ -540,6 +530,7 @@ public class User extends BaseBean {
     // Here will be methods which should be in UserService but are used by jsp
     // files
 
+    @Override
     public String getFullName() {
         return this.getSurname() + ", " + this.getName();
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Workflow.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Workflow.java
@@ -28,10 +28,11 @@ import javax.persistence.Table;
 
 import org.kitodo.data.database.enums.WorkflowStatus;
 import org.kitodo.data.database.persistence.WorkflowDAO;
+import org.kitodo.data.interfaces.WorkflowInterface;
 
 @Entity
 @Table(name = "workflow")
-public class Workflow extends BaseIndexedBean {
+public class Workflow extends BaseIndexedBean implements WorkflowInterface {
 
     @Column(name = "title")
     private String title;
@@ -66,39 +67,22 @@ public class Workflow extends BaseIndexedBean {
         this.title = title;
     }
 
-    /**
-     * Get title.
-     *
-     * @return value of title
-     */
+    @Override
     public String getTitle() {
         return title;
     }
 
-    /**
-     * Set title.
-     *
-     * @param title
-     *            as String
-     */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
 
-    /**
-     * Get status of the workflow.
-     *
-     * @return value of status
-     */
+    @Override
     public WorkflowStatus getStatus() {
         return status;
     }
 
-    /**
-     * Set status of the workflow.
-     *
-     * @param status as org.kitodo.data.database.beans.Workflow.Status
-     */
+    @Override
     public void setStatus(WorkflowStatus status) {
         this.status = status;
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/BatchInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/BatchInterface.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.util.List;
+
+/**
+ * Interface for batches of processes. Processes can be assembled in batches to
+ * take on or complete tasks for entire batches with a single user interaction.
+ */
+public interface BatchInterface extends DataInterface {
+
+    /**
+     * Returns the title of the batch. If no textual title was assigned, the
+     * title returned is “Batch ‹i›” with its database ID.
+     *
+     * @return the title of the batch
+     */
+    String getTitle();
+
+    /**
+     * Gives the batch a text-based title.
+     *
+     * @param title
+     *            title to use
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the processes belonging to the batch. This list is not guaranteed
+     * to be in reliable order.
+     *
+     * @return the processes belonging to the batch
+     */
+    List<ProcessInterface> getProcesses();
+
+    /**
+     * Sets the list of processes belonging to the batch. The list should not
+     * contain duplicates, and must not contain {@code null}s.
+     *
+     * @param processes
+     *            contain the list of processes belonging to the batch to be
+     *            determined
+     */
+    void setProcesses(List<ProcessInterface> processes);
+
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/BatchInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/BatchInterface.java
@@ -41,7 +41,7 @@ public interface BatchInterface extends DataInterface {
      *
      * @return the processes belonging to the batch
      */
-    List<ProcessInterface> getProcesses();
+    List<? extends ProcessInterface> getProcesses();
 
     /**
      * Sets the list of processes belonging to the batch. The list should not
@@ -51,6 +51,6 @@ public interface BatchInterface extends DataInterface {
      *            contain the list of processes belonging to the batch to be
      *            determined
      */
-    void setProcesses(List<ProcessInterface> processes);
+    void setProcesses(List<? extends ProcessInterface> processes);
 
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/BatchInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/BatchInterface.java
@@ -20,8 +20,8 @@ import java.util.List;
 public interface BatchInterface extends DataInterface {
 
     /**
-     * Returns the title of the batch. If no textual title was assigned, the
-     * title returned is “Batch ‹i›” with its database ID.
+     * Returns the title of the batch. Using titles for batches is optional, the
+     * field may be {@code null}. If so, the function returns null.
      *
      * @return the title of the batch
      */

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ClientInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ClientInterface.java
@@ -41,7 +41,7 @@ public interface ClientInterface extends DataInterface {
      *
      * @return the users who work for this client
      */
-    List<UserInterface> getUsers();
+    List<? extends UserInterface> getUsers();
 
     /**
      * Sets the list of users working for this client. The list should not
@@ -50,7 +50,7 @@ public interface ClientInterface extends DataInterface {
      * @param users
      *            The users.
      */
-    void setUsers(List<UserInterface> users);
+    void setUsers(List<? extends UserInterface> users);
 
     /**
      * Returns the client's projects. This list is not guaranteed to be in
@@ -58,7 +58,7 @@ public interface ClientInterface extends DataInterface {
      *
      * @return the client's projects
      */
-    List<ProjectInterface> getProjects();
+    List<? extends ProjectInterface> getProjects();
 
     /**
      * Sets the lists of the client's projects. The list should not contain
@@ -67,5 +67,5 @@ public interface ClientInterface extends DataInterface {
      * @param projects
      *            The projects.
      */
-    void setProjects(List<ProjectInterface> projects);
+    void setProjects(List<? extends ProjectInterface> projects);
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ClientInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ClientInterface.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.util.List;
+
+/**
+ * Interface for working with clients. Clients are related organizations that
+ * are allowed to use this instance of Production for their own projects. Users
+ * can work for several clients or just one.
+ */
+public interface ClientInterface extends DataInterface {
+
+    /**
+     * Returns the name of the client.
+     *
+     * @return the name of the client
+     */
+    String getName();
+
+    /**
+     * Sets the name of the client.
+     *
+     * @param name
+     *            the name of the client
+     */
+    void setName(String name);
+
+    /**
+     * Specifies the users who work for this client. This list is not guaranteed
+     * to be in reliable order.
+     *
+     * @return the users who work for this client
+     */
+    List<UserInterface> getUsers();
+
+    /**
+     * Sets the list of users working for this client. The list should not
+     * contain duplicates, and must not contain {@code null}s.
+     *
+     * @param users
+     *            The users.
+     */
+    void setUsers(List<UserInterface> users);
+
+    /**
+     * Returns the client's projects. This list is not guaranteed to be in
+     * reliable order.
+     *
+     * @return the client's projects
+     */
+    List<ProjectInterface> getProjects();
+
+    /**
+     * Sets the lists of the client's projects. The list should not contain
+     * duplicates, and must not contain {@code null}s.
+     *
+     * @param projects
+     *            The projects.
+     */
+    void setProjects(List<ProjectInterface> projects);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataFactoryInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataFactoryInterface.java
@@ -1,0 +1,118 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+/**
+ * Factory interface for the objects of the interface. An instance of the
+ * interface can be used to obtain objects of the interface. This allows new
+ * objects of the interface to be obtained without being aware of the
+ * implementation.
+ */
+public interface DataFactoryInterface {
+
+    /**
+     * Returns a new batch. The batch has not yet been persisted and does not
+     * yet have a database ID.
+     * 
+     * @return a new batch
+     */
+    BatchInterface newBatch();
+
+    /**
+     * Returns a new client. The client has not yet been persisted and does not
+     * yet have a database ID.
+     * 
+     * @return a new client
+     */
+    ClientInterface newClient();
+
+    /**
+     * Returns a new docket generation statement. The client has not yet been
+     * persisted and does not yet have a database ID.
+     * 
+     * @return a new docket generation
+     */
+    DocketInterface newDocket();
+
+    /**
+     * Returns a new store for a search string. The filter string has not yet
+     * been persisted and does not yet have a database ID.
+     * 
+     * @return a new search string
+     */
+    FilterInterface newFilter();
+
+    /**
+     * Returns a new process. The process has not yet been persisted and does
+     * not yet have a database ID.
+     * 
+     * @return a new process
+     */
+    ProcessInterface newProcess();
+
+    /**
+     * Returns a new project. The project has not yet been persisted and does
+     * not yet have a database ID.
+     * 
+     * @return a new project
+     */
+    ProjectInterface newProject();
+
+    /**
+     * Returns a new container for a property key-value pair. The property has
+     * not yet been persisted and does not yet have a database ID.
+     * 
+     * @return a new property
+     */
+    PropertyInterface newProperty();
+
+    /**
+     * Returns a new storage for the business domain specification. The ruleset
+     * has not yet been persisted and does not yet have a database ID.
+     * 
+     * @return a new business specification
+     */
+    RulesetInterface newRuleset();
+
+    /**
+     * Returns a new task. The task has not yet been persisted and does not yet
+     * have a database ID.
+     * 
+     * @return a new task
+     */
+    TaskInterface newTask();
+
+    /**
+     * Returns a new production template. The production template has not yet
+     * been persisted and does not yet have a database ID.
+     * 
+     * @return a new template
+     */
+    TemplateInterface newTemplate();
+
+    /**
+     * Returns a new user. The user has not yet been persisted and does not yet
+     * have a database ID.
+     * 
+     * @return a new user
+     */
+    UserInterface newUser();
+
+    /**
+     * Returns a new workflow. Returns a new workflow reference. The workflow
+     * has not yet been persisted in the database and does not yet have a record
+     * number.
+     * 
+     * @return a new batch
+     */
+    WorkflowInterface newWorkflow();
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataInterface.java
@@ -11,15 +11,12 @@
 
 package org.kitodo.data.interfaces;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-
 /**
  * Meta interface over the data interfaces of this interface.
  */
 public interface DataInterface {
 
-    static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     /**
      * Returns the record number of the object in the database. Can be

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataInterface.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+/**
+ * Meta interface over the data interfaces of this interface.
+ */
+public interface DataInterface {
+    /**
+     * Returns the record number of the object in the database. Can be
+     * {@code null} if the object has not yet been persisted.
+     *
+     * @return the record number
+     */
+    Integer getId();
+
+    /**
+     * Sets the data record number of the object. This should only happen when
+     * data from a third-party source is integrated during operation, or in
+     * tests. Normally the data record number is assigned by the database when
+     * the object is saved.
+     *
+     * @param id
+     *            data record number to use
+     */
+    void setId(Integer id);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DataInterface.java
@@ -11,10 +11,16 @@
 
 package org.kitodo.data.interfaces;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
 /**
  * Meta interface over the data interfaces of this interface.
  */
 public interface DataInterface {
+
+    static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
     /**
      * Returns the record number of the object in the database. Can be
      * {@code null} if the object has not yet been persisted.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DocketInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/DocketInterface.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+/**
+ * Interface for configuring the docket generator.
+ */
+public interface DocketInterface extends DataInterface {
+
+    /**
+     * Returns the name of the configuration file, without a path. The file must
+     * exist in the XSLT directory. The directory is set in the configuration
+     * file.
+     *
+     * @return the XSLT file name
+     */
+    String getFile();
+
+    /**
+     * Sets the name of the configuration file. The file must exist in the XSLT
+     * directory. The file name must be specified without a path.
+     *
+     * @param file
+     *            XSLT file name
+     */
+    void setFile(String file);
+
+    /**
+     * Returns the display name of the configuration. It is displayed to the
+     * user in a selection dialog.
+     *
+     * @return the display name
+     */
+    String getTitle();
+
+    /**
+     * Sets the display name of the configuration.
+     *
+     * @param title
+     *            the display name
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the client that this docket generator configuration is associated
+     * with. Technically, multiple client can use the same docket generator
+     * configuration (file), but they must be made available independently for
+     * each client using one configuration object each. This determines which
+     * docket generator configurations are visible to a client at all, and they
+     * can be named differently.
+     *
+     * @return client that this docket is associated with
+     */
+    ClientInterface getClient();
+
+    /**
+     * Sets the client to which this docket generator configuration is
+     * associated.
+     *
+     * @param client
+     *            client to which this docket is associated
+     */
+    void setClient(ClientInterface client);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/FilterInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/FilterInterface.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+/**
+ * Interface for persisting search queries from users.
+ */
+public interface FilterInterface extends DataInterface {
+
+    /**
+     * Returns the search query string.
+     * 
+     * @return the search query
+     */
+    String getValue();
+
+    /**
+     * Sets the search query string.
+     * 
+     * @param value
+     *            query string to specify
+     */
+    void setValue(String value);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
@@ -11,10 +11,12 @@
 
 package org.kitodo.data.interfaces;
 
+import java.net.URI;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.kitodo.data.database.enums.CorrectionComments;
 
@@ -346,8 +348,37 @@ public interface ProcessInterface extends DataInterface {
      * the application's processes directory on the file system.
      *
      * @return the union resource identifier of the process
+     * @deprecated Use {@link #getProcessBaseUri()}.
      */
-    String getProcessBaseUri();
+    @Deprecated
+    default String getProcessBase() {
+        URI processBaseUri = getProcessBaseUri();
+        return Objects.isNull(processBaseUri) ? null : processBaseUri.toString();
+    }
+
+    /**
+     * Returns a process identifier URI. Internally, this is the record number
+     * of the process in the processes table of the database, but for external
+     * data it can also be another identifier that resolves to a directory in
+     * the application's processes directory on the file system.
+     *
+     * @return the union resource identifier of the process
+     */
+    URI getProcessBaseUri();
+
+    /**
+     * Sets the union resource identifier of the process. This should only be
+     * set manually if the data comes from a third party source, otherwise, this
+     * is the process record number set by the database.
+     *
+     * @param processBaseUri
+     *            the identification URI of the process
+     * @deprecated Use {@link #setProcessBaseUri(URI)}.
+     */
+    @Deprecated
+    default void setProcessBase(String processBaseUri) {
+        setProcessBaseUri(Objects.isNull(processBaseUri) ? null : URI.create(processBaseUri));
+    }
 
     /**
      * Sets the union resource identifier of the process. This should only be
@@ -357,7 +388,7 @@ public interface ProcessInterface extends DataInterface {
      * @param processBaseUri
      *            the identification URI of the process
      */
-    void setProcessBaseUri(String processBaseUri);
+    void setProcessBaseUri(URI processBaseUri);
 
     /**
      * Returns all batches to which the process belongs. A comma-space-separated

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
@@ -49,20 +49,48 @@ public interface ProcessInterface extends DataInterface {
      * Returns the time the process was created. The string is formatted
      * according to {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
-     * @return the time the process was created
+     * @return the creation time
+     * @deprecated Use {@link #getCreationDate()}.
      */
-    String getCreationDate();
+    @Deprecated
+    default String getCreationTime() {
+        Date creationDate = getCreationDate();
+        return Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+    }
 
     /**
-     * Sets the time of process creation. The string must be parsable with
+     * Returns the time the process was created. {@link Date} is a specific
+     * instant in time, with millisecond precision.
+     *
+     * @return the creation time
+     */
+    Date getCreationDate();
+
+    /**
+     * Sets the time the process was created. The string must be parsable with
      * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @param creationDate
-     *            the time of process creation
+     *            creation time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     * @deprecated Use {@link #setCreationDate(Date)}.
+     */
+    @Deprecated
+    default void setCreationTime(String creationDate) throws ParseException {
+        setCreationDate(Objects.nonNull(creationDate) ? DATE_FORMAT.parse(creationDate) : null);
+    }
+
+    /**
+     * Sets the time the process was created. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param creationDate
+     *            creation time to set
      * @throws ParseException
      *             if the time cannot be converted
      */
-    void setCreationDate(String creationDate);
+    void setCreationDate(Date creationDate);
 
     /**
      * Returns the docket generation statement to use when creating a docket for

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
@@ -99,7 +99,7 @@ public interface ProcessInterface extends DataInterface {
      *
      * @return the task list
      */
-    List<TaskInterface> getTasks();
+    List<? extends TaskInterface> getTasks();
 
     /**
      * Sets the task list of this process.
@@ -107,7 +107,7 @@ public interface ProcessInterface extends DataInterface {
      * @param tasks
      *            the task list
      */
-    void setTasks(List<TaskInterface> tasks);
+    void setTasks(List<? extends TaskInterface> tasks);
 
     /**
      * Returns the project the process belongs to. Digitization processes are
@@ -132,7 +132,7 @@ public interface ProcessInterface extends DataInterface {
      *
      * @return the batches to which the process is assigned
      */
-    List<BatchInterface> getBatches();
+    List<? extends BatchInterface> getBatches();
 
     /**
      * Sets the list that specifies the batches to which the process is
@@ -143,7 +143,7 @@ public interface ProcessInterface extends DataInterface {
      * @param batches
      *            list of batches to which the process is associated
      */
-    void setBatches(List<BatchInterface> batches);
+    void setBatches(List<? extends BatchInterface> batches);
 
     /**
      * Returns the operational properties of the process. Properties are a tool
@@ -153,7 +153,7 @@ public interface ProcessInterface extends DataInterface {
      *
      * @return list of properties
      */
-    List<PropertyInterface> getProperties();
+    List<? extends PropertyInterface> getProperties();
 
     /**
      * Sets the list of operational properties of the process. This list is not
@@ -162,7 +162,7 @@ public interface ProcessInterface extends DataInterface {
      * @param properties
      *            list of properties as PropertyInterface
      */
-    void setProperties(List<PropertyInterface> properties);
+    void setProperties(List<? extends PropertyInterface> properties);
 
     /**
      * Returns the user who is currently blocking the process's business data.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
@@ -238,8 +238,12 @@ public interface ProcessInterface extends DataInterface {
      *
      * @param progressClosed
      *            the percentage of completed tasks
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setProgressClosed(Double progressClosed);
+    default void setProgressClosed(Double progressClosed) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns the percentage of tasks in the process that are currently being
@@ -264,8 +268,12 @@ public interface ProcessInterface extends DataInterface {
      *
      * @param progressInProcessing
      *            percentage of tasks currently being processed
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setProgressInProcessing(Double progressInProcessing);
+    default void setProgressInProcessing(Double progressInProcessing) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns the percentage of tasks in the process, that cannot yet be
@@ -292,8 +300,12 @@ public interface ProcessInterface extends DataInterface {
      *
      * @param progressLocked
      *            percentage of tasks waiting
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setProgressLocked(Double progressLocked);
+    default void setProgressLocked(Double progressLocked) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns the contents of the wiki field as HTML. Wiki means that something
@@ -337,8 +349,12 @@ public interface ProcessInterface extends DataInterface {
      *
      * @param progressOpen
      *            percentage of startable tasks
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setProgressOpen(Double progressOpen);
+    default void setProgressOpen(Double progressOpen) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns a coded overview of the progress of the process. The larger the
@@ -366,8 +382,12 @@ public interface ProcessInterface extends DataInterface {
      * @param progressCombined
      *            coded overview of the progress with pattern
      *            <code>([01]\d{2}){4}</code>
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setProgressCombined(String progressCombined);
+    default void setProgressCombined(String progressCombined) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns a process identifier URI. Internally, this is the record number
@@ -435,8 +455,12 @@ public interface ProcessInterface extends DataInterface {
      * @param batchID
      *            human-readable information about which batches the process
      *            belongs to
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setBatchID(String batchID);
+    default void setBatchID(String batchID) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns the record number of the parent process, if any. Is {@code null}
@@ -666,42 +690,56 @@ public interface ProcessInterface extends DataInterface {
      *
      * @param lastEditingUser
      *            user name, comma-separated, last name first
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setLastEditingUser(String lastEditingUser);
+    default void setLastEditingUser(String lastEditingUser) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
-     * Returns the day on which a task of this process was last started.
+     * Returns time day on which a task of this process was last started.
      *
-     * @return day on which a task of this process was last started
+     * @return time on which a task of this process was last started
      */
     Date getProcessingBeginLastTask();
 
     /**
-     * Sets the day on which a task of this process was last started. This
+     * Sets the time on which a task of this process was last started. This
      * should only be set if the data comes from a third party; internally, it
      * is determined in the database.
      * 
      * @param processingBeginLastTask
-     *            the day on which a task of this process was last started
+     *            the time on which a task of this process was last started
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setProcessingBeginLastTask(Date processingBeginLastTask);
+    default void setProcessingBeginLastTask(Date processingBeginLastTask) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
-     * Returns the day on which a task from this process was last completed.
+     * Returns the time on which a task from this process was last completed.
      *
-     * @return day on which a task from this process was last completed
+     * @return time on which a task from this process was last completed
      */
     Date getProcessingEndLastTask();
 
     /**
-     * Sets the day on which a task of this process was last completed. This
+     * Sets the time on which a task of this process was last completed. This
      * should only be set if the data comes from a third party; internally, it
      * is determined in the database.
      * 
      * @param processingEndLastTask
-     *            the day on which a task of this process was last completed
+     *            the time on which a task of this process was last completed
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setProcessingEndLastTask(Date processingEndLastTask);
+    default void setProcessingEndLastTask(Date processingEndLastTask) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns the error corrections processing state of the process. The value
@@ -717,8 +755,12 @@ public interface ProcessInterface extends DataInterface {
      * 
      * @param status
      *            the error corrections processing state
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setCorrectionCommentStatus(Integer status);
+    default void setCorrectionCommentStatus(Integer status) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns whether the process has any comments.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
@@ -1,0 +1,680 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import org.kitodo.data.database.enums.CorrectionComments;
+
+/**
+ * An interface for processes. A process represents one production process of
+ * creating a digital copy of an archival item, according to a workflow based on
+ * a production template. It consists of several tasks that must be carried out
+ * by humans or automatically.
+ */
+public interface ProcessInterface extends DataInterface {
+
+    /**
+     * Returns the process name.
+     *
+     * @return the process name
+     */
+    String getTitle();
+
+    /**
+     * Sets the process name. Since the process name is used in file paths, it
+     * should only contain characters compatible with the operating file system.
+     * Also, for scripting, there should be no spaces in the process name.
+     *
+     * @param title
+     *            the process name
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the time the process was created. The string is formatted
+     * according to {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @return the time the process was created
+     */
+    String getCreationDate();
+
+    /**
+     * Sets the time of process creation. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param creationDate
+     *            the time of process creation
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setCreationDate(String creationDate);
+
+    /**
+     * Returns the docket generation statement to use when creating a docket for
+     * this process.
+     *
+     * @return the docket generation statement
+     */
+    DocketInterface getDocket();
+
+    /**
+     * Sets the docket generation statement to use when creating a docket for
+     * this process.
+     *
+     * @param docket
+     *            the docket generation statement
+     */
+    void setDocket(DocketInterface docket);
+
+    /**
+     * Returns the business domain specification this process is using.
+     *
+     * @return the business domain specification
+     */
+    RulesetInterface getRuleset();
+
+    /**
+     * Sets the business domain specification this process is using.
+     *
+     * @param ruleset
+     *            the business domain specification
+     */
+    void setRuleset(RulesetInterface ruleset);
+
+    /**
+     * Returns the task list of this process.
+     *
+     * @return the task list
+     */
+    List<TaskInterface> getTasks();
+
+    /**
+     * Sets the task list of this process.
+     *
+     * @param tasks
+     *            the task list
+     */
+    void setTasks(List<TaskInterface> tasks);
+
+    /**
+     * Returns the project the process belongs to. Digitization processes are
+     * organized in projects.
+     *
+     * @return the project the process belongs to
+     */
+    ProjectInterface getProject();
+
+    /**
+     * Specifies the project to which the process belongs.
+     *
+     * @param project
+     *            project to which the process should belong
+     */
+    void setProject(ProjectInterface project);
+
+    /**
+     * Specifies the batches to which the process is assigned. A process can
+     * belong to several batches, but for batch automation to work, a process
+     * must be assigned to exactly one batch.
+     *
+     * @return the batches to which the process is assigned
+     */
+    List<BatchInterface> getBatches();
+
+    /**
+     * Sets the list that specifies the batches to which the process is
+     * associated. A process can belong to several batches, but but for batch
+     * automation to work, a process must be assigned to exactly one batch. The
+     * list should not contain duplicates, and must not contain {@code null}s.
+     *
+     * @param batches
+     *            list of batches to which the process is associated
+     */
+    void setBatches(List<BatchInterface> batches);
+
+    /**
+     * Returns the operational properties of the process. Properties are a tool
+     * for third-party modules to store operational properties as key-value
+     * pairs, that the application has no knowledge of. This list is not
+     * guaranteed to be in reliable order.
+     *
+     * @return list of properties
+     */
+    List<PropertyInterface> getProperties();
+
+    /**
+     * Sets the list of operational properties of the process. This list is not
+     * guaranteed to preserve its order. It must not contain {@code null}s.
+     *
+     * @param properties
+     *            list of properties as PropertyInterface
+     */
+    void setProperties(List<PropertyInterface> properties);
+
+    /**
+     * Returns the user who is currently blocking the process's business data.
+     * Since the business data is in a file, a user can be granted exclusive
+     * access to this file, so that several users do not overwrite concurrent
+     * changes by each other. Can be {@code null} if the business data is not
+     * currently blocked by any user.
+     *
+     * @return the user blocking the process
+     */
+    UserInterface getBlockedUser();
+
+    /**
+     * Sets exclusive (write) access to the business data in this process for a
+     * user. Or, set {@code null} to release the blockage. This is a transient
+     * value that is not persisted.
+     *
+     * @param blockedUser
+     *            user to grant write access to
+     */
+    void setBlockedUser(UserInterface blockedUser);
+
+    /**
+     * Returns the percentage of tasks in the process that are completed. The
+     * total of tasks awaiting preconditions, startable, in progress, and
+     * completed is {@code 100.0d}.
+     *
+     * @return percentage of tasks completed
+     */
+    Double getProgressClosed();
+
+    /**
+     * Sets the percentage of completed tasks. This should only be set manually
+     * if this information is obtained from a third party source. Normally, the
+     * percentage is determined from the statuses of the tasks in the process.
+     * If you set this, it will only be used for display to the user, the status
+     * of the tasks will not be changed. The value must be between {@code 0.0d}
+     * and {@code 100.0d}, and the values set by
+     * {@link #setProgressLocked(Double)}, {@link #setProgressOpen(Double)},
+     * {@link #setProgressInProcessing(Double)} and
+     * {@link #setProgressClosed(Double)} must total {@code 100.0d}. For a
+     * process with no tasks, set {@code 0.0d}.
+     *
+     * @param progressClosed
+     *            the percentage of completed tasks
+     */
+    void setProgressClosed(Double progressClosed);
+
+    /**
+     * Returns the percentage of tasks in the process that are currently being
+     * processed. The progress total of tasks waiting for preconditions,
+     * startable, in progress, and completed is {@code 100.0d}.
+     *
+     * @return percentage of tasks in progress
+     */
+    Double getProgressInProcessing();
+
+    /**
+     * Sets the percentage of tasks that are currently being processed. This
+     * should only be set manually if this information is obtained from a third
+     * party source. Normally, the percentage is determined from the statuses of
+     * the tasks in the process. If you set this, it will only be used for
+     * display to the user, the status of the tasks will not be changed. The
+     * value must be between {@code 0.0d} and {@code 100.0d}, and the values set
+     * by {@link #setProgressLocked(Double)}, {@link #setProgressOpen(Double)},
+     * {@link #setProgressInProcessing(Double)} and
+     * {@link #setProgressClosed(Double)} must total {@code 100.0d}. For a
+     * process with no tasks, set {@code 0.0d}.
+     *
+     * @param progressInProcessing
+     *            percentage of tasks currently being processed
+     */
+    void setProgressInProcessing(Double progressInProcessing);
+
+    /**
+     * Returns the percentage of tasks in the process, that cannot yet be
+     * carried out, because previous tasks have not yet been completed. The
+     * progress total of tasks waiting for preconditions, startable, in
+     * progress, and completed is {@code 100.0d}.
+     *
+     * @return percentage of tasks waiting
+     */
+    Double getProgressLocked();
+
+    /**
+     * Sets the percentage of tasks, that cannot yet be carried out, because
+     * previous tasks have not yet been completed. This should only be set
+     * manually if this information is obtained from a third party source.
+     * Normally, the percentage is determined from the statuses of the tasks in
+     * the process. If you set this, it will only be used for display to the
+     * user, the status of the tasks will not be changed. The value must be
+     * between {@code 0.0d} and {@code 100.0d}, and the values set by
+     * {@link #setProgressLocked(Double)}, {@link #setProgressOpen(Double)},
+     * {@link #setProgressInProcessing(Double)} and
+     * {@link #setProgressClosed(Double)} must total {@code 100.0d}. For a
+     * process with no tasks, set {@code 100.0d}.
+     *
+     * @param progressLocked
+     *            percentage of tasks waiting
+     */
+    void setProgressLocked(Double progressLocked);
+
+    /**
+     * Returns the contents of the wiki field as HTML. Wiki means that something
+     * can be changed quickly by anyone. It is a kind of sticky note on which
+     * editors can exchange information about a process.
+     *
+     * @return wiki field as HTML
+     */
+    String getWikiField();
+
+    /**
+     * Sets the content of the wiki field. Primitive HTML tags formatting may be
+     * used.
+     *
+     * @param wikiField
+     *            wiki field as HTML
+     */
+    void setWikiField(String wikiField);
+
+    /**
+     * Returns the percentage of the process's tasks that are now ready to be
+     * processed but have not yet been started. The progress total of tasks
+     * waiting for preconditions, startable, in progress, and completed is
+     * {@code 100.0d}.
+     *
+     * @return percentage of startable tasks
+     */
+    Double getProgressOpen();
+
+    /**
+     * Sets the percentage of tasks, that are now ready to be processed. This
+     * should only be set manually if this information is obtained from a third
+     * party source. Normally, the percentage is determined from the statuses of
+     * the tasks in the process. If you set this, it will only be used for
+     * display to the user, the status of the tasks will not be changed. The
+     * value must be between {@code 0.0d} and {@code 100.0d}, and the values set
+     * by {@link #setProgressLocked(Double)}, {@link #setProgressOpen(Double)},
+     * {@link #setProgressInProcessing(Double)} and
+     * {@link #setProgressClosed(Double)} must total {@code 100.0d}. For a
+     * process with no tasks, set {@code 0.0d}.
+     *
+     * @param progressOpen
+     *            percentage of startable tasks
+     */
+    void setProgressOpen(Double progressOpen);
+
+    /**
+     * Returns a coded overview of the progress of the process. The larger the
+     * number, the more advanced the process is, so it can be used to sort by
+     * progress. The numeric code consists of twelve digits, each three digits
+     * from 000 to 100 indicate the percentage of tasks completed, currently in
+     * progress, ready to start and not yet ready, in that order. For example,
+     * 000000025075 means that 25% of the tasks are ready to be started and 75%
+     * of the tasks are not yet ready to be started because previous tasks have
+     * not yet been processed.
+     * 
+     * @return overview of the processing status
+     */
+    String getProgressCombined();
+
+    /**
+     * Sets the coded overview of the processing status of the process. This
+     * should only be set manually if this information comes from a third-party
+     * source. Typically, sorting progress is determined from the progress
+     * properties of the tasks in the process. The numeric code consists of
+     * twelve digits, each three digits from 000 to 100 indicate the percentage
+     * of tasks completed, currently in progress, ready to start and not yet
+     * ready, in that order. The sum of the four groups of numbers must be 100.
+     * 
+     * @param progressCombined
+     *            coded overview of the progress with pattern
+     *            <code>([01]\d{2}){4}</code>
+     */
+    void setProgressCombined(String progressCombined);
+
+    /**
+     * Returns a process identifier URI. Internally, this is the record number
+     * of the process in the processes table of the database, but for external
+     * data it can also be another identifier that resolves to a directory in
+     * the application's processes directory on the file system.
+     *
+     * @return the union resource identifier of the process
+     */
+    String getProcessBaseUri();
+
+    /**
+     * Sets the union resource identifier of the process. This should only be
+     * set manually if the data comes from a third party source, otherwise, this
+     * is the process record number set by the database.
+     *
+     * @param processBaseUri
+     *            the identification URI of the process
+     */
+    void setProcessBaseUri(String processBaseUri);
+
+    /**
+     * Returns all batches to which the process belongs. A comma-space-separated
+     * list of the batch labels is returned. If not, it's a blank string.
+     *
+     * @return batches to which the process belongs
+     */
+    String getBatchID();
+
+    /**
+     * Sets all batches to which the process belongs as a comma-space-separated
+     * list (for display). The setter should be used by data from a third party
+     * source. Internally, this information is fetched from the database. Set to
+     * "" if not.
+     *
+     * @param batchID
+     *            human-readable information about which batches the process
+     *            belongs to
+     */
+    void setBatchID(String batchID);
+
+    /**
+     * Returns the record number of the parent process, if any. Is {@code null}
+     * if there is no parent process above.
+     *
+     * @return record number of the parent process
+     */
+    Integer getParentID();
+
+    /**
+     * Sets a parent process based on its record number. Or {@code null} to not
+     * set a parent process.
+     *
+     * @param parentID
+     *            record number of the parent process
+     */
+    void setParentID(Integer parentID);
+
+    /**
+     * Returns whether the process has children.
+     *
+     * @return whether the process has children
+     */
+    boolean hasChildren();
+
+    /**
+     * Sets whether the process is a parent. The setter can be used when
+     * representing data from a third-party source. Internally, parenthood
+     * results from a parent relationship of the process in the database.
+     * Setting this to true cannot insert child processes into the database.
+     *
+     * @param hasChildren
+     *            whether the process has children
+     * @throws UnsupportedOperationException
+     *             when trying to set this to true for a process without
+     *             children
+     */
+    void setHasChildren(boolean hasChildren);
+
+    /**
+     * Returns the sort count. Sort counting is applicable to a process, if it
+     * is a child process and is a counted item of a series. This allows to sort
+     * the children according to their count. Can be {@code null} if there is no
+     * count.
+     *
+     * @return the sort count
+     */
+    Integer getSortHelperArticles();
+
+    /**
+     * Sets the sort count.
+     *
+     * @param sortHelperArticles
+     *            the sort count
+     */
+    void setSortHelperArticles(Integer sortHelperArticles);
+
+    /**
+     * Returns the number of outline elements in a process. This is a business
+     * statistical characteristic.
+     *
+     * @return the number of outline elements in a process
+     */
+    Integer getSortHelperDocstructs();
+
+    /**
+     * Sets the number of outline elements in a process. Since the detailed
+     * business objects are in a file, the number can be stored here when
+     * saving, so that statistics on the number of outline elements can be
+     * obtained with an acceptable response time.
+     *
+     * @param sortHelperDocstructs
+     *            the number of outline elements in a process
+     */
+    void setSortHelperDocstructs(Integer sortHelperDocstructs);
+
+    /**
+     * Returns a coded overview of the progress of the process. The larger the
+     * number, the more advanced the process is, so it can be used to sort by
+     * progress. The numeric code consists of twelve digits, each three digits
+     * from 000 to 100 indicate the percentage of tasks completed, currently in
+     * progress, ready to start and not yet ready, in that order. For example,
+     * 000000025075 means that 25% of the tasks are ready to be started and 75%
+     * of the tasks are not yet ready to be started because previous tasks have
+     * not yet been processed.
+     * 
+     * @return overview of the processing status
+     */
+    String getSortHelperStatus();
+
+    /**
+     * Sets the coded overview of the processing status of the process. This
+     * should only be set manually if this information comes from a third-party
+     * source. Typically, sorting progress is determined from the progress
+     * properties of the tasks in the process. The numeric code consists of
+     * twelve digits, each three digits from 000 to 100 indicate the percentage
+     * of tasks completed, currently in progress, ready to start and not yet
+     * ready, in that order. The sum of the four groups of numbers must be 100.
+     * 
+     * @param sortHelperStatus
+     *            coded overview of the progress with pattern
+     *            <code>([01]\d{2}){4}</code>
+     */
+    void setSortHelperStatus(String sortHelperStatus);
+
+    /**
+     * Returns the number of media in a process. This is a business statistical
+     * characteristic.
+     *
+     * @return the number of media in a process
+     */
+    Integer getSortHelperImages();
+
+    /**
+     * Sets the number of media in a process. Since counting all media files on
+     * the file system for many processes is slow, the number can be stored here
+     * when saving, so that statistics on the number of media can be obtained
+     * with an acceptable response time.
+     *
+     * @param sortHelperImages
+     *            the number of media in a process
+     */
+    void setSortHelperImages(Integer sortHelperImages);
+
+    /**
+     * Returns the number of metadata entries in a process. This is a business
+     * statistical characteristic.
+     *
+     * @return the number of media in a process
+     */
+    Integer getSortHelperMetadata();
+
+    /**
+     * Sets the number of metadata entries in a process. Since the detailed
+     * business objects are in a file, the number can be stored here when
+     * saving, so that statistics on the number of metadata entries can be
+     * obtained with an acceptable response time.
+     *
+     * @param sortHelperMetadata
+     *            the number of metadata entries in a process
+     */
+    void setSortHelperMetadata(Integer sortHelperMetadata);
+
+    /**
+     * Returns the media form of the business object at runtime. Can be
+     * {@code null} if no runtime value is available.
+     *
+     * @return the id of the division representing the media form
+     */
+    String getBaseType();
+
+    /**
+     * Sets the media form of the business object in the database. This is a
+     * transient value that is not persisted.
+     *
+     * @param baseType
+     *            id of the division representing the media form
+     */
+    void setBaseType(String baseType);
+
+    /**
+     * Returns the amount of metadata of the process at runtime. Can be
+     * {@code null} if no runtime value is available.
+     *
+     * @return the amount of metadata
+     */
+    Integer getNumberOfMetadata();
+
+    /**
+     * Sets the number of metadata entries in a process. This is a transient
+     * value that is not persisted.
+     *
+     * @param numberOfMetadata
+     *            the number of metadata entries in a process
+     */
+    void setNumberOfMetadata(Integer numberOfMetadata);
+
+    /**
+     * Returns the number of media in a process at runtime. Can be {@code null}
+     * if no runtime value is available.
+     *
+     * @return the number of media in a process
+     */
+    Integer getNumberOfImages();
+
+    /**
+     * Sets the number of media in a process. This is a transient value that is
+     * not persisted.
+     *
+     * @param numberOfImages
+     *            the number of media in a process
+     */
+    void setNumberOfImages(Integer numberOfImages);
+
+    /**
+     * Returns the number of outline elements in a process. Can be {@code null}
+     * if no runtime value is available.
+     *
+     * @return the number of outline elements in a process
+     */
+    Integer getNumberOfStructures();
+
+    /**
+     * Sets the number of outline elements in a process at runtime. This is a
+     * transient value that is not persisted.
+     *
+     * @param numberOfStructures
+     *            the number of outline elements in a process
+     */
+    void setNumberOfStructures(Integer numberOfStructures);
+
+    /**
+     * Returns the name of the last user who was involved in the process. This
+     * is the user who recently has a task of the process in progress, or who
+     * most recently had one in progress. The name is returned comma-separated,
+     * last name first. Can be {@code null} if no user has worked on the process
+     * yet.
+     *
+     * @return name of last user handling task
+     */
+    String getLastEditingUser();
+
+    /**
+     * Sets the name of the last user who was involved in the process. This
+     * should only be set if the data comes from a third party; internally, it
+     * is determined in the database.
+     *
+     * @param lastEditingUser
+     *            user name, comma-separated, last name first
+     */
+    void setLastEditingUser(String lastEditingUser);
+
+    /**
+     * Returns the day on which a task of this process was last started.
+     *
+     * @return day on which a task of this process was last started
+     */
+    Date getProcessingBeginLastTask();
+
+    /**
+     * Sets the day on which a task of this process was last started. This
+     * should only be set if the data comes from a third party; internally, it
+     * is determined in the database.
+     * 
+     * @param processingBeginLastTask
+     *            the day on which a task of this process was last started
+     */
+    void setProcessingBeginLastTask(Date processingBeginLastTask);
+
+    /**
+     * Returns the day on which a task from this process was last completed.
+     *
+     * @return day on which a task from this process was last completed
+     */
+    Date getProcessingEndLastTask();
+
+    /**
+     * Sets the day on which a task of this process was last completed. This
+     * should only be set if the data comes from a third party; internally, it
+     * is determined in the database.
+     * 
+     * @param processingEndLastTask
+     *            the day on which a task of this process was last completed
+     */
+    void setProcessingEndLastTask(Date processingEndLastTask);
+
+    /**
+     * Returns the error corrections processing state of the process. The value
+     * is specified as integer of {@link CorrectionComments}.
+     * 
+     * @return the error corrections processing state
+     */
+    Integer getCorrectionCommentStatus();
+
+    /**
+     * Sets the error corrections processing state of the process. The value
+     * must be specified as integer of {@link CorrectionComments}.
+     * 
+     * @param status
+     *            the error corrections processing state
+     */
+    void setCorrectionCommentStatus(Integer status);
+
+    /**
+     * Returns whether the process has any comments.
+     *
+     * @return whether the process has comments
+     */
+    boolean hasComments();
+
+    /**
+     * Sets whether the process has any comments. This should only be set if the
+     * data comes from a third party; internally, it is determined in the
+     * database.
+     *
+     * @param hasComments
+     *            whether the process has comments
+     */
+    void setHasComments(boolean hasComments);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProcessInterface.java
@@ -55,7 +55,7 @@ public interface ProcessInterface extends DataInterface {
     @Deprecated
     default String getCreationTime() {
         Date creationDate = getCreationDate();
-        return Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+        return Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).format(creationDate) : null;
     }
 
     /**
@@ -78,7 +78,7 @@ public interface ProcessInterface extends DataInterface {
      */
     @Deprecated
     default void setCreationTime(String creationDate) throws ParseException {
-        setCreationDate(Objects.nonNull(creationDate) ? DATE_FORMAT.parse(creationDate) : null);
+        setCreationDate(Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).parse(creationDate) : null);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
@@ -11,10 +11,11 @@
 
 package org.kitodo.data.interfaces;
 
-import java.util.List;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.text.ParseException;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * An interface to manage digitization projects.
@@ -45,8 +46,23 @@ public interface ProjectInterface extends DataInterface {
      * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @return the start time
+     * @deprecated Use {@link #getStartDate()}.
      */
-    String getStartDate();
+    @Deprecated
+    default String getStartTime() {
+        Date startDate = getStartDate();
+        return Objects.nonNull(startDate) ? DATE_FORMAT.format(startDate) : null;
+    }
+
+    /**
+     * Returns the start time of the project. {@link Date} is a specific instant
+     * in time, with millisecond precision. It is a freely configurable value,
+     * not the date the project object was created in the database. This can be,
+     * for example, the start of the funding period.
+     *
+     * @return the start time
+     */
+    Date getStartDate();
 
     /**
      * Sets the start time of the project. The string must be parsable with
@@ -56,8 +72,20 @@ public interface ProjectInterface extends DataInterface {
      *            the start time
      * @throws ParseException
      *             if the time cannot be converted
+     * @deprecated Use {@link #setStartDate(Date)}.
      */
-    void setStartDate(String startDate);
+    @Deprecated
+    default void setStartTime(String startDate) throws ParseException {
+        setStartDate(Objects.nonNull(startDate) ? DATE_FORMAT.parse(startDate) : null);
+    }
+
+    /**
+     * Sets the start time of the project.
+     *
+     * @param startDate
+     *            the start time
+     */
+    void setStartDate(Date startDate);
 
     /**
      * Returns the project end time. The value is a {@link Date} (a specific
@@ -72,8 +100,39 @@ public interface ProjectInterface extends DataInterface {
      * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @return the end time
+     * @deprecated Use {@linkplain #getEndDate()}.
      */
-    String getEndDate();
+    @Deprecated
+    default String getEndTime() {
+        Date endDate = getEndDate();
+        return Objects.nonNull(endDate) ? DATE_FORMAT.format(endDate) : null;
+    }
+
+    /**
+     * Returns the project end time. {@link Date} is a specific instant in time,
+     * with millisecond precision. This is a freely configurable value,
+     * regardless of when the project was last actually worked on. For example,
+     * this can be the time at which the project must be completed in order to
+     * be billed. The timing can be used to monitor that the project is on time.
+     *
+     * @return the end time
+     */
+    Date getEndDate();
+
+    /**
+     * Sets the project end time. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param endDate
+     *            the end time
+     * @throws ParseException
+     *             if the time cannot be converted
+     * @deprecated Use {@link #setEndDate(Date)}.
+     */
+    @Deprecated
+    default void setEndTime(String endDate) throws ParseException {
+        setEndDate(Objects.nonNull(endDate) ? DATE_FORMAT.parse(endDate) : null);
+    }
 
     /**
      * Sets the project end time. The string must be parsable with
@@ -84,7 +143,7 @@ public interface ProjectInterface extends DataInterface {
      * @throws ParseException
      *             if the time cannot be converted
      */
-    void setEndDate(String endDate);
+    void setEndDate(Date endDate);
 
     /**
      * Returned the file format for exporting the project's business objects. In
@@ -121,6 +180,7 @@ public interface ProjectInterface extends DataInterface {
      * @deprecated The less suitable formats are no longer supported since
      *             version 3.
      */
+    @Deprecated
     default String getFileFormatInternal() {
         return "";
     }
@@ -132,7 +192,9 @@ public interface ProjectInterface extends DataInterface {
      *            unused
      * @deprecated Functionless today.
      */
-    void setFileFormatInternal(String fileFormatInternal);
+    @Deprecated
+    default void setFileFormatInternal(String fileFormatInternal) {
+    }
 
     /**
      * Returns the name of the copyright holder of the business objects. These

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
@@ -230,7 +230,7 @@ public interface ProjectInterface extends DataInterface {
      *
      * @return the active production templates
      */
-    List<TemplateInterface> getActiveTemplates();
+    List<? extends TemplateInterface> getActiveTemplates();
 
     /**
      * Sets the active production templates associated with the project. This
@@ -239,14 +239,14 @@ public interface ProjectInterface extends DataInterface {
      * @param templates
      *            the active production templates
      */
-    void setActiveTemplates(List<TemplateInterface> templates);
+    void setActiveTemplates(List<? extends TemplateInterface> templates);
 
     /**
      * Returns the users contributing to this project.
      *
      * @return the users contributing to this project
      */
-    List<UserInterface> getUsers();
+    List<? extends UserInterface> getUsers();
 
     /**
      * Specifies the users who will contribute to this project.
@@ -254,7 +254,7 @@ public interface ProjectInterface extends DataInterface {
      * @param users
      *            the users contributing to this project
      */
-    void setUsers(List<UserInterface> users);
+    void setUsers(List<? extends UserInterface> users);
 
     /**
      * Returns whether processes exist in the project. A project that contains

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
@@ -260,7 +260,7 @@ public interface ProjectInterface extends DataInterface {
      *
      * @return whether the project is active
      */
-    Boolean isActive();
+    boolean isActive();
 
     /**
      * Sets whether the project is active. Deactivated projects are hidden from

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
@@ -1,0 +1,281 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.util.List;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.text.ParseException;
+
+/**
+ * An interface to manage digitization projects.
+ */
+public interface ProjectInterface extends DataInterface {
+
+    /**
+     * Returns the name of the project.
+     *
+     * @return the name of the project
+     */
+    String getTitle();
+
+    /**
+     * Sets the name of the project.
+     *
+     * @param title
+     *            the name of the project
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the start time of the project. The value is a {@link Date} (a
+     * specific instant in time, with millisecond precision). It is a freely
+     * configurable value, not the date the project object was created in the
+     * database. This can be, for example, the start of the funding period. The
+     * string is formatted according to
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @return the start time
+     */
+    String getStartDate();
+
+    /**
+     * Sets the start time of the project. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param startDate
+     *            the start time
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setStartDate(String startDate);
+
+    /**
+     * Returns the project end time. The value is a {@link Date} (a specific
+     * instant in time, with millisecond precision). This is a freely
+     * configurable value, regardless of when the project was last actually
+     * worked on. For example, this can be the time at which the project must be
+     * completed in order to be billed. The timing can be used to monitor that
+     * the project is on time.
+     * 
+     * <p>
+     * The string is formatted according to
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @return the end time
+     */
+    String getEndDate();
+
+    /**
+     * Sets the project end time. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param endDate
+     *            the end time
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setEndDate(String endDate);
+
+    /**
+     * Returned the file format for exporting the project's business objects. In
+     * earlier times, the business objects were converted into the target format
+     * using native Java code. The desired target format was returned here.
+     * Today the export is done using XSLT, which is not covered by this.
+     *
+     * @return always empty
+     * @deprecated Today the export is done using XSLT, which is configured
+     *             elsewhere.
+     */
+    @Deprecated
+    default String getFileFormatDmsExport() {
+        return "";
+    }
+
+    /**
+     * Formerly to set the file format for exporting business objects.
+     *
+     * @param fileFormatDmsExport
+     *            unused
+     * @deprecated Functionless today.
+     */
+    @Deprecated
+    default void setFileFormatDmsExport(String fileFormatDmsExport) {
+    }
+
+    /**
+     * Returned the file format used to store business objects internally. In
+     * earlier times, several more bad than good file formats were used to store
+     * the business objects internally.
+     *
+     * @return always empty
+     * @deprecated The less suitable formats are no longer supported since
+     *             version 3.
+     */
+    default String getFileFormatInternal() {
+        return "";
+    }
+
+    /**
+     * Set the file format used to store business objects internally.
+     *
+     * @param fileFormatInternal
+     *            unused
+     * @deprecated Functionless today.
+     */
+    void setFileFormatInternal(String fileFormatInternal);
+
+    /**
+     * Returns the name of the copyright holder of the business objects. These
+     * are often the digitizing institution and also the sponsor.
+     *
+     * @return metsRightsOwner the name of the copyright holder
+     */
+    String getMetsRightsOwner();
+
+    /**
+     * Sets the name of the copyright owner of the business objects. The
+     * effective maximum length of this VARCHAR field is subject to the maximum
+     * row size of 64k shared by all columns, and the charset.
+     *
+     * @param metsRightsOwner
+     *            the name of the copyright holder
+     */
+    void setMetsRightsOwner(String metsRightsOwner);
+
+    /**
+     * Returns the number of media objects to produce. This is a freely
+     * configurable value, not a determined statistic. The value can be used to
+     * monitor whether the project is on time.
+     *
+     * @return the number of media objects to produce
+     */
+    Integer getNumberOfPages();
+
+    /**
+     * Sets the number of media objects to produce. This is usually roughly
+     * determined as part of project planning and can be stored here as a
+     * reminder.
+     *
+     * @param numberOfPages
+     *            the number of media objects to produce
+     */
+    void setNumberOfPages(Integer numberOfPages);
+
+    /**
+     * Returns the number of physical archival items to be digitized. This is a
+     * freely configurable value, not a collected statistical value. The value
+     * can be used to monitor whether the project is on time.
+     *
+     * @return number of volumes as Integer
+     */
+    Integer getNumberOfVolumes();
+
+    /**
+     * Sets the number of physical archival materials to be digitized. This is
+     * usually roughly determined as part of project planning and can be stored
+     * here as a reminder.
+     *
+     * @param numberOfVolumes
+     *            as Integer
+     */
+    void setNumberOfVolumes(Integer numberOfVolumes);
+
+    /**
+     * Returns whether the project is active. Completed projects are typically
+     * not hard deleted, but are simply marked as completed. This means that
+     * even in the event of complaints, the old stocks can still be accessed and
+     * corrected.
+     *
+     * @return whether the project is active
+     */
+    Boolean isActive();
+
+    /**
+     * Sets whether the project is active. Deactivated projects are hidden from
+     * general operation.
+     *
+     * @param active
+     *            whether project is active
+     */
+    void setActive(boolean active);
+
+    /**
+     * Returns the client running this project.
+     *
+     * @return the client
+     */
+    ClientInterface getClient();
+
+    /**
+     * Specifies the tenant that is executing this project.
+     *
+     * @param client
+     *            the client
+     */
+    void setClient(ClientInterface client);
+
+    /**
+     * Returns the non-deactivated production templates associated with the
+     * project.
+     *
+     * @return the active production templates
+     */
+    List<TemplateInterface> getActiveTemplates();
+
+    /**
+     * Sets the active production templates associated with the project. This
+     * list is not guaranteed to be in reliable order.
+     *
+     * @param templates
+     *            the active production templates
+     */
+    void setActiveTemplates(List<TemplateInterface> templates);
+
+    /**
+     * Returns the users contributing to this project.
+     *
+     * @return the users contributing to this project
+     */
+    List<UserInterface> getUsers();
+
+    /**
+     * Specifies the users who will contribute to this project.
+     *
+     * @param users
+     *            the users contributing to this project
+     */
+    void setUsers(List<UserInterface> users);
+
+    /**
+     * Returns whether processes exist in the project. A project that contains
+     * processes cannot be deleted.
+     *
+     * @return whether processes exist in the project
+     */
+    boolean hasProcesses();
+
+    /**
+     * Set whether project has processes. The setter can be used when
+     * representing data from a third-party source. Internally it depends on,
+     * whether there are process objects in the database for a project. Setting
+     * this to true cannot insert processes into the database.
+     *
+     * @param hasProcesses
+     *            as boolean
+     * @throws UnsupportedOperationException
+     *             when trying to set this to true for a project without
+     *             processes
+     */
+    void setHasProcesses(boolean hasProcesses);
+
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/ProjectInterface.java
@@ -51,7 +51,7 @@ public interface ProjectInterface extends DataInterface {
     @Deprecated
     default String getStartTime() {
         Date startDate = getStartDate();
-        return Objects.nonNull(startDate) ? DATE_FORMAT.format(startDate) : null;
+        return Objects.nonNull(startDate) ? new SimpleDateFormat(DATE_FORMAT).format(startDate) : null;
     }
 
     /**
@@ -76,7 +76,7 @@ public interface ProjectInterface extends DataInterface {
      */
     @Deprecated
     default void setStartTime(String startDate) throws ParseException {
-        setStartDate(Objects.nonNull(startDate) ? DATE_FORMAT.parse(startDate) : null);
+        setStartDate(Objects.nonNull(startDate) ? new SimpleDateFormat(DATE_FORMAT).parse(startDate) : null);
     }
 
     /**
@@ -105,7 +105,7 @@ public interface ProjectInterface extends DataInterface {
     @Deprecated
     default String getEndTime() {
         Date endDate = getEndDate();
-        return Objects.nonNull(endDate) ? DATE_FORMAT.format(endDate) : null;
+        return Objects.nonNull(endDate) ? new SimpleDateFormat(DATE_FORMAT).format(endDate) : null;
     }
 
     /**
@@ -131,7 +131,7 @@ public interface ProjectInterface extends DataInterface {
      */
     @Deprecated
     default void setEndTime(String endDate) throws ParseException {
-        setEndDate(Objects.nonNull(endDate) ? DATE_FORMAT.parse(endDate) : null);
+        setEndDate(Objects.nonNull(endDate) ? new SimpleDateFormat(DATE_FORMAT).parse(endDate) : null);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/PropertyInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/PropertyInterface.java
@@ -62,7 +62,7 @@ public interface PropertyInterface extends DataInterface {
     @Deprecated
     default String getCreationTime() {
         Date creationDate = getCreationDate();
-        return Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+        return Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).format(creationDate) : null;
     }
 
     /**
@@ -85,7 +85,7 @@ public interface PropertyInterface extends DataInterface {
      */
     @Deprecated
     default void setCreationTime(String creationDate) throws ParseException {
-        setCreationDate(Objects.nonNull(creationDate) ? DATE_FORMAT.parse(creationDate) : null);
+        setCreationDate(Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).parse(creationDate) : null);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/PropertyInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/PropertyInterface.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+/**
+ * An interface to manage process properties. Properties are key-value pairs
+ * that can be added to processes by third-party modules. They should not be
+ * used to store technical metadata. Such should be part of the business domain.
+ */
+public interface PropertyInterface extends DataInterface {
+    /**
+     * Returns the key of the property's key-value pair.
+     *
+     * @return the key
+     */
+    String getTitle();
+
+    /**
+     * Sets the key of the property's key-value pair.
+     *
+     * @param title
+     *            key to set
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the value of the property's key-value pair.
+     *
+     * @return the value
+     */
+    String getValue();
+
+    /**
+     * Sets the value of the property's key-value pair.
+     *
+     * @param value
+     *            value to set
+     */
+    void setValue(String value);
+
+    /**
+     * Returns the creation time of the property. The string is formatted
+     * according to {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @return the creation time
+     */
+    String getCreationDate();
+
+    /**
+     * Sets the creation time of the property. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param creationDate
+     *            creation time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setCreationDate(String creationDate);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/PropertyInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/PropertyInterface.java
@@ -13,6 +13,8 @@ package org.kitodo.data.interfaces;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Objects;
 
 /**
  * An interface to manage process properties. Properties are key-value pairs
@@ -55,8 +57,36 @@ public interface PropertyInterface extends DataInterface {
      * according to {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @return the creation time
+     * @deprecated Use {@link #getCreationDate()}.
      */
-    String getCreationDate();
+    @Deprecated
+    default String getCreationTime() {
+        Date creationDate = getCreationDate();
+        return Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+    }
+
+    /**
+     * Returns the creation time of the property. {@link Date} is a specific
+     * instant in time, with millisecond precision.
+     *
+     * @return the creation time
+     */
+    Date getCreationDate();
+
+    /**
+     * Sets the creation time of the property. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param creationDate
+     *            creation time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     * @deprecated Use {@link #setCreationDate(Date)}.
+     */
+    @Deprecated
+    default void setCreationTime(String creationDate) throws ParseException {
+        setCreationDate(Objects.nonNull(creationDate) ? DATE_FORMAT.parse(creationDate) : null);
+    }
 
     /**
      * Sets the creation time of the property. The string must be parsable with
@@ -67,5 +97,5 @@ public interface PropertyInterface extends DataInterface {
      * @throws ParseException
      *             if the time cannot be converted
      */
-    void setCreationDate(String creationDate);
+    void setCreationDate(Date creationDate);
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RoleInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RoleInterface.java
@@ -58,7 +58,9 @@ public interface RoleInterface extends DataInterface {
      * Returns how many users hold this role.
      *
      * @return how many users hold this role
+     * @deprecated Use {@link #getUsers()}{@code .size()}.
      */
+    @Deprecated
     default Integer getUsersSize() {
         List<? extends UserInterface> users = getUsers();
         return Objects.nonNull(users) ? users.size() : null;
@@ -76,7 +78,9 @@ public interface RoleInterface extends DataInterface {
      *             when trying to assign this role to unspecified users
      * @throws IndexOutOfBoundsException
      *             for an illegal endpoint index value
+     * @deprecated {@link #getUsers()} and edit them consciously.
      */
+    @Deprecated
     default void setUsersSize(Integer size) {
         int newSize = Objects.nonNull(size) ? size : 0;
         List<? extends UserInterface> users = Optional.of(getUsers()).orElse(Collections.emptyList());

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RoleInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RoleInterface.java
@@ -44,7 +44,7 @@ public interface RoleInterface extends DataInterface {
      *
      * @return list of users who hold this role
      */
-    List<UserInterface> getUsers();
+    List<? extends UserInterface> getUsers();
 
     /**
      * Sets the list of users who hold this role.
@@ -52,7 +52,7 @@ public interface RoleInterface extends DataInterface {
      * @param users
      *            list of users who hold this role to set
      */
-    void setUsers(List<UserInterface> users);
+    void setUsers(List<? extends UserInterface> users);
 
     /**
      * Returns how many users hold this role.
@@ -60,7 +60,7 @@ public interface RoleInterface extends DataInterface {
      * @return how many users hold this role
      */
     default Integer getUsersSize() {
-        List<UserInterface> users = getUsers();
+        List<? extends UserInterface> users = getUsers();
         return Objects.nonNull(users) ? users.size() : null;
     }
 
@@ -79,7 +79,7 @@ public interface RoleInterface extends DataInterface {
      */
     default void setUsersSize(Integer size) {
         int newSize = Objects.nonNull(size) ? size : 0;
-        List<UserInterface> users = Optional.of(getUsers()).orElse(Collections.emptyList());
+        List<? extends UserInterface> users = Optional.of(getUsers()).orElse(Collections.emptyList());
         int currentSize = users.size();
         if (newSize == currentSize) {
             return;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RoleInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RoleInterface.java
@@ -1,0 +1,107 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An interface for managing user roles. Users can have different task-related
+ * or general-administrative roles, including different roles for different
+ * clients they work for. A role is always assigned to one client.
+ */
+public interface RoleInterface extends DataInterface {
+
+    /**
+     * Returns the name of the role.
+     *
+     * @return the name of the role
+     */
+    String getTitle();
+
+    /**
+     * Sets the name of the role.
+     *
+     * @param title
+     *            name of the role to set
+     */
+    void setTitle(String title);
+
+    /**
+     * Specifies the users who hold this role. This list is not guaranteed to be
+     * in reliable order.
+     *
+     * @return list of users who hold this role
+     */
+    List<UserInterface> getUsers();
+
+    /**
+     * Sets the list of users who hold this role.
+     *
+     * @param users
+     *            list of users who hold this role to set
+     */
+    void setUsers(List<UserInterface> users);
+
+    /**
+     * Returns how many users hold this role.
+     *
+     * @return how many users hold this role
+     */
+    default Integer getUsersSize() {
+        List<UserInterface> users = getUsers();
+        return Objects.nonNull(users) ? users.size() : null;
+    }
+
+    /**
+     * Sets how many users hold this role. The setter can be used when
+     * representing data from a third-party source. Internally it depends on,
+     * whether there are user objects in the database linked to the role. No
+     * additional users can be added to the role here.
+     *
+     * @param size
+     *            how many users hold this role to set
+     * @throws SecurityException
+     *             when trying to assign this role to unspecified users
+     * @throws IndexOutOfBoundsException
+     *             for an illegal endpoint index value
+     */
+    default void setUsersSize(Integer size) {
+        int newSize = Objects.nonNull(size) ? size : 0;
+        List<UserInterface> users = Optional.of(getUsers()).orElse(Collections.emptyList());
+        int currentSize = users.size();
+        if (newSize == currentSize) {
+            return;
+        }
+        if (newSize > currentSize) {
+            throw new SecurityException("cannot add arbitrary users");
+        }
+        setUsers(users.subList(0, newSize));
+    }
+
+    /**
+     * Returns the client in whose realm this role grants permissions.
+     *
+     * @return the client in whose realm this role grants permissions
+     */
+    ClientInterface getClient();
+
+    /**
+     * Sets the client in whose realm this role grants permissions.
+     *
+     * @param client
+     *            client in whose realm this role grants permissions to set.
+     */
+    void setClient(ClientInterface client);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RulesetInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/RulesetInterface.java
@@ -1,0 +1,110 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+/**
+ * An interface for managing the business domain in the form of a ruleset. The
+ * ruleset defines divisions and metadata keys with their value ranges, and
+ * describes which division must or may be marked with which metadata. It also
+ * contains visual settings of the editor GUI.
+ */
+public interface RulesetInterface extends DataInterface {
+
+    /**
+     * Returns the name of the configuration file, without a path. The file must
+     * exist in the ruleset directory. The directory is set in the configuration
+     * file.
+     *
+     * @return the XML file name
+     */
+    String getFile();
+
+    /**
+     * Sets the name of the configuration file. The file must exist in the
+     * ruleset directory. The file name must be specified without a path.
+     *
+     * @param file
+     *            XML file name
+     */
+    void setFile(String file);
+
+    /**
+     * Returns the display name of the business domain model. It is displayed to
+     * the user in a selection dialog.
+     *
+     * @return the display name
+     */
+    String getTitle();
+
+    /**
+     * Sets the display name of the business domain model.
+     *
+     * @param title
+     *            the display name
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns whether the elements of the ruleset should be displayed in the
+     * declared order. If not, they are displayed alphabetically. It varies at
+     * which points this sorting takes effect and what is sorted on.
+     *
+     * @return whether the elements should be in declared order
+     */
+    boolean isOrderMetadataByRuleset();
+
+    /**
+     * Sets whether the elements of the ruleset should be displayed in the
+     * declared order.
+     *
+     * @param orderMetadataByRuleset
+     *            whether the elements should be in declared order
+     */
+    void setOrderMetadataByRuleset(boolean orderMetadataByRuleset);
+
+    /**
+     * Determines whether the ruleset is active. A deactivated rule set is not
+     * offered for selection, but can continue to be used where it is already in
+     * use.
+     *
+     * @return whether the ruleset is active
+     */
+    Boolean isActive();
+
+    /**
+     * Sets whether the ruleset is active.
+     *
+     * @param active
+     *            whether the ruleset is active
+     */
+    void setActive(boolean active);
+
+    /**
+     * Returns the client that this ruleset is associated with. Technically,
+     * multiple client can use the same docket generator configuration (file),
+     * but they must be made available independently for each client using one
+     * configuration object each. This determines which rulesets are visible to
+     * a client at all, and they can be named differently.
+     *
+     * @return client that this ruleset is associated with
+     */
+    ClientInterface getClient();
+
+    /**
+     * Sets the client to which this ruleset is associated.
+     *
+     * @param client
+     *            client to which this ruleset is associated
+     */
+    void setClient(ClientInterface client);
+
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
@@ -199,7 +199,7 @@ public interface TaskInterface extends DataInterface {
     @Deprecated
     default String getProcessingMoment() {
         Date processingTime = getProcessingTime();
-        return Objects.nonNull(processingTime) ? DATE_FORMAT.format(processingTime) : null;
+        return Objects.nonNull(processingTime) ? new SimpleDateFormat(DATE_FORMAT).format(processingTime) : null;
     }
 
     /**
@@ -223,7 +223,8 @@ public interface TaskInterface extends DataInterface {
      */
     @Deprecated
     default void setProcessingMoment(String processingTime) throws ParseException {
-        setProcessingTime(Objects.nonNull(processingTime) ? DATE_FORMAT.parse(processingTime) : null);
+        setProcessingTime(
+            Objects.nonNull(processingTime) ? new SimpleDateFormat(DATE_FORMAT).parse(processingTime) : null);
     }
 
     /**
@@ -246,7 +247,7 @@ public interface TaskInterface extends DataInterface {
     @Deprecated
     default String getProcessingBeginTime() {
         Date processingBegin = getProcessingBegin();
-        return Objects.nonNull(processingBegin) ? DATE_FORMAT.format(processingBegin) : null;
+        return Objects.nonNull(processingBegin) ? new SimpleDateFormat(DATE_FORMAT).format(processingBegin) : null;
     }
 
     /**
@@ -268,7 +269,8 @@ public interface TaskInterface extends DataInterface {
      */
     @Deprecated
     default void setProcessingBeginTime(String processingBegin) throws ParseException {
-        setProcessingBegin(Objects.nonNull(processingBegin) ? DATE_FORMAT.parse(processingBegin) : null);
+        setProcessingBegin(
+            Objects.nonNull(processingBegin) ? new SimpleDateFormat(DATE_FORMAT).parse(processingBegin) : null);
     }
 
     /**
@@ -289,7 +291,7 @@ public interface TaskInterface extends DataInterface {
     @Deprecated
     default String getProcessingEndTime() {
         Date processingEnd = getProcessingEnd();
-        return Objects.nonNull(processingEnd) ? DATE_FORMAT.format(processingEnd) : null;
+        return Objects.nonNull(processingEnd) ? new SimpleDateFormat(DATE_FORMAT).format(processingEnd) : null;
     }
 
     /**
@@ -311,7 +313,8 @@ public interface TaskInterface extends DataInterface {
      */
     @Deprecated
     default void setProcessingEndTime(String processingEnd) throws ParseException {
-        setProcessingEnd(Objects.nonNull(processingEnd) ? DATE_FORMAT.parse(processingEnd) : null);
+        setProcessingEnd(
+            Objects.nonNull(processingEnd) ? new SimpleDateFormat(DATE_FORMAT).parse(processingEnd) : null);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
@@ -1,0 +1,508 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.kitodo.data.database.enums.TaskEditType;
+import org.kitodo.data.database.enums.TaskStatus;
+
+public interface TaskInterface extends DataInterface {
+
+    /**
+     * Returns the name of the task. This is usually a human-readable,
+     * aphoristic summary of the activity to be performed.
+     *
+     * @return the name
+     */
+    String getTitle();
+
+    /**
+     * Sets the name of the task.
+     *
+     * @param title
+     *            name to set
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the translated name of the task at runtime. This can be
+     * translated at runtime for the user currently performing this task via the
+     * application's language resource files. Can be {@code null} if currently
+     * no value is available.
+     *
+     * @return translated name
+     */
+    String getLocalizedTitle();
+
+    /**
+     * Sets the translated name of the task at runtime. This is a transient
+     * value that is not persisted.
+     *
+     * @param localizedTitle
+     *            translated name to set
+     */
+    void setLocalizedTitle(String localizedTitle);
+
+    /**
+     * Returns the ordinal number of the task. Tasks can be processed
+     * sequentially. When a task with a lower ordinal number is completed, the
+     * task with the next higher ordinal number can be processed. If several
+     * tasks share the same ordinal number, they can be processed in parallel.
+     *
+     * @return ordinal number of the task
+     */
+    Integer getOrdering();
+
+    /**
+     * Sets the ordinal number of the task. This sets the consecutive execution
+     * point relative to the other tasks in the process. May be the same as the
+     * number of another task if they are to be processed in parallel. Must not
+     * be {@code null}.
+     *
+     * @param ordering
+     *            ordinal number of the task
+     */
+    void setOrdering(Integer ordering);
+
+    /**
+     * Returns the processing status of the task. A task can:
+     * <dl>
+     * <dt>LOCKED</dt>
+     * <dd>wait for previous tasks to complete to become ready to start</dd>
+     * <dt>OPEN</dt>
+     * <dd>ready to go and waiting to be taken over</dd>
+     * <dt>INWORK</dt>
+     * <dd>currently being carried out</dd>
+     * <dt>DONE</dt>
+     * <dd>be finished</dd>
+     * </dl>
+     *
+     * @return the processing status
+     */
+    TaskStatus getProcessingStatus();
+
+    /**
+     * Sets the processing status of the task.
+     *
+     * @param processingStatus
+     *            processing status to set
+     */
+    void setProcessingStatus(TaskStatus processingStatus);
+
+    /**
+     * Returns the translated processing status of the task at runtime. This can
+     * be translated at runtime for the user currently displaying this task. Can
+     * be {@code null} if currently no value is available.
+     *
+     * @return translated processing status
+     */
+    String getProcessingStatusTitle();
+
+    /**
+     * Sets the translated processing status of the task at runtime. This is a
+     * transient value that is not persisted.
+     *
+     * @param processingStatus
+     *            translated processing status to set
+     */
+    void setProcessingStatusTitle(String processingStatusTitle);
+
+    /**
+     * Returns the processing type of the task. Possible are:
+     * <dl>
+     * <dt>UNNOWKN</dt>
+     * <dd>The processing type of the task is not defined.</dd>
+     * <dt>MANUAL_SINGLE</dt>
+     * <dd>The task was taken over and carried out by a user.</dd>
+     * <dt>MANUAL_MULTI</dt>
+     * <dd>The task was taken over and carried out by a user as part of the
+     * batch processing functionality.</dd>
+     * <dt>ADMIN</dt>
+     * <dd>The task status has been changed administratively using the status
+     * increase or status decrease functions.</dd>
+     * <dt>AUTOMATIC</dt>
+     * <dd>The automatic task was carried out by the workflow system.</dd>
+     * <dt>QUEUE</dt>
+     * <dd>The task status was changed via the Active MQ interface.</dd>
+     * </dl>
+     *
+     * @return the processing type
+     */
+    TaskEditType getEditType();
+
+    /**
+     * Sets the processing type of the task.
+     *
+     * @param editType
+     *            processing type to set
+     */
+    void setEditType(TaskEditType editType);
+
+    /**
+     * Returns the translated processing type of the task at runtime. This can
+     * be translated at runtime for the user currently displaying this task. Can
+     * be {@code null} if currently no value is available.
+     *
+     * @return translated processing status
+     */
+    String getEditTypeTitle();
+
+    /**
+     * Sets the translated processing tipe of the task at runtime. This is a
+     * transient value that is not persisted.
+     *
+     * @param processingStatus
+     *            translated processing type to set
+     */
+    void setEditTypeTitle(String editTypeTitle);
+
+    /**
+     * Returns the user who last worked on the task.
+     *
+     * @return the user who last worked on the task
+     */
+    UserInterface getProcessingUser();
+
+    /**
+     * Sets the user who last worked on the task.
+     *
+     * @param processingUser
+     *            user to set
+     */
+    void setProcessingUser(UserInterface processingUser);
+
+    /**
+     * Returns the time the task status was last changed. This references
+     * <i>any</i> activity on the task that involves a change in status. The
+     * string is formatted according to
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @return the time the task status was last changed
+     */
+    String getProcessingTime();
+
+    /**
+     * Sets the time the task status was last changed. The string must be
+     * parsable with {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param processingTime
+     *            time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setProcessingTime(String processingTime);
+
+    /**
+     * Returns the time when the task was accepted for processing. The string is
+     * formatted according to
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @return the time when the task was accepted for processing
+     */
+    String getProcessingBegin();
+
+    /**
+     * Sets the time the task was accepted for processing. The string must be
+     * parsable with {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param processingTime
+     *            time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setProcessingBegin(String processingBegin);
+
+    /**
+     * Returns the time when the task was completed. The string is formatted
+     * according to {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @return the time when the task was completed
+     */
+    String getProcessingEnd();
+
+    /**
+     * Sets the time the task was completed. The string must be parsable with
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param processingTime
+     *            time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setProcessingEnd(String processingEnd);
+
+    /**
+     * Returns the process this task belongs to. Can be {@code null} if the task
+     * belongs to a production template, and not a process.
+     *
+     * @return the process this task belongs to
+     */
+    ProcessInterface getProcess();
+
+    /**
+     * Sets the process this task belongs to. A task can only ever be assigned
+     * to <i>either</i> a process <i>or</i> a production template.
+     *
+     * @param process
+     *            process this task belongs to
+     */
+    void setProcess(ProcessInterface process);
+
+    /**
+     * Returns the project the process belongs to.
+     *
+     * @return the project the process belongs to
+     */
+    ProjectInterface getProject();
+
+    /**
+     * Sets the project the process belongs to.
+     *
+     * @param project
+     *            project to set
+     */
+    void setProject(ProjectInterface project);
+
+    /**
+     * Returns the production template this task belongs to. Can be {@code null}
+     * if the task belongs to a process, and not a production template.
+     *
+     * @return the production template this task belongs to
+     */
+    TemplateInterface getTemplate();
+
+    /**
+     * Sets the production template this task belongs to. A task can only ever
+     * be assigned to <i>either</i> a production template <i>or</i> a process.
+     *
+     * @param process
+     *            process this task belongs to
+     */
+    void setTemplate(TemplateInterface template);
+
+    /**
+     * Returns a list of the IDs of the roles, whose holders are allowed to
+     * perform this task. This list is not guaranteed to be in reliable order.
+     *
+     * @return list of the IDs of the roles
+     */
+    List<Integer> getRoleIds();
+
+    /**
+     * Specifies a list of role IDs whose holders are allowed to perform this
+     * task. The list should not contain duplicates, and must not contain
+     * {@code null}s. It is not specified whether setting the roles using IDs is
+     * an action at the current time. Subsequent edits to the ID list may or may
+     * not affect the stored roles.
+     *
+     * @param roleIds
+     *            list of role IDs
+     */
+    void setRoleIds(List<Integer> roleIds);
+
+    /**
+     * Returns how many roles are allowed to take on this task.
+     *
+     * @return how many roles are allowed to take on this task
+     */
+    default int getRolesSize() {
+        List<Integer> roles = getRoleIds();
+        return Objects.nonNull(roles) ? roles.size() : 0;
+    }
+
+    /**
+     * Sets how many roles are allowed to take on this task. The setter can be
+     * used when representing data from a third-party source. Internally it
+     * depends on, whether there are role objects in the database linked to the
+     * process. No additional roles can be added to the process here.
+     *
+     * @param size
+     *            how many users hold this role to set
+     * @throws SecurityException
+     *             when trying to assign unspecified roles to this process
+     * @throws IndexOutOfBoundsException
+     *             for an illegal endpoint index value
+     */
+    default void setRolesSize(int rolesSize) {
+        int newSize = Objects.nonNull(rolesSize) ? rolesSize : 0;
+        List<Integer> users = Optional.of(getRoleIds()).orElse(Collections.emptyList());
+        int currentSize = users.size();
+        if (newSize == currentSize) {
+            return;
+        }
+        if (newSize > currentSize) {
+            throw new SecurityException("cannot add arbitrary roles");
+        }
+        setRoleIds(users.subList(0, newSize));
+    }
+
+    /**
+     * Returns whether the task is in a correction run. In a five-step workflow,
+     * if a correction request occurs from the fourth step to the second step,
+     * steps two and three are in the correction run.
+     *
+     * @return whether the task is in a correction run
+     */
+    boolean isCorrection();
+
+    /**
+     * Sets whether the task is in a correction run.
+     *
+     * @param correction
+     *            whether the task is in a correction run
+     */
+    void setCorrection(boolean correction);
+
+    /**
+     * Returns whether the task is of automatic type. Automatic tasks are taken
+     * over by the workflow system itself, the actions selected in it are
+     * carried out, such as an export or a script call, and then the task is
+     * completed.
+     *
+     * @return whether the task is automatic
+     */
+    boolean isTypeAutomatic();
+
+    /**
+     * Sets whether the task is of automatic type.
+     *
+     * @param typeAutomatic
+     *            whether the task is automatic
+     */
+    void setTypeAutomatic(boolean typeAutomatic);
+
+    /**
+     * Returns whether the editor for the digital copy is made available to the
+     * user. The editor offers a UI in which the structure of the previously
+     * loosely digitized media can be detailed.
+     *
+     * @return whether the editor is available
+     */
+    boolean isTypeMetadata();
+
+    /**
+     * Sets whether the editor is available in the task.
+     *
+     * @param typeMetadata
+     *            whether the editor is available
+     */
+    void setTypeMetadata(boolean typeMetadata);
+
+    /**
+     * Returns whether this task gives the user file system access. They can
+     * then access the folder for or containing the digitized files and create,
+     * view or edit files.
+     *
+     * @return whether the user gets file access
+     */
+    boolean isTypeImagesRead();
+
+    /**
+     * Sets whether this task gives the user file system access.
+     *
+     * @param typeImagesRead
+     *            whether the user gets file access
+     */
+    void setTypeImagesRead(boolean typeImagesRead);
+
+    /**
+     * Returns whether the user is allowed to create or modify files. When
+     * digitizing, the user probably needs write access to the file area of the
+     * process, but perhaps not for control tasks.
+     *
+     * @return whether the user gets write access
+     */
+    boolean isTypeImagesWrite();
+
+    /**
+     * Sets whether the user is allowed to create or modify files.
+     *
+     * @param typeImagesWrite
+     *            whether the user gets write access
+     */
+    void setTypeImagesWrite(boolean typeImagesWrite);
+
+    /**
+     * Returns whether accepting or completing this task applies to the batch.
+     * If so, with a single UI interaction, the user automatically executes an
+     * action for all tasks of all processes in the batch that, have the same
+     * name and are in the same state. This saves users from a lot of mouse
+     * work.
+     *
+     * @return whether actions apply to the batch
+     */
+    boolean isBatchStep();
+
+    /**
+     * Set information if batch is available for task - there is more than one
+     * task with the same title assigned to the batch.).
+     *
+     * @param batchAvailable
+     *            as boolean
+     */
+    void setBatchAvailable(boolean batchAvailable);
+
+    /**
+     * Returns whether batch automation is possible for this task. For
+     * automation to work, the process containing the task must be assigned to
+     * exactly one batch.
+     *
+     * @return whether batch automation is possible
+     */
+    boolean isBatchAvailable();
+
+    /**
+     * Sets whether batch automation is possible for this task. The setter can
+     * be used when representing data from a third-party source. Internally it
+     * depends on, whether the process containing the task is assigned to
+     * exactly one batch.
+     *
+     * @param batchStep
+     *            whether batch automation is possible
+     * @throws UnsupportedOperationException
+     *             when the value doesn't match the background database
+     */
+    void setBatchStep(boolean batchStep);
+
+    /**
+     * Returns the status of the task regarding necessary corrections. Possible
+     * are:
+     * <dl>
+     * <dt>0</dt>
+     * <dd>There are no corrections.</dd>
+     * <dt>1</dt>
+     * <dd>All necessary corrections have been made.</dd>
+     * <dt>2</dt>
+     * <dd>Corrections are pending.</dd>
+     * </dl>
+     * 
+     * @return the status regarding corrections
+     * @see org.kitodo.data.database.enums.CorrectionComments
+     */
+    Integer getCorrectionCommentStatus();
+
+    /**
+     * Sets the status of the task regarding necessary corrections. Must be a
+     * number from 0 to 2.
+     * 
+     * @param status
+     *            the status regarding corrections
+     * @see org.kitodo.data.database.enums.CorrectionComments
+     */
+    void setCorrectionCommentStatus(Integer status);
+
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
@@ -12,7 +12,9 @@
 package org.kitodo.data.interfaces;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -192,8 +194,22 @@ public interface TaskInterface extends DataInterface {
      * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @return the time the task status was last changed
+     * @deprecated Use {@link #getProcessingTime()}.
      */
-    String getProcessingTime();
+    @Deprecated
+    default String getProcessingMoment() {
+        Date processingTime = getProcessingTime();
+        return Objects.nonNull(processingTime) ? DATE_FORMAT.format(processingTime) : null;
+    }
+
+    /**
+     * Returns the time the task status was last changed. This references
+     * <i>any</i> activity on the task that involves a change in status.
+     * {@link Date} is a specific instant in time, with millisecond precision.
+     *
+     * @return the time the task status was last changed
+     */
+    Date getProcessingTime();
 
     /**
      * Sets the time the task status was last changed. The string must be
@@ -203,8 +219,21 @@ public interface TaskInterface extends DataInterface {
      *            time to set
      * @throws ParseException
      *             if the time cannot be converted
+     * @deprecated Use {@link #setProcessingTime(Date)}.
      */
-    void setProcessingTime(String processingTime);
+    @Deprecated
+    default void setProcessingMoment(String processingTime) throws ParseException {
+        setProcessingTime(Objects.nonNull(processingTime) ? DATE_FORMAT.parse(processingTime) : null);
+    }
+
+    /**
+     * Sets the time the task status was last changed. The string must be
+     * parsable with {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param processingTime
+     *            time to set
+     */
+    void setProcessingTime(Date processingTime);
 
     /**
      * Returns the time when the task was accepted for processing. The string is
@@ -212,8 +241,20 @@ public interface TaskInterface extends DataInterface {
      * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @return the time when the task was accepted for processing
+     * @deprecated Use {@link #getProcessingBegin()}.
      */
-    String getProcessingBegin();
+    @Deprecated
+    default String getProcessingBeginTime() {
+        Date processingBegin = getProcessingBegin();
+        return Objects.nonNull(processingBegin) ? DATE_FORMAT.format(processingBegin) : null;
+    }
+
+    /**
+     * Returns the time when the task was accepted for processing.
+     *
+     * @return the time when the task was accepted for processing
+     */
+    Date getProcessingBegin();
 
     /**
      * Sets the time the task was accepted for processing. The string must be
@@ -223,16 +264,40 @@ public interface TaskInterface extends DataInterface {
      *            time to set
      * @throws ParseException
      *             if the time cannot be converted
+     * @deprecated Use {@link #setProcessingBegin(Date)}.
      */
-    void setProcessingBegin(String processingBegin);
+    @Deprecated
+    default void setProcessingBeginTime(String processingBegin) throws ParseException {
+        setProcessingBegin(Objects.nonNull(processingBegin) ? DATE_FORMAT.parse(processingBegin) : null);
+    }
+
+    /**
+     * Sets the time the task was accepted for processing.
+     *
+     * @param processingTime
+     *            time to set
+     */
+    void setProcessingBegin(Date processingBegin);
 
     /**
      * Returns the time when the task was completed. The string is formatted
      * according to {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @return the time when the task was completed
+     * @deprecated Use {@link #getProcessingEnd()}.
      */
-    String getProcessingEnd();
+    @Deprecated
+    default String getProcessingEndTime() {
+        Date processingEnd = getProcessingEnd();
+        return Objects.nonNull(processingEnd) ? DATE_FORMAT.format(processingEnd) : null;
+    }
+
+    /**
+     * Returns the time when the task was completed.
+     *
+     * @return the time when the task was completed
+     */
+    Date getProcessingEnd();
 
     /**
      * Sets the time the task was completed. The string must be parsable with
@@ -242,8 +307,20 @@ public interface TaskInterface extends DataInterface {
      *            time to set
      * @throws ParseException
      *             if the time cannot be converted
+     * @deprecated Use {@link #setProcessingEnd(Date)}.
      */
-    void setProcessingEnd(String processingEnd);
+    @Deprecated
+    default void setProcessingEndTime(String processingEnd) throws ParseException {
+        setProcessingEnd(Objects.nonNull(processingEnd) ? DATE_FORMAT.parse(processingEnd) : null);
+    }
+
+    /**
+     * Sets the time the task was completed.
+     *
+     * @param processingTime
+     *            time to set
+     */
+    void setProcessingEnd(Date processingEnd);
 
     /**
      * Returns the process this task belongs to. Can be {@code null} if the task

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TaskInterface.java
@@ -118,7 +118,7 @@ public interface TaskInterface extends DataInterface {
      * Sets the translated processing status of the task at runtime. This is a
      * transient value that is not persisted.
      *
-     * @param processingStatus
+     * @param processingStatusTitle
      *            translated processing status to set
      */
     void setProcessingStatusTitle(String processingStatusTitle);
@@ -164,10 +164,10 @@ public interface TaskInterface extends DataInterface {
     String getEditTypeTitle();
 
     /**
-     * Sets the translated processing tipe of the task at runtime. This is a
+     * Sets the translated processing type of the task at runtime. This is a
      * transient value that is not persisted.
      *
-     * @param processingStatus
+     * @param editTypeTitle
      *            translated processing type to set
      */
     void setEditTypeTitle(String editTypeTitle);
@@ -260,7 +260,7 @@ public interface TaskInterface extends DataInterface {
      * Sets the time the task was accepted for processing. The string must be
      * parsable with {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
-     * @param processingTime
+     * @param processingBegin
      *            time to set
      * @throws ParseException
      *             if the time cannot be converted
@@ -274,7 +274,7 @@ public interface TaskInterface extends DataInterface {
     /**
      * Sets the time the task was accepted for processing.
      *
-     * @param processingTime
+     * @param processingBegin
      *            time to set
      */
     void setProcessingBegin(Date processingBegin);
@@ -303,7 +303,7 @@ public interface TaskInterface extends DataInterface {
      * Sets the time the task was completed. The string must be parsable with
      * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
-     * @param processingTime
+     * @param processingEnd
      *            time to set
      * @throws ParseException
      *             if the time cannot be converted
@@ -317,7 +317,7 @@ public interface TaskInterface extends DataInterface {
     /**
      * Sets the time the task was completed.
      *
-     * @param processingTime
+     * @param processingEnd
      *            time to set
      */
     void setProcessingEnd(Date processingEnd);
@@ -343,16 +343,25 @@ public interface TaskInterface extends DataInterface {
      * Returns the project the process belongs to.
      *
      * @return the project the process belongs to
+     * @deprecated Use {@link #getProcess()}{@code .getProject()}.
      */
-    ProjectInterface getProject();
+    @Deprecated
+    default ProjectInterface getProject() {
+        return getProcess().getProject();
+    }
 
     /**
      * Sets the project the process belongs to.
      *
      * @param project
      *            project to set
+     * @deprecated Use
+     *             {@link #getProcess()}{@code .setProject(ProjectInterface)}.
      */
-    void setProject(ProjectInterface project);
+    @Deprecated
+    default void setProject(ProjectInterface project) {
+        getProcess().setProject(project);
+    }
 
     /**
      * Returns the production template this task belongs to. Can be {@code null}
@@ -366,8 +375,8 @@ public interface TaskInterface extends DataInterface {
      * Sets the production template this task belongs to. A task can only ever
      * be assigned to <i>either</i> a production template <i>or</i> a process.
      *
-     * @param process
-     *            process this task belongs to
+     * @param template
+     *            template this task belongs to
      */
     void setTemplate(TemplateInterface template);
 
@@ -388,8 +397,12 @@ public interface TaskInterface extends DataInterface {
      *
      * @param roleIds
      *            list of role IDs
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setRoleIds(List<Integer> roleIds);
+    default void setRoleIds(List<Integer> roleIds) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns how many roles are allowed to take on this task.
@@ -407,7 +420,7 @@ public interface TaskInterface extends DataInterface {
      * depends on, whether there are role objects in the database linked to the
      * process. No additional roles can be added to the process here.
      *
-     * @param size
+     * @param rolesSize
      *            how many users hold this role to set
      * @throws SecurityException
      *             when trying to assign unspecified roles to this process
@@ -525,13 +538,19 @@ public interface TaskInterface extends DataInterface {
     boolean isBatchStep();
 
     /**
-     * Set information if batch is available for task - there is more than one
-     * task with the same title assigned to the batch.).
+     * Sets whether batch automation is possible for this task. The setter can
+     * be used when representing data from a third-party source. Internally it
+     * depends on whether the task's process is assigned to exactly one batch.
+     * Setting this to true cannot fix problems.
      *
      * @param batchAvailable
      *            as boolean
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setBatchAvailable(boolean batchAvailable);
+    default void setBatchAvailable(boolean batchAvailable) {
+        throw new UnsupportedOperationException("not supported");
+    }
 
     /**
      * Returns whether batch automation is possible for this task. For
@@ -540,7 +559,10 @@ public interface TaskInterface extends DataInterface {
      *
      * @return whether batch automation is possible
      */
-    boolean isBatchAvailable();
+    default boolean isBatchAvailable() {
+        var batches = getProcess().getBatches();
+        return Objects.nonNull(batches) && batches.size() == 1;
+    }
 
     /**
      * Sets whether batch automation is possible for this task. The setter can
@@ -569,8 +591,13 @@ public interface TaskInterface extends DataInterface {
      * 
      * @return the status regarding corrections
      * @see org.kitodo.data.database.enums.CorrectionComments
+     * @deprecated Use
+     *             {@link #getProcess()}{@code .getCorrectionCommentStatus()}.
      */
-    Integer getCorrectionCommentStatus();
+    @Deprecated
+    default Integer getCorrectionCommentStatus() {
+        return getProcess().getCorrectionCommentStatus();
+    }
 
     /**
      * Sets the status of the task regarding necessary corrections. Must be a
@@ -579,7 +606,10 @@ public interface TaskInterface extends DataInterface {
      * @param status
      *            the status regarding corrections
      * @see org.kitodo.data.database.enums.CorrectionComments
+     * @throws UnsupportedOperationException
+     *             if setting is not supported
      */
-    void setCorrectionCommentStatus(Integer status);
-
+    default void setCorrectionCommentStatus(Integer status) {
+        throw new UnsupportedOperationException("not supported");
+    }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
@@ -11,7 +11,6 @@
 
 package org.kitodo.data.interfaces;
 
-import java.io.InputStream;
 import java.util.List;
 
 public interface TemplateInterface extends DataInterface {
@@ -94,15 +93,6 @@ public interface TemplateInterface extends DataInterface {
      *            the task list
      */
     void setTasks(List<? extends TaskInterface> tasks);
-
-    /**
-     * Returns a read handle for the SVG image of this production template's
-     * workflow. If the file cannot be read (due to an error), returns an empty
-     * input stream.
-     *
-     * @return read file handle for the SVG
-     */
-    InputStream getDiagramImage();
 
     /**
      * Returns whether this production template is active. Production templates

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
@@ -11,7 +11,11 @@
 
 package org.kitodo.data.interfaces;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 public interface TemplateInterface extends DataInterface {
 
@@ -31,19 +35,52 @@ public interface TemplateInterface extends DataInterface {
     void setTitle(String title);
 
     /**
-     * Returns the day the process template was created.
+     * Returns the time the process template was created. The string is
+     * formatted according to
+     * {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
-     * @return the day the process template was created
+     * @return the creation time
+     * @deprecated Use {@link #getCreationDate()}.
      */
-    String getCreationDate();
+    @Deprecated
+    default String getCreationTime() {
+        Date creationDate = getCreationDate();
+        return Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+    }
 
     /**
-     * Sets the day of process template creation.
+     * Returns the time the process template was created. {@link Date} is a
+     * specific instant in time, with millisecond precision.
+     *
+     * @return the creation time
+     */
+    Date getCreationDate();
+
+    /**
+     * Sets the time the process template was created. The string must be
+     * parsable with {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
      *
      * @param creationDate
-     *            the day of process template creation
+     *            creation time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     * @deprecated Use {@link #setCreationDate(Date)}.
      */
-    void setCreationDate(String creationDate);
+    @Deprecated
+    default void setCreationTime(String creationDate) throws ParseException {
+        setCreationDate(Objects.nonNull(creationDate) ? DATE_FORMAT.parse(creationDate) : null);
+    }
+
+    /**
+     * Sets the time the process template was created. The string must be
+     * parsable with {@link SimpleDateFormat}{@code ("yyyy-MM-dd HH:mm:ss")}.
+     *
+     * @param creationDate
+     *            creation time to set
+     * @throws ParseException
+     *             if the time cannot be converted
+     */
+    void setCreationDate(Date creationDate);
 
     /**
      * Returns the docket generation statement to use when creating dockets for

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
@@ -85,7 +85,7 @@ public interface TemplateInterface extends DataInterface {
      *
      * @return the task list
      */
-    List<TaskInterface> getTasks();
+    List<? extends TaskInterface> getTasks();
 
     /**
      * Sets the task list of this process template.
@@ -93,7 +93,7 @@ public interface TemplateInterface extends DataInterface {
      * @param tasks
      *            the task list
      */
-    void setTasks(List<TaskInterface> tasks);
+    void setTasks(List<? extends TaskInterface> tasks);
 
     /**
      * Returns a read handle for the SVG image of this production template's
@@ -169,7 +169,7 @@ public interface TemplateInterface extends DataInterface {
      *
      * @return the list of all projects that use this production template
      */
-    List<ProjectInterface> getProjects();
+    List<? extends ProjectInterface> getProjects();
 
     /**
      * Sets the list of all projects that use this production template. The list
@@ -178,5 +178,5 @@ public interface TemplateInterface extends DataInterface {
      * @param projects
      *            projects list to set
      */
-    void setProjects(List<ProjectInterface> projects);
+    void setProjects(List<? extends ProjectInterface> projects);
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
@@ -1,0 +1,182 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.io.InputStream;
+import java.util.List;
+
+public interface TemplateInterface extends DataInterface {
+
+    /**
+     * Returns the process template name.
+     *
+     * @return the process template name
+     */
+    String getTitle();
+
+    /**
+     * Sets the process template name.
+     *
+     * @param title
+     *            the process template name
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the day the process template was created.
+     *
+     * @return the day the process template was created
+     */
+    String getCreationDate();
+
+    /**
+     * Sets the day of process template creation.
+     *
+     * @param creationDate
+     *            the day of process template creation
+     */
+    void setCreationDate(String creationDate);
+
+    /**
+     * Returns the docket generation statement to use when creating dockets for
+     * processes derived from this process template.
+     *
+     * @return the docket generation statement
+     */
+    DocketInterface getDocket();
+
+    /**
+     * Sets the docket generation statement to use when creating dockets for
+     * processes derived from this process template.
+     *
+     * @param docket
+     *            the docket generation statement
+     */
+    void setDocket(DocketInterface docket);
+
+    /**
+     * Returns the business domain specification processes derived from this
+     * process template template shall be using.
+     *
+     * @return the business domain specification
+     */
+    RulesetInterface getRuleset();
+
+    /**
+     * Sets the business domain specification processes derived from this
+     * process template template shall be using.
+     *
+     * @param ruleset
+     *            the business domain specification
+     */
+    void setRuleset(RulesetInterface ruleset);
+
+    /**
+     * Returns the task list of this process template.
+     *
+     * @return the task list
+     */
+    List<TaskInterface> getTasks();
+
+    /**
+     * Sets the task list of this process template.
+     *
+     * @param tasks
+     *            the task list
+     */
+    void setTasks(List<TaskInterface> tasks);
+
+    /**
+     * Returns a read handle for the SVG image of this production template's
+     * workflow. If the file cannot be read (due to an error), returns an empty
+     * input stream.
+     *
+     * @return read file handle for the SVG
+     */
+    InputStream getDiagramImage();
+
+    /**
+     * Returns whether this production template is active. Production templates
+     * that are no not to be used (anymore) can be deactivated. If processes
+     * exist from them, they cannot be deleted.
+     *
+     * @return whether this production template is active
+     */
+    boolean isActive();
+
+    /**
+     * Sets whether this production template is active.
+     *
+     * @param active
+     *            whether this production template is active
+     */
+    void setActive(boolean active);
+
+    /**
+     * Sets the workflow from which the production template was created.
+     *
+     * @param workflow
+     *            workflow to set
+     */
+    void setWorkflow(WorkflowInterface workflow);
+
+    /**
+     * Returns the workflow from which the production template was created. The
+     * tasks of the production template are not created directly in the
+     * production template, but are edited using the workflow.
+     *
+     * @return the workflow
+     */
+    WorkflowInterface getWorkflow();
+
+    /**
+     * Returns whether the production template is valid. To do this, it must
+     * contain at least one task and each task must have at least one role
+     * assigned to it.
+     *
+     * @return whether the production template is valid
+     */
+    boolean isCanBeUsedForProcess();
+
+    /**
+     * Sets whether the production template is valid. The setter can be used
+     * when representing data from a third-party source. Internally it depends
+     * on whether the production template is valid. Setting this to true cannot
+     * fix errors.
+     *
+     * @param canBeUsedForProcess
+     *            as boolean
+     * @throws UnsupportedOperationException
+     *             when trying to set this on the database
+     */
+    default void setCanBeUsedForProcess(boolean canBeUsedForProcess) {
+        throw new UnsupportedOperationException("not allowed");
+    }
+
+    /**
+     * Returns the list of all projects that use this production template. A
+     * production template can be used in multiple projects, even across
+     * multiple clients. This list is not guaranteed to be in reliable order.
+     *
+     * @return the list of all projects that use this production template
+     */
+    List<ProjectInterface> getProjects();
+
+    /**
+     * Sets the list of all projects that use this production template. The list
+     * should not contain duplicates, and must not contain {@code null}s.
+     *
+     * @param projects
+     *            projects list to set
+     */
+    void setProjects(List<ProjectInterface> projects);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
@@ -100,16 +100,16 @@ public interface TemplateInterface extends DataInterface {
     void setDocket(DocketInterface docket);
 
     /**
-     * Returns the business domain specification processes derived from this
-     * process template template shall be using.
+     * Returns the business domain specification derived from this process
+     * template template shall be using.
      *
      * @return the business domain specification
      */
     RulesetInterface getRuleset();
 
     /**
-     * Sets the business domain specification processes derived from this
-     * process template template shall be using.
+     * Sets the business domain specification derived from this process template
+     * template shall be using.
      *
      * @param ruleset
      *            the business domain specification

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
@@ -45,7 +45,7 @@ public interface TemplateInterface extends DataInterface {
     @Deprecated
     default String getCreationTime() {
         Date creationDate = getCreationDate();
-        return Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+        return Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).format(creationDate) : null;
     }
 
     /**
@@ -68,7 +68,7 @@ public interface TemplateInterface extends DataInterface {
      */
     @Deprecated
     default void setCreationTime(String creationDate) throws ParseException {
-        setCreationDate(Objects.nonNull(creationDate) ? DATE_FORMAT.parse(creationDate) : null);
+        setCreationDate(Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).parse(creationDate) : null);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/TemplateInterface.java
@@ -157,7 +157,9 @@ public interface TemplateInterface extends DataInterface {
      *            as boolean
      * @throws UnsupportedOperationException
      *             when trying to set this on the database
+     * @deprecated Avoid creating invalid production templates.
      */
+    @Deprecated
     default void setCanBeUsedForProcess(boolean canBeUsedForProcess) {
         throw new UnsupportedOperationException("not allowed");
     }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
@@ -155,7 +155,7 @@ public interface UserInterface extends DataInterface {
      *
      * @return the saved search queries
      */
-    List<FilterInterface> getFilters();
+    List<? extends FilterInterface> getFilters();
 
     /**
      * Sets a list of the user's saved searches. The list should not contain
@@ -164,7 +164,7 @@ public interface UserInterface extends DataInterface {
      * @param filters
      *            list of saved search queries to set
      */
-    void setFilters(List<FilterInterface> filters);
+    void setFilters(List<? extends FilterInterface> filters);
 
     /**
      * Returns the number of saved search queries.
@@ -172,7 +172,7 @@ public interface UserInterface extends DataInterface {
      * @return the number of saved search queries
      */
     default Integer getFiltersSize() {
-        List<FilterInterface> queries = getFilters();
+        List<? extends FilterInterface> queries = getFilters();
         return Objects.nonNull(queries) ? queries.size() : null;
     }
 
@@ -194,7 +194,7 @@ public interface UserInterface extends DataInterface {
             setFilters(null);
             return;
         }
-        List<FilterInterface> filters = Optional.of(getFilters()).orElse(Collections.emptyList());
+        List<? extends FilterInterface> filters = Optional.of(getFilters()).orElse(Collections.emptyList());
         if (filtersSize == filters.size()) {
             return;
         }
@@ -210,7 +210,7 @@ public interface UserInterface extends DataInterface {
      *
      * @return a list of all roles of the user
      */
-    List<RoleInterface> getRoles();
+    List<? extends RoleInterface> getRoles();
 
     /**
      * Sets a list of all of the user's roles.
@@ -218,7 +218,7 @@ public interface UserInterface extends DataInterface {
      * @param roles
      *            list to set
      */
-    void setRoles(List<RoleInterface> roles);
+    void setRoles(List<? extends RoleInterface> roles);
 
     /**
      * Returns the number of roles the user has.
@@ -226,7 +226,7 @@ public interface UserInterface extends DataInterface {
      * @return the number of roles
      */
     default int getRolesSize() {
-        List<RoleInterface> roles = getRoles();
+        List<? extends RoleInterface> roles = getRoles();
         return Objects.nonNull(roles) ? roles.size() : 0;
     }
 
@@ -245,7 +245,7 @@ public interface UserInterface extends DataInterface {
      */
     default void setRolesSize(Integer rolesSize) {
         int newSize = Objects.nonNull(rolesSize) ? rolesSize : 0;
-        List<RoleInterface> users = Optional.of(getRoles()).orElse(Collections.emptyList());
+        List<? extends RoleInterface> users = Optional.of(getRoles()).orElse(Collections.emptyList());
         int currentSize = users.size();
         if (newSize == currentSize) {
             return;
@@ -261,7 +261,7 @@ public interface UserInterface extends DataInterface {
      *
      * @return the clients
      */
-    List<ClientInterface> getClients();
+    List<? extends ClientInterface> getClients();
 
     /**
      * Sets the list of all clients that the user interacts with.
@@ -269,7 +269,7 @@ public interface UserInterface extends DataInterface {
      * @param clients
      *            clients to set
      */
-    void setClients(List<ClientInterface> clients);
+    void setClients(List<? extends ClientInterface> clients);
 
     /**
      * Returns the number of clients the user interacts with.
@@ -277,7 +277,7 @@ public interface UserInterface extends DataInterface {
      * @return the number of clients
      */
     default int getClientsSize() {
-        List<ClientInterface> clients = getClients();
+        List<? extends ClientInterface> clients = getClients();
         return Objects.nonNull(clients) ? clients.size() : 0;
     }
 
@@ -296,7 +296,7 @@ public interface UserInterface extends DataInterface {
      */
     default void setClientsSize(Integer clientsSize) {
         int newSize = Objects.nonNull(clientsSize) ? clientsSize : 0;
-        List<ClientInterface> users = Optional.of(getClients()).orElse(Collections.emptyList());
+        List<? extends ClientInterface> users = Optional.of(getClients()).orElse(Collections.emptyList());
         int currentSize = users.size();
         if (newSize == currentSize) {
             return;
@@ -312,7 +312,7 @@ public interface UserInterface extends DataInterface {
      *
      * @return all projects
      */
-    List<ProjectInterface> getProjects();
+    List<? extends ProjectInterface> getProjects();
 
     /**
      * Sets the list of all projects the user is working on.
@@ -320,7 +320,7 @@ public interface UserInterface extends DataInterface {
      * @param projects
      *            list of projects to set
      */
-    void setProjects(List<ProjectInterface> projects);
+    void setProjects(List<? extends ProjectInterface> projects);
 
     /**
      * Returns the number of projects the user is working on.
@@ -328,7 +328,7 @@ public interface UserInterface extends DataInterface {
      * @return the number of projects
      */
     default int getProjectsSize() {
-        List<ProjectInterface> projects = getProjects();
+        List<? extends ProjectInterface> projects = getProjects();
         return Objects.nonNull(projects) ? projects.size() : 0;
     }
 
@@ -347,7 +347,7 @@ public interface UserInterface extends DataInterface {
      */
     default void setProjectsSize(Integer projectsSize) {
         int newSize = Objects.nonNull(projectsSize) ? projectsSize : 0;
-        List<ProjectInterface> users = Optional.of(getProjects()).orElse(Collections.emptyList());
+        List<? extends ProjectInterface> users = Optional.of(getProjects()).orElse(Collections.emptyList());
         int currentSize = users.size();
         if (newSize == currentSize) {
             return;
@@ -363,7 +363,7 @@ public interface UserInterface extends DataInterface {
      *
      * @return all tasks the user is working on
      */
-    List<TaskInterface> getProcessingTasks();
+    List<? extends TaskInterface> getProcessingTasks();
 
     /**
      * Sets a list of all tasks that the user should work on.
@@ -371,5 +371,5 @@ public interface UserInterface extends DataInterface {
      * @param processingTasks
      *            list of tasks to set
      */
-    void setProcessingTasks(List<TaskInterface> processingTasks);
+    void setProcessingTasks(List<? extends TaskInterface> processingTasks);
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
@@ -83,7 +83,16 @@ public interface UserInterface extends DataInterface {
      * @param fullName
      *            full name to set
      */
-    void setFullName(String fullName);
+    default void setFullName(String fullName) {
+        if (Objects.isNull(fullName)) {
+            setName(null);
+            setSurname(null);
+        } else {
+            String[] parts = fullName.split(", ", 2);
+            setName((parts.length == 2) ? parts[1] : "");
+            setSurname(parts[0]);
+        }
+    }
 
     /**
      * Returns the user's location. Users from different locations collaborate
@@ -186,7 +195,7 @@ public interface UserInterface extends DataInterface {
      * whether there are filter objects in the database linked to the user. No
      * additional filters can be added to the process here.
      *
-     * @param size
+     * @param filtersSize
      *            how many users hold this role to set
      * @throws UnsupportedOperationException
      *             when trying to add unspecified filters to this user
@@ -244,7 +253,7 @@ public interface UserInterface extends DataInterface {
      * whether there are role objects in the database linked to the user. No
      * additional roles can be added to the user here.
      *
-     * @param size
+     * @param rolesSize
      *            number of roles to set
      * @throws SecurityException
      *             when trying to assign unspecified roles to this user
@@ -299,8 +308,8 @@ public interface UserInterface extends DataInterface {
      * whether there are role objects in the database linked to the user. No
      * additional roles can be added to the user here.
      *
-     * @param size
-     *            number of roles to set
+     * @param clientsSize
+     *            number of clients to set
      * @throws SecurityException
      *             when trying to assign unspecified roles to this user
      * @throws IndexOutOfBoundsException
@@ -354,8 +363,8 @@ public interface UserInterface extends DataInterface {
      * whether there are role objects in the database linked to the user. No
      * additional roles can be added to the user here.
      *
-     * @param size
-     *            number of roles to set
+     * @param projectsSize
+     *            number of projects to set
      * @throws UnsupportedOperationException
      *             when trying to assign unspecified projects to this user
      * @throws IndexOutOfBoundsException

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
@@ -142,7 +142,9 @@ public interface UserInterface extends DataInterface {
      *            as boolean
      * @throws UnsupportedOperationException
      *             when trying to change this
+     * @deprecated Use servlet container user control.
      */
+    @Deprecated
     default void setActive(boolean active) {
         if (active != isActive()) {
             throw new UnsupportedOperationException(active ? "cannot log user in" : "cannot log user out");
@@ -170,7 +172,9 @@ public interface UserInterface extends DataInterface {
      * Returns the number of saved search queries.
      *
      * @return the number of saved search queries
+     * @deprecated Use {@link #getFilters()}{@code .size()}.
      */
+    @Deprecated
     default Integer getFiltersSize() {
         List<? extends FilterInterface> queries = getFilters();
         return Objects.nonNull(queries) ? queries.size() : null;
@@ -188,7 +192,9 @@ public interface UserInterface extends DataInterface {
      *             when trying to add unspecified filters to this user
      * @throws IndexOutOfBoundsException
      *             for an illegal endpoint index value
+     * @deprecated {@link #getFilters()} and edit them consciously.
      */
+    @Deprecated
     default void setFiltersSize(Integer filtersSize) {
         if (Objects.isNull(filtersSize)) {
             setFilters(null);
@@ -224,7 +230,9 @@ public interface UserInterface extends DataInterface {
      * Returns the number of roles the user has.
      *
      * @return the number of roles
+     * @deprecated Use {@link #getRoles()}{@code .size()}.
      */
+    @Deprecated
     default int getRolesSize() {
         List<? extends RoleInterface> roles = getRoles();
         return Objects.nonNull(roles) ? roles.size() : 0;
@@ -242,7 +250,9 @@ public interface UserInterface extends DataInterface {
      *             when trying to assign unspecified roles to this user
      * @throws IndexOutOfBoundsException
      *             for an illegal endpoint index value
+     * @deprecated {@link #getRoles()} and edit them consciously.
      */
+    @Deprecated
     default void setRolesSize(Integer rolesSize) {
         int newSize = Objects.nonNull(rolesSize) ? rolesSize : 0;
         List<? extends RoleInterface> users = Optional.of(getRoles()).orElse(Collections.emptyList());
@@ -275,7 +285,9 @@ public interface UserInterface extends DataInterface {
      * Returns the number of clients the user interacts with.
      *
      * @return the number of clients
+     * @deprecated Use {@link #getClients()}{@code .size()}.
      */
+    @Deprecated
     default int getClientsSize() {
         List<? extends ClientInterface> clients = getClients();
         return Objects.nonNull(clients) ? clients.size() : 0;
@@ -293,7 +305,9 @@ public interface UserInterface extends DataInterface {
      *             when trying to assign unspecified roles to this user
      * @throws IndexOutOfBoundsException
      *             for an illegal endpoint index value
+     * @deprecated {@link #getClients()} and edit them consciously.
      */
+    @Deprecated
     default void setClientsSize(Integer clientsSize) {
         int newSize = Objects.nonNull(clientsSize) ? clientsSize : 0;
         List<? extends ClientInterface> users = Optional.of(getClients()).orElse(Collections.emptyList());
@@ -326,7 +340,9 @@ public interface UserInterface extends DataInterface {
      * Returns the number of projects the user is working on.
      *
      * @return the number of projects
+     * @deprecated Use {@link #getProjects()}{@code .size()}.
      */
+    @Deprecated
     default int getProjectsSize() {
         List<? extends ProjectInterface> projects = getProjects();
         return Objects.nonNull(projects) ? projects.size() : 0;
@@ -344,7 +360,9 @@ public interface UserInterface extends DataInterface {
      *             when trying to assign unspecified projects to this user
      * @throws IndexOutOfBoundsException
      *             for an illegal endpoint index value
+     * @deprecated {@link #getProjects()} and edit them consciously.
      */
+    @Deprecated
     default void setProjectsSize(Integer projectsSize) {
         int newSize = Objects.nonNull(projectsSize) ? projectsSize : 0;
         List<? extends ProjectInterface> users = Optional.of(getProjects()).orElse(Collections.emptyList());

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/UserInterface.java
@@ -1,0 +1,375 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An interface for editing users of the web application.
+ */
+public interface UserInterface extends DataInterface {
+
+    /**
+     * Returns the user's login name.
+     *
+     * @return the user name
+     */
+    String getLogin();
+
+    /**
+     * Sets the user's login name. Since the user is also created as a Linux
+     * system user, the user name should follow the naming conventions and not
+     * match any existing Linux user. To avoid hassle when accessing file space
+     * using case-insensitive CIFS, it is recommended to only use lowercase
+     * letters in the name.
+     *
+     * @param login
+     *            user name to set
+     */
+    void setLogin(String login);
+
+    /**
+     * Returns the user's first name.
+     *
+     * @return the first name
+     */
+    String getName();
+
+    /**
+     * Sets the user's first name.
+     *
+     * @param name
+     *            first name to set
+     */
+    void setName(String name);
+
+    /**
+     * Returns the user's surname.
+     *
+     * @return the surname
+     */
+    String getSurname();
+
+    /**
+     * Sets the user's surname.
+     *
+     * @param surname
+     *            surname to set
+     */
+    void setSurname(String surname);
+
+    /**
+     * Returns the user's full name. The spelling is last name—comma—first name.
+     *
+     * @return the full name
+     */
+    String getFullName();
+
+    /**
+     * Sets the user's full name.
+     *
+     * @param fullName
+     *            full name to set
+     */
+    void setFullName(String fullName);
+
+    /**
+     * Returns the user's location. Users from different locations collaborate
+     * in this web application. Specifying the location simplifies user
+     * maintenance.
+     *
+     * @return the location
+     */
+    String getLocation();
+
+    /**
+     * Sets the user's location.
+     *
+     * @param location
+     *            place name
+     */
+    void setLocation(String location);
+
+    /**
+     * Returns the login name to the directory service. This provides the
+     * ability to use a username independent of the Linux username to
+     * authenticate against a corporate directory service. For logging into the
+     * web application, the user can use either username.
+     *
+     * @return different user name for the directory service
+     */
+    String getLdapLogin();
+
+    /**
+     * Sets a different user name for the directory service. The emphasis here
+     * is on "different", the remote username must not be the same as <i>any</i>
+     * primary username. Multiple local users cannot be mapped to the same
+     * remote username either.
+     *
+     * @param ldapLogin
+     *            different user name to set
+     */
+    void setLdapLogin(String ldapLogin);
+
+    /**
+     * Returns whether the user is logged in. This allows a administrators to
+     * check whether they can stop the application for maintenance purposes, or
+     * who they needs to call first.
+     *
+     * @return whether the user is logged in
+     */
+    boolean isActive();
+
+    /**
+     * Sets whether the user is logged in. The setter can be used when
+     * representing data from a third-party source. Internally, this depends on
+     * the existence of a user session in the servlet container. This cannot be
+     * changed here.
+     *
+     * @param active
+     *            as boolean
+     * @throws UnsupportedOperationException
+     *             when trying to change this
+     */
+    default void setActive(boolean active) {
+        if (active != isActive()) {
+            throw new UnsupportedOperationException(active ? "cannot log user in" : "cannot log user out");
+        }
+    }
+
+    /**
+     * Returns the user's saved search queries. This list is not guaranteed to
+     * be in reliable order.
+     *
+     * @return the saved search queries
+     */
+    List<FilterInterface> getFilters();
+
+    /**
+     * Sets a list of the user's saved searches. The list should not contain
+     * duplicates, and must not contain {@code null}s.
+     *
+     * @param filters
+     *            list of saved search queries to set
+     */
+    void setFilters(List<FilterInterface> filters);
+
+    /**
+     * Returns the number of saved search queries.
+     *
+     * @return the number of saved search queries
+     */
+    default Integer getFiltersSize() {
+        List<FilterInterface> queries = getFilters();
+        return Objects.nonNull(queries) ? queries.size() : null;
+    }
+
+    /**
+     * Sets the number of saved search queries. The setter can be used when
+     * representing data from a third-party source. Internally it depends on,
+     * whether there are filter objects in the database linked to the user. No
+     * additional filters can be added to the process here.
+     *
+     * @param size
+     *            how many users hold this role to set
+     * @throws UnsupportedOperationException
+     *             when trying to add unspecified filters to this user
+     * @throws IndexOutOfBoundsException
+     *             for an illegal endpoint index value
+     */
+    default void setFiltersSize(Integer filtersSize) {
+        if (Objects.isNull(filtersSize)) {
+            setFilters(null);
+            return;
+        }
+        List<FilterInterface> filters = Optional.of(getFilters()).orElse(Collections.emptyList());
+        if (filtersSize == filters.size()) {
+            return;
+        }
+        while (filtersSize > filters.size()) {
+            throw new UnsupportedOperationException("cannot add arbitrary filters");
+        }
+        setFilters(filters.subList(0, filtersSize));
+    }
+
+    /**
+     * Returns all of the user's roles. This list is not guaranteed to be in
+     * reliable order.
+     *
+     * @return a list of all roles of the user
+     */
+    List<RoleInterface> getRoles();
+
+    /**
+     * Sets a list of all of the user's roles.
+     *
+     * @param roles
+     *            list to set
+     */
+    void setRoles(List<RoleInterface> roles);
+
+    /**
+     * Returns the number of roles the user has.
+     *
+     * @return the number of roles
+     */
+    default int getRolesSize() {
+        List<RoleInterface> roles = getRoles();
+        return Objects.nonNull(roles) ? roles.size() : 0;
+    }
+
+    /**
+     * Sets the number of roles the user has. The setter can be used when
+     * representing data from a third-party source. Internally it depends on,
+     * whether there are role objects in the database linked to the user. No
+     * additional roles can be added to the user here.
+     *
+     * @param size
+     *            number of roles to set
+     * @throws SecurityException
+     *             when trying to assign unspecified roles to this user
+     * @throws IndexOutOfBoundsException
+     *             for an illegal endpoint index value
+     */
+    default void setRolesSize(Integer rolesSize) {
+        int newSize = Objects.nonNull(rolesSize) ? rolesSize : 0;
+        List<RoleInterface> users = Optional.of(getRoles()).orElse(Collections.emptyList());
+        int currentSize = users.size();
+        if (newSize == currentSize) {
+            return;
+        }
+        if (newSize > currentSize) {
+            throw new SecurityException("cannot add arbitrary roles");
+        }
+        setRoles(users.subList(0, newSize));
+    }
+
+    /**
+     * Returns all clients the user interacts with.
+     *
+     * @return the clients
+     */
+    List<ClientInterface> getClients();
+
+    /**
+     * Sets the list of all clients that the user interacts with.
+     *
+     * @param clients
+     *            clients to set
+     */
+    void setClients(List<ClientInterface> clients);
+
+    /**
+     * Returns the number of clients the user interacts with.
+     *
+     * @return the number of clients
+     */
+    default int getClientsSize() {
+        List<ClientInterface> clients = getClients();
+        return Objects.nonNull(clients) ? clients.size() : 0;
+    }
+
+    /**
+     * Sets the number of roles the user has. The setter can be used when
+     * representing data from a third-party source. Internally it depends on,
+     * whether there are role objects in the database linked to the user. No
+     * additional roles can be added to the user here.
+     *
+     * @param size
+     *            number of roles to set
+     * @throws SecurityException
+     *             when trying to assign unspecified roles to this user
+     * @throws IndexOutOfBoundsException
+     *             for an illegal endpoint index value
+     */
+    default void setClientsSize(Integer clientsSize) {
+        int newSize = Objects.nonNull(clientsSize) ? clientsSize : 0;
+        List<ClientInterface> users = Optional.of(getClients()).orElse(Collections.emptyList());
+        int currentSize = users.size();
+        if (newSize == currentSize) {
+            return;
+        }
+        if (newSize > currentSize) {
+            throw new SecurityException("cannot add arbitrary clients");
+        }
+        setClients(users.subList(0, newSize));
+    }
+
+    /**
+     * Returns all projects the user collaborates on.
+     *
+     * @return all projects
+     */
+    List<ProjectInterface> getProjects();
+
+    /**
+     * Sets the list of all projects the user is working on.
+     *
+     * @param projects
+     *            list of projects to set
+     */
+    void setProjects(List<ProjectInterface> projects);
+
+    /**
+     * Returns the number of projects the user is working on.
+     *
+     * @return the number of projects
+     */
+    default int getProjectsSize() {
+        List<ProjectInterface> projects = getProjects();
+        return Objects.nonNull(projects) ? projects.size() : 0;
+    }
+
+    /**
+     * Sets the number of roles the user has. The setter can be used when
+     * representing data from a third-party source. Internally it depends on,
+     * whether there are role objects in the database linked to the user. No
+     * additional roles can be added to the user here.
+     *
+     * @param size
+     *            number of roles to set
+     * @throws UnsupportedOperationException
+     *             when trying to assign unspecified projects to this user
+     * @throws IndexOutOfBoundsException
+     *             for an illegal endpoint index value
+     */
+    default void setProjectsSize(Integer projectsSize) {
+        int newSize = Objects.nonNull(projectsSize) ? projectsSize : 0;
+        List<ProjectInterface> users = Optional.of(getProjects()).orElse(Collections.emptyList());
+        int currentSize = users.size();
+        if (newSize == currentSize) {
+            return;
+        }
+        if (newSize > currentSize) {
+            throw new UnsupportedOperationException("cannot add arbitrary projects");
+        }
+        setProjects(users.subList(0, newSize));
+    }
+
+    /**
+     * Returns all tasks the user is currently working on.
+     *
+     * @return all tasks the user is working on
+     */
+    List<TaskInterface> getProcessingTasks();
+
+    /**
+     * Sets a list of all tasks that the user should work on.
+     *
+     * @param processingTasks
+     *            list of tasks to set
+     */
+    void setProcessingTasks(List<TaskInterface> processingTasks);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
@@ -11,6 +11,9 @@
 
 package org.kitodo.data.interfaces;
 
+import java.util.Objects;
+
+import org.apache.logging.log4j.util.Strings;
 import org.kitodo.data.database.enums.WorkflowStatus;
 
 public interface WorkflowInterface extends DataInterface {
@@ -43,8 +46,29 @@ public interface WorkflowInterface extends DataInterface {
      * </dl>
      *
      * @return the stage
+     * @deprecated Use {@link #getStatus()}.
      */
-    String getStatus();
+    @Deprecated
+    default String getWorkflowStatus() {
+        WorkflowStatus status = getStatus();
+        return Objects.nonNull(status) ? status.toString() : "";
+    }
+
+    /**
+     * Returns the stage of the workflow. Statuses:
+     *
+     * <dl>
+     * <dt>DRAFT</dt>
+     * <dd>the workflow is being created</dd>
+     * <dt>ACTIVE</dt>
+     * <dd>the workflow is in use</dd>
+     * <dt>ARCHIVED</dt>
+     * <dd>the workflow is no longer used</dd>
+     * </dl>
+     *
+     * @return the stage
+     */
+    WorkflowStatus getStatus();
 
     /**
      * Sets the stage of the workflow. One of {@link WorkflowStatus}.
@@ -54,6 +78,18 @@ public interface WorkflowInterface extends DataInterface {
      * @throws IllegalArgumentException
      *             if {@link WorkflowStatus} has no constant with the specified
      *             name
+     * @deprecated Use {@link #setStatus(WorkflowStatus)}.
      */
-    void setStatus(String status);
+    @Deprecated
+    default void setWorkflowStatus(String status) {
+        setStatus(Strings.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null);
+    }
+
+    /**
+     * Sets the stage of the workflow.
+     *
+     * @param status
+     *            as String
+     */
+    void setStatus(WorkflowStatus status);
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.data.interfaces;
+
+import org.kitodo.data.database.enums.WorkflowStatus;
+
+public interface WorkflowInterface extends DataInterface {
+
+    /**
+     * Returns the label of the workflow.
+     *
+     * @return the label
+     */
+    String getTitle();
+
+    /**
+     * Sets the label of the workflow.
+     *
+     * @param title
+     *            label to set
+     */
+    void setTitle(String title);
+
+    /**
+     * Returns the stage of the workflow. Statuses:
+     *
+     * <dl>
+     * <dt>DRAFT</dt>
+     * <dd>the workflow is being created</dd>
+     * <dt>ACTIVE</dt>
+     * <dd>the workflow is in use</dd>
+     * <dt>ARCHIVED</dt>
+     * <dd>the workflow is no longer used</dd>
+     * </dl>
+     *
+     * @return the stage
+     */
+    String getStatus();
+
+    /**
+     * Sets the stage of the workflow. One of {@link WorkflowStatus}.
+     *
+     * @param status
+     *            as String
+     * @throws IllegalArgumentException
+     *             if {@link WorkflowStatus} has no constant with the specified
+     *             name
+     */
+    void setStatus(String status);
+}

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
@@ -13,7 +13,7 @@ package org.kitodo.data.interfaces;
 
 import java.util.Objects;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.data.database.enums.WorkflowStatus;
 
 public interface WorkflowInterface extends DataInterface {
@@ -82,7 +82,7 @@ public interface WorkflowInterface extends DataInterface {
      */
     @Deprecated
     default void setWorkflowStatus(String status) {
-        setStatus(Strings.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null);
+        setStatus(StringUtils.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/WorkflowInterface.java
@@ -82,7 +82,7 @@ public interface WorkflowInterface extends DataInterface {
      */
     @Deprecated
     default void setWorkflowStatus(String status) {
-        setStatus(StringUtils.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null);
+        setStatus(StringUtils.isNotBlank(status) ? WorkflowStatus.valueOf(status) : null);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/package-info.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/interfaces/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+/**
+ * Provides an interface for some particularly central data objects of the
+ * application. Data objects from the database or third-party sources can be
+ * used agnostically in the implementation via the interface. These are:
+ * <ul>
+ * <li>for access management: users ({@link UserInterface}) with roles
+ * ({@link RoleInterface}) who work for clients ({@link ClientInterface})
+ * <li>for project management: business domain configurations
+ * ({@link RulesetInterface}), workflows ({@link WorkflowInterface}), production
+ * templates ({@link TemplateInterface}) and runnotes ({@link DocketInterface})
+ * <li>for operations: processes ({@link ProcessInterface}) with properties
+ * ({@link PropertyInterface}), with their tasks ({@link TaskInterface}), in
+ * batches ({@link BatchInterface})
+ * </ul>
+ * The interface objects are based on the common interface
+ * {@link DataInterface}. The factory methods are provided by the
+ * {@link DataFactoryInterface}.
+ */
+package org.kitodo.data.interfaces;

--- a/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/IllustratedSelectItemConverter.java
@@ -30,7 +30,7 @@ public class IllustratedSelectItemConverter implements Converter, Serializable {
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (StringUtils.isNotEmpty(value)) {
+        if (StringUtils.isNotBlank(value)) {
             List<IllustratedSelectItem> illustratedSelectItems = (List<IllustratedSelectItem>) component.getAttributes()
                     .get("illustratedSelectItems");
             for (IllustratedSelectItem illustratedSelectItem : illustratedSelectItems) {

--- a/Kitodo/src/main/java/org/kitodo/production/converter/OcrdWorkflowConverter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/converter/OcrdWorkflowConverter.java
@@ -28,7 +28,7 @@ public class OcrdWorkflowConverter extends BeanConverter implements Converter<Ob
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (StringUtils.isNotEmpty(value)) {
+        if (StringUtils.isNotBlank(value)) {
             return ServiceManager.getOcrdWorkflowService().getOcrdWorkflow(value);
         }
         return null;

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseDTO.java
@@ -13,7 +13,9 @@ package org.kitodo.production.dto;
 
 import java.io.Serializable;
 
-public abstract class BaseDTO implements Serializable {
+import org.kitodo.data.interfaces.DataInterface;
+
+public abstract class BaseDTO implements Serializable, DataInterface {
 
     private Integer id;
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.dto;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -132,7 +133,8 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      */
     public Date getCreationDate() {
         try {
-            return Strings.isNotEmpty(this.creationDate) ? DATE_FORMAT.parse(this.creationDate) : null;
+            return Strings.isNotEmpty(this.creationDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
+                    : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -145,6 +147,7 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      *            as Date
      */
     public void setCreationDate(Date creationDate) {
-        this.creationDate = Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+        this.creationDate = Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).format(creationDate)
+                : null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
@@ -24,7 +24,7 @@ public abstract class BaseTemplateDTO extends BaseDTO {
     private String creationDate;
     private DocketInterface docket;
     private RulesetInterface ruleset;
-    private List<TaskInterface> tasks = new ArrayList<>();
+    private List<? extends TaskInterface> tasks = new ArrayList<>();
 
     /**
      * Get title.
@@ -107,7 +107,7 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      *
      * @return list of tasks as TaskInterface
      */
-    public List<TaskInterface> getTasks() {
+    public List<? extends TaskInterface> getTasks() {
         return tasks;
     }
 
@@ -117,7 +117,7 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      * @param tasks
      *            list of tasks as TaskInterface
      */
-    public void setTasks(List<TaskInterface> tasks) {
+    public void setTasks(List<? extends TaskInterface> tasks) {
         this.tasks = tasks;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
@@ -125,6 +125,11 @@ public abstract class BaseTemplateDTO extends BaseDTO {
         this.tasks = tasks;
     }
 
+    /**
+     * Get creation date.
+     *
+     * @return creation date as Date
+     */
     public Date getCreationDate() {
         try {
             return Strings.isNotEmpty(this.creationDate) ? DATE_FORMAT.parse(this.creationDate) : null;
@@ -133,6 +138,12 @@ public abstract class BaseTemplateDTO extends BaseDTO {
         }
     }
 
+    /**
+     * Set creation date.
+     *
+     * @param creationDate
+     *            as Date
+     */
     public void setCreationDate(Date creationDate) {
         this.creationDate = Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
@@ -11,9 +11,13 @@
 
 package org.kitodo.production.dto;
 
+import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
+import org.apache.logging.log4j.util.Strings;
 import org.kitodo.data.interfaces.DocketInterface;
 import org.kitodo.data.interfaces.RulesetInterface;
 import org.kitodo.data.interfaces.TaskInterface;
@@ -21,7 +25,7 @@ import org.kitodo.data.interfaces.TaskInterface;
 public abstract class BaseTemplateDTO extends BaseDTO {
 
     private String title;
-    private String creationDate;
+    protected String creationDate;
     private DocketInterface docket;
     private RulesetInterface ruleset;
     private List<? extends TaskInterface> tasks = new ArrayList<>();
@@ -50,7 +54,7 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      *
      * @return creation date as String
      */
-    public String getCreationDate() {
+    public String getCreationTime() {
         return creationDate;
     }
 
@@ -60,7 +64,7 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      * @param creationDate
      *            as String
      */
-    public void setCreationDate(String creationDate) {
+    public void setCreationTime(String creationDate) {
         this.creationDate = creationDate;
     }
 
@@ -119,5 +123,17 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      */
     public void setTasks(List<? extends TaskInterface> tasks) {
         this.tasks = tasks;
+    }
+
+    public Date getCreationDate() {
+        try {
+            return Strings.isNotEmpty(this.creationDate) ? DATE_FORMAT.parse(this.creationDate) : null;
+        } catch (ParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
@@ -18,7 +18,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.data.interfaces.DocketInterface;
 import org.kitodo.data.interfaces.RulesetInterface;
 import org.kitodo.data.interfaces.TaskInterface;
@@ -133,7 +133,8 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      */
     public Date getCreationDate() {
         try {
-            return Strings.isNotEmpty(this.creationDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
+            return StringUtils.isNotEmpty(this.creationDate)
+                    ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
                     : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
@@ -133,7 +133,7 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      */
     public Date getCreationDate() {
         try {
-            return StringUtils.isNotEmpty(this.creationDate)
+            return StringUtils.isNotBlank(this.creationDate)
                     ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
                     : null;
         } catch (ParseException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BaseTemplateDTO.java
@@ -14,13 +14,17 @@ package org.kitodo.production.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kitodo.data.interfaces.DocketInterface;
+import org.kitodo.data.interfaces.RulesetInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+
 public abstract class BaseTemplateDTO extends BaseDTO {
 
     private String title;
     private String creationDate;
-    private DocketDTO docket;
-    private RulesetDTO ruleset;
-    private List<TaskDTO> tasks = new ArrayList<>();
+    private DocketInterface docket;
+    private RulesetInterface ruleset;
+    private List<TaskInterface> tasks = new ArrayList<>();
 
     /**
      * Get title.
@@ -63,9 +67,9 @@ public abstract class BaseTemplateDTO extends BaseDTO {
     /**
      * Get docket.
      *
-     * @return docket as DocketDTO
+     * @return docket as DocketInterface
      */
-    public DocketDTO getDocket() {
+    public DocketInterface getDocket() {
         return docket;
     }
 
@@ -73,18 +77,18 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      * Set docket.
      *
      * @param docket
-     *            as DocketDTO
+     *            as DocketInterface
      */
-    public void setDocket(DocketDTO docket) {
+    public void setDocket(DocketInterface docket) {
         this.docket = docket;
     }
 
     /**
      * Get ruleset.
      *
-     * @return ruleset as RulesetDTO
+     * @return ruleset as RulesetInterface
      */
-    public RulesetDTO getRuleset() {
+    public RulesetInterface getRuleset() {
         return ruleset;
     }
 
@@ -92,18 +96,18 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      * Set ruleset.
      *
      * @param ruleset
-     *            as RulesetDTO
+     *            as RulesetInterface
      */
-    public void setRuleset(RulesetDTO ruleset) {
+    public void setRuleset(RulesetInterface ruleset) {
         this.ruleset = ruleset;
     }
 
     /**
      * Get list of tasks.
      *
-     * @return list of tasks as TaskDTO
+     * @return list of tasks as TaskInterface
      */
-    public List<TaskDTO> getTasks() {
+    public List<TaskInterface> getTasks() {
         return tasks;
     }
 
@@ -111,9 +115,9 @@ public abstract class BaseTemplateDTO extends BaseDTO {
      * Set list of tasks.
      *
      * @param tasks
-     *            list of tasks as TaskDTO
+     *            list of tasks as TaskInterface
      */
-    public void setTasks(List<TaskDTO> tasks) {
+    public void setTasks(List<TaskInterface> tasks) {
         this.tasks = tasks;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BatchDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BatchDTO.java
@@ -14,13 +14,16 @@ package org.kitodo.production.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kitodo.data.interfaces.BatchInterface;
+import org.kitodo.data.interfaces.ProcessInterface;
+
 /**
  * Batch DTO object.
  */
-public class BatchDTO extends BaseDTO {
+public class BatchDTO extends BaseDTO implements BatchInterface {
 
     private String title;
-    private List<ProcessDTO> processes = new ArrayList<>();
+    private List<ProcessInterface> processes = new ArrayList<>();
 
     /**
      * Get title.
@@ -46,7 +49,7 @@ public class BatchDTO extends BaseDTO {
      *
      * @return List of processes as ProcessDTO
      */
-    public List<ProcessDTO> getProcesses() {
+    public List<ProcessInterface> getProcesses() {
         return processes;
     }
 
@@ -56,7 +59,7 @@ public class BatchDTO extends BaseDTO {
      * @param processes
      *            as List of processes as ProcessDTO
      */
-    public void setProcesses(List<ProcessDTO> processes) {
+    public void setProcesses(List<ProcessInterface> processes) {
         this.processes = processes;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/BatchDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/BatchDTO.java
@@ -23,7 +23,7 @@ import org.kitodo.data.interfaces.ProcessInterface;
 public class BatchDTO extends BaseDTO implements BatchInterface {
 
     private String title;
-    private List<ProcessInterface> processes = new ArrayList<>();
+    private List<? extends ProcessInterface> processes = new ArrayList<>();
 
     /**
      * Get title.
@@ -49,7 +49,7 @@ public class BatchDTO extends BaseDTO implements BatchInterface {
      *
      * @return List of processes as ProcessDTO
      */
-    public List<ProcessInterface> getProcesses() {
+    public List<? extends ProcessInterface> getProcesses() {
         return processes;
     }
 
@@ -59,7 +59,7 @@ public class BatchDTO extends BaseDTO implements BatchInterface {
      * @param processes
      *            as List of processes as ProcessDTO
      */
-    public void setProcesses(List<ProcessInterface> processes) {
+    public void setProcesses(List<? extends ProcessInterface> processes) {
         this.processes = processes;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ClientDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ClientDTO.java
@@ -21,8 +21,8 @@ import org.kitodo.data.interfaces.UserInterface;
 public class ClientDTO extends BaseDTO implements ClientInterface {
 
     private String name;
-    private List<UserInterface> users = new ArrayList<>();
-    private List<ProjectInterface> projects = new ArrayList<>();
+    private List<? extends UserInterface> users = new ArrayList<>();
+    private List<? extends ProjectInterface> projects = new ArrayList<>();
 
     /**
      * Gets title.
@@ -48,7 +48,7 @@ public class ClientDTO extends BaseDTO implements ClientInterface {
      *
      * @return The users.
      */
-    public List<UserInterface> getUsers() {
+    public List<? extends UserInterface> getUsers() {
         return users;
     }
 
@@ -58,7 +58,7 @@ public class ClientDTO extends BaseDTO implements ClientInterface {
      * @param users
      *            The users.
      */
-    public void setUsers(List<UserInterface> users) {
+    public void setUsers(List<? extends UserInterface> users) {
         this.users = users;
     }
 
@@ -67,7 +67,7 @@ public class ClientDTO extends BaseDTO implements ClientInterface {
      *
      * @return The projects.
      */
-    public List<ProjectInterface> getProjects() {
+    public List<? extends ProjectInterface> getProjects() {
         return projects;
     }
 
@@ -77,7 +77,7 @@ public class ClientDTO extends BaseDTO implements ClientInterface {
      * @param projects
      *            The projects.
      */
-    public void setProjects(List<ProjectInterface> projects) {
+    public void setProjects(List<? extends ProjectInterface> projects) {
         this.projects = projects;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ClientDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ClientDTO.java
@@ -14,11 +14,15 @@ package org.kitodo.production.dto;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ClientDTO extends BaseDTO {
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.UserInterface;
+
+public class ClientDTO extends BaseDTO implements ClientInterface {
 
     private String name;
-    private List<UserDTO> users = new ArrayList<>();
-    private List<ProjectDTO> projects = new ArrayList<>();
+    private List<UserInterface> users = new ArrayList<>();
+    private List<ProjectInterface> projects = new ArrayList<>();
 
     /**
      * Gets title.
@@ -44,7 +48,7 @@ public class ClientDTO extends BaseDTO {
      *
      * @return The users.
      */
-    public List<UserDTO> getUsers() {
+    public List<UserInterface> getUsers() {
         return users;
     }
 
@@ -54,7 +58,7 @@ public class ClientDTO extends BaseDTO {
      * @param users
      *            The users.
      */
-    public void setUsers(List<UserDTO> users) {
+    public void setUsers(List<UserInterface> users) {
         this.users = users;
     }
 
@@ -63,7 +67,7 @@ public class ClientDTO extends BaseDTO {
      *
      * @return The projects.
      */
-    public List<ProjectDTO> getProjects() {
+    public List<ProjectInterface> getProjects() {
         return projects;
     }
 
@@ -73,7 +77,7 @@ public class ClientDTO extends BaseDTO {
      * @param projects
      *            The projects.
      */
-    public void setProjects(List<ProjectDTO> projects) {
+    public void setProjects(List<ProjectInterface> projects) {
         this.projects = projects;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/DTOFactory.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/DTOFactory.java
@@ -1,0 +1,106 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.dto;
+
+import org.kitodo.data.interfaces.BatchInterface;
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.DataFactoryInterface;
+import org.kitodo.data.interfaces.DocketInterface;
+import org.kitodo.data.interfaces.FilterInterface;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.PropertyInterface;
+import org.kitodo.data.interfaces.RulesetInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
+import org.kitodo.data.interfaces.UserInterface;
+import org.kitodo.data.interfaces.WorkflowInterface;
+
+/**
+ * A factory object for data transfer objects.
+ */
+public class DTOFactory implements DataFactoryInterface {
+
+    private static final DTOFactory instance = new DTOFactory();
+
+    /**
+     * Returns the instance of the factory object. The factory object implements
+     * the {@link DataFactoryInterface}. Since interfaces cannot have static
+     * methods, it must be accessed here via an instance of the class, even
+     * though the class has no state (no fields).
+     * 
+     * @return the factory instance
+     */
+    public static DTOFactory instance() {
+        return instance;
+    }
+
+    @Override
+    public BatchInterface newBatch() {
+        return new BatchDTO();
+    }
+
+    @Override
+    public ClientInterface newClient() {
+        return new ClientDTO();
+    }
+
+    @Override
+    public DocketInterface newDocket() {
+        return new DocketDTO();
+    }
+
+    @Override
+    public FilterInterface newFilter() {
+        return new FilterDTO();
+    }
+
+    @Override
+    public ProcessInterface newProcess() {
+        return new ProcessDTO();
+    }
+
+    @Override
+    public ProjectInterface newProject() {
+        return new ProjectDTO();
+    }
+
+    @Override
+    public PropertyInterface newProperty() {
+        return new PropertyDTO();
+    }
+
+    @Override
+    public RulesetInterface newRuleset() {
+        return new RulesetDTO();
+    }
+
+    @Override
+    public TaskInterface newTask() {
+        return new TaskDTO();
+    }
+
+    @Override
+    public TemplateInterface newTemplate() {
+        return new TemplateDTO();
+    }
+
+    @Override
+    public UserInterface newUser() {
+        return new UserDTO();
+    }
+
+    @Override
+    public WorkflowInterface newWorkflow() {
+        return new WorkflowDTO();
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/dto/DocketDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/DocketDTO.java
@@ -84,7 +84,7 @@ public class DocketDTO extends BaseDTO implements DocketInterface {
     /**
      * Get client object.
      *
-     * @return value of clientInterface
+     * @return value of client
      */
     public ClientInterface getClient() {
         return client;

--- a/Kitodo/src/main/java/org/kitodo/production/dto/DocketDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/DocketDTO.java
@@ -11,15 +11,18 @@
 
 package org.kitodo.production.dto;
 
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.DocketInterface;
+
 /**
  * Docket DTO object.
  */
-public class DocketDTO extends BaseDTO {
+public class DocketDTO extends BaseDTO implements DocketInterface {
 
     private String file;
     private String title;
     private Boolean active = true;
-    private ClientDTO client;
+    private ClientInterface client;
 
     /**
      * Get file.
@@ -81,9 +84,9 @@ public class DocketDTO extends BaseDTO {
     /**
      * Get client object.
      *
-     * @return value of clientDTO
+     * @return value of clientInterface
      */
-    public ClientDTO getClient() {
+    public ClientInterface getClient() {
         return client;
     }
 
@@ -91,9 +94,9 @@ public class DocketDTO extends BaseDTO {
      * Set client object.
      *
      * @param client
-     *            as org.kitodo.production.dto.ClientDTO
+     *            as org.kitodo.production.dto.ClientInterface
      */
-    public void setClientDTO(ClientDTO client) {
+    public void setClient(ClientInterface client) {
         this.client = client;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/FilterDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/FilterDTO.java
@@ -11,10 +11,12 @@
 
 package org.kitodo.production.dto;
 
+import org.kitodo.data.interfaces.FilterInterface;
+
 /**
  * Filter DTO object.
  */
-public class FilterDTO extends BaseDTO {
+public class FilterDTO extends BaseDTO implements FilterInterface {
 
     private String value;
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
@@ -69,11 +69,11 @@ public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
     /**
      * Set project.
      *
-     * @param projectInterface
+     * @param project
      *            as ProjectInterface
      */
-    public void setProject(ProjectInterface projectInterface) {
-        this.project = (ProjectInterface) projectInterface;
+    public void setProject(ProjectInterface project) {
+        this.project = (ProjectInterface) project;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
@@ -11,6 +11,7 @@
 
 package org.kitodo.production.dto;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -257,8 +258,13 @@ public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
      *
      * @return process base URI as String.
      */
-    public String getProcessBaseUri() {
+    public String getProcessBase() {
         return processBaseUri;
+    }
+
+    @Override
+    public URI getProcessBaseUri() {
+        return Objects.isNull(processBaseUri) ? null : URI.create(processBaseUri);
     }
 
     /**
@@ -267,8 +273,13 @@ public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
      * @param processBaseUri
      *            as String
      */
-    public void setProcessBaseUri(String processBaseUri) {
+    public void setProcessBase(String processBaseUri) {
         this.processBaseUri = processBaseUri;
+    }
+
+    @Override
+    public void setProcessBaseUri(URI processBaseUri) {
+        this.processBaseUri = Objects.isNull(processBaseUri) ? null : processBaseUri.toString();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
@@ -28,8 +28,8 @@ import org.kitodo.data.interfaces.UserInterface;
 public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
 
     private ProjectInterface project;
-    private List<BatchInterface> batches = new ArrayList<>();
-    private List<PropertyInterface> properties = new ArrayList<>();
+    private List<? extends BatchInterface> batches = new ArrayList<>();
+    private List<? extends PropertyInterface> properties = new ArrayList<>();
     private UserInterface blockedUser;
     private Double progressClosed;
     private Double progressInProcessing;
@@ -80,7 +80,7 @@ public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
      *
      * @return list of batches as BatchInterface
      */
-    public List<BatchInterface> getBatches() {
+    public List<? extends BatchInterface> getBatches() {
         return batches;
     }
 
@@ -99,7 +99,7 @@ public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
      *
      * @return list of properties as PropertyInterface
      */
-    public List<PropertyInterface> getProperties() {
+    public List<? extends PropertyInterface> getProperties() {
         if (Objects.isNull(this.properties)) {
             properties = new ArrayList<>();
         }
@@ -112,7 +112,7 @@ public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
      * @param properties
      *            list of properties as PropertyInterface
      */
-    public void setProperties(List<PropertyInterface> properties) {
+    public void setProperties(List<? extends PropertyInterface> properties) {
         this.properties = properties;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessDTO.java
@@ -16,15 +16,21 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
+import org.kitodo.data.interfaces.BatchInterface;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.PropertyInterface;
+import org.kitodo.data.interfaces.UserInterface;
+
 /**
  * Process DTO object.
  */
-public class ProcessDTO extends BaseTemplateDTO {
+public class ProcessDTO extends BaseTemplateDTO implements ProcessInterface {
 
-    private ProjectDTO project;
-    private List<BatchDTO> batches = new ArrayList<>();
-    private List<PropertyDTO> properties = new ArrayList<>();
-    private UserDTO blockedUser;
+    private ProjectInterface project;
+    private List<BatchInterface> batches = new ArrayList<>();
+    private List<PropertyInterface> properties = new ArrayList<>();
+    private UserInterface blockedUser;
     private Double progressClosed;
     private Double progressInProcessing;
     private Double progressOpen;
@@ -53,28 +59,28 @@ public class ProcessDTO extends BaseTemplateDTO {
     /**
      * Get project.
      *
-     * @return project as ProjectDTO
+     * @return project as ProjectInterface
      */
-    public ProjectDTO getProject() {
+    public ProjectInterface getProject() {
         return project;
     }
 
     /**
      * Set project.
      *
-     * @param project
-     *            as ProjectDTO
+     * @param projectInterface
+     *            as ProjectInterface
      */
-    public void setProject(ProjectDTO project) {
-        this.project = project;
+    public void setProject(ProjectInterface projectInterface) {
+        this.project = (ProjectInterface) projectInterface;
     }
 
     /**
      * Get list of batches.
      *
-     * @return list of batches as BatchDTO
+     * @return list of batches as BatchInterface
      */
-    public List<BatchDTO> getBatches() {
+    public List<BatchInterface> getBatches() {
         return batches;
     }
 
@@ -82,18 +88,18 @@ public class ProcessDTO extends BaseTemplateDTO {
      * Set list of batches.
      *
      * @param batches
-     *            list of batches as BatchDTO
+     *            list of batches as BatchInterface
      */
-    public void setBatches(List<BatchDTO> batches) {
+    public void setBatches(List batches) {
         this.batches = batches;
     }
 
     /**
      * Get list of properties.
      *
-     * @return list of properties as PropertyDTO
+     * @return list of properties as PropertyInterface
      */
-    public List<PropertyDTO> getProperties() {
+    public List<PropertyInterface> getProperties() {
         if (Objects.isNull(this.properties)) {
             properties = new ArrayList<>();
         }
@@ -104,18 +110,18 @@ public class ProcessDTO extends BaseTemplateDTO {
      * Set list of properties.
      *
      * @param properties
-     *            list of properties as PropertyDTO
+     *            list of properties as PropertyInterface
      */
-    public void setProperties(List<PropertyDTO> properties) {
+    public void setProperties(List<PropertyInterface> properties) {
         this.properties = properties;
     }
 
     /**
      * Get blocked user.
      *
-     * @return blocked user as UserDTO
+     * @return blocked user as UserInterface
      */
-    public UserDTO getBlockedUser() {
+    public UserInterface getBlockedUser() {
         return blockedUser;
     }
 
@@ -123,9 +129,9 @@ public class ProcessDTO extends BaseTemplateDTO {
      * Set blocked user.
      *
      * @param blockedUser
-     *            as UserDTO
+     *            as UserInterface
      */
-    public void setBlockedUser(UserDTO blockedUser) {
+    public void setBlockedUser(UserInterface blockedUser) {
         this.blockedUser = blockedUser;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.dto;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -290,7 +291,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
     @Override
     public Date getStartDate() {
         try {
-            return Strings.isNotEmpty(this.startDate) ? DATE_FORMAT.parse(this.startDate) : null;
+            return Strings.isNotEmpty(this.startDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.startDate) : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -298,13 +299,13 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
 
     @Override
     public void setStartDate(Date startDate) {
-        this.startDate = Objects.nonNull(startDate) ? DATE_FORMAT.format(startDate) : null;
+        this.startDate = Objects.nonNull(startDate) ? new SimpleDateFormat(DATE_FORMAT).format(startDate) : null;
     }
 
     @Override
     public Date getEndDate() {
         try {
-            return Strings.isNotEmpty(this.endDate) ? DATE_FORMAT.parse(this.endDate) : null;
+            return Strings.isNotEmpty(this.endDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.endDate) : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -312,7 +313,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
 
     @Override
     public void setEndDate(Date endDate) {
-        this.endDate = Objects.nonNull(endDate) ? DATE_FORMAT.format(endDate) : null;
+        this.endDate = Objects.nonNull(endDate) ? new SimpleDateFormat(DATE_FORMAT).format(endDate) : null;
        
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
@@ -317,7 +317,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
     @Override
     public Date getStartDate() {
         try {
-            return StringUtils.isNotEmpty(this.startDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.startDate)
+            return StringUtils.isNotBlank(this.startDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.startDate)
                     : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
@@ -332,7 +332,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
     @Override
     public Date getEndDate() {
         try {
-            return StringUtils.isNotEmpty(this.endDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.endDate) : null;
+            return StringUtils.isNotBlank(this.endDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.endDate) : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
@@ -11,9 +11,13 @@
 
 package org.kitodo.production.dto;
 
+import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
+import org.apache.logging.log4j.util.Strings;
 import org.kitodo.data.interfaces.ClientInterface;
 import org.kitodo.data.interfaces.ProjectInterface;
 import org.kitodo.data.interfaces.TemplateInterface;
@@ -62,7 +66,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return start date as String
      */
-    public String getStartDate() {
+    public String getStartTime() {
         return startDate;
     }
 
@@ -72,7 +76,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param startDate
      *            as String
      */
-    public void setStartDate(String startDate) {
+    public void setStartTime(String startDate) {
         this.startDate = startDate;
     }
 
@@ -81,7 +85,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return end date as String
      */
-    public String getEndDate() {
+    public String getEndTime() {
         return endDate;
     }
 
@@ -91,7 +95,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param endDate
      *            as String
      */
-    public void setEndDate(String endDate) {
+    public void setEndTime(String endDate) {
         this.endDate = endDate;
     }
 
@@ -281,5 +285,34 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      */
     public void setHasProcesses(boolean hasProcesses) {
         this.hasProcesses = hasProcesses;
+    }
+
+    @Override
+    public Date getStartDate() {
+        try {
+            return Strings.isNotEmpty(this.startDate) ? DATE_FORMAT.parse(this.startDate) : null;
+        } catch (ParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setStartDate(Date startDate) {
+        this.startDate = Objects.nonNull(startDate) ? DATE_FORMAT.format(startDate) : null;
+    }
+
+    @Override
+    public Date getEndDate() {
+        try {
+            return Strings.isNotEmpty(this.endDate) ? DATE_FORMAT.parse(this.endDate) : null;
+        } catch (ParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setEndDate(Date endDate) {
+        this.endDate = Objects.nonNull(endDate) ? DATE_FORMAT.format(endDate) : null;
+       
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
@@ -199,8 +199,8 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return whether project is active or not
      */
-    public Boolean isActive() {
-        return this.active;
+    public boolean isActive() {
+        return Boolean.TRUE.equals(this.active);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
@@ -18,7 +18,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.data.interfaces.ClientInterface;
 import org.kitodo.data.interfaces.ProjectInterface;
 import org.kitodo.data.interfaces.TemplateInterface;
@@ -48,6 +48,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return title as String
      */
+    @Override
     public String getTitle() {
         return title;
     }
@@ -58,6 +59,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param title
      *            as String
      */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
@@ -67,6 +69,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return start date as String
      */
+    @Override
     public String getStartTime() {
         return startDate;
     }
@@ -77,6 +80,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param startDate
      *            as String
      */
+    @Override
     public void setStartTime(String startDate) {
         this.startDate = startDate;
     }
@@ -86,6 +90,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return end date as String
      */
+    @Override
     public String getEndTime() {
         return endDate;
     }
@@ -96,6 +101,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param endDate
      *            as String
      */
+    @Override
     public void setEndTime(String endDate) {
         this.endDate = endDate;
     }
@@ -105,6 +111,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return DMS export file format as String
      */
+    @Override
     public String getFileFormatDmsExport() {
         return this.fileFormatDmsExport;
     }
@@ -115,6 +122,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param fileFormatDmsExport
      *            as String
      */
+    @Override
     public void setFileFormatDmsExport(String fileFormatDmsExport) {
         this.fileFormatDmsExport = fileFormatDmsExport;
     }
@@ -124,6 +132,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return internal file format as String
      */
+    @Override
     public String getFileFormatInternal() {
         return this.fileFormatInternal;
     }
@@ -134,6 +143,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param fileFormatInternal
      *            as String
      */
+    @Override
     public void setFileFormatInternal(String fileFormatInternal) {
         this.fileFormatInternal = fileFormatInternal;
     }
@@ -143,6 +153,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return metsRightsOwner as String
      */
+    @Override
     public String getMetsRightsOwner() {
         return metsRightsOwner;
     }
@@ -153,6 +164,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param metsRightsOwner
      *            as String
      */
+    @Override
     public void setMetsRightsOwner(String metsRightsOwner) {
         this.metsRightsOwner = metsRightsOwner;
     }
@@ -162,6 +174,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return number of pages as Integer
      */
+    @Override
     public Integer getNumberOfPages() {
         return numberOfPages;
     }
@@ -172,6 +185,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param numberOfPages
      *            as Integer
      */
+    @Override
     public void setNumberOfPages(Integer numberOfPages) {
         this.numberOfPages = numberOfPages;
     }
@@ -181,6 +195,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return number of volumes as Integer
      */
+    @Override
     public Integer getNumberOfVolumes() {
         return numberOfVolumes;
     }
@@ -191,6 +206,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param numberOfVolumes
      *            as Integer
      */
+    @Override
     public void setNumberOfVolumes(Integer numberOfVolumes) {
         this.numberOfVolumes = numberOfVolumes;
     }
@@ -200,6 +216,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return whether project is active or not
      */
+    @Override
     public boolean isActive() {
         return Boolean.TRUE.equals(this.active);
     }
@@ -210,6 +227,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param active
      *            whether project is active or not
      */
+    @Override
     public void setActive(boolean active) {
         this.active = active;
     }
@@ -219,6 +237,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return The client.
      */
+    @Override
     public ClientInterface getClient() {
         return client;
     }
@@ -228,6 +247,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @param client The client.
      */
+    @Override
     public void setClient(ClientInterface client) {
         this.client = client;
     }
@@ -237,6 +257,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return list of active templates as TemplateDTO
      */
+    @Override
     public List<? extends TemplateInterface> getActiveTemplates() {
         return templates;
     }
@@ -247,6 +268,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param templates
      *            as list of TemplateDTO
      */
+    @Override
     public void setActiveTemplates(List<? extends TemplateInterface> templates) {
         this.templates = templates;
     }
@@ -256,6 +278,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return list of users as UserDTO
      */
+    @Override
     public List<? extends UserInterface> getUsers() {
         return users;
     }
@@ -266,6 +289,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param users
      *            as list of UserDTO
      */
+    @Override
     public void setUsers(List<? extends UserInterface> users) {
         this.users = users;
     }
@@ -275,6 +299,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return value of hasProcesses
      */
+    @Override
     public boolean hasProcesses() {
         return hasProcesses;
     }
@@ -284,6 +309,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @param hasProcesses as boolean
      */
+    @Override
     public void setHasProcesses(boolean hasProcesses) {
         this.hasProcesses = hasProcesses;
     }
@@ -291,7 +317,8 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
     @Override
     public Date getStartDate() {
         try {
-            return Strings.isNotEmpty(this.startDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.startDate) : null;
+            return StringUtils.isNotEmpty(this.startDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.startDate)
+                    : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -305,7 +332,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
     @Override
     public Date getEndDate() {
         try {
-            return Strings.isNotEmpty(this.endDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.endDate) : null;
+            return StringUtils.isNotEmpty(this.endDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.endDate) : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
@@ -14,10 +14,15 @@ package org.kitodo.production.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
+import org.kitodo.data.interfaces.UserInterface;
+
 /**
  * Project DTO object.
  */
-public class ProjectDTO extends BaseDTO {
+public class ProjectDTO extends BaseDTO implements ProjectInterface {
 
     private String title;
     private String startDate;
@@ -28,9 +33,9 @@ public class ProjectDTO extends BaseDTO {
     private Integer numberOfPages;
     private Integer numberOfVolumes;
     private Boolean active = true;
-    private ClientDTO client;
-    private List<TemplateDTO> templates = new ArrayList<>();
-    private List<UserDTO> users = new ArrayList<>();
+    private ClientInterface client;
+    private List<TemplateInterface> templates = new ArrayList<>();
+    private List<UserInterface> users = new ArrayList<>();
     private boolean hasProcesses;
 
     /**
@@ -209,7 +214,7 @@ public class ProjectDTO extends BaseDTO {
      *
      * @return The client.
      */
-    public ClientDTO getClient() {
+    public ClientInterface getClient() {
         return client;
     }
 
@@ -218,7 +223,7 @@ public class ProjectDTO extends BaseDTO {
      *
      * @param client The client.
      */
-    public void setClient(ClientDTO client) {
+    public void setClient(ClientInterface client) {
         this.client = client;
     }
 
@@ -227,7 +232,7 @@ public class ProjectDTO extends BaseDTO {
      *
      * @return list of active templates as TemplateDTO
      */
-    public List<TemplateDTO> getTemplates() {
+    public List<TemplateInterface> getActiveTemplates() {
         return templates;
     }
 
@@ -237,7 +242,7 @@ public class ProjectDTO extends BaseDTO {
      * @param templates
      *            as list of TemplateDTO
      */
-    public void setTemplates(List<TemplateDTO> templates) {
+    public void setActiveTemplates(List<TemplateInterface> templates) {
         this.templates = templates;
     }
 
@@ -246,7 +251,7 @@ public class ProjectDTO extends BaseDTO {
      *
      * @return list of users as UserDTO
      */
-    public List<UserDTO> getUsers() {
+    public List<UserInterface> getUsers() {
         return users;
     }
 
@@ -256,7 +261,7 @@ public class ProjectDTO extends BaseDTO {
      * @param users
      *            as list of UserDTO
      */
-    public void setUsers(List<UserDTO> users) {
+    public void setUsers(List<UserInterface> users) {
         this.users = users;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProjectDTO.java
@@ -34,8 +34,8 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
     private Integer numberOfVolumes;
     private Boolean active = true;
     private ClientInterface client;
-    private List<TemplateInterface> templates = new ArrayList<>();
-    private List<UserInterface> users = new ArrayList<>();
+    private List<? extends TemplateInterface> templates = new ArrayList<>();
+    private List<? extends UserInterface> users = new ArrayList<>();
     private boolean hasProcesses;
 
     /**
@@ -232,7 +232,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return list of active templates as TemplateDTO
      */
-    public List<TemplateInterface> getActiveTemplates() {
+    public List<? extends TemplateInterface> getActiveTemplates() {
         return templates;
     }
 
@@ -242,7 +242,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param templates
      *            as list of TemplateDTO
      */
-    public void setActiveTemplates(List<TemplateInterface> templates) {
+    public void setActiveTemplates(List<? extends TemplateInterface> templates) {
         this.templates = templates;
     }
 
@@ -251,7 +251,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      *
      * @return list of users as UserDTO
      */
-    public List<UserInterface> getUsers() {
+    public List<? extends UserInterface> getUsers() {
         return users;
     }
 
@@ -261,7 +261,7 @@ public class ProjectDTO extends BaseDTO implements ProjectInterface {
      * @param users
      *            as list of UserDTO
      */
-    public void setUsers(List<UserInterface> users) {
+    public void setUsers(List<? extends UserInterface> users) {
         this.users = users;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
@@ -94,7 +94,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
     @Override
     public Date getCreationDate() {
         try {
-            return StringUtils.isNotEmpty(this.creationDate)
+            return StringUtils.isNotBlank(this.creationDate)
                     ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
                     : null;
         } catch (ParseException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
@@ -11,10 +11,12 @@
 
 package org.kitodo.production.dto;
 
+import org.kitodo.data.interfaces.PropertyInterface;
+
 /**
  * Property DTO object.
  */
-public class PropertyDTO extends BaseDTO {
+public class PropertyDTO extends BaseDTO implements PropertyInterface {
 
     private String title;
     private String value;

--- a/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
@@ -16,7 +16,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.data.interfaces.PropertyInterface;
 
 /**
@@ -33,6 +33,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      *
      * @return title as String
      */
+    @Override
     public String getTitle() {
         return title;
     }
@@ -43,6 +44,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      * @param title
      *            as String
      */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
@@ -52,6 +54,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      *
      * @return value as String
      */
+    @Override
     public String getValue() {
         return value;
     }
@@ -62,6 +65,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      * @param value
      *            as String
      */
+    @Override
     public void setValue(String value) {
         this.value = value;
     }
@@ -71,6 +75,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      *
      * @return creation date as String.
      */
+    @Override
     public String getCreationTime() {
         return creationDate;
     }
@@ -81,6 +86,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      * @param creationDate
      *            as String
      */
+    @Override
     public void setCreationTime(String creationDate) {
         this.creationDate = creationDate;
     }
@@ -88,7 +94,8 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
     @Override
     public Date getCreationDate() {
         try {
-            return Strings.isNotEmpty(this.creationDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
+            return StringUtils.isNotEmpty(this.creationDate)
+                    ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
                     : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);

--- a/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
@@ -11,6 +11,11 @@
 
 package org.kitodo.production.dto;
 
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Objects;
+
+import org.apache.logging.log4j.util.Strings;
 import org.kitodo.data.interfaces.PropertyInterface;
 
 /**
@@ -65,7 +70,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      *
      * @return creation date as String.
      */
-    public String getCreationDate() {
+    public String getCreationTime() {
         return creationDate;
     }
 
@@ -75,7 +80,21 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
      * @param creationDate
      *            as String
      */
-    public void setCreationDate(String creationDate) {
+    public void setCreationTime(String creationDate) {
         this.creationDate = creationDate;
+    }
+
+    @Override
+    public Date getCreationDate() {
+        try {
+            return Strings.isNotEmpty(this.creationDate) ? DATE_FORMAT.parse(this.creationDate) : null;
+        } catch (ParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/PropertyDTO.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.dto;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
@@ -87,7 +88,8 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
     @Override
     public Date getCreationDate() {
         try {
-            return Strings.isNotEmpty(this.creationDate) ? DATE_FORMAT.parse(this.creationDate) : null;
+            return Strings.isNotEmpty(this.creationDate) ? new SimpleDateFormat(DATE_FORMAT).parse(this.creationDate)
+                    : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -95,6 +97,7 @@ public class PropertyDTO extends BaseDTO implements PropertyInterface {
 
     @Override
     public void setCreationDate(Date creationDate) {
-        this.creationDate = Objects.nonNull(creationDate) ? DATE_FORMAT.format(creationDate) : null;
+        this.creationDate = Objects.nonNull(creationDate) ? new SimpleDateFormat(DATE_FORMAT).format(creationDate)
+                : null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/RoleDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/RoleDTO.java
@@ -14,15 +14,19 @@ package org.kitodo.production.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.RoleInterface;
+import org.kitodo.data.interfaces.UserInterface;
+
 /**
  * Role DTO object.
  */
-public class RoleDTO extends BaseDTO {
+public class RoleDTO extends BaseDTO implements RoleInterface {
 
     private String title;
-    private List<UserDTO> users = new ArrayList<>();
+    private List<UserInterface> users = new ArrayList<>();
     private Integer usersSize;
-    private ClientDTO client;
+    private ClientInterface client;
 
     /**
      * Get title.
@@ -46,9 +50,9 @@ public class RoleDTO extends BaseDTO {
     /**
      * Get list of users.
      *
-     * @return list of users as UserDTO
+     * @return list of users as UserInterface
      */
-    public List<UserDTO> getUsers() {
+    public List<UserInterface> getUsers() {
         return users;
     }
 
@@ -56,9 +60,9 @@ public class RoleDTO extends BaseDTO {
      * Set list of users.
      *
      * @param users
-     *            list of users as UserDTO
+     *            list of users as UserInterface
      */
-    public void setUsers(List<UserDTO> users) {
+    public void setUsers(List<UserInterface> users) {
         this.users = users;
     }
 
@@ -84,18 +88,18 @@ public class RoleDTO extends BaseDTO {
     /**
      * Get client FTO object.
      *
-     * @return the client DTO object
+     * @return the client Interface object
      */
-    public ClientDTO getClient() {
+    public ClientInterface getClient() {
         return client;
     }
 
     /**
-     * Set client DTO object.
+     * Set client Interface object.
      *
-     * @param client as DTO object.
+     * @param client as Interface object.
      */
-    public void setClient(ClientDTO client) {
+    public void setClient(ClientInterface client) {
         this.client = client;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/RoleDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/RoleDTO.java
@@ -24,7 +24,7 @@ import org.kitodo.data.interfaces.UserInterface;
 public class RoleDTO extends BaseDTO implements RoleInterface {
 
     private String title;
-    private List<UserInterface> users = new ArrayList<>();
+    private List<? extends UserInterface> users = new ArrayList<>();
     private Integer usersSize;
     private ClientInterface client;
 
@@ -52,7 +52,7 @@ public class RoleDTO extends BaseDTO implements RoleInterface {
      *
      * @return list of users as UserInterface
      */
-    public List<UserInterface> getUsers() {
+    public List<? extends UserInterface> getUsers() {
         return users;
     }
 
@@ -62,7 +62,7 @@ public class RoleDTO extends BaseDTO implements RoleInterface {
      * @param users
      *            list of users as UserInterface
      */
-    public void setUsers(List<UserInterface> users) {
+    public void setUsers(List<? extends UserInterface> users) {
         this.users = users;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/RulesetDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/RulesetDTO.java
@@ -11,16 +11,19 @@
 
 package org.kitodo.production.dto;
 
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.RulesetInterface;
+
 /**
  * Ruleset DTO object.
  */
-public class RulesetDTO extends BaseDTO {
+public class RulesetDTO extends BaseDTO implements RulesetInterface {
 
     private String file;
     private String title;
     private Boolean orderMetadataByRuleset = false;
     private Boolean active = true;
-    private ClientDTO client;
+    private ClientInterface client;
 
     /**
      * Get file.
@@ -101,9 +104,9 @@ public class RulesetDTO extends BaseDTO {
     /**
      * Get client object.
      *
-     * @return value of clientDTO
+     * @return value of clientInterface
      */
-    public ClientDTO getClient() {
+    public ClientInterface getClient() {
         return client;
     }
 
@@ -111,9 +114,9 @@ public class RulesetDTO extends BaseDTO {
      * Set client object.
      *
      * @param client
-     *            as org.kitodo.production.dto.ClientDTO
+     *            as org.kitodo.production.dto.ClientInterface
      */
-    public void setClientDTO(ClientDTO client) {
+    public void setClient(ClientInterface client) {
         this.client = client;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/RulesetDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/RulesetDTO.java
@@ -104,7 +104,7 @@ public class RulesetDTO extends BaseDTO implements RulesetInterface {
     /**
      * Get client object.
      *
-     * @return value of clientInterface
+     * @return value of client
      */
     public ClientInterface getClient() {
         return client;

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.dto;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -516,7 +517,9 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
     @Override
     public Date getProcessingTime() {
         try {
-            return Strings.isNotEmpty(this.processingTime) ? DATE_FORMAT.parse(this.processingTime) : null;
+            return Strings.isNotEmpty(this.processingTime)
+                    ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingTime)
+                    : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -524,13 +527,16 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
 
     @Override
     public void setProcessingTime(Date processingTime) {
-        this.processingTime = Objects.nonNull(processingTime) ? DATE_FORMAT.format(processingTime) : null;
+        this.processingTime = Objects.nonNull(processingTime) ? new SimpleDateFormat(DATE_FORMAT).format(processingTime)
+                : null;
     }
 
     @Override
     public Date getProcessingBegin() {
         try {
-            return Strings.isNotEmpty(this.processingBegin) ? DATE_FORMAT.parse(this.processingBegin) : null;
+            return Strings.isNotEmpty(this.processingBegin)
+                    ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingBegin)
+                    : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -538,13 +544,16 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
 
     @Override
     public void setProcessingBegin(Date processingBegin) {
-        this.processingBegin = Objects.nonNull(processingBegin) ? DATE_FORMAT.format(processingBegin) : null;
+        this.processingBegin = Objects.nonNull(processingBegin)
+                ? new SimpleDateFormat(DATE_FORMAT).format(processingBegin)
+                : null;
     }
 
     @Override
     public Date getProcessingEnd() {
         try {
-            return Strings.isNotEmpty(this.processingEnd) ? DATE_FORMAT.parse(this.processingEnd) : null;
+            return Strings.isNotEmpty(this.processingEnd) ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingEnd)
+                    : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -552,6 +561,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
 
     @Override
     public void setProcessingEnd(Date processingEnd) {
-        this.processingEnd = Objects.nonNull(processingEnd) ? DATE_FORMAT.format(processingEnd) : null;
+        this.processingEnd = Objects.nonNull(processingEnd) ? new SimpleDateFormat(DATE_FORMAT).format(processingEnd)
+                : null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
@@ -18,7 +18,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.data.database.enums.TaskEditType;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.interfaces.ProcessInterface;
@@ -63,6 +63,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return title as String
      */
+    @Override
     public String getTitle() {
         return title;
     }
@@ -73,6 +74,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param title
      *            as String
      */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
@@ -82,6 +84,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return localized title as String
      */
+    @Override
     public String getLocalizedTitle() {
         return localizedTitle;
     }
@@ -92,6 +95,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param localizedTitle
      *            as String
      */
+    @Override
     public void setLocalizedTitle(String localizedTitle) {
         this.localizedTitle = localizedTitle;
     }
@@ -101,6 +105,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return ordering as Integer
      */
+    @Override
     public Integer getOrdering() {
         return this.ordering;
     }
@@ -111,6 +116,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param ordering
      *            as Integer
      */
+    @Override
     public void setOrdering(Integer ordering) {
         this.ordering = ordering;
     }
@@ -120,6 +126,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing status as TaskStatus object
      */
+    @Override
     public TaskStatus getProcessingStatus() {
         return processingStatus;
     }
@@ -130,6 +137,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingStatus
      *            as TaskStatus object
      */
+    @Override
     public void setProcessingStatus(TaskStatus processingStatus) {
         this.processingStatus = processingStatus;
     }
@@ -139,6 +147,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing status title as String
      */
+    @Override
     public String getProcessingStatusTitle() {
         return processingStatusTitle;
     }
@@ -149,6 +158,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingStatusTitle
      *            as String
      */
+    @Override
     public void setProcessingStatusTitle(String processingStatusTitle) {
         this.processingStatusTitle = processingStatusTitle;
     }
@@ -158,6 +168,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return current edit type
      */
+    @Override
     public TaskEditType getEditType() {
         return editType;
     }
@@ -168,6 +179,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param editType
      *            as {@link TaskEditType}
      */
+    @Override
     public void setEditType(TaskEditType editType) {
         this.editType = editType;
     }
@@ -177,6 +189,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return current edit type title as String
      */
+    @Override
     public String getEditTypeTitle() {
         return editTypeTitle;
     }
@@ -187,6 +200,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param editTypeTitle
      *            as String
      */
+    @Override
     public void setEditTypeTitle(String editTypeTitle) {
         this.editTypeTitle = editTypeTitle;
     }
@@ -196,6 +210,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing user as UserInterface
      */
+    @Override
     public UserInterface getProcessingUser() {
         return processingUser;
     }
@@ -206,6 +221,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingUser
      *            as UserInterface
      */
+    @Override
     public void setProcessingUser(UserInterface processingUser) {
         this.processingUser = processingUser;
     }
@@ -215,6 +231,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing time as String
      */
+    @Override
     public String getProcessingMoment() {
         return processingTime;
     }
@@ -225,6 +242,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingTime
      *            as String
      */
+    @Override
     public void setProcessingMoment(String processingTime) {
         this.processingTime = processingTime;
     }
@@ -234,6 +252,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing begin time as String
      */
+    @Override
     public String getProcessingBeginTime() {
         return processingBegin;
     }
@@ -244,6 +263,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingBegin
      *            as String
      */
+    @Override
     public void setProcessingBeginTime(String processingBegin) {
         this.processingBegin = processingBegin;
     }
@@ -253,6 +273,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing end time as String
      */
+    @Override
     public String getProcessingEndTime() {
         return processingEnd;
     }
@@ -263,6 +284,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingEnd
      *            as String
      */
+    @Override
     public void setProcessingEndTime(String processingEnd) {
         this.processingEnd = processingEnd;
     }
@@ -272,6 +294,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return process as ProcessInterface
      */
+    @Override
     public ProcessInterface getProcess() {
         return process;
     }
@@ -282,6 +305,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param process
      *            as ProcessInterface
      */
+    @Override
     public void setProcess(ProcessInterface process) {
         this.process = process;
     }
@@ -291,6 +315,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return project as ProjectInterface
      */
+    @Override
     public ProjectInterface getProject() {
         return project;
     }
@@ -301,6 +326,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param project
      *            as ProjectInterface
      */
+    @Override
     public void setProject(ProjectInterface project) {
         this.project = project;
     }
@@ -310,6 +336,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return template as TemplateInterface
      */
+    @Override
     public TemplateInterface getTemplate() {
         return template;
     }
@@ -320,6 +347,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param template
      *            as TemplateInterface
      */
+    @Override
     public void setTemplate(TemplateInterface template) {
         this.template = template;
     }
@@ -329,6 +357,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return list of role ids as Integer
      */
+    @Override
     public List<Integer> getRoleIds() {
         return roleIds;
     }
@@ -339,6 +368,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param roleIds
      *            list of role ids as Integer
      */
+    @Override
     public void setRoleIds(List<Integer> roleIds) {
         this.roleIds = roleIds;
     }
@@ -348,6 +378,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return the size of the roles list
      */
+    @Override
     public int getRolesSize() {
         return this.rolesSize;
     }
@@ -358,6 +389,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param rolesSize
      *            as int
      */
+    @Override
     public void setRolesSize(int rolesSize) {
         this.rolesSize = rolesSize;
     }
@@ -367,6 +399,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return value of correction
      */
+    @Override
     public boolean isCorrection() {
         return correction;
     }
@@ -376,6 +409,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @param correction as boolean
      */
+    @Override
     public void setCorrection(boolean correction) {
         this.correction = correction;
     }
@@ -385,6 +419,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return true or false
      */
+    @Override
     public boolean isTypeAutomatic() {
         return typeAutomatic;
     }
@@ -395,6 +430,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param typeAutomatic
      *            as boolean
      */
+    @Override
     public void setTypeAutomatic(boolean typeAutomatic) {
         this.typeAutomatic = typeAutomatic;
     }
@@ -404,6 +440,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return true or false
      */
+    @Override
     public boolean isTypeMetadata() {
         return typeMetadata;
     }
@@ -414,6 +451,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param typeMetadata
      *            as boolean
      */
+    @Override
     public void setTypeMetadata(boolean typeMetadata) {
         this.typeMetadata = typeMetadata;
     }
@@ -423,6 +461,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return true or false
      */
+    @Override
     public boolean isTypeImagesRead() {
         return typeImagesRead;
     }
@@ -433,6 +472,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param typeImagesRead
      *            as boolean
      */
+    @Override
     public void setTypeImagesRead(boolean typeImagesRead) {
         this.typeImagesRead = typeImagesRead;
     }
@@ -442,6 +482,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return true or false
      */
+    @Override
     public boolean isTypeImagesWrite() {
         return typeImagesWrite;
     }
@@ -452,6 +493,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param typeImagesWrite
      *            as boolean
      */
+    @Override
     public void setTypeImagesWrite(boolean typeImagesWrite) {
         this.typeImagesWrite = typeImagesWrite;
     }
@@ -461,6 +503,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return true or false
      */
+    @Override
     public boolean isBatchStep() {
         return batchStep;
     }
@@ -472,6 +515,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param batchAvailable
      *            as boolean
      */
+    @Override
     public void setBatchAvailable(boolean batchAvailable) {
         this.batchAvailable = batchAvailable;
     }
@@ -482,6 +526,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return true or false
      */
+    @Override
     public boolean isBatchAvailable() {
         return batchAvailable;
     }
@@ -492,6 +537,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param batchStep
      *            as boolean
      */
+    @Override
     public void setBatchStep(boolean batchStep) {
         this.batchStep = batchStep;
     }
@@ -501,6 +547,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * 
      * @return the correction comment status as integer
      */
+    @Override
     public Integer getCorrectionCommentStatus() {
         return this.correctionCommentStatus;
     }
@@ -510,6 +557,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * 
      * @param status the status as integer
      */
+    @Override
     public void setCorrectionCommentStatus(Integer status) {
         this.correctionCommentStatus = status;
     }
@@ -517,7 +565,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
     @Override
     public Date getProcessingTime() {
         try {
-            return Strings.isNotEmpty(this.processingTime)
+            return StringUtils.isNotEmpty(this.processingTime)
                     ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingTime)
                     : null;
         } catch (ParseException e) {
@@ -534,7 +582,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
     @Override
     public Date getProcessingBegin() {
         try {
-            return Strings.isNotEmpty(this.processingBegin)
+            return StringUtils.isNotEmpty(this.processingBegin)
                     ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingBegin)
                     : null;
         } catch (ParseException e) {
@@ -552,7 +600,8 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
     @Override
     public Date getProcessingEnd() {
         try {
-            return Strings.isNotEmpty(this.processingEnd) ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingEnd)
+            return StringUtils.isNotEmpty(this.processingEnd)
+                    ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingEnd)
                     : null;
         } catch (ParseException e) {
             throw new IllegalStateException(e.getMessage(), e);

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
@@ -16,11 +16,16 @@ import java.util.List;
 
 import org.kitodo.data.database.enums.TaskEditType;
 import org.kitodo.data.database.enums.TaskStatus;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
+import org.kitodo.data.interfaces.UserInterface;
 
 /**
  * Task DTO object.
  */
-public class TaskDTO extends BaseDTO {
+public class TaskDTO extends BaseDTO implements TaskInterface {
 
     private String title;
     private String localizedTitle;
@@ -29,13 +34,13 @@ public class TaskDTO extends BaseDTO {
     private String processingStatusTitle;
     private TaskEditType editType;
     private String editTypeTitle;
-    private UserDTO processingUser;
+    private UserInterface processingUser;
     private String processingTime;
     private String processingBegin;
     private String processingEnd;
-    private ProcessDTO process;
-    private ProjectDTO project;
-    private TemplateDTO template;
+    private ProcessInterface process;
+    private ProjectInterface project;
+    private TemplateInterface template;
     private List<Integer> roleIds = new ArrayList<>();
     private int rolesSize;
     private boolean correction;
@@ -182,21 +187,21 @@ public class TaskDTO extends BaseDTO {
     }
 
     /**
-     * Get processing user as UserDTO.
+     * Get processing user as UserInterface.
      *
-     * @return processing user as UserDTO
+     * @return processing user as UserInterface
      */
-    public UserDTO getProcessingUser() {
+    public UserInterface getProcessingUser() {
         return processingUser;
     }
 
     /**
-     * Set processing user as UserDTO.
+     * Set processing user as UserInterface.
      *
      * @param processingUser
-     *            as UserDTO
+     *            as UserInterface
      */
-    public void setProcessingUser(UserDTO processingUser) {
+    public void setProcessingUser(UserInterface processingUser) {
         this.processingUser = processingUser;
     }
 
@@ -258,30 +263,30 @@ public class TaskDTO extends BaseDTO {
     }
 
     /**
-     * Get process as ProcessDTO.
+     * Get process as ProcessInterface.
      *
-     * @return process as ProcessDTO
+     * @return process as ProcessInterface
      */
-    public ProcessDTO getProcess() {
+    public ProcessInterface getProcess() {
         return process;
     }
 
     /**
-     * Set process as ProcessDTO.
+     * Set process as ProcessInterface.
      *
      * @param process
-     *            as ProcessDTO
+     *            as ProcessInterface
      */
-    public void setProcess(ProcessDTO process) {
+    public void setProcess(ProcessInterface process) {
         this.process = process;
     }
 
     /**
      * Get project.
      *
-     * @return project as ProjectDTO
+     * @return project as ProjectInterface
      */
-    public ProjectDTO getProject() {
+    public ProjectInterface getProject() {
         return project;
     }
 
@@ -289,28 +294,28 @@ public class TaskDTO extends BaseDTO {
      * Set project.
      *
      * @param project
-     *            as ProjectDTO
+     *            as ProjectInterface
      */
-    public void setProject(ProjectDTO project) {
+    public void setProject(ProjectInterface project) {
         this.project = project;
     }
 
     /**
-     * Get template as TemplateDTO.
+     * Get template as TemplateInterface.
      *
-     * @return template as TemplateDTO
+     * @return template as TemplateInterface
      */
-    public TemplateDTO getTemplate() {
+    public TemplateInterface getTemplate() {
         return template;
     }
 
     /**
-     * Set template as TemplateDTO.
+     * Set template as TemplateInterface.
      *
      * @param template
-     *            as TemplateDTO
+     *            as TemplateInterface
      */
-    public void setTemplate(TemplateDTO template) {
+    public void setTemplate(TemplateInterface template) {
         this.template = template;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
@@ -11,9 +11,13 @@
 
 package org.kitodo.production.dto;
 
+import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
+import org.apache.logging.log4j.util.Strings;
 import org.kitodo.data.database.enums.TaskEditType;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.interfaces.ProcessInterface;
@@ -210,7 +214,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing time as String
      */
-    public String getProcessingTime() {
+    public String getProcessingMoment() {
         return processingTime;
     }
 
@@ -220,7 +224,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingTime
      *            as String
      */
-    public void setProcessingTime(String processingTime) {
+    public void setProcessingMoment(String processingTime) {
         this.processingTime = processingTime;
     }
 
@@ -229,7 +233,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing begin time as String
      */
-    public String getProcessingBegin() {
+    public String getProcessingBeginTime() {
         return processingBegin;
     }
 
@@ -239,7 +243,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingBegin
      *            as String
      */
-    public void setProcessingBegin(String processingBegin) {
+    public void setProcessingBeginTime(String processingBegin) {
         this.processingBegin = processingBegin;
     }
 
@@ -248,7 +252,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      *
      * @return processing end time as String
      */
-    public String getProcessingEnd() {
+    public String getProcessingEndTime() {
         return processingEnd;
     }
 
@@ -258,7 +262,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
      * @param processingEnd
      *            as String
      */
-    public void setProcessingEnd(String processingEnd) {
+    public void setProcessingEndTime(String processingEnd) {
         this.processingEnd = processingEnd;
     }
 
@@ -509,4 +513,45 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
         this.correctionCommentStatus = status;
     }
 
+    @Override
+    public Date getProcessingTime() {
+        try {
+            return Strings.isNotEmpty(this.processingTime) ? DATE_FORMAT.parse(this.processingTime) : null;
+        } catch (ParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setProcessingTime(Date processingTime) {
+        this.processingTime = Objects.nonNull(processingTime) ? DATE_FORMAT.format(processingTime) : null;
+    }
+
+    @Override
+    public Date getProcessingBegin() {
+        try {
+            return Strings.isNotEmpty(this.processingBegin) ? DATE_FORMAT.parse(this.processingBegin) : null;
+        } catch (ParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setProcessingBegin(Date processingBegin) {
+        this.processingBegin = Objects.nonNull(processingBegin) ? DATE_FORMAT.format(processingBegin) : null;
+    }
+
+    @Override
+    public Date getProcessingEnd() {
+        try {
+            return Strings.isNotEmpty(this.processingEnd) ? DATE_FORMAT.parse(this.processingEnd) : null;
+        } catch (ParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setProcessingEnd(Date processingEnd) {
+        this.processingEnd = Objects.nonNull(processingEnd) ? DATE_FORMAT.format(processingEnd) : null;
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TaskDTO.java
@@ -565,7 +565,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
     @Override
     public Date getProcessingTime() {
         try {
-            return StringUtils.isNotEmpty(this.processingTime)
+            return StringUtils.isNotBlank(this.processingTime)
                     ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingTime)
                     : null;
         } catch (ParseException e) {
@@ -582,7 +582,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
     @Override
     public Date getProcessingBegin() {
         try {
-            return StringUtils.isNotEmpty(this.processingBegin)
+            return StringUtils.isNotBlank(this.processingBegin)
                     ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingBegin)
                     : null;
         } catch (ParseException e) {
@@ -600,7 +600,7 @@ public class TaskDTO extends BaseDTO implements TaskInterface {
     @Override
     public Date getProcessingEnd() {
         try {
-            return StringUtils.isNotEmpty(this.processingEnd)
+            return StringUtils.isNotBlank(this.processingEnd)
                     ? new SimpleDateFormat(DATE_FORMAT).parse(this.processingEnd)
                     : null;
         } catch (ParseException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TemplateDTO.java
@@ -16,14 +16,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
+import org.kitodo.data.interfaces.WorkflowInterface;
 import org.kitodo.production.services.ServiceManager;
 
-public class TemplateDTO extends BaseTemplateDTO {
+public class TemplateDTO extends BaseTemplateDTO implements TemplateInterface {
 
     private boolean active;
-    private WorkflowDTO workflow;
+    private WorkflowInterface workflow;
     private boolean canBeUsedForProcess;
-    private List<ProjectDTO> projects = new ArrayList<>();
+    private List<ProjectInterface> projects = new ArrayList<>();
 
     /**
      * Get diagram image.
@@ -59,9 +62,9 @@ public class TemplateDTO extends BaseTemplateDTO {
     /**
      * Set workflow.
      *
-     * @param workflow as org.kitodo.production.dto.WorkflowDTO
+     * @param workflow as org.kitodo.production.dto.WorkflowInterface
      */
-    public void setWorkflow(WorkflowDTO workflow) {
+    public void setWorkflow(WorkflowInterface workflow) {
         this.workflow = workflow;
     }
 
@@ -70,7 +73,7 @@ public class TemplateDTO extends BaseTemplateDTO {
      *
      * @return value of workflow
      */
-    public WorkflowDTO getWorkflow() {
+    public WorkflowInterface getWorkflow() {
         return workflow;
     }
 
@@ -98,7 +101,7 @@ public class TemplateDTO extends BaseTemplateDTO {
      *
      * @return value of projects
      */
-    public List<ProjectDTO> getProjects() {
+    public List<ProjectInterface> getProjects() {
         return projects;
     }
 
@@ -106,9 +109,9 @@ public class TemplateDTO extends BaseTemplateDTO {
      * Set projects.
      *
      * @param projects
-     *            as List of ProjectDTO
+     *            as List of ProjectInterface
      */
-    public void setProjects(List<ProjectDTO> projects) {
+    public void setProjects(List<ProjectInterface> projects) {
         this.projects = projects;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TemplateDTO.java
@@ -26,7 +26,7 @@ public class TemplateDTO extends BaseTemplateDTO implements TemplateInterface {
     private boolean active;
     private WorkflowInterface workflow;
     private boolean canBeUsedForProcess;
-    private List<ProjectInterface> projects = new ArrayList<>();
+    private List<? extends ProjectInterface> projects = new ArrayList<>();
 
     /**
      * Get diagram image.
@@ -101,7 +101,7 @@ public class TemplateDTO extends BaseTemplateDTO implements TemplateInterface {
      *
      * @return value of projects
      */
-    public List<ProjectInterface> getProjects() {
+    public List<? extends ProjectInterface> getProjects() {
         return projects;
     }
 
@@ -111,7 +111,7 @@ public class TemplateDTO extends BaseTemplateDTO implements TemplateInterface {
      * @param projects
      *            as List of ProjectInterface
      */
-    public void setProjects(List<ProjectInterface> projects) {
+    public void setProjects(List<? extends ProjectInterface> projects) {
         this.projects = projects;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/TemplateDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/TemplateDTO.java
@@ -11,15 +11,12 @@
 
 package org.kitodo.production.dto;
 
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.kitodo.data.interfaces.ProjectInterface;
 import org.kitodo.data.interfaces.TemplateInterface;
 import org.kitodo.data.interfaces.WorkflowInterface;
-import org.kitodo.production.services.ServiceManager;
 
 public class TemplateDTO extends BaseTemplateDTO implements TemplateInterface {
 
@@ -27,18 +24,6 @@ public class TemplateDTO extends BaseTemplateDTO implements TemplateInterface {
     private WorkflowInterface workflow;
     private boolean canBeUsedForProcess;
     private List<? extends ProjectInterface> projects = new ArrayList<>();
-
-    /**
-     * Get diagram image.
-     *
-     * @return value of diagramImage
-     */
-    public InputStream getDiagramImage() {
-        if (Objects.nonNull(this.workflow)) {
-            return ServiceManager.getTemplateService().getTasksDiagram(this.workflow.getTitle());
-        }
-        return ServiceManager.getTemplateService().getTasksDiagram("");
-    }
 
     /**
      * Get active.

--- a/Kitodo/src/main/java/org/kitodo/production/dto/UserDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/UserDTO.java
@@ -33,15 +33,15 @@ public class UserDTO extends BaseDTO implements UserInterface {
     private String location;
     private String ldapLogin;
     private boolean active = true;
-    private List<FilterInterface> filters = new ArrayList<>();
+    private List<? extends FilterInterface> filters = new ArrayList<>();
     private Integer filtersSize;
-    private List<RoleInterface> roles = new ArrayList<>();
+    private List<? extends RoleInterface> roles = new ArrayList<>();
     private Integer rolesSize;
-    private List<ClientInterface> clients = new ArrayList<>();
+    private List<? extends ClientInterface> clients = new ArrayList<>();
     private int clientsSize;
-    private List<ProjectInterface> projects = new ArrayList<>();
+    private List<? extends ProjectInterface> projects = new ArrayList<>();
     private Integer projectsSize;
-    private List<TaskInterface> processingTasks = new ArrayList<>();
+    private List<? extends TaskInterface> processingTasks = new ArrayList<>();
 
     /**
      * Get login.
@@ -181,7 +181,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      *
      * @return list of filters as FilterInterface
      */
-    public List<FilterInterface> getFilters() {
+    public List<? extends FilterInterface> getFilters() {
         return filters;
     }
 
@@ -191,7 +191,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      * @param filters
      *            list of filters as FilterInterface
      */
-    public void setFilters(List<FilterInterface> filters) {
+    public void setFilters(List<? extends FilterInterface> filters) {
         this.filters = filters;
     }
 
@@ -219,7 +219,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      *
      * @return list of roles as RoleInterface
      */
-    public List<RoleInterface> getRoles() {
+    public List<? extends RoleInterface> getRoles() {
         return roles;
     }
 
@@ -229,7 +229,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      * @param roles
      *            list of roles as RoleInterface
      */
-    public void setRoles(List<RoleInterface> roles) {
+    public void setRoles(List<? extends RoleInterface> roles) {
         this.roles = roles;
     }
 
@@ -257,7 +257,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      *
      * @return The clients.
      */
-    public List<ClientInterface> getClients() {
+    public List<? extends ClientInterface> getClients() {
         return clients;
     }
 
@@ -266,7 +266,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      *
      * @param clients The clients.
      */
-    public void setClients(List<ClientInterface> clients) {
+    public void setClients(List<? extends ClientInterface> clients) {
         this.clients = clients;
     }
 
@@ -293,7 +293,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      *
      * @return list of projects as ProjectInterface
      */
-    public List<ProjectInterface> getProjects() {
+    public List<? extends ProjectInterface> getProjects() {
         return projects;
     }
 
@@ -303,7 +303,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      * @param projects
      *            list of projects as ProjectInterface
      */
-    public void setProjects(List<ProjectInterface> projects) {
+    public void setProjects(List<? extends ProjectInterface> projects) {
         this.projects = projects;
     }
 
@@ -332,7 +332,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      *
      * @return list of processing tasks as TaskInterface
      */
-    public List<TaskInterface> getProcessingTasks() {
+    public List<? extends TaskInterface> getProcessingTasks() {
         return processingTasks;
     }
 
@@ -342,7 +342,7 @@ public class UserDTO extends BaseDTO implements UserInterface {
      * @param processingTasks
      *            list of processing tasks as TaskInterface
      */
-    public void setProcessingTasks(List<TaskInterface> processingTasks) {
+    public void setProcessingTasks(List<? extends TaskInterface> processingTasks) {
         this.processingTasks = processingTasks;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/UserDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/UserDTO.java
@@ -14,10 +14,17 @@ package org.kitodo.production.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.FilterInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.RoleInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.UserInterface;
+
 /**
  * User DTO object.
  */
-public class UserDTO extends BaseDTO {
+public class UserDTO extends BaseDTO implements UserInterface {
 
     private String login;
     private String name;
@@ -26,15 +33,15 @@ public class UserDTO extends BaseDTO {
     private String location;
     private String ldapLogin;
     private boolean active = true;
-    private List<FilterDTO> filters = new ArrayList<>();
+    private List<FilterInterface> filters = new ArrayList<>();
     private Integer filtersSize;
-    private List<RoleDTO> roles = new ArrayList<>();
+    private List<RoleInterface> roles = new ArrayList<>();
     private Integer rolesSize;
-    private List<ClientDTO> clients = new ArrayList<>();
+    private List<ClientInterface> clients = new ArrayList<>();
     private int clientsSize;
-    private List<ProjectDTO> projects = new ArrayList<>();
+    private List<ProjectInterface> projects = new ArrayList<>();
     private Integer projectsSize;
-    private List<TaskDTO> processingTasks = new ArrayList<>();
+    private List<TaskInterface> processingTasks = new ArrayList<>();
 
     /**
      * Get login.
@@ -172,9 +179,9 @@ public class UserDTO extends BaseDTO {
     /**
      * Get list of filters.
      *
-     * @return list of filters as FilterDTO
+     * @return list of filters as FilterInterface
      */
-    public List<FilterDTO> getFilters() {
+    public List<FilterInterface> getFilters() {
         return filters;
     }
 
@@ -182,9 +189,9 @@ public class UserDTO extends BaseDTO {
      * Set list of filters.
      *
      * @param filters
-     *            list of filters as FilterDTO
+     *            list of filters as FilterInterface
      */
-    public void setFilters(List<FilterDTO> filters) {
+    public void setFilters(List<FilterInterface> filters) {
         this.filters = filters;
     }
 
@@ -210,9 +217,9 @@ public class UserDTO extends BaseDTO {
     /**
      * Get list of roles.
      *
-     * @return list of roles as RoleDTO
+     * @return list of roles as RoleInterface
      */
-    public List<RoleDTO> getRoles() {
+    public List<RoleInterface> getRoles() {
         return roles;
     }
 
@@ -220,9 +227,9 @@ public class UserDTO extends BaseDTO {
      * Set list of roles.
      *
      * @param roles
-     *            list of roles as RoleDTO
+     *            list of roles as RoleInterface
      */
-    public void setRoles(List<RoleDTO> roles) {
+    public void setRoles(List<RoleInterface> roles) {
         this.roles = roles;
     }
 
@@ -250,7 +257,7 @@ public class UserDTO extends BaseDTO {
      *
      * @return The clients.
      */
-    public List<ClientDTO> getClients() {
+    public List<ClientInterface> getClients() {
         return clients;
     }
 
@@ -259,7 +266,7 @@ public class UserDTO extends BaseDTO {
      *
      * @param clients The clients.
      */
-    public void setClients(List<ClientDTO> clients) {
+    public void setClients(List<ClientInterface> clients) {
         this.clients = clients;
     }
 
@@ -284,9 +291,9 @@ public class UserDTO extends BaseDTO {
     /**
      * Get list of projects.
      *
-     * @return list of projects as ProjectDTO
+     * @return list of projects as ProjectInterface
      */
-    public List<ProjectDTO> getProjects() {
+    public List<ProjectInterface> getProjects() {
         return projects;
     }
 
@@ -294,9 +301,9 @@ public class UserDTO extends BaseDTO {
      * Set list of projects.
      *
      * @param projects
-     *            list of projects as ProjectDTO
+     *            list of projects as ProjectInterface
      */
-    public void setProjects(List<ProjectDTO> projects) {
+    public void setProjects(List<ProjectInterface> projects) {
         this.projects = projects;
     }
 
@@ -323,9 +330,9 @@ public class UserDTO extends BaseDTO {
     /**
      * Get list of processing tasks.
      *
-     * @return list of processing tasks as TaskDTO
+     * @return list of processing tasks as TaskInterface
      */
-    public List<TaskDTO> getProcessingTasks() {
+    public List<TaskInterface> getProcessingTasks() {
         return processingTasks;
     }
 
@@ -333,9 +340,9 @@ public class UserDTO extends BaseDTO {
      * Set list of processing tasks.
      *
      * @param processingTasks
-     *            list of processing tasks as TaskDTO
+     *            list of processing tasks as TaskInterface
      */
-    public void setProcessingTasks(List<TaskDTO> processingTasks) {
+    public void setProcessingTasks(List<TaskInterface> processingTasks) {
         this.processingTasks = processingTasks;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
@@ -11,7 +11,9 @@
 
 package org.kitodo.production.dto;
 
-public class WorkflowDTO extends BaseDTO {
+import org.kitodo.data.interfaces.WorkflowInterface;
+
+public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
 
     private String title;
     private String status;

--- a/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
@@ -11,6 +11,10 @@
 
 package org.kitodo.production.dto;
 
+import java.util.Objects;
+
+import org.apache.logging.log4j.util.Strings;
+import org.kitodo.data.database.enums.WorkflowStatus;
 import org.kitodo.data.interfaces.WorkflowInterface;
 
 public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
@@ -42,7 +46,7 @@ public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
      *
      * @return value of status
      */
-    public String getStatus() {
+    public String getWorkflowStatus() {
         return status.toLowerCase();
     }
 
@@ -52,7 +56,17 @@ public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
      * @param status
      *            as String
      */
-    public void setStatus(String status) {
+    public void setWorkflowStatus(String status) {
         this.status = status;
+    }
+
+    @Override
+    public WorkflowStatus getStatus() {
+        return Strings.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null;
+    }
+
+    @Override
+    public void setStatus(WorkflowStatus status) {
+        this.status = Objects.nonNull(status) ? status.toString() : null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
@@ -66,7 +66,7 @@ public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
 
     @Override
     public WorkflowStatus getStatus() {
-        return StringUtils.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null;
+        return StringUtils.isNotBlank(status) ? WorkflowStatus.valueOf(status) : null;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/WorkflowDTO.java
@@ -13,7 +13,7 @@ package org.kitodo.production.dto;
 
 import java.util.Objects;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.kitodo.data.database.enums.WorkflowStatus;
 import org.kitodo.data.interfaces.WorkflowInterface;
 
@@ -27,6 +27,7 @@ public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
      *
      * @return value of title
      */
+    @Override
     public String getTitle() {
         return title;
     }
@@ -37,6 +38,7 @@ public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
      * @param title
      *            as String
      */
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
@@ -46,6 +48,7 @@ public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
      *
      * @return value of status
      */
+    @Override
     public String getWorkflowStatus() {
         return status.toLowerCase();
     }
@@ -56,13 +59,14 @@ public class WorkflowDTO extends BaseDTO implements WorkflowInterface {
      * @param status
      *            as String
      */
+    @Override
     public void setWorkflowStatus(String status) {
         this.status = status;
     }
 
     @Override
     public WorkflowStatus getStatus() {
-        return Strings.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null;
+        return StringUtils.isNotEmpty(status) ? WorkflowStatus.valueOf(status) : null;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
@@ -35,8 +35,8 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.enums.CommentType;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.export.ExportDms;
-import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.batch.BatchProcessHelper;
@@ -108,7 +108,7 @@ public class BatchForm extends BaseForm {
      * Filter processes.
      */
     public void filterProcesses() {
-        List<ProcessDTO> processDTOS = new ArrayList<>();
+        List<ProcessInterface> processInterfaces = new ArrayList<>();
         QueryBuilder query = new BoolQueryBuilder();
 
         if (Objects.nonNull(this.processfilter)) {
@@ -123,17 +123,17 @@ public class BatchForm extends BaseForm {
         int batchMaxSize = ConfigCore.getIntParameter(ParameterCore.BATCH_DISPLAY_LIMIT, -1);
         try {
             if (batchMaxSize > 0) {
-                processDTOS = ServiceManager.getProcessService().findByQuery(query,
+                processInterfaces = ServiceManager.getProcessService().findByQuery(query,
                     ServiceManager.getProcessService().sortByCreationDate(SortOrder.DESC), 0, batchMaxSize, false);
             } else {
-                processDTOS = ServiceManager.getProcessService().findByQuery(query,
+                processInterfaces = ServiceManager.getProcessService().findByQuery(query,
                     ServiceManager.getProcessService().sortByCreationDate(SortOrder.DESC), false);
             }
         } catch (DataException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
         try {
-            this.currentProcesses = ServiceManager.getProcessService().convertDtosToBeans(processDTOS);
+            this.currentProcesses = ServiceManager.getProcessService().convertDtosToBeans(processInterfaces);
         } catch (DAOException e) {
             this.currentProcesses = new ArrayList<>();
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/BatchForm.java
@@ -108,7 +108,7 @@ public class BatchForm extends BaseForm {
      * Filter processes.
      */
     public void filterProcesses() {
-        List<ProcessInterface> processInterfaces = new ArrayList<>();
+        List<ProcessInterface> processes = new ArrayList<>();
         QueryBuilder query = new BoolQueryBuilder();
 
         if (Objects.nonNull(this.processfilter)) {
@@ -123,17 +123,17 @@ public class BatchForm extends BaseForm {
         int batchMaxSize = ConfigCore.getIntParameter(ParameterCore.BATCH_DISPLAY_LIMIT, -1);
         try {
             if (batchMaxSize > 0) {
-                processInterfaces = ServiceManager.getProcessService().findByQuery(query,
+                processes = ServiceManager.getProcessService().findByQuery(query,
                     ServiceManager.getProcessService().sortByCreationDate(SortOrder.DESC), 0, batchMaxSize, false);
             } else {
-                processInterfaces = ServiceManager.getProcessService().findByQuery(query,
+                processes = ServiceManager.getProcessService().findByQuery(query,
                     ServiceManager.getProcessService().sortByCreationDate(SortOrder.DESC), false);
             }
         } catch (DataException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
         try {
-            this.currentProcesses = ServiceManager.getProcessService().convertDtosToBeans(processInterfaces);
+            this.currentProcesses = ServiceManager.getProcessService().convertDtosToBeans(processes);
         } catch (DAOException e) {
             this.currentProcesses = new ArrayList<>();
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
@@ -43,16 +43,16 @@ public class CommentTooltipView {
     /**
      * Get comments of given process.
      *
-     * @param processInterface process as ProcessInterface
+     * @param process process as ProcessInterface
      * @return List of Comment objects
      */
-    public List<Comment> getComments(ProcessInterface processInterface) {
-        if (comments.containsKey(processInterface)) {
-            return comments.get(processInterface);
+    public List<Comment> getComments(ProcessInterface process) {
+        if (comments.containsKey(process)) {
+            return comments.get(process);
         }
         try {
-            comments.put(processInterface, ServiceManager.getProcessService().getComments(processInterface));
-            return comments.get(processInterface);
+            comments.put(process, ServiceManager.getProcessService().getComments(process));
+            return comments.get(process);
         } catch (DAOException e) {
             Helper.setErrorMessage(e);
             return Collections.emptyList();
@@ -62,10 +62,10 @@ public class CommentTooltipView {
     /**
      * Get comments of process containing the given task.
      *
-     * @param taskInterface task as TaskInterface
+     * @param task task as TaskInterface
      * @return List of Comment objects
      */
-    public List<Comment> getComments(TaskInterface taskInterface) {
-        return getComments(taskInterface.getProcess());
+    public List<Comment> getComments(TaskInterface task) {
+        return getComments(task.getProcess());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
@@ -22,8 +22,8 @@ import javax.inject.Named;
 
 import org.kitodo.data.database.beans.Comment;
 import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.production.dto.ProcessDTO;
-import org.kitodo.production.dto.TaskDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.TaskInterface;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 
@@ -31,7 +31,7 @@ import org.kitodo.production.services.ServiceManager;
 @RequestScoped
 public class CommentTooltipView {
 
-    private final Map<ProcessDTO, List<Comment>> comments;
+    private final Map<ProcessInterface, List<Comment>> comments;
 
     /**
      * Default constructor.
@@ -43,16 +43,16 @@ public class CommentTooltipView {
     /**
      * Get comments of given process.
      *
-     * @param processDTO process as ProcessDTO
+     * @param processInterface process as ProcessInterface
      * @return List of Comment objects
      */
-    public List<Comment> getComments(ProcessDTO processDTO) {
-        if (comments.containsKey(processDTO)) {
-            return comments.get(processDTO);
+    public List<Comment> getComments(ProcessInterface processInterface) {
+        if (comments.containsKey(processInterface)) {
+            return comments.get(processInterface);
         }
         try {
-            comments.put(processDTO, ServiceManager.getProcessService().getComments(processDTO));
-            return comments.get(processDTO);
+            comments.put(processInterface, ServiceManager.getProcessService().getComments(processInterface));
+            return comments.get(processInterface);
         } catch (DAOException e) {
             Helper.setErrorMessage(e);
             return Collections.emptyList();
@@ -62,10 +62,10 @@ public class CommentTooltipView {
     /**
      * Get comments of process containing the given task.
      *
-     * @param taskDTO task as TaskDTO
+     * @param taskInterface task as TaskInterface
      * @return List of Comment objects
      */
-    public List<Comment> getComments(TaskDTO taskDTO) {
-        return getComments(taskDTO.getProcess());
+    public List<Comment> getComments(TaskInterface taskInterface) {
+        return getComments(taskInterface.getProcess());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -38,9 +38,9 @@ import org.kitodo.data.database.enums.TaskEditType;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.TaskInterface;
 import org.kitodo.export.ExportDms;
 import org.kitodo.export.TiffHeader;
-import org.kitodo.production.dto.TaskDTO;
 import org.kitodo.production.enums.GenerationMode;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.filters.FilterMenu;
@@ -66,7 +66,7 @@ public class CurrentTaskForm extends BaseForm {
     private static final Logger logger = LogManager.getLogger(CurrentTaskForm.class);
     private Process myProcess = new Process();
     private Task currentTask = new Task();
-    private List<TaskDTO> selectedTasks = new ArrayList<>();
+    private List<TaskInterface> selectedTasks = new ArrayList<>();
     private final WebDav myDav = new WebDav();
     private String scriptPath;
     private transient BatchTaskHelper batchHelper;
@@ -417,7 +417,7 @@ public class CurrentTaskForm extends BaseForm {
      *
      * @return List of selected Tasks
      */
-    public List<TaskDTO> getSelectedTasks() {
+    public List<TaskInterface> getSelectedTasks() {
         return this.selectedTasks;
     }
 
@@ -427,7 +427,7 @@ public class CurrentTaskForm extends BaseForm {
      * @param selectedTasks
      *            provided by data table
      */
-    public void setSelectedTasks(List<TaskDTO> selectedTasks) {
+    public void setSelectedTasks(List<TaskInterface> selectedTasks) {
         this.selectedTasks = selectedTasks;
     }
 
@@ -743,12 +743,12 @@ public class CurrentTaskForm extends BaseForm {
 
     /**
      * Retrieve and return process property value of property with given name 'propertyName' from process of given
-     * TaskDTO 'task'.
-     * @param task the TaskDTO object from which the property value is retrieved
+     * TaskInterface 'task'.
+     * @param task the TaskInterface object from which the property value is retrieved
      * @param propertyName name of the property for the property value is retrieved
      * @return property value if process has property with name 'propertyName', empty String otherwise
      */
-    public static String getTaskProcessPropertyValue(TaskDTO task, String propertyName) {
+    public static String getTaskProcessPropertyValue(TaskInterface task, String propertyName) {
         return ProcessService.getPropertyValue(task.getProcess(), propertyName);
     }
 
@@ -765,10 +765,10 @@ public class CurrentTaskForm extends BaseForm {
     /**
      * Calculate and return age of given tasks process as a String.
      *
-     * @param task TaskDTO object whose process is used
+     * @param task TaskInterface object whose process is used
      * @return process age of given tasks process
      */
-    public String getProcessDuration(TaskDTO task) {
+    public String getProcessDuration(TaskInterface task) {
         return ProcessService.getProcessDuration(task.getProcess());
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
@@ -25,10 +25,10 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TaskInterface;
 import org.kitodo.exceptions.ProjectDeletionException;
-import org.kitodo.production.dto.ProcessDTO;
-import org.kitodo.production.dto.ProjectDTO;
-import org.kitodo.production.dto.TaskDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.WebDav;
@@ -43,9 +43,9 @@ public class DesktopForm extends BaseForm {
     private static final Logger logger = LogManager.getLogger(DesktopForm.class);
     private static final String SORT_TITLE = "title";
     private static final String SORT_ID = "id";
-    private List<TaskDTO> taskList = new ArrayList<>();
-    private List<ProcessDTO> processList = new ArrayList<>();
-    private List<ProjectDTO> projectList = new ArrayList<>();
+    private List<TaskInterface> taskList = new ArrayList<>();
+    private List<ProcessInterface> processList = new ArrayList<>();
+    private List<ProjectInterface> projectList = new ArrayList<>();
 
     /**
      * Default constructor.
@@ -78,7 +78,7 @@ public class DesktopForm extends BaseForm {
      *
      * @return task list
      */
-    public List<TaskDTO> getTasks() {
+    public List<TaskInterface> getTasks() {
         try {
             if (ServiceManager.getSecurityAccessService().hasAuthorityToViewTaskList() && taskList.isEmpty()) {
                 taskList = ServiceManager.getTaskService().loadData(0, 10, SORT_TITLE, SortOrder.ASCENDING, new HashMap<>());
@@ -95,7 +95,7 @@ public class DesktopForm extends BaseForm {
      *
      * @return process list
      */
-    public List<ProcessDTO> getProcesses() {
+    public List<ProcessInterface> getProcesses() {
         try {
             if (ServiceManager.getSecurityAccessService().hasAuthorityToViewProcessList() && processList.isEmpty()) {
                 processList = ServiceManager.getProcessService().loadData(0, 10, SORT_ID, SortOrder.DESCENDING, null);
@@ -112,7 +112,7 @@ public class DesktopForm extends BaseForm {
      *
      * @return project list
      */
-    public List<ProjectDTO> getProjects() {
+    public List<ProjectInterface> getProjects() {
         try {
             if (ServiceManager.getSecurityAccessService().hasAuthorityToViewProjectList() && projectList.isEmpty()) {
                 projectList = ServiceManager.getProjectService().loadData(0, 10, SORT_TITLE, SortOrder.ASCENDING, null);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -1134,7 +1134,8 @@ public class ProcessForm extends TemplateBaseForm {
      * @return List of filtered tasks as Interface objects
      */
     public List<TaskInterface> getCurrentTasksForUser(ProcessInterface processInterface) {
-        return ServiceManager.getProcessService().getCurrentTasksForUser(processInterface, ServiceManager.getUserService().getCurrentUser());
+        return ServiceManager.getProcessService().getCurrentTasksForUser(processInterface,
+            ServiceManager.getUserService().getCurrentUser());
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -167,12 +167,12 @@ public class ProcessForm extends TemplateBaseForm {
     /**
      * Calculate and return age of given process as a String.
      *
-     * @param processInterface
+     * @param process
      *            ProcessInterface object whose duration/age is calculated
      * @return process age of given process
      */
-    public static String getProcessDuration(ProcessInterface processInterface) {
-        return ProcessService.getProcessDuration(processInterface);
+    public static String getProcessDuration(ProcessInterface process) {
+        return ProcessService.getProcessDuration(process);
     }
 
     /**
@@ -202,15 +202,15 @@ public class ProcessForm extends TemplateBaseForm {
 
     /**
      * Create Child for given Process.
-     * @param processInterface the process to create a child for.
+     * @param process the process to create a child for.
      * @return path to createProcessForm
      */
-    public String createProcessAsChild(ProcessInterface processInterface) {
+    public String createProcessAsChild(ProcessInterface process) {
         try {
-            Process process = ServiceManager.getProcessService().getById(processInterface.getId());
-            if (Objects.nonNull(process.getTemplate()) && Objects.nonNull(process.getProject())) {
-                return CREATE_PROCESS_PATH + "&templateId=" + process.getTemplate().getId() + "&projectId="
-                        + process.getProject().getId() + "&parentId=" + process.getId();
+            Process processBean = ServiceManager.getProcessService().getById(process.getId());
+            if (Objects.nonNull(processBean.getTemplate()) && Objects.nonNull(processBean.getProject())) {
+                return CREATE_PROCESS_PATH + "&templateId=" + processBean.getTemplate().getId() + "&projectId="
+                        + processBean.getProject().getId() + "&parentId=" + processBean.getId();
             }
         } catch (DAOException e) {
             Helper.setErrorMessage(ERROR_READING, new Object[] {ObjectType.PROCESS.getTranslationSingular() }, logger,
@@ -1059,7 +1059,7 @@ public class ProcessForm extends TemplateBaseForm {
     }
 
     private String filterList() {
-        this.selectedProcessesOrProcessDTOs.clear();
+        this.selectedProcesses.clear();
         return processesPage;
     }
 
@@ -1073,12 +1073,12 @@ public class ProcessForm extends TemplateBaseForm {
      * Returns a String containing titles of all current tasks of the given process, e.g. "OPEN" tasks and tasks
      * "INWORK".
      *
-     * @param processInterface
+     * @param process
      *          process for which current task titles are returned
      * @return String containing titles of current tasks of given process
      */
-    public String getCurrentTaskTitles(ProcessInterface processInterface) {
-        return ServiceManager.getProcessService().createProgressTooltip(processInterface);
+    public String getCurrentTaskTitles(ProcessInterface process) {
+        return ServiceManager.getProcessService().createProgressTooltip(process);
     }
 
     /**
@@ -1130,11 +1130,11 @@ public class ProcessForm extends TemplateBaseForm {
 
     /**
      * Get all tasks of given process which should be visible to the user.
-     * @param processInterface process as Interface object
+     * @param process process as Interface object
      * @return List of filtered tasks as Interface objects
      */
-    public List<TaskInterface> getCurrentTasksForUser(ProcessInterface processInterface) {
-        return ServiceManager.getProcessService().getCurrentTasksForUser(processInterface,
+    public List<TaskInterface> getCurrentTasksForUser(ProcessInterface process) {
+        return ServiceManager.getProcessService().getCurrentTasksForUser(process,
             ServiceManager.getUserService().getCurrentUser());
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -48,11 +48,11 @@ import org.kitodo.data.database.enums.PropertyType;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.TaskInterface;
 import org.kitodo.exceptions.InvalidImagesException;
 import org.kitodo.exceptions.MediaNotFoundException;
 import org.kitodo.production.controller.SecurityAccessController;
-import org.kitodo.production.dto.ProcessDTO;
-import org.kitodo.production.dto.TaskDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.filters.FilterMenu;
 import org.kitodo.production.helper.CustomListColumnInitializer;
@@ -151,28 +151,28 @@ public class ProcessForm extends TemplateBaseForm {
 
     /**
      * Retrieve and return process property value of property with given name
-     * 'propertyName' from given ProcessDTO 'process'.
+     * 'propertyName' from given ProcessInterface 'process'.
      *
      * @param process
-     *            the ProcessDTO object from which the property value is retrieved
+     *            the ProcessInterface object from which the property value is retrieved
      * @param propertyName
      *            name of the property for the property value is retrieved
      * @return property value if process has property with name 'propertyName',
      *         empty String otherwise
      */
-    public static String getPropertyValue(ProcessDTO process, String propertyName) {
+    public static String getPropertyValue(ProcessInterface process, String propertyName) {
         return ProcessService.getPropertyValue(process, propertyName);
     }
 
     /**
      * Calculate and return age of given process as a String.
      *
-     * @param processDTO
-     *            ProcessDTO object whose duration/age is calculated
+     * @param processInterface
+     *            ProcessInterface object whose duration/age is calculated
      * @return process age of given process
      */
-    public static String getProcessDuration(ProcessDTO processDTO) {
-        return ProcessService.getProcessDuration(processDTO);
+    public static String getProcessDuration(ProcessInterface processInterface) {
+        return ProcessService.getProcessDuration(processInterface);
     }
 
     /**
@@ -202,12 +202,12 @@ public class ProcessForm extends TemplateBaseForm {
 
     /**
      * Create Child for given Process.
-     * @param processDTO the process to create a child for.
+     * @param processInterface the process to create a child for.
      * @return path to createProcessForm
      */
-    public String createProcessAsChild(ProcessDTO processDTO) {
+    public String createProcessAsChild(ProcessInterface processInterface) {
         try {
-            Process process = ServiceManager.getProcessService().getById(processDTO.getId());
+            Process process = ServiceManager.getProcessService().getById(processInterface.getId());
             if (Objects.nonNull(process.getTemplate()) && Objects.nonNull(process.getProject())) {
                 return CREATE_PROCESS_PATH + "&templateId=" + process.getTemplate().getId() + "&projectId="
                         + process.getProject().getId() + "&parentId=" + process.getId();
@@ -652,11 +652,11 @@ public class ProcessForm extends TemplateBaseForm {
 
     private List<Process> getProcessesForActions() {
         // TODO: find a way to pass filters
-        List<ProcessDTO> filteredProcesses = new ArrayList<>();
+        List<ProcessInterface> filteredProcesses = new ArrayList<>();
         for (Object object : lazyDTOModel.load(0, 100000, "",
                 SortOrder.ASCENDING, null)) {
-            if (object instanceof ProcessDTO) {
-                filteredProcesses.add((ProcessDTO) object);
+            if (object instanceof ProcessInterface) {
+                filteredProcesses.add((ProcessInterface) object);
             }
         }
         List<Process> processesForActions = new ArrayList<>();
@@ -1073,12 +1073,12 @@ public class ProcessForm extends TemplateBaseForm {
      * Returns a String containing titles of all current tasks of the given process, e.g. "OPEN" tasks and tasks
      * "INWORK".
      *
-     * @param processDTO
+     * @param processInterface
      *          process for which current task titles are returned
      * @return String containing titles of current tasks of given process
      */
-    public String getCurrentTaskTitles(ProcessDTO processDTO) {
-        return ServiceManager.getProcessService().createProgressTooltip(processDTO);
+    public String getCurrentTaskTitles(ProcessInterface processInterface) {
+        return ServiceManager.getProcessService().createProgressTooltip(processInterface);
     }
 
     /**
@@ -1130,11 +1130,11 @@ public class ProcessForm extends TemplateBaseForm {
 
     /**
      * Get all tasks of given process which should be visible to the user.
-     * @param processDTO process as DTO object
-     * @return List of filtered tasks as DTO objects
+     * @param processInterface process as Interface object
+     * @return List of filtered tasks as Interface objects
      */
-    public List<TaskDTO> getCurrentTasksForUser(ProcessDTO processDTO) {
-        return ServiceManager.getProcessService().getCurrentTasksForUser(processDTO, ServiceManager.getUserService().getCurrentUser());
+    public List<TaskInterface> getCurrentTasksForUser(ProcessInterface processInterface) {
+        return ServiceManager.getProcessService().getCurrentTasksForUser(processInterface, ServiceManager.getUserService().getCurrentUser());
     }
 
     /**
@@ -1215,7 +1215,7 @@ public class ProcessForm extends TemplateBaseForm {
         if (process instanceof Process) {
             return ((Process) process).getId();
         } else {
-            return ((ProcessDTO) process).getId();
+            return ((ProcessInterface) process).getId();
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
@@ -11,6 +11,8 @@
 
 package org.kitodo.production.forms;
 
+import com.itextpdf.text.DocumentException;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -45,8 +47,6 @@ import org.primefaces.component.datatable.DataTable;
 import org.primefaces.event.data.PageEvent;
 import org.primefaces.model.charts.hbar.HorizontalBarChartModel;
 import org.primefaces.model.charts.pie.PieChartModel;
-
-import com.itextpdf.text.DocumentException;
 
 public class ProcessListBaseView extends BaseForm {
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
@@ -125,9 +125,9 @@ public class ProcessListBaseView extends BaseForm {
         ProcessService processService = ServiceManager.getProcessService();
         if (allSelected) {
             try {
-                this.selectedProcesses = processService.findByQuery(processService.getQueryForFilter(
-                                this.isShowClosedProcesses(), isShowInactiveProjects(), getFilter())
-                        .mustNot(processService.createSetQueryForIds(new ArrayList<>(excludedProcessIds))), false);
+                this.selectedProcesses = processService.findSelectedProcesses(
+                    this.isShowClosedProcesses(), isShowInactiveProjects(), getFilter(),
+                    new ArrayList<>(excludedProcessIds));
             } catch (DataException e) {
                 logger.error(e.getMessage());
             }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
@@ -11,8 +11,6 @@
 
 package org.kitodo.production.forms;
 
-import com.itextpdf.text.DocumentException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -31,8 +29,8 @@ import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.export.ExportDms;
-import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.enums.ChartMode;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
@@ -47,6 +45,8 @@ import org.primefaces.component.datatable.DataTable;
 import org.primefaces.event.data.PageEvent;
 import org.primefaces.model.charts.hbar.HorizontalBarChartModel;
 import org.primefaces.model.charts.pie.PieChartModel;
+
+import com.itextpdf.text.DocumentException;
 
 public class ProcessListBaseView extends BaseForm {
 
@@ -115,7 +115,7 @@ public class ProcessListBaseView extends BaseForm {
 
     /**
      * Returns the list of the processes currently selected in the user interface.
-     * Converts ProcessDTO instances to Process instances in case of displaying search results.
+     * Converts ProcessInterface instances to Process instances in case of displaying search results.
      *
      * @return value of selectedProcesses
      */
@@ -133,11 +133,11 @@ public class ProcessListBaseView extends BaseForm {
             }
         }
         if (!selectedProcessesOrProcessDTOs.isEmpty()) {
-            if (selectedProcessesOrProcessDTOs.get(0) instanceof ProcessDTO) {
-                // list contains ProcessDTO instances
+            if (selectedProcessesOrProcessDTOs.get(0) instanceof ProcessInterface) {
+                // list contains ProcessInterface instances
                 try {
                     selectedProcesses = ServiceManager.getProcessService()
-                            .convertDtosToBeans((List<ProcessDTO>) selectedProcessesOrProcessDTOs);
+                            .convertDtosToBeans((List<ProcessInterface>) selectedProcessesOrProcessDTOs);
                 } catch (DAOException e) {
                     Helper.setErrorMessage(ERROR_LOADING_MANY,
                             new Object[]{ObjectType.PROCESS.getTranslationPlural()}, logger, e);
@@ -432,13 +432,13 @@ public class ProcessListBaseView extends BaseForm {
     /**
      * If processes are generated with calendar.
      *
-     * @param processDTO
+     * @param processInterface
      *            the process dto to check.
      * @return true if processes are created with calendar, false otherwise
      */
-    public boolean createProcessesWithCalendar(ProcessDTO processDTO) {
+    public boolean createProcessesWithCalendar(ProcessInterface processInterface) {
         try {
-            return ProcessService.canCreateProcessWithCalendar(processDTO);
+            return ProcessService.canCreateProcessWithCalendar(processInterface);
         } catch (IOException | DAOException e) {
             Helper.setErrorMessage(ERROR_READING, new Object[] {ObjectType.PROCESS.getTranslationSingular() }, logger,
                     e);
@@ -449,13 +449,13 @@ public class ProcessListBaseView extends BaseForm {
     /**
      * If a process can be created as child.
      *
-     * @param processDTO
+     * @param processInterface
      *            the process dto to check.
      * @return true if processes can be created as child, false otherwise
      */
-    public boolean createProcessAsChildPossible(ProcessDTO processDTO) {
+    public boolean createProcessAsChildPossible(ProcessInterface processInterface) {
         try {
-            return ProcessService.canCreateChildProcess(processDTO);
+            return ProcessService.canCreateChildProcess(processInterface);
         } catch (IOException | DAOException e) {
             Helper.setErrorMessage(ERROR_READING, new Object[] {ObjectType.PROCESS.getTranslationSingular() }, logger,
                     e);
@@ -479,9 +479,9 @@ public class ProcessListBaseView extends BaseForm {
     /**
      * Starts generation of xml logfile for current process.
      */
-    public void createXML(ProcessDTO processDTO) {
+    public void createXML(ProcessInterface processInterface) {
         try {
-            ProcessService.createXML(ServiceManager.getProcessService().getById(processDTO.getId()), getUser());
+            ProcessService.createXML(ServiceManager.getProcessService().getById(processInterface.getId()), getUser());
         } catch (IOException | DAOException e) {
             Helper.setErrorMessage("Error creating log file in home directory", logger, e);
         }
@@ -529,26 +529,26 @@ public class ProcessListBaseView extends BaseForm {
     /**
      * Upload from home for single process.
      */
-    public void uploadFromHome(ProcessDTO processDTO) {
+    public void uploadFromHome(ProcessInterface processInterface) {
         try {
             WebDav myDav = new WebDav();
-            myDav.uploadFromHome(ServiceManager.getProcessService().getById(processDTO.getId()));
-            Helper.setMessage("directoryRemoved", processDTO.getTitle());
+            myDav.uploadFromHome(ServiceManager.getProcessService().getById(processInterface.getId()));
+            Helper.setMessage("directoryRemoved", processInterface.getTitle());
         } catch (DAOException e) {
             Helper.setErrorMessage(ERROR_LOADING_ONE,
-                    new Object[] {ObjectType.PROCESS.getTranslationSingular(), processDTO.getId() }, logger, e);
+                    new Object[] {ObjectType.PROCESS.getTranslationSingular(), processInterface.getId() }, logger, e);
         }
     }
 
     /**
      * Delete Process.
      *
-     * @param processDTO
+     * @param processInterface
      *            process to delete.
      */
-    public void delete(ProcessDTO processDTO) {
+    public void delete(ProcessInterface processInterface) {
         try {
-            Process process = ServiceManager.getProcessService().getById(processDTO.getId());
+            Process process = ServiceManager.getProcessService().getById(processInterface.getId());
             if (process.getChildren().isEmpty()) {
                 try {
                     ProcessService.deleteProcess(process);
@@ -597,16 +597,16 @@ public class ProcessListBaseView extends BaseForm {
     /**
      * Returns the list of currently selected processes. This list is used both when displaying search results 
      * and when displaying the process list, which is why it may contain either instances of Process or 
-     * instances of ProcessDTO.
+     * instances of ProcessInterface.
      * 
-     * @return list of instances of Process or ProcessDTO
+     * @return list of instances of Process or ProcessInterface
      */
     public List<? extends Object> getSelectedProcessesOrProcessDTOs() {
         return selectedProcessesOrProcessDTOs;
     }
 
-    public void setSelectedProcessesOrProcessDTOs(List<? extends Object> selectedProcessesOrProcessDTOs) {
-        this.selectedProcessesOrProcessDTOs = selectedProcessesOrProcessDTOs;
+    public void setSelectedProcessesOrProcessDTOs(List<? extends Object> selectedProcessesOrProcessInterfaces) {
+        this.selectedProcessesOrProcessDTOs = selectedProcessesOrProcessInterfaces;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectForm.java
@@ -46,11 +46,11 @@ import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.enums.PreviewHoverMode;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
 import org.kitodo.exceptions.ProjectDeletionException;
 import org.kitodo.forms.FolderGenerator;
 import org.kitodo.production.controller.SecurityAccessController;
-import org.kitodo.production.dto.ProjectDTO;
-import org.kitodo.production.dto.TemplateDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.model.LazyDTOModel;
@@ -373,7 +373,7 @@ public class ProjectForm extends BaseForm {
      *
      * @return list of assignable templates
      */
-    public List<TemplateDTO> getTemplates() {
+    public List<TemplateInterface> getTemplates() {
         try {
             return ServiceManager.getTemplateService().findAllAvailableForAssignToProject(this.project.getId());
         } catch (DataException e) {
@@ -827,7 +827,7 @@ public class ProjectForm extends BaseForm {
      *
      * @return list of projects
      */
-    public List<ProjectDTO> getProjects() {
+    public List<ProjectInterface> getProjects() {
         try {
             return ServiceManager.getProjectService().findAll();
         } catch (DataException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
@@ -68,8 +68,8 @@ public class SearchResultForm extends ProcessListBaseView {
         List<ProcessInterface> results;
         try {
             results = processService.findByAnything(searchQuery);
-            for (ProcessInterface processInterface : results) {
-                resultHash.put(processInterface.getId(), processInterface);
+            for (ProcessInterface process : results) {
+                resultHash.put(process.getId(), process);
             }
             this.resultList = new ArrayList<>(resultHash.values());
             refreshFilteredList();
@@ -99,9 +99,9 @@ public class SearchResultForm extends ProcessListBaseView {
      */
     void filterListByTaskAndStatus() {
         if (Objects.nonNull(currentTaskFilter) && Objects.nonNull(currentTaskStatusFilter)) {
-            for (ProcessInterface processInterface : new ArrayList<>(this.filteredList)) {
+            for (ProcessInterface process : new ArrayList<>(this.filteredList)) {
                 boolean remove = true;
-                for (TaskInterface task : processInterface.getTasks()) {
+                for (TaskInterface task : process.getTasks()) {
                     if (task.getTitle().equalsIgnoreCase(currentTaskFilter)
                             && task.getProcessingStatus().getValue().equals(currentTaskStatusFilter)) {
                         remove = false;
@@ -109,7 +109,7 @@ public class SearchResultForm extends ProcessListBaseView {
                     }
                 }
                 if (remove) {
-                    this.filteredList.remove(processInterface);
+                    this.filteredList.remove(process);
                 }
 
             }
@@ -146,8 +146,8 @@ public class SearchResultForm extends ProcessListBaseView {
      */
     public Collection<TaskInterface> getTasksForFiltering() {
         HashMap<String, TaskInterface> tasksForFiltering = new HashMap<>();
-        for (ProcessInterface processInterface : this.resultList) {
-            for (TaskInterface currentTask : processInterface.getTasks()) {
+        for (ProcessInterface process : this.resultList) {
+            for (TaskInterface currentTask : process.getTasks()) {
                 tasksForFiltering.put(currentTask.getTitle(), currentTask);
             }
         }
@@ -170,24 +170,24 @@ public class SearchResultForm extends ProcessListBaseView {
     /**
      * Delete Process.
      *
-     * @param processInterface
+     * @param process
      *            process to delete.
      */
     @Override
-    public void delete(ProcessInterface processInterface) {
+    public void delete(ProcessInterface process) {
         try {
-            Process process = ServiceManager.getProcessService().getById(processInterface.getId());
-            if (process.getChildren().isEmpty()) {
+            Process processBean = ServiceManager.getProcessService().getById(process.getId());
+            if (processBean.getChildren().isEmpty()) {
                 try {
-                    ProcessService.deleteProcess(process);
-                    this.filteredList.remove(processInterface);
+                    ProcessService.deleteProcess(processBean);
+                    this.filteredList.remove(processBean);
                 } catch (DataException | IOException e) {
                     Helper.setErrorMessage(ERROR_DELETING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },
                             logger, e);
                 }
             } else {
                 this.deleteProcessDialog = new DeleteProcessDialog();
-                this.deleteProcessDialog.setProcess(process);
+                this.deleteProcessDialog.setProcess(processBean);
                 PrimeFaces.current().executeScript("PF('deleteChildrenDialog').show();");
             }
         } catch (DAOException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/SearchResultForm.java
@@ -30,9 +30,9 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProcessDTO;
-import org.kitodo.production.dto.ProjectDTO;
-import org.kitodo.production.dto.TaskDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TaskInterface;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
@@ -48,8 +48,8 @@ public class SearchResultForm extends ProcessListBaseView {
     private static final String SEARCH_RESULT_VIEW_ID = "/pages/searchResult.xhtml";
     private static final String SEARCH_RESULT_TABLE_ID = "searchResultTabView:searchResultForm:searchResultTable";
 
-    private List<ProcessDTO> filteredList = new ArrayList<>();
-    private List<ProcessDTO> resultList = new ArrayList<>();
+    private List<ProcessInterface> filteredList = new ArrayList<>();
+    private List<ProcessInterface> resultList = new ArrayList<>();
     private String searchQuery;
     private String currentTaskFilter;
     private Integer currentProjectFilter;
@@ -64,12 +64,12 @@ public class SearchResultForm extends ProcessListBaseView {
      */
     public String searchForProcessesBySearchQuery() {
         ProcessService processService = ServiceManager.getProcessService();
-        HashMap<Integer, ProcessDTO> resultHash = new HashMap<>();
-        List<ProcessDTO> results;
+        HashMap<Integer, ProcessInterface> resultHash = new HashMap<>();
+        List<ProcessInterface> results;
         try {
             results = processService.findByAnything(searchQuery);
-            for (ProcessDTO processDTO : results) {
-                resultHash.put(processDTO.getId(), processDTO);
+            for (ProcessInterface processInterface : results) {
+                resultHash.put(processInterface.getId(), processInterface);
             }
             this.resultList = new ArrayList<>(resultHash.values());
             refreshFilteredList();
@@ -99,9 +99,9 @@ public class SearchResultForm extends ProcessListBaseView {
      */
     void filterListByTaskAndStatus() {
         if (Objects.nonNull(currentTaskFilter) && Objects.nonNull(currentTaskStatusFilter)) {
-            for (ProcessDTO processDTO : new ArrayList<>(this.filteredList)) {
+            for (ProcessInterface processInterface : new ArrayList<>(this.filteredList)) {
                 boolean remove = true;
-                for (TaskDTO task : processDTO.getTasks()) {
+                for (TaskInterface task : processInterface.getTasks()) {
                     if (task.getTitle().equalsIgnoreCase(currentTaskFilter)
                             && task.getProcessingStatus().getValue().equals(currentTaskStatusFilter)) {
                         remove = false;
@@ -109,7 +109,7 @@ public class SearchResultForm extends ProcessListBaseView {
                     }
                 }
                 if (remove) {
-                    this.filteredList.remove(processDTO);
+                    this.filteredList.remove(processInterface);
                 }
 
             }
@@ -131,9 +131,9 @@ public class SearchResultForm extends ProcessListBaseView {
      *
      * @return A list of projects for filter list
      */
-    public Collection<ProjectDTO> getProjectsForFiltering() {
-        HashMap<Integer, ProjectDTO> projectsForFiltering = new HashMap<>();
-        for (ProcessDTO process : this.resultList) {
+    public Collection<ProjectInterface> getProjectsForFiltering() {
+        HashMap<Integer, ProjectInterface> projectsForFiltering = new HashMap<>();
+        for (ProcessInterface process : this.resultList) {
             projectsForFiltering.put(process.getProject().getId(), process.getProject());
         }
         return projectsForFiltering.values();
@@ -144,10 +144,10 @@ public class SearchResultForm extends ProcessListBaseView {
      *
      * @return A list of tasks for filter list
      */
-    public Collection<TaskDTO> getTasksForFiltering() {
-        HashMap<String, TaskDTO> tasksForFiltering = new HashMap<>();
-        for (ProcessDTO processDTO : this.resultList) {
-            for (TaskDTO currentTask : processDTO.getTasks()) {
+    public Collection<TaskInterface> getTasksForFiltering() {
+        HashMap<String, TaskInterface> tasksForFiltering = new HashMap<>();
+        for (ProcessInterface processInterface : this.resultList) {
+            for (TaskInterface currentTask : processInterface.getTasks()) {
                 tasksForFiltering.put(currentTask.getTitle(), currentTask);
             }
         }
@@ -170,17 +170,17 @@ public class SearchResultForm extends ProcessListBaseView {
     /**
      * Delete Process.
      *
-     * @param processDTO
+     * @param processInterface
      *            process to delete.
      */
     @Override
-    public void delete(ProcessDTO processDTO) {
+    public void delete(ProcessInterface processInterface) {
         try {
-            Process process = ServiceManager.getProcessService().getById(processDTO.getId());
+            Process process = ServiceManager.getProcessService().getById(processInterface.getId());
             if (process.getChildren().isEmpty()) {
                 try {
                     ProcessService.deleteProcess(process);
-                    this.filteredList.remove(processDTO);
+                    this.filteredList.remove(processInterface);
                 } catch (DataException | IOException e) {
                     Helper.setErrorMessage(ERROR_DELETING, new Object[] {ObjectType.PROCESS.getTranslationSingular() },
                             logger, e);
@@ -213,9 +213,9 @@ public class SearchResultForm extends ProcessListBaseView {
     /**
      * Gets the filtered list.
      *
-     * @return a list of ProcessDTO
+     * @return a list of ProcessInterface
      */
-    public List<ProcessDTO> getFilteredList() {
+    public List<ProcessInterface> getFilteredList() {
         return this.filteredList;
     }
 
@@ -223,9 +223,9 @@ public class SearchResultForm extends ProcessListBaseView {
      * Sets the filtered list.
      *
      * @param filteredList
-     *            a list of ProcessDTO
+     *            a list of ProcessInterface
      */
-    public void setFilteredList(List<ProcessDTO> filteredList) {
+    public void setFilteredList(List<ProcessInterface> filteredList) {
         this.filteredList = filteredList;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
@@ -240,6 +240,20 @@ public class TemplateForm extends TemplateBaseForm {
     }
 
     /**
+     * Returns a read handle for the SVG image of this production template's
+     * workflow. If the file cannot be read (due to an error), returns an empty
+     * input stream.
+     *
+     * @return read file handle for the SVG
+     */
+    public InputStream getDiagramImage(String title) {
+        if (Objects.nonNull(title)) {
+            return ServiceManager.getTemplateService().getTasksDiagram(title);
+        }
+        return ServiceManager.getTemplateService().getTasksDiagram("");
+    }
+
+    /**
      * Get list of dockets for select list.
      *
      * @return list of dockets

--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -54,7 +54,7 @@ import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProjectDTO;
+import org.kitodo.data.interfaces.ProjectInterface;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.filters.FilterMenu;
 import org.kitodo.production.forms.dataeditor.GalleryViewMode;
@@ -563,10 +563,10 @@ public class UserForm extends BaseForm {
      *
      * @return list of projects available for assignment to the user
      */
-    public List<ProjectDTO> getProjects() {
+    public List<ProjectInterface> getProjects() {
         try {
             return ServiceManager.getProjectService().findAllAvailableForAssignToUser(this.userObject)
-                    .stream().sorted(Comparator.comparing(ProjectDTO::getTitle)).collect(Collectors.toList());
+                    .stream().sorted(Comparator.comparing(ProjectInterface::getTitle)).collect(Collectors.toList());
         } catch (DataException e) {
             Helper.setErrorMessage(ERROR_LOADING_MANY, new Object[] {ObjectType.PROJECT.getTranslationPlural() },
                 logger, e);
@@ -626,11 +626,11 @@ public class UserForm extends BaseForm {
     }
 
     /**
-     * Check and return whether given UserDTO 'user' is logged in.
+     * Check and return whether given UserInterface 'user' is logged in.
      *
      * @param user
-     *            UserDTO to check
-     * @return whether given UserDTO is checked in
+     *            UserInterface to check
+     * @return whether given UserInterface is checked in
      */
     public static boolean checkUserLoggedIn(User user) {
         for (SecuritySession securitySession : ServiceManager.getSessionService().getActiveSessions()) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -50,13 +50,13 @@ import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.exceptions.RecordIdentifierMissingDetail;
 import org.kitodo.exceptions.RulesetNotFoundException;
-import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.forms.BaseForm;
 import org.kitodo.production.helper.Helper;
@@ -435,7 +435,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                     defaultConfigurationType = null;
                 }
                 if (Objects.nonNull(parentId) && parentId != 0) {
-                    ProcessDTO parentProcess = ServiceManager.getProcessService().findById(parentId);
+                    ProcessInterface parentProcess = ServiceManager.getProcessService().findById(parentId);
                     RulesetManagementInterface rulesetManagement = ServiceManager.getRulesetService()
                             .openRuleset(ServiceManager.getRulesetService().getById(parentProcess.getRuleset().getId()));
                     Map<String, String> allowedSubstructuralElements = rulesetManagement

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectProjectDialogView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectProjectDialogView.java
@@ -39,26 +39,26 @@ public class SelectProjectDialogView implements Serializable {
 
     private static final Logger logger = LogManager.getLogger(SelectProjectDialogView.class);
     private int selectedProjectId = 0;
-    private TemplateInterface templateInterface;
+    private TemplateInterface template;
     protected static final String ERROR_LOADING_ONE = "errorLoadingOne";
     private static final String CREATE_PROCESS_PATH = "/pages/processFromTemplate.jsf?faces-redirect=true";
 
     /**
      * Get template.
      *
-     * @return value of templateInterface
+     * @return value of template
      */
     public TemplateInterface getTemplate() {
-        return templateInterface;
+        return template;
     }
 
     /**
-     * Set templateInterface.
+     * Set template.
      *
-     * @param templateInterface as org.kitodo.production.dto.TemplateInterface
+     * @param template as org.kitodo.data.interfaces.TemplateInterface
      */
-    public void setTemplateInterface(TemplateInterface templateInterface) {
-        this.templateInterface = templateInterface;
+    public void setTemplate(TemplateInterface template) {
+        this.template = template;
     }
 
     /**
@@ -86,12 +86,12 @@ public class SelectProjectDialogView implements Serializable {
      */
     public List<Project> getTemplateProjects() {
         try {
-            Template template = ServiceManager.getTemplateService().getById(this.templateInterface.getId());
+            Template template = ServiceManager.getTemplateService().getById(this.template.getId());
             return template.getProjects().stream().sorted(Comparator.comparing(Project::getTitle))
                     .collect(Collectors.toList());
         } catch (DAOException e) {
             Helper.setErrorMessage(ERROR_LOADING_ONE, new Object[] {ObjectType.TEMPLATE.getTranslationSingular(),
-                    this.templateInterface.getId()}, logger, e);
+                    this.template.getId()}, logger, e);
         }
         return Collections.emptyList();
     }
@@ -103,20 +103,20 @@ public class SelectProjectDialogView implements Serializable {
      * Display error message if the current template is not used in any project.
      */
     public void createProcessFromTemplate() {
-        if (this.templateInterface.getProjects().size() == 1) {
-            this.selectedProjectId = this.templateInterface.getProjects().get(0).getId();
+        if (this.template.getProjects().size() == 1) {
+            this.selectedProjectId = this.template.getProjects().get(0).getId();
         }
         if (this.selectedProjectId > 0) {
             try {
                 FacesContext context = FacesContext.getCurrentInstance();
                 String path = context.getExternalContext().getRequestContextPath() + CREATE_PROCESS_PATH
-                        + "&templateId=" + this.templateInterface.getId() + "&projectId=" + this.selectedProjectId
+                        + "&templateId=" + this.template.getId() + "&projectId=" + this.selectedProjectId
                         + "&referrer=" + context.getViewRoot().getViewId();
                 context.getExternalContext().redirect(path);
             } catch (IOException e) {
                 Helper.setErrorMessage(e.getLocalizedMessage());
             }
-        } else if (templateInterface.getProjects().size() > 1) {
+        } else if (template.getProjects().size() > 1) {
             PrimeFaces.current().ajax().update("selectProjectDialog");
             PrimeFaces.current().executeScript("PF('selectProjectDialog').show();");
         } else {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectProjectDialogView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectProjectDialogView.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.exceptions.DAOException;
-import org.kitodo.production.dto.TemplateDTO;
+import org.kitodo.data.interfaces.TemplateInterface;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
@@ -39,26 +39,26 @@ public class SelectProjectDialogView implements Serializable {
 
     private static final Logger logger = LogManager.getLogger(SelectProjectDialogView.class);
     private int selectedProjectId = 0;
-    private TemplateDTO templateDTO;
+    private TemplateInterface templateInterface;
     protected static final String ERROR_LOADING_ONE = "errorLoadingOne";
     private static final String CREATE_PROCESS_PATH = "/pages/processFromTemplate.jsf?faces-redirect=true";
 
     /**
      * Get template.
      *
-     * @return value of templateDTO
+     * @return value of templateInterface
      */
-    public TemplateDTO getTemplate() {
-        return templateDTO;
+    public TemplateInterface getTemplate() {
+        return templateInterface;
     }
 
     /**
-     * Set templateDTO.
+     * Set templateInterface.
      *
-     * @param templateDTO as org.kitodo.production.dto.TemplateDTO
+     * @param templateInterface as org.kitodo.production.dto.TemplateInterface
      */
-    public void setTemplateDTO(TemplateDTO templateDTO) {
-        this.templateDTO = templateDTO;
+    public void setTemplateInterface(TemplateInterface templateInterface) {
+        this.templateInterface = templateInterface;
     }
 
     /**
@@ -86,12 +86,12 @@ public class SelectProjectDialogView implements Serializable {
      */
     public List<Project> getTemplateProjects() {
         try {
-            Template template = ServiceManager.getTemplateService().getById(this.templateDTO.getId());
+            Template template = ServiceManager.getTemplateService().getById(this.templateInterface.getId());
             return template.getProjects().stream().sorted(Comparator.comparing(Project::getTitle))
                     .collect(Collectors.toList());
         } catch (DAOException e) {
             Helper.setErrorMessage(ERROR_LOADING_ONE, new Object[] {ObjectType.TEMPLATE.getTranslationSingular(),
-                    this.templateDTO.getId()}, logger, e);
+                    this.templateInterface.getId()}, logger, e);
         }
         return Collections.emptyList();
     }
@@ -103,20 +103,20 @@ public class SelectProjectDialogView implements Serializable {
      * Display error message if the current template is not used in any project.
      */
     public void createProcessFromTemplate() {
-        if (this.templateDTO.getProjects().size() == 1) {
-            this.selectedProjectId = this.templateDTO.getProjects().get(0).getId();
+        if (this.templateInterface.getProjects().size() == 1) {
+            this.selectedProjectId = this.templateInterface.getProjects().get(0).getId();
         }
         if (this.selectedProjectId > 0) {
             try {
                 FacesContext context = FacesContext.getCurrentInstance();
                 String path = context.getExternalContext().getRequestContextPath() + CREATE_PROCESS_PATH
-                        + "&templateId=" + this.templateDTO.getId() + "&projectId=" + this.selectedProjectId
+                        + "&templateId=" + this.templateInterface.getId() + "&projectId=" + this.selectedProjectId
                         + "&referrer=" + context.getViewRoot().getViewId();
                 context.getExternalContext().redirect(path);
             } catch (IOException e) {
                 Helper.setErrorMessage(e.getLocalizedMessage());
             }
-        } else if (templateDTO.getProjects().size() > 1) {
+        } else if (templateInterface.getProjects().size() > 1) {
             PrimeFaces.current().ajax().update("selectProjectDialog");
             PrimeFaces.current().executeScript("PF('selectProjectDialog').show();");
         } else {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectTemplateDialogView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectTemplateDialogView.java
@@ -19,8 +19,8 @@ import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 
-import org.kitodo.production.dto.ProjectDTO;
-import org.kitodo.production.dto.TemplateDTO;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TemplateInterface;
 import org.kitodo.production.helper.Helper;
 import org.primefaces.PrimeFaces;
 
@@ -29,7 +29,7 @@ import org.primefaces.PrimeFaces;
 public class SelectTemplateDialogView implements Serializable {
 
     private int selectedTemplateId = 0;
-    private ProjectDTO project;
+    private ProjectInterface project;
     protected static final String ERROR_LOADING_ONE = "errorLoadingOne";
     private static final String CREATE_PROCESS_PATH = "/pages/processFromTemplate.jsf?faces-redirect=true";
     private static final String MASSIMPORT_PATH = "/pages/massImport.jsf?faces-redirect=true";
@@ -40,16 +40,16 @@ public class SelectTemplateDialogView implements Serializable {
      *
      * @return value of project
      */
-    public ProjectDTO getProject() {
+    public ProjectInterface getProject() {
         return project;
     }
 
     /**
      * Set project.
      *
-     * @param project as org.kitodo.production.dto.ProjectDTO
+     * @param project as org.kitodo.production.dto.ProjectInterface
      */
-    public void setProject(ProjectDTO project) {
+    public void setProject(ProjectInterface project) {
         this.project = project;
     }
 
@@ -65,7 +65,7 @@ public class SelectTemplateDialogView implements Serializable {
     /**
      * Set selectedTemplateId.
      *
-     * @param selectedTemplateId as org.kitodo.production.dto.TemplateDTO
+     * @param selectedTemplateId as org.kitodo.production.dto.TemplateInterface
      */
     public void setSelectedTemplateId(int selectedTemplateId) {
         this.selectedTemplateId = selectedTemplateId;
@@ -94,7 +94,7 @@ public class SelectTemplateDialogView implements Serializable {
      * Display error message if no template is configured for current project.
      */
     public void checkForTemplates() {
-        List<TemplateDTO> availableTemplates = this.project.getTemplates();
+        List<TemplateInterface> availableTemplates = this.project.getActiveTemplates();
         if (availableTemplates.size() == 1) {
             this.selectedTemplateId = availableTemplates.get(0).getId();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectTemplateDialogView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/SelectTemplateDialogView.java
@@ -94,7 +94,7 @@ public class SelectTemplateDialogView implements Serializable {
      * Display error message if no template is configured for current project.
      */
     public void checkForTemplates() {
-        List<TemplateInterface> availableTemplates = this.project.getActiveTemplates();
+        List<? extends TemplateInterface> availableTemplates = this.project.getActiveTemplates();
         if (availableTemplates.size() == 1) {
             this.selectedTemplateId = availableTemplates.get(0).getId();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -36,7 +36,7 @@ import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.MetadataEditor;
 import org.kitodo.production.services.ServiceManager;
@@ -307,14 +307,14 @@ public class TitleRecordLinkTab {
             return;
         }
         try {
-            List<ProcessDTO> processes = ServiceManager.getProcessService().findLinkableParentProcesses(searchQuery,
+            List<ProcessInterface> processes = ServiceManager.getProcessService().findLinkableParentProcesses(searchQuery,
                 createProcessForm.getProject().getId(), createProcessForm.getTemplate().getRuleset().getId());
             if (processes.isEmpty()) {
                 Helper.setMessage("createProcessForm.titleRecordLinkTab.searchButtonClick.noHits");
             }
             indicationOfMoreHitsVisible = processes.size() > MAXIMUM_NUMBER_OF_HITS;
             possibleParentProcesses = new ArrayList<>();
-            for (ProcessDTO process : processes.subList(0, Math.min(processes.size(), MAXIMUM_NUMBER_OF_HITS))) {
+            for (ProcessInterface process : processes.subList(0, Math.min(processes.size(), MAXIMUM_NUMBER_OF_HITS))) {
                 possibleParentProcesses.add(new SelectItem(process.getId().toString(), process.getTitle()));
             }
         } catch (DataException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/AddDocStrucTypeDialog.java
@@ -45,10 +45,10 @@ import org.kitodo.api.dataformat.View;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.exceptions.UnknownTreeNodeDataException;
-import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.metadata.InsertionPosition;
 import org.kitodo.production.metadata.MetadataEditor;
@@ -631,7 +631,7 @@ public class AddDocStrucTypeDialog {
                     .getAllowedSubstructuralElements().keySet();
             List<Integer> ids = ServiceManager.getProcessService().findLinkableChildProcesses(processNumber,
                 dataEditor.getProcess().getRuleset().getId(), allowedSubstructuralElements)
-                    .stream().map(ProcessDTO::getId).collect(Collectors.toList());
+                    .stream().map(ProcessInterface::getId).collect(Collectors.toList());
             if (ids.isEmpty()) {
                 alert(Helper.getTranslation("dialogAddDocStrucType.searchButtonClick.noHits"));
             }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MediaPartialForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MediaPartialForm.java
@@ -78,7 +78,7 @@ public class MediaPartialForm implements Serializable {
      * @return True if validation error is not empty.
      */
     public boolean hasValidationError() {
-        return StringUtils.isNotEmpty(validationError);
+        return StringUtils.isNotBlank(validationError);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -308,7 +308,7 @@ public class Helper {
 
         String compoundMessage = msg.replaceFirst(":\\s*$", "");
         if (createCompoundMessage) {
-            if (StringUtils.isNotEmpty(descript)) {
+            if (StringUtils.isNotBlank(descript)) {
                 compoundMessage += ": " + descript;
             }
             detail = null;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -79,7 +79,7 @@ public class ProcessHelper {
     /**
      * Create and return an instance of 'ProcessFieldedMetadata' for the given
      * LogicalDivision 'structure', RulesetManagementInterface
-     * 'managementInterface', acquisition stage String 'stage' and List of
+     * 'management', acquisition stage String 'stage' and List of
      * LanguageRange 'priorityList'.
      *
      * @param structure

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -24,7 +24,7 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.kitodo.data.elasticsearch.index.type.enums.ProcessTypeField;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.services.ServiceManager;
 
@@ -60,16 +60,16 @@ public class SearchResultGeneration {
         return getWorkbook();
     }
 
-    private List<ProcessDTO> getResultsWithFilter() {
-        List<ProcessDTO> processDTOS = new ArrayList<>();
+    private List<ProcessInterface> getResultsWithFilter() {
+        List<ProcessInterface> processInterfaces = new ArrayList<>();
         try {
-            processDTOS = ServiceManager.getProcessService().findByQuery(getQueryForFilter(ObjectType.PROCESS),
+            processInterfaces = ServiceManager.getProcessService().findByQuery(getQueryForFilter(ObjectType.PROCESS),
                 ServiceManager.getProcessService().sortById(SortOrder.ASC), true);
         } catch (DataException e) {
             logger.error(e.getMessage(), e);
         }
 
-        return processDTOS;
+        return processInterfaces;
     }
 
     /**
@@ -121,25 +121,25 @@ public class SearchResultGeneration {
             Long numberOfExpectedProcesses = ServiceManager.getProcessService()
                     .count(getQueryForFilter(ObjectType.PROCESS));
             if (numberOfExpectedProcesses > elasticsearchLimit) {
-                List<ProcessDTO> processDTOS;
+                List<ProcessInterface> processInterfaces;
                 int queriedIds = 0;
                 while (numberOfProcessedProcesses < numberOfExpectedProcesses) {
                     RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(ProcessTypeField.ID.toString());
                     rangeQueryBuilder.gte(queriedIds).lt(queriedIds + elasticsearchLimit);
                     BoolQueryBuilder queryForFilter = getQueryForFilter(ObjectType.PROCESS);
                     queryForFilter.must(rangeQueryBuilder);
-                    processDTOS = ServiceManager.getProcessService().findByQuery(queryForFilter,
+                    processInterfaces = ServiceManager.getProcessService().findByQuery(queryForFilter,
                         ServiceManager.getProcessService().sortById(SortOrder.ASC), true);
                     queriedIds += elasticsearchLimit;
-                    for (ProcessDTO processDTO : processDTOS) {
+                    for (ProcessInterface processDTO : processInterfaces) {
                         prepareRow(rowCounter, sheet, processDTO);
                         rowCounter++;
                     }
-                    numberOfProcessedProcesses += processDTOS.size();
+                    numberOfProcessedProcesses += processInterfaces.size();
                 }
             } else {
-                List<ProcessDTO> resultsWithFilter = getResultsWithFilter();
-                for (ProcessDTO processDTO : resultsWithFilter) {
+                List<ProcessInterface> resultsWithFilter = getResultsWithFilter();
+                for (ProcessInterface processDTO : resultsWithFilter) {
                     prepareRow(rowCounter, sheet, processDTO);
                     rowCounter++;
                 }
@@ -161,15 +161,15 @@ public class SearchResultGeneration {
         rowHeader.createCell(7).setCellValue(Helper.getTranslation("Status"));
     }
 
-    private void prepareRow(int rowCounter, HSSFSheet sheet, ProcessDTO processDTO) {
+    private void prepareRow(int rowCounter, HSSFSheet sheet, ProcessInterface processInterface) {
         HSSFRow row = sheet.createRow(rowCounter);
-        row.createCell(0).setCellValue(processDTO.getTitle());
-        row.createCell(1).setCellValue(processDTO.getId());
-        row.createCell(2).setCellValue(processDTO.getCreationDate());
-        row.createCell(3).setCellValue(processDTO.getNumberOfImages());
-        row.createCell(4).setCellValue(processDTO.getNumberOfStructures());
-        row.createCell(5).setCellValue(processDTO.getNumberOfMetadata());
-        row.createCell(6).setCellValue(processDTO.getProject().getTitle());
-        row.createCell(7).setCellValue(processDTO.getSortHelperStatus());
+        row.createCell(0).setCellValue(processInterface.getTitle());
+        row.createCell(1).setCellValue(processInterface.getId());
+        row.createCell(2).setCellValue(processInterface.getCreationDate());
+        row.createCell(3).setCellValue(processInterface.getNumberOfImages());
+        row.createCell(4).setCellValue(processInterface.getNumberOfStructures());
+        row.createCell(5).setCellValue(processInterface.getNumberOfMetadata());
+        row.createCell(6).setCellValue(processInterface.getProject().getTitle());
+        row.createCell(7).setCellValue(processInterface.getSortHelperStatus());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -165,7 +165,7 @@ public class SearchResultGeneration {
         HSSFRow row = sheet.createRow(rowCounter);
         row.createCell(0).setCellValue(processInterface.getTitle());
         row.createCell(1).setCellValue(processInterface.getId());
-        row.createCell(2).setCellValue(processInterface.getCreationDate());
+        row.createCell(2).setCellValue(processInterface.getCreationTime());
         row.createCell(3).setCellValue(processInterface.getNumberOfImages());
         row.createCell(4).setCellValue(processInterface.getNumberOfStructures());
         row.createCell(5).setCellValue(processInterface.getNumberOfMetadata());

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -61,15 +61,15 @@ public class SearchResultGeneration {
     }
 
     private List<ProcessInterface> getResultsWithFilter() {
-        List<ProcessInterface> processInterfaces = new ArrayList<>();
+        List<ProcessInterface> processes = new ArrayList<>();
         try {
-            processInterfaces = ServiceManager.getProcessService().findByQuery(getQueryForFilter(ObjectType.PROCESS),
+            processes = ServiceManager.getProcessService().findByQuery(getQueryForFilter(ObjectType.PROCESS),
                 ServiceManager.getProcessService().sortById(SortOrder.ASC), true);
         } catch (DataException e) {
             logger.error(e.getMessage(), e);
         }
 
-        return processInterfaces;
+        return processes;
     }
 
     /**
@@ -121,26 +121,26 @@ public class SearchResultGeneration {
             Long numberOfExpectedProcesses = ServiceManager.getProcessService()
                     .count(getQueryForFilter(ObjectType.PROCESS));
             if (numberOfExpectedProcesses > elasticsearchLimit) {
-                List<ProcessInterface> processInterfaces;
+                List<ProcessInterface> processes;
                 int queriedIds = 0;
                 while (numberOfProcessedProcesses < numberOfExpectedProcesses) {
                     RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(ProcessTypeField.ID.toString());
                     rangeQueryBuilder.gte(queriedIds).lt(queriedIds + elasticsearchLimit);
                     BoolQueryBuilder queryForFilter = getQueryForFilter(ObjectType.PROCESS);
                     queryForFilter.must(rangeQueryBuilder);
-                    processInterfaces = ServiceManager.getProcessService().findByQuery(queryForFilter,
+                    processes = ServiceManager.getProcessService().findByQuery(queryForFilter,
                         ServiceManager.getProcessService().sortById(SortOrder.ASC), true);
                     queriedIds += elasticsearchLimit;
-                    for (ProcessInterface processDTO : processInterfaces) {
-                        prepareRow(rowCounter, sheet, processDTO);
+                    for (ProcessInterface process : processes) {
+                        prepareRow(rowCounter, sheet, process);
                         rowCounter++;
                     }
-                    numberOfProcessedProcesses += processInterfaces.size();
+                    numberOfProcessedProcesses += processes.size();
                 }
             } else {
                 List<ProcessInterface> resultsWithFilter = getResultsWithFilter();
-                for (ProcessInterface processDTO : resultsWithFilter) {
-                    prepareRow(rowCounter, sheet, processDTO);
+                for (ProcessInterface process : resultsWithFilter) {
+                    prepareRow(rowCounter, sheet, process);
                     rowCounter++;
                 }
             }
@@ -161,15 +161,15 @@ public class SearchResultGeneration {
         rowHeader.createCell(7).setCellValue(Helper.getTranslation("Status"));
     }
 
-    private void prepareRow(int rowCounter, HSSFSheet sheet, ProcessInterface processInterface) {
+    private void prepareRow(int rowCounter, HSSFSheet sheet, ProcessInterface process) {
         HSSFRow row = sheet.createRow(rowCounter);
-        row.createCell(0).setCellValue(processInterface.getTitle());
-        row.createCell(1).setCellValue(processInterface.getId());
-        row.createCell(2).setCellValue(processInterface.getCreationTime());
-        row.createCell(3).setCellValue(processInterface.getNumberOfImages());
-        row.createCell(4).setCellValue(processInterface.getNumberOfStructures());
-        row.createCell(5).setCellValue(processInterface.getNumberOfMetadata());
-        row.createCell(6).setCellValue(processInterface.getProject().getTitle());
-        row.createCell(7).setCellValue(processInterface.getSortHelperStatus());
+        row.createCell(0).setCellValue(process.getTitle());
+        row.createCell(1).setCellValue(process.getId());
+        row.createCell(2).setCellValue(process.getCreationTime());
+        row.createCell(3).setCellValue(process.getNumberOfImages());
+        row.createCell(4).setCellValue(process.getNumberOfStructures());
+        row.createCell(5).setCellValue(process.getNumberOfMetadata());
+        row.createCell(6).setCellValue(process.getProject().getTitle());
+        row.createCell(7).setCellValue(process.getSortHelperStatus());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -289,7 +289,7 @@ public class VariableReplacer {
             return variableFinder.group(1);
         }
 
-        if (StringUtils.isNotEmpty(process.getOcrdWorkflowId())) {
+        if (StringUtils.isNotBlank(process.getOcrdWorkflowId())) {
             return variableFinder.group(1) + process.getOcrdWorkflowId();
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyDTOModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyDTOModel.java
@@ -32,8 +32,8 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
 import org.kitodo.data.elasticsearch.index.IndexRestClient;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.DataInterface;
 import org.kitodo.exceptions.FilterException;
-import org.kitodo.production.dto.BaseDTO;
 import org.kitodo.production.services.data.FilterService;
 import org.kitodo.production.services.data.base.SearchDatabaseService;
 import org.primefaces.PrimeFaces;
@@ -82,8 +82,8 @@ public class LazyDTOModel extends LazyDataModel<Object> {
 
     @Override
     public Object getRowKey(Object inObject) {
-        if (inObject instanceof BaseDTO) {
-            BaseDTO dto = (BaseDTO) inObject;
+        if (inObject instanceof DataInterface) {
+            DataInterface dto = (DataInterface) inObject;
             return dto.getId();
         } else if (inObject instanceof BaseBean) {
             BaseBean bean = (BaseBean) inObject;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
@@ -13,6 +13,7 @@ package org.kitodo.production.services.data;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -36,9 +37,11 @@ import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.TitleSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseBatchServiceInterface;
 import org.primefaces.model.SortOrder;
 
-public class BatchService extends TitleSearchService<Batch, BatchInterface, BatchDAO> {
+public class BatchService extends TitleSearchService<Batch, BatchInterface, BatchDAO>
+        implements DatabaseBatchServiceInterface {
 
     private static volatile BatchService instance = null;
     private static final String BATCH = "batch";
@@ -120,7 +123,7 @@ public class BatchService extends TitleSearchService<Batch, BatchInterface, Batc
      * @param batches
      *            to remove
      */
-    public void removeAll(Iterable<Batch> batches) throws DataException {
+    public void removeAll(Collection<Batch> batches) throws DataException {
         for (Batch batch : batches) {
             remove(batch);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
@@ -151,18 +151,18 @@ public class BatchService extends TitleSearchService<Batch, BatchInterface, Batc
     }
 
     @Override
-    public BatchInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        BatchInterface batchInterface = DTOFactory.instance().newBatch();
-        batchInterface.setId(getIdFromJSONObject(jsonObject));
-        batchInterface.setTitle(BatchTypeField.TITLE.getStringValue(jsonObject));
+    public BatchInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        BatchInterface batch = DTOFactory.instance().newBatch();
+        batch.setId(getIdFromJSONObject(jsonObject));
+        batch.setTitle(BatchTypeField.TITLE.getStringValue(jsonObject));
         if (!related) {
-            convertRelatedJSONObjects(jsonObject, batchInterface);
+            convertRelatedJSONObjects(jsonObject, batch);
         }
-        return batchInterface;
+        return batch;
     }
 
-    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, BatchInterface batchInterface) throws DataException {
-        batchInterface.setProcesses(convertRelatedJSONObjectToInterface(jsonObject, BatchTypeField.PROCESSES.getKey(),
+    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, BatchInterface batch) throws DataException {
+        batch.setProcesses(convertRelatedJSONObjectTo(jsonObject, BatchTypeField.PROCESSES.getKey(),
             ServiceManager.getProcessService()));
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BatchService.java
@@ -31,13 +31,14 @@ import org.kitodo.data.elasticsearch.index.type.BatchType;
 import org.kitodo.data.elasticsearch.index.type.enums.BatchTypeField;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.BatchDTO;
+import org.kitodo.data.interfaces.BatchInterface;
+import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.TitleSearchService;
 import org.primefaces.model.SortOrder;
 
-public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> {
+public class BatchService extends TitleSearchService<Batch, BatchInterface, BatchDAO> {
 
     private static volatile BatchService instance = null;
     private static final String BATCH = "batch";
@@ -150,18 +151,18 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
     }
 
     @Override
-    public BatchDTO convertJSONObjectToDTO(Map<String, Object> jsonObject, boolean related) throws DataException {
-        BatchDTO batchDTO = new BatchDTO();
-        batchDTO.setId(getIdFromJSONObject(jsonObject));
-        batchDTO.setTitle(BatchTypeField.TITLE.getStringValue(jsonObject));
+    public BatchInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
+        BatchInterface batchInterface = DTOFactory.instance().newBatch();
+        batchInterface.setId(getIdFromJSONObject(jsonObject));
+        batchInterface.setTitle(BatchTypeField.TITLE.getStringValue(jsonObject));
         if (!related) {
-            convertRelatedJSONObjects(jsonObject, batchDTO);
+            convertRelatedJSONObjects(jsonObject, batchInterface);
         }
-        return batchDTO;
+        return batchInterface;
     }
 
-    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, BatchDTO batchDTO) throws DataException {
-        batchDTO.setProcesses(convertRelatedJSONObjectToDTO(jsonObject, BatchTypeField.PROCESSES.getKey(),
+    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, BatchInterface batchInterface) throws DataException {
+        batchInterface.setProcesses(convertRelatedJSONObjectToInterface(jsonObject, BatchTypeField.PROCESSES.getKey(),
             ServiceManager.getProcessService()));
     }
 
@@ -211,7 +212,7 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
      *
      * @return a readable label for the batch
      */
-    public String getLabel(BatchDTO batch) {
+    public String getLabel(BatchInterface batch) {
         return Objects.nonNull(batch.getTitle()) ? batch.getTitle() : getNumericLabel(batch);
     }
 
@@ -233,7 +234,7 @@ public class BatchService extends TitleSearchService<Batch, BatchDTO, BatchDAO> 
      *
      * @return a readable label for the batch
      */
-    private String getNumericLabel(BatchDTO batch) {
+    private String getNumericLabel(BatchInterface batch) {
         return Helper.getTranslation(BATCH) + ' ' + batch.getId();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
@@ -99,18 +99,18 @@ public class DocketService extends ClientSearchService<Docket, DocketInterface, 
     }
 
     @Override
-    public DocketInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        DocketInterface docketInterface = DTOFactory.instance().newDocket();
-        docketInterface.setId(getIdFromJSONObject(jsonObject));
-        docketInterface.setTitle(DocketTypeField.TITLE.getStringValue(jsonObject));
-        docketInterface.setFile(DocketTypeField.FILE.getStringValue(jsonObject));
+    public DocketInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        DocketInterface docket = DTOFactory.instance().newDocket();
+        docket.setId(getIdFromJSONObject(jsonObject));
+        docket.setTitle(DocketTypeField.TITLE.getStringValue(jsonObject));
+        docket.setFile(DocketTypeField.FILE.getStringValue(jsonObject));
 
-        ClientInterface clientInterface = DTOFactory.instance().newClient();
-        clientInterface.setId(DocketTypeField.CLIENT_ID.getIntValue(jsonObject));
-        clientInterface.setName(DocketTypeField.CLIENT_NAME.getStringValue(jsonObject));
+        ClientInterface client = DTOFactory.instance().newClient();
+        client.setId(DocketTypeField.CLIENT_ID.getIntValue(jsonObject));
+        client.setName(DocketTypeField.CLIENT_NAME.getStringValue(jsonObject));
 
-        docketInterface.setClient(clientInterface);
-        return docketInterface;
+        docket.setClient(client);
+        return docket;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
@@ -27,13 +27,14 @@ import org.kitodo.data.elasticsearch.index.type.DocketType;
 import org.kitodo.data.elasticsearch.index.type.enums.DocketTypeField;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ClientDTO;
-import org.kitodo.production.dto.DocketDTO;
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.DocketInterface;
+import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
 import org.primefaces.model.SortOrder;
 
-public class DocketService extends ClientSearchService<Docket, DocketDTO, DocketDAO> {
+public class DocketService extends ClientSearchService<Docket, DocketInterface, DocketDAO> {
 
     private static volatile DocketService instance = null;
 
@@ -80,7 +81,7 @@ public class DocketService extends ClientSearchService<Docket, DocketDTO, Docket
     }
 
     @Override
-    public List<DocketDTO> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
+    public List<DocketInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
             throws DataException {
         return findByQuery(getDocketsForCurrentUserQuery(), getSortBuilder(sortField, sortOrder), first, pageSize,
             false);
@@ -98,18 +99,18 @@ public class DocketService extends ClientSearchService<Docket, DocketDTO, Docket
     }
 
     @Override
-    public DocketDTO convertJSONObjectToDTO(Map<String, Object> jsonObject, boolean related) throws DataException {
-        DocketDTO docketDTO = new DocketDTO();
-        docketDTO.setId(getIdFromJSONObject(jsonObject));
-        docketDTO.setTitle(DocketTypeField.TITLE.getStringValue(jsonObject));
-        docketDTO.setFile(DocketTypeField.FILE.getStringValue(jsonObject));
+    public DocketInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
+        DocketInterface docketInterface = DTOFactory.instance().newDocket();
+        docketInterface.setId(getIdFromJSONObject(jsonObject));
+        docketInterface.setTitle(DocketTypeField.TITLE.getStringValue(jsonObject));
+        docketInterface.setFile(DocketTypeField.FILE.getStringValue(jsonObject));
 
-        ClientDTO clientDTO = new ClientDTO();
-        clientDTO.setId(DocketTypeField.CLIENT_ID.getIntValue(jsonObject));
-        clientDTO.setName(DocketTypeField.CLIENT_NAME.getStringValue(jsonObject));
+        ClientInterface clientInterface = DTOFactory.instance().newClient();
+        clientInterface.setId(DocketTypeField.CLIENT_ID.getIntValue(jsonObject));
+        clientInterface.setName(DocketTypeField.CLIENT_NAME.getStringValue(jsonObject));
 
-        docketDTO.setClientDTO(clientDTO);
-        return docketDTO;
+        docketInterface.setClient(clientInterface);
+        return docketInterface;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DocketService.java
@@ -32,9 +32,11 @@ import org.kitodo.data.interfaces.DocketInterface;
 import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseDocketServiceInterface;
 import org.primefaces.model.SortOrder;
 
-public class DocketService extends ClientSearchService<Docket, DocketInterface, DocketDAO> {
+public class DocketService extends ClientSearchService<Docket, DocketInterface, DocketDAO>
+        implements DatabaseDocketServiceInterface {
 
     private static volatile DocketService instance = null;
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -140,11 +140,11 @@ public class FilterService extends SearchService<Filter, FilterInterface, Filter
     }
 
     @Override
-    public FilterInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        FilterInterface filterInterface = DTOFactory.instance().newFilter();
-        filterInterface.setId(getIdFromJSONObject(jsonObject));
-        filterInterface.setValue(FilterTypeField.VALUE.getStringValue(jsonObject));
-        return filterInterface;
+    public FilterInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        FilterInterface filter = DTOFactory.instance().newFilter();
+        filter.setId(getIdFromJSONObject(jsonObject));
+        filter.setValue(FilterTypeField.VALUE.getStringValue(jsonObject));
+        return filter;
     }
 
     /**
@@ -275,8 +275,8 @@ public class FilterService extends SearchService<Filter, FilterInterface, Filter
 
     Set<Integer> collectIds(List<? extends DataInterface> dtos) {
         Set<Integer> ids = new HashSet<>();
-        for (DataInterface processInterface : dtos) {
-            ids.add(processInterface.getId());
+        for (DataInterface process : dtos) {
+            ids.add(process.getId());
         }
         return ids;
     }
@@ -552,9 +552,9 @@ public class FilterService extends SearchService<Filter, FilterInterface, Filter
         if (objectType == ObjectType.PROCESS) {
             return createSetQuery("batches.id", filterValuesAsIntegers(filter, FilterString.BATCH), negate);
         } else if (objectType == ObjectType.TASK) {
-            List<ProcessInterface> processInterfaces = ServiceManager.getProcessService().findByQuery(
+            List<ProcessInterface> processes = ServiceManager.getProcessService().findByQuery(
                 createSetQuery("batches.id", filterValuesAsIntegers(filter, FilterString.BATCH), negate), true);
-            return createSetQuery(TaskTypeField.PROCESS_ID.getKey(), collectIds(processInterfaces), negate);
+            return createSetQuery(TaskTypeField.PROCESS_ID.getKey(), collectIds(processes), negate);
         }
         return new BoolQueryBuilder();
     }
@@ -851,20 +851,20 @@ public class FilterService extends SearchService<Filter, FilterInterface, Filter
         /*
          * filtering by a certain done step, which the current user finished
          */
-        /*List<TaskInterface> taskInterfaces = new ArrayList<>();
+        /*List<TaskInterface> tasks = new ArrayList<>();
         String login = getFilterValueFromFilterString(filter, FilterString.TASKDONEUSER);
         try {
             Map<String, Object> user = ServiceManager.getUserService().findByLogin(login);
-            UserInterface userInterface = ServiceManager.getUserService().convertJSONObjectToInterface(user, false);
-            taskInterfaces = userInterface.getProcessingTasks();
+            UserInterface user = ServiceManager.getUserService().convertJSONObjectTo(user, false);
+            tasks = user.getProcessingTasks();
         } catch (DataException e) {
             logger.error(e.getMessage(), e);
         }
 
         if (objectType == ObjectType.PROCESS) {
-            return createSetQuery("tasks.id", collectIds(taskInterfaces), true);
+            return createSetQuery("tasks.id", collectIds(tasks), true);
         } else if (objectType == ObjectType.TASK) {
-            return createSetQuery("_id", collectIds(taskInterfaces), true);
+            return createSetQuery("_id", collectIds(tasks), true);
         }*/
         return new BoolQueryBuilder();
     }
@@ -964,8 +964,8 @@ public class FilterService extends SearchService<Filter, FilterInterface, Filter
     private QueryBuilder getQueryAccordingToObjectTypeAndSearchInTask(ObjectType objectType, QueryBuilder query)
             throws DataException {
         if (objectType == ObjectType.PROCESS) {
-            List<TaskInterface> taskInterfaces = ServiceManager.getTaskService().findByQuery(query, true);
-            return createSetQuery("tasks.id", collectIds(taskInterfaces), true);
+            List<TaskInterface> tasks = ServiceManager.getTaskService().findByQuery(query, true);
+            return createSetQuery("tasks.id", collectIds(tasks), true);
         } else if (objectType == ObjectType.TASK) {
             return query;
         }
@@ -977,8 +977,8 @@ public class FilterService extends SearchService<Filter, FilterInterface, Filter
         if (objectType == ObjectType.PROCESS) {
             return query;
         } else if (objectType == ObjectType.TASK) {
-            List<ProcessInterface> processInterfaces = ServiceManager.getProcessService().findByQuery(query, true);
-            return createSetQuery(TaskTypeField.PROCESS_ID.getKey(), collectIds(processInterfaces), true);
+            List<ProcessInterface> processes = ServiceManager.getProcessService().findByQuery(query, true);
+            return createSetQuery(TaskTypeField.PROCESS_ID.getKey(), collectIds(processes), true);
         }
         return new BoolQueryBuilder();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -61,12 +61,14 @@ import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.SearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseFilterServiceInterface;
 import org.primefaces.model.SortOrder;
 
 /**
  * Service for Filter bean.
  */
-public class FilterService extends SearchService<Filter, FilterInterface, FilterDAO> {
+public class FilterService extends SearchService<Filter, FilterInterface, FilterDAO>
+        implements DatabaseFilterServiceInterface {
 
     private static final Logger logger = LogManager.getLogger(FilterService.class);
     private static volatile FilterService instance = null;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -77,6 +77,7 @@ import org.kitodo.data.database.enums.TaskEditType;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.exceptions.CatalogException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.ConfigException;
@@ -89,7 +90,6 @@ import org.kitodo.exceptions.ParameterNotFoundException;
 import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.exceptions.RecordIdentifierMissingDetail;
 import org.kitodo.exceptions.UnsupportedFormatException;
-import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.forms.createprocess.ProcessBooleanMetadata;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.forms.createprocess.ProcessFieldedMetadata;
@@ -956,8 +956,8 @@ public class ImportService {
                 HashMap<String, String> parentIDMetadata = new HashMap<>();
                 parentIDMetadata.put(identifierMetadata, parentId);
                 try {
-                    for (ProcessDTO processDTO : ServiceManager.getProcessService().findByMetadata(parentIDMetadata, true)) {
-                        Process process = ServiceManager.getProcessService().getById(processDTO.getId());
+                    for (ProcessInterface processInterface : ServiceManager.getProcessService().findByMetadata(parentIDMetadata, true)) {
+                        Process process = ServiceManager.getProcessService().getById(processInterface.getId());
                         if (Objects.isNull(process.getRuleset()) || Objects.isNull(process.getRuleset().getId())) {
                             throw new ProcessGenerationException("Ruleset or ruleset ID of potential parent process "
                                     + process.getId() + " is null!");

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -956,15 +956,15 @@ public class ImportService {
                 HashMap<String, String> parentIDMetadata = new HashMap<>();
                 parentIDMetadata.put(identifierMetadata, parentId);
                 try {
-                    for (ProcessInterface processInterface : ServiceManager.getProcessService().findByMetadata(parentIDMetadata, true)) {
-                        Process process = ServiceManager.getProcessService().getById(processInterface.getId());
-                        if (Objects.isNull(process.getRuleset()) || Objects.isNull(process.getRuleset().getId())) {
+                    for (ProcessInterface process : ServiceManager.getProcessService().findByMetadata(parentIDMetadata, true)) {
+                        Process processBean = ServiceManager.getProcessService().getById(process.getId());
+                        if (Objects.isNull(processBean.getRuleset()) || Objects.isNull(processBean.getRuleset().getId())) {
                             throw new ProcessGenerationException("Ruleset or ruleset ID of potential parent process "
-                                    + process.getId() + " is null!");
+                                    + processBean.getId() + " is null!");
                         }
-                        if (process.getProject().getId() == projectId
-                                && process.getRuleset().getId().equals(ruleset.getId())) {
-                            parentProcess = process;
+                        if (processBean.getProject().getId() == projectId
+                                && processBean.getRuleset().getId().equals(ruleset.getId())) {
+                            parentProcess = processBean;
                             break;
                         }
                     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -159,6 +159,7 @@ import org.kitodo.production.metadata.copier.CopierData;
 import org.kitodo.production.metadata.copier.DataCopier;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ProjectSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseProcessServiceInterface;
 import org.kitodo.production.services.dataformat.MetsService;
 import org.kitodo.production.services.file.FileService;
 import org.kitodo.production.services.workflow.WorkflowControllerService;
@@ -175,7 +176,8 @@ import org.primefaces.model.charts.pie.PieChartModel;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-public class ProcessService extends ProjectSearchService<Process, ProcessInterface, ProcessDAO> {
+public class ProcessService extends ProjectSearchService<Process, ProcessInterface, ProcessDAO>
+        implements DatabaseProcessServiceInterface {
     private static final FileService fileService = ServiceManager.getFileService();
     private static final Logger logger = LogManager.getLogger(ProcessService.class);
     private static volatile ProcessService instance = null;
@@ -821,6 +823,14 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
                 .must(new MatchQueryBuilder(ProcessTypeField.PROJECT_ID.getKey(), projectId))
                 .must(new MatchQueryBuilder(ProcessTypeField.RULESET.getKey(), rulesetId));
         return findByQuery(query, false);
+    }
+
+    @Override
+    public List<ProcessInterface> findSelectedProcesses(boolean showClosedProcesses, boolean showInactiveProjects,
+            String filter, Collection<Integer> excludedProcessIds) throws DataException {
+        return findByQuery(getQueryForFilter(showClosedProcesses, showInactiveProjects, filter)
+                .mustNot(createSetQueryForIds(new ArrayList<>(excludedProcessIds))),
+            false);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -782,8 +782,8 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
                 .must(new MatchQueryBuilder(ProcessTypeField.RULESET.getKey(), rulesetId));
         List<ProcessInterface> linkableProcesses = new LinkedList<>();
 
-        List<ProcessInterface> processInterfaces = findByQuery(query, false);
-        for (ProcessInterface process : processInterfaces) {
+        List<ProcessInterface> processes = findByQuery(query, false);
+        for (ProcessInterface process : processes) {
             if (allowedStructuralElementTypes.contains(getBaseType(process.getId()))) {
                 linkableProcesses.add(process);
             }
@@ -906,125 +906,125 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
      */
     public List<Process> convertDtosToBeans(List<ProcessInterface> dtos) throws DAOException {
         List<Process> processes = new ArrayList<>();
-        for (ProcessInterface processInterface : dtos) {
-            processes.add(getById(processInterface.getId()));
+        for (ProcessInterface process : dtos) {
+            processes.add(getById(process.getId()));
         }
         return processes;
     }
 
     @Override
-    public ProcessInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        ProcessInterface processInterface = DTOFactory.instance().newProcess();
+    public ProcessInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        ProcessInterface process = DTOFactory.instance().newProcess();
         if (!jsonObject.isEmpty()) {
-            processInterface.setId(getIdFromJSONObject(jsonObject));
-            processInterface.setTitle(ProcessTypeField.TITLE.getStringValue(jsonObject));
-            processInterface.setWikiField(ProcessTypeField.WIKI_FIELD.getStringValue(jsonObject));
+            process.setId(getIdFromJSONObject(jsonObject));
+            process.setTitle(ProcessTypeField.TITLE.getStringValue(jsonObject));
+            process.setWikiField(ProcessTypeField.WIKI_FIELD.getStringValue(jsonObject));
             try {
-                processInterface.setCreationTime(ProcessTypeField.CREATION_DATE.getStringValue(jsonObject));
+                process.setCreationTime(ProcessTypeField.CREATION_DATE.getStringValue(jsonObject));
             } catch (ParseException e) {
                 throw new DataException(e);
             }
-            processInterface.setSortHelperArticles(ProcessTypeField.SORT_HELPER_ARTICLES.getIntValue(jsonObject));
-            processInterface.setSortHelperDocstructs(ProcessTypeField.SORT_HELPER_DOCSTRUCTS.getIntValue(jsonObject));
-            processInterface.setSortHelperImages(ProcessTypeField.SORT_HELPER_IMAGES.getIntValue(jsonObject));
-            processInterface.setSortHelperMetadata(ProcessTypeField.SORT_HELPER_METADATA.getIntValue(jsonObject));
-            processInterface.setSortHelperStatus(ProcessTypeField.SORT_HELPER_STATUS.getStringValue(jsonObject));
-            processInterface.setProcessBase(ProcessTypeField.PROCESS_BASE_URI.getStringValue(jsonObject));
-            processInterface.setHasChildren(ProcessTypeField.HAS_CHILDREN.getBooleanValue(jsonObject));
-            processInterface.setParentID(ProcessTypeField.PARENT_ID.getIntValue(jsonObject));
-            processInterface.setNumberOfImages(ProcessTypeField.NUMBER_OF_IMAGES.getIntValue(jsonObject));
-            processInterface.setNumberOfMetadata(ProcessTypeField.NUMBER_OF_METADATA.getIntValue(jsonObject));
-            processInterface.setNumberOfStructures(ProcessTypeField.NUMBER_OF_STRUCTURES.getIntValue(jsonObject));
-            processInterface.setBaseType(ProcessTypeField.BASE_TYPE.getStringValue(jsonObject));
-            processInterface.setLastEditingUser(ProcessTypeField.LAST_EDITING_USER.getStringValue(jsonObject));
-            processInterface.setCorrectionCommentStatus(ProcessTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
-            processInterface.setHasComments(!ProcessTypeField.COMMENTS_MESSAGE.getStringValue(jsonObject).isEmpty());
-            convertLastProcessingDates(jsonObject, processInterface);
-            convertTaskProgress(jsonObject, processInterface);
+            process.setSortHelperArticles(ProcessTypeField.SORT_HELPER_ARTICLES.getIntValue(jsonObject));
+            process.setSortHelperDocstructs(ProcessTypeField.SORT_HELPER_DOCSTRUCTS.getIntValue(jsonObject));
+            process.setSortHelperImages(ProcessTypeField.SORT_HELPER_IMAGES.getIntValue(jsonObject));
+            process.setSortHelperMetadata(ProcessTypeField.SORT_HELPER_METADATA.getIntValue(jsonObject));
+            process.setSortHelperStatus(ProcessTypeField.SORT_HELPER_STATUS.getStringValue(jsonObject));
+            process.setProcessBase(ProcessTypeField.PROCESS_BASE_URI.getStringValue(jsonObject));
+            process.setHasChildren(ProcessTypeField.HAS_CHILDREN.getBooleanValue(jsonObject));
+            process.setParentID(ProcessTypeField.PARENT_ID.getIntValue(jsonObject));
+            process.setNumberOfImages(ProcessTypeField.NUMBER_OF_IMAGES.getIntValue(jsonObject));
+            process.setNumberOfMetadata(ProcessTypeField.NUMBER_OF_METADATA.getIntValue(jsonObject));
+            process.setNumberOfStructures(ProcessTypeField.NUMBER_OF_STRUCTURES.getIntValue(jsonObject));
+            process.setBaseType(ProcessTypeField.BASE_TYPE.getStringValue(jsonObject));
+            process.setLastEditingUser(ProcessTypeField.LAST_EDITING_USER.getStringValue(jsonObject));
+            process.setCorrectionCommentStatus(ProcessTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
+            process.setHasComments(!ProcessTypeField.COMMENTS_MESSAGE.getStringValue(jsonObject).isEmpty());
+            convertLastProcessingDates(jsonObject, process);
+            convertTaskProgress(jsonObject, process);
 
-            processInterface.setProperties(convertProperties(jsonObject));
+            process.setProperties(convertProperties(jsonObject));
 
             if (!related) {
-                convertRelatedJSONObjects(jsonObject, processInterface);
+                convertRelatedJSONObjects(jsonObject, process);
             } else {
-                ProjectInterface projectInterface = DTOFactory.instance().newProject();
-                projectInterface.setId(ProcessTypeField.PROJECT_ID.getIntValue(jsonObject));
-                projectInterface.setTitle(ProcessTypeField.PROJECT_TITLE.getStringValue(jsonObject));
-                projectInterface.setActive(ProcessTypeField.PROJECT_ACTIVE.getBooleanValue(jsonObject));
-                processInterface.setProject(projectInterface);
+                ProjectInterface project = DTOFactory.instance().newProject();
+                project.setId(ProcessTypeField.PROJECT_ID.getIntValue(jsonObject));
+                project.setTitle(ProcessTypeField.PROJECT_TITLE.getStringValue(jsonObject));
+                project.setActive(ProcessTypeField.PROJECT_ACTIVE.getBooleanValue(jsonObject));
+                process.setProject(project);
             }
         }
-        return processInterface;
+        return process;
     }
 
     /**
-     * Parses last processing dates from the jsonObject and adds them to the processInterface bean.
+     * Parses last processing dates from the jsonObject and adds them to the process bean.
      * 
      * @param jsonObject the json object retrieved from elastic search
-     * @param processInterface the processInterface bean that will receive the processing dates
+     * @param process the process bean that will receive the processing dates
      */
-    private void convertLastProcessingDates(Map<String, Object> jsonObject, ProcessInterface processInterface) throws DataException {
+    private void convertLastProcessingDates(Map<String, Object> jsonObject, ProcessInterface process) throws DataException {
         String processingBeginLastTask = ProcessTypeField.PROCESSING_BEGIN_LAST_TASK.getStringValue(jsonObject);
-        processInterface.setProcessingBeginLastTask(Helper.parseDateFromFormattedString(processingBeginLastTask));
+        process.setProcessingBeginLastTask(Helper.parseDateFromFormattedString(processingBeginLastTask));
         String processingEndLastTask = ProcessTypeField.PROCESSING_END_LAST_TASK.getStringValue(jsonObject);
-        processInterface.setProcessingEndLastTask(Helper.parseDateFromFormattedString(processingEndLastTask));
+        process.setProcessingEndLastTask(Helper.parseDateFromFormattedString(processingEndLastTask));
     }
 
     /**
-     * Parses task progress properties from the jsonObject and adds them to the processInterface bean.
+     * Parses task progress properties from the jsonObject and adds them to the process bean.
      * 
      * @param jsonObject the json object retrieved from elastic search
-     * @param processInterface the processInterface bean that will receive the progress information
+     * @param process the process bean that will receive the progress information
      */
-    private void convertTaskProgress(Map<String, Object> jsonObject, ProcessInterface processInterface) throws DataException {
-        processInterface.setProgressClosed(ProcessTypeField.PROGRESS_CLOSED.getDoubleValue(jsonObject));
-        processInterface.setProgressInProcessing(ProcessTypeField.PROGRESS_IN_PROCESSING.getDoubleValue(jsonObject));
-        processInterface.setProgressOpen(ProcessTypeField.PROGRESS_OPEN.getDoubleValue(jsonObject));
-        processInterface.setProgressLocked(ProcessTypeField.PROGRESS_LOCKED.getDoubleValue(jsonObject));
-        processInterface.setProgressCombined(ProcessTypeField.PROGRESS_COMBINED.getStringValue(jsonObject));
+    private void convertTaskProgress(Map<String, Object> jsonObject, ProcessInterface process) throws DataException {
+        process.setProgressClosed(ProcessTypeField.PROGRESS_CLOSED.getDoubleValue(jsonObject));
+        process.setProgressInProcessing(ProcessTypeField.PROGRESS_IN_PROCESSING.getDoubleValue(jsonObject));
+        process.setProgressOpen(ProcessTypeField.PROGRESS_OPEN.getDoubleValue(jsonObject));
+        process.setProgressLocked(ProcessTypeField.PROGRESS_LOCKED.getDoubleValue(jsonObject));
+        process.setProgressCombined(ProcessTypeField.PROGRESS_COMBINED.getStringValue(jsonObject));
     }
 
     private List<PropertyInterface> convertProperties(Map<String, Object> jsonObject) throws DataException {
         List<Map<String, Object>> jsonArray = ProcessTypeField.PROPERTIES.getJsonArray(jsonObject);
         List<PropertyInterface> properties = new ArrayList<>();
         for (Map<String, Object> stringObjectMap : jsonArray) {
-            PropertyInterface propertyInterface = DTOFactory.instance().newProperty();
+            PropertyInterface property = DTOFactory.instance().newProperty();
             Object title = stringObjectMap.get(JSON_TITLE);
             Object value = stringObjectMap.get(JSON_VALUE);
             if (Objects.nonNull(title)) {
-                propertyInterface.setTitle(title.toString());
-                propertyInterface.setValue(Objects.nonNull(value) ? value.toString() : "");
-                properties.add(propertyInterface);
+                property.setTitle(title.toString());
+                property.setValue(Objects.nonNull(value) ? value.toString() : "");
+                properties.add(property);
             }
         }
         return properties;
     }
 
-    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, ProcessInterface processInterface) throws DataException {
+    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, ProcessInterface process) throws DataException {
         int project = ProcessTypeField.PROJECT_ID.getIntValue(jsonObject);
         if (project > 0) {
-            processInterface.setProject(ServiceManager.getProjectService().findById(project, true));
+            process.setProject(ServiceManager.getProjectService().findById(project, true));
         }
         int ruleset = ProcessTypeField.RULESET.getIntValue(jsonObject);
         if (ruleset > 0) {
-            processInterface.setRuleset(ServiceManager.getRulesetService().findById(ruleset, true));
+            process.setRuleset(ServiceManager.getRulesetService().findById(ruleset, true));
         }
 
-        processInterface.setBatchID(getBatchID(processInterface));
-        processInterface.setBatches(getBatchesForProcessInterface(jsonObject));
+        process.setBatchID(getBatchID(process));
+        process.setBatches(getBatchesForProcess(jsonObject));
         // TODO: leave it for now - right now it displays only status
-        processInterface.setTasks(convertRelatedJSONObjectToInterface(jsonObject, ProcessTypeField.TASKS.getKey(),
+        process.setTasks(convertRelatedJSONObjectTo(jsonObject, ProcessTypeField.TASKS.getKey(),
             ServiceManager.getTaskService()));
     }
 
-    private List<BatchInterface> getBatchesForProcessInterface(Map<String, Object> jsonObject) throws DataException {
+    private List<BatchInterface> getBatchesForProcess(Map<String, Object> jsonObject) throws DataException {
         List<Map<String, Object>> jsonArray = ProcessTypeField.BATCHES.getJsonArray(jsonObject);
         List<BatchInterface> batchInterfaceList = new ArrayList<>();
         for (Map<String, Object> singleObject : jsonArray) {
-            BatchInterface batchInterface = DTOFactory.instance().newBatch();
-            batchInterface.setId(BatchTypeField.ID.getIntValue(singleObject));
-            batchInterface.setTitle(BatchTypeField.TITLE.getStringValue(singleObject));
-            batchInterfaceList.add(batchInterface);
+            BatchInterface batch = DTOFactory.instance().newBatch();
+            batch.setId(BatchTypeField.ID.getIntValue(singleObject));
+            batch.setTitle(BatchTypeField.TITLE.getStringValue(singleObject));
+            batchInterfaceList.add(batch);
         }
         return batchInterfaceList;
     }
@@ -1203,15 +1203,15 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
      * Get process data directory.
      * Don't save it to the database, if it is for indexingAll.
      *
-     * @param processInterface
-     *            processInterface to get the dataDirectory from
+     * @param process
+     *            process to get the dataDirectory from
      * @return path
      */
-    public String getProcessDataDirectory(ProcessInterface processInterface) {
-        if (Objects.isNull(processInterface.getProcessBase())) {
-            processInterface.setProcessBase(fileService.getProcessBaseUriForExistingProcess(processInterface));
+    public String getProcessDataDirectory(ProcessInterface process) {
+        if (Objects.isNull(process.getProcessBase())) {
+            process.setProcessBase(fileService.getProcessBaseUriForExistingProcess(process));
         }
-        return processInterface.getProcessBase();
+        return process.getProcessBase();
     }
 
     /**
@@ -1322,17 +1322,17 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
      * Create and return String used as progress tooltip for a given process. Tooltip contains OPEN tasks and tasks
      * INWORK.
      *
-     * @param processInterface
+     * @param process
      *          process for which the tooltop is created
      * @return String containing the progress tooltip for the given process
      */
-    public String createProgressTooltip(ProcessInterface processInterface) {
-        String openTasks = getOpenTasks(processInterface).stream()
+    public String createProgressTooltip(ProcessInterface process) {
+        String openTasks = getOpenTasks(process).stream()
                 .map(t -> " - " + Helper.getTranslation(t.getTitle())).collect(Collectors.joining(NEW_LINE_ENTITY));
         if (!openTasks.isEmpty()) {
             openTasks = Helper.getTranslation(TaskStatus.OPEN.getTitle()) + ":" + NEW_LINE_ENTITY + openTasks;
         }
-        String tasksInWork = getTasksInWork(processInterface).stream()
+        String tasksInWork = getTasksInWork(process).stream()
                 .map(t -> " - " + Helper.getTranslation(t.getTitle())).collect(Collectors.joining(NEW_LINE_ENTITY));
         if (!tasksInWork.isEmpty()) {
             tasksInWork = Helper.getTranslation(TaskStatus.INWORK.getTitle()) + ":" + NEW_LINE_ENTITY + tasksInWork;
@@ -1351,12 +1351,12 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
     /**
      * Get current task.
      *
-     * @param processInterface
+     * @param process
      *            Interfaceobject
      * @return current task
      */
-    public TaskInterface getCurrentTaskInterface(ProcessInterface processInterface) {
-        for (TaskInterface task : processInterface.getTasks()) {
+    public TaskInterface getCurrentTask(ProcessInterface process) {
+        for (TaskInterface task : process.getTasks()) {
             if (task.getProcessingStatus().equals(TaskStatus.OPEN)
                     || task.getProcessingStatus().equals(TaskStatus.INWORK)) {
                 return task;
@@ -1712,9 +1712,9 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
      *          cannot be found in the index)
      */
     public String getBaseType(int processId) throws DataException {
-        ProcessInterface processInterface = findById(processId, true);
-        if (Objects.nonNull(processInterface)) {
-            return processInterface.getBaseType();
+        ProcessInterface process = findById(processId, true);
+        if (Objects.nonNull(process)) {
+            return process.getBaseType();
         }
         return "";
     }
@@ -2502,32 +2502,32 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
     /**
      * Retrieve comments for the given process.
      *
-     * @param processInterface
+     * @param process
      *          process for which the tooltip is created
      * @return List containing comments of given process
      *
      * @throws DAOException thrown when process cannot be loaded from database
      */
-    public List<Comment> getComments(ProcessInterface processInterface) throws DAOException {
-        Process process = ServiceManager.getProcessService().getById(processInterface.getId());
-        return ServiceManager.getCommentService().getAllCommentsByProcess(process);
+    public List<Comment> getComments(ProcessInterface process) throws DAOException {
+        Process processBean = ServiceManager.getProcessService().getById(process.getId());
+        return ServiceManager.getCommentService().getAllCommentsByProcess(processBean);
     }
 
     /**
-     * Check and return if child process for given ProcessInterface processInterface can be created via calendar or not.
+     * Check and return if child process for given ProcessInterface process can be created via calendar or not.
      *
-     * @param processInterface ProcessInterface for which child processes may be created via calendar
+     * @param process ProcessInterface for which child processes may be created via calendar
      * @return whether child processes for the given ProcessInterface can be created via the calendar or not
      * @throws DAOException if process could not be loaded from database
      * @throws IOException if ruleset file could not be read
      */
-    public static boolean canCreateProcessWithCalendar(ProcessInterface processInterface)
+    public static boolean canCreateProcessWithCalendar(ProcessInterface process)
             throws DAOException, IOException {
         Collection<String> functionalDivisions;
-        if (Objects.isNull(processInterface.getRuleset())) {
+        if (Objects.isNull(process.getRuleset())) {
             return false;
         }
-        Integer rulesetId = processInterface.getRuleset().getId();
+        Integer rulesetId = process.getRuleset().getId();
         if (RULESET_CACHE_FOR_CREATE_FROM_CALENDAR.containsKey(rulesetId)) {
             functionalDivisions = RULESET_CACHE_FOR_CREATE_FROM_CALENDAR.get(rulesetId);
         } else {
@@ -2536,24 +2536,24 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
                     .getFunctionalDivisions(FunctionalDivision.CREATE_CHILDREN_WITH_CALENDAR);
             RULESET_CACHE_FOR_CREATE_FROM_CALENDAR.put(rulesetId, functionalDivisions);
         }
-        return functionalDivisions.contains(processInterface.getBaseType());
+        return functionalDivisions.contains(process.getBaseType());
     }
 
     /**
-     * Check and return if child process for given ProcessInterface processInterface can be created or not.
+     * Check and return if child process for given ProcessInterface process can be created or not.
      *
-     * @param processInterface ProcessInterface for which child processes may be created
+     * @param process ProcessInterface for which child processes may be created
      * @return whether child processes for the given ProcessInterface can be created via the calendar or not
      * @throws DAOException if process could not be loaded from database
      * @throws IOException if ruleset file could not be read
      */
-    public static boolean canCreateChildProcess(ProcessInterface processInterface) throws DAOException,
+    public static boolean canCreateChildProcess(ProcessInterface process) throws DAOException,
             IOException {
         Collection<String> functionalDivisions;
-        if (Objects.isNull(processInterface.getRuleset())) {
+        if (Objects.isNull(process.getRuleset())) {
             return false;
         }
-        Integer rulesetId = processInterface.getRuleset().getId();
+        Integer rulesetId = process.getRuleset().getId();
         if (RULESET_CACHE_FOR_CREATE_CHILD_FROM_PARENT.containsKey(rulesetId)) {
             functionalDivisions = RULESET_CACHE_FOR_CREATE_CHILD_FROM_PARENT.get(rulesetId);
         } else {
@@ -2562,7 +2562,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
                     .getFunctionalDivisions(FunctionalDivision.CREATE_CHILDREN_FROM_PARENT);
             RULESET_CACHE_FOR_CREATE_CHILD_FROM_PARENT.put(rulesetId, functionalDivisions);
         }
-        return functionalDivisions.contains(processInterface.getBaseType());
+        return functionalDivisions.contains(process.getBaseType());
     }
 
     /**
@@ -2691,15 +2691,15 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
 
     /**
      * Get all tasks of given process which should be visible to the user.
-     * @param processInterface process as Interface object
+     * @param process process as Interface object
      * @param user user to filter the tasks for
      * @return List of filtered tasks as Interface objects
      */
-    public List<TaskInterface> getCurrentTasksForUser(ProcessInterface processInterface, User user) {
+    public List<TaskInterface> getCurrentTasksForUser(ProcessInterface process, User user) {
         Set<Integer> userRoles = user.getRoles().stream()
                 .map(Role::getId)
                 .collect(Collectors.toSet());
-        return processInterface.getTasks().stream()
+        return process.getTasks().stream()
                 .filter(task -> TaskStatus.OPEN.equals(task.getProcessingStatus()) || TaskStatus.INWORK.equals(task.getProcessingStatus()))
                 .filter(task -> !task.getRoleIds().stream()
                         .filter(userRoles::contains)
@@ -2736,8 +2736,8 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
         BoolQueryBuilder inChoiceListShownQuery = new BoolQueryBuilder();
         MatchQueryBuilder matchQuery = matchQuery(ProcessTypeField.IN_CHOICE_LIST_SHOWN.getKey(), true);
         inChoiceListShownQuery.must(matchQuery);
-        for (ProcessInterface processInterface : ServiceManager.getProcessService().findByQuery(matchQuery, true)) {
-            templateProcesses.add(getById(processInterface.getId()));
+        for (ProcessInterface process : ServiceManager.getProcessService().findByQuery(matchQuery, true)) {
+            templateProcesses.add(getById(process.getId()));
         }
         templateProcesses.sort(Comparator.comparing(Process::getTitle));
         return templateProcesses;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1028,7 +1028,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
      *            list of batches for checkout
      * @return true or false
      */
-    boolean isProcessAssignedToOnlyOneBatch(List<BatchInterface> list) {
+    boolean isProcessAssignedToOnlyOneBatch(List<? extends BatchInterface> list) {
         return list.size() == 1;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -18,6 +18,14 @@ import static org.kitodo.data.database.enums.CorrectionComments.NO_CORRECTION_CO
 import static org.kitodo.data.database.enums.CorrectionComments.NO_OPEN_CORRECTION_COMMENTS;
 import static org.kitodo.data.database.enums.CorrectionComments.OPEN_CORRECTION_COMMENTS;
 
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.PageSize;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.Rectangle;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FilenameFilter;
@@ -166,14 +174,6 @@ import org.primefaces.model.charts.pie.PieChartDataSet;
 import org.primefaces.model.charts.pie.PieChartModel;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-
-import com.itextpdf.text.Document;
-import com.itextpdf.text.DocumentException;
-import com.itextpdf.text.PageSize;
-import com.itextpdf.text.Paragraph;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.PdfPTable;
-import com.itextpdf.text.pdf.PdfWriter;
 
 public class ProcessService extends ProjectSearchService<Process, ProcessInterface, ProcessDAO> {
     private static final FileService fileService = ServiceManager.getFileService();
@@ -942,19 +942,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
             convertLastProcessingDates(jsonObject, processInterface);
             convertTaskProgress(jsonObject, processInterface);
 
-            List<Map<String, Object>> jsonArray = ProcessTypeField.PROPERTIES.getJsonArray(jsonObject);
-            List<PropertyInterface> properties = new ArrayList<>();
-            for (Map<String, Object> stringObjectMap : jsonArray) {
-                PropertyInterface propertyInterface = DTOFactory.instance().newProperty();
-                Object title = stringObjectMap.get(JSON_TITLE);
-                Object value = stringObjectMap.get(JSON_VALUE);
-                if (Objects.nonNull(title)) {
-                    propertyInterface.setTitle(title.toString());
-                    propertyInterface.setValue(Objects.nonNull(value) ? value.toString() : "");
-                    properties.add(propertyInterface);
-                }
-            }
-            processInterface.setProperties(properties);
+            processInterface.setProperties(convertProperties(jsonObject));
 
             if (!related) {
                 convertRelatedJSONObjects(jsonObject, processInterface);
@@ -968,7 +956,6 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
         }
         return processInterface;
     }
-
 
     /**
      * Parses last processing dates from the jsonObject and adds them to the processInterface bean.
@@ -995,6 +982,22 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
         processInterface.setProgressOpen(ProcessTypeField.PROGRESS_OPEN.getDoubleValue(jsonObject));
         processInterface.setProgressLocked(ProcessTypeField.PROGRESS_LOCKED.getDoubleValue(jsonObject));
         processInterface.setProgressCombined(ProcessTypeField.PROGRESS_COMBINED.getStringValue(jsonObject));
+    }
+
+    private List<PropertyInterface> convertProperties(Map<String, Object> jsonObject) throws DataException {
+        List<Map<String, Object>> jsonArray = ProcessTypeField.PROPERTIES.getJsonArray(jsonObject);
+        List<PropertyInterface> properties = new ArrayList<>();
+        for (Map<String, Object> stringObjectMap : jsonArray) {
+            PropertyInterface propertyInterface = DTOFactory.instance().newProperty();
+            Object title = stringObjectMap.get(JSON_TITLE);
+            Object value = stringObjectMap.get(JSON_VALUE);
+            if (Objects.nonNull(title)) {
+                propertyInterface.setTitle(title.toString());
+                propertyInterface.setValue(Objects.nonNull(value) ? value.toString() : "");
+                properties.add(propertyInterface);
+            }
+        }
+        return properties;
     }
 
     private void convertRelatedJSONObjects(Map<String, Object> jsonObject, ProcessInterface processInterface) throws DataException {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -924,7 +924,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
             processInterface.setSortHelperImages(ProcessTypeField.SORT_HELPER_IMAGES.getIntValue(jsonObject));
             processInterface.setSortHelperMetadata(ProcessTypeField.SORT_HELPER_METADATA.getIntValue(jsonObject));
             processInterface.setSortHelperStatus(ProcessTypeField.SORT_HELPER_STATUS.getStringValue(jsonObject));
-            processInterface.setProcessBaseUri(ProcessTypeField.PROCESS_BASE_URI.getStringValue(jsonObject));
+            processInterface.setProcessBase(ProcessTypeField.PROCESS_BASE_URI.getStringValue(jsonObject));
             processInterface.setHasChildren(ProcessTypeField.HAS_CHILDREN.getBooleanValue(jsonObject));
             processInterface.setParentID(ProcessTypeField.PARENT_ID.getIntValue(jsonObject));
             processInterface.setNumberOfImages(ProcessTypeField.NUMBER_OF_IMAGES.getIntValue(jsonObject));
@@ -1200,10 +1200,10 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
      * @return path
      */
     public String getProcessDataDirectory(ProcessInterface processInterface) {
-        if (Objects.isNull(processInterface.getProcessBaseUri())) {
-            processInterface.setProcessBaseUri(fileService.getProcessBaseUriForExistingProcess(processInterface));
+        if (Objects.isNull(processInterface.getProcessBase())) {
+            processInterface.setProcessBase(fileService.getProcessBaseUriForExistingProcess(processInterface));
         }
-        return processInterface.getProcessBaseUri();
+        return processInterface.getProcessBase();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -918,7 +919,11 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
             processInterface.setId(getIdFromJSONObject(jsonObject));
             processInterface.setTitle(ProcessTypeField.TITLE.getStringValue(jsonObject));
             processInterface.setWikiField(ProcessTypeField.WIKI_FIELD.getStringValue(jsonObject));
-            processInterface.setCreationDate(ProcessTypeField.CREATION_DATE.getStringValue(jsonObject));
+            try {
+                processInterface.setCreationTime(ProcessTypeField.CREATION_DATE.getStringValue(jsonObject));
+            } catch (ParseException e) {
+                throw new DataException(e);
+            }
             processInterface.setSortHelperArticles(ProcessTypeField.SORT_HELPER_ARTICLES.getIntValue(jsonObject));
             processInterface.setSortHelperDocstructs(ProcessTypeField.SORT_HELPER_DOCSTRUCTS.getIntValue(jsonObject));
             processInterface.setSortHelperImages(ProcessTypeField.SORT_HELPER_IMAGES.getIntValue(jsonObject));
@@ -2192,7 +2197,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessInterfa
      * @return process age of given process
      */
     public static String getProcessDuration(ProcessInterface process) {
-        String creationDateTimeString = process.getCreationDate();
+        String creationDateTimeString = process.getCreationTime();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         LocalDateTime createLocalDate = LocalDateTime.parse(creationDateTimeString, formatter);
         Duration duration = Duration.between(createLocalDate, LocalDateTime.now());

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
@@ -14,6 +14,7 @@ package org.kitodo.production.services.data;
 import static org.kitodo.constants.StringConstants.COMMA_DELIMITER;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -199,8 +200,12 @@ public class ProjectService extends ClientSearchService<Project, ProjectInterfac
         ProjectInterface projectInterface = DTOFactory.instance().newProject();
         projectInterface.setId(getIdFromJSONObject(jsonObject));
         projectInterface.setTitle(ProjectTypeField.TITLE.getStringValue(jsonObject));
-        projectInterface.setStartDate(ProjectTypeField.START_DATE.getStringValue(jsonObject));
-        projectInterface.setEndDate(ProjectTypeField.END_DATE.getStringValue(jsonObject));
+        try {
+            projectInterface.setStartTime(ProjectTypeField.START_DATE.getStringValue(jsonObject));
+            projectInterface.setEndTime(ProjectTypeField.END_DATE.getStringValue(jsonObject));
+        } catch (ParseException e) {
+            throw new DataException(e);
+        }
         projectInterface.setMetsRightsOwner(ProjectTypeField.METS_RIGTS_OWNER.getStringValue(jsonObject));
         projectInterface.setNumberOfPages(ProjectTypeField.NUMBER_OF_PAGES.getIntValue(jsonObject));
         projectInterface.setNumberOfVolumes(ProjectTypeField.NUMBER_OF_VOLUMES.getIntValue(jsonObject));

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
@@ -52,9 +52,11 @@ import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseProjectServiceInterface;
 import org.primefaces.model.SortOrder;
 
-public class ProjectService extends ClientSearchService<Project, ProjectInterface, ProjectDAO> {
+public class ProjectService extends ClientSearchService<Project, ProjectInterface, ProjectDAO>
+        implements DatabaseProjectServiceInterface {
 
     private static volatile ProjectService instance = null;
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -39,16 +39,17 @@ import org.kitodo.data.elasticsearch.index.type.enums.DocketTypeField;
 import org.kitodo.data.elasticsearch.index.type.enums.RulesetTypeField;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ClientInterface;
+import org.kitodo.data.interfaces.RulesetInterface;
 import org.kitodo.exceptions.RulesetNotFoundException;
-import org.kitodo.production.dto.ClientDTO;
-import org.kitodo.production.dto.RulesetDTO;
+import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
 import org.primefaces.model.SortOrder;
 
-public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, RulesetDAO> {
+public class RulesetService extends ClientSearchService<Ruleset, RulesetInterface, RulesetDAO> {
 
     private static final Logger logger = LogManager.getLogger(RulesetService.class);
     private static volatile RulesetService instance = null;
@@ -96,7 +97,7 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, Rul
     }
 
     @Override
-    public List<RulesetDTO> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
+    public List<RulesetInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
             throws DataException {
         return findByQuery(getRulesetsForCurrentUserQuery(), getSortBuilder(sortField, sortOrder), first, pageSize,
             false);
@@ -114,20 +115,20 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetDTO, Rul
     }
 
     @Override
-    public RulesetDTO convertJSONObjectToDTO(Map<String, Object> jsonObject, boolean related) throws DataException {
-        RulesetDTO rulesetDTO = new RulesetDTO();
-        rulesetDTO.setId(getIdFromJSONObject(jsonObject));
-        rulesetDTO.setTitle(RulesetTypeField.TITLE.getStringValue(jsonObject));
-        rulesetDTO.setFile(RulesetTypeField.FILE.getStringValue(jsonObject));
-        rulesetDTO.setOrderMetadataByRuleset(
+    public RulesetInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
+        RulesetInterface rulesetInterface = DTOFactory.instance().newRuleset();
+        rulesetInterface.setId(getIdFromJSONObject(jsonObject));
+        rulesetInterface.setTitle(RulesetTypeField.TITLE.getStringValue(jsonObject));
+        rulesetInterface.setFile(RulesetTypeField.FILE.getStringValue(jsonObject));
+        rulesetInterface.setOrderMetadataByRuleset(
             RulesetTypeField.ORDER_METADATA_BY_RULESET.getBooleanValue(jsonObject));
 
-        ClientDTO clientDTO = new ClientDTO();
-        clientDTO.setId(RulesetTypeField.CLIENT_ID.getIntValue(jsonObject));
-        clientDTO.setName(RulesetTypeField.CLIENT_NAME.getStringValue(jsonObject));
+        ClientInterface clientInterface = DTOFactory.instance().newClient();
+        clientInterface.setId(RulesetTypeField.CLIENT_ID.getIntValue(jsonObject));
+        clientInterface.setName(RulesetTypeField.CLIENT_NAME.getStringValue(jsonObject));
 
-        rulesetDTO.setClientDTO(clientDTO);
-        return rulesetDTO;
+        rulesetInterface.setClient(clientInterface);
+        return rulesetInterface;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -47,9 +47,11 @@ import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseRulesetServiceInterface;
 import org.primefaces.model.SortOrder;
 
-public class RulesetService extends ClientSearchService<Ruleset, RulesetInterface, RulesetDAO> {
+public class RulesetService extends ClientSearchService<Ruleset, RulesetInterface, RulesetDAO>
+        implements DatabaseRulesetServiceInterface {
 
     private static final Logger logger = LogManager.getLogger(RulesetService.class);
     private static volatile RulesetService instance = null;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/RulesetService.java
@@ -115,20 +115,20 @@ public class RulesetService extends ClientSearchService<Ruleset, RulesetInterfac
     }
 
     @Override
-    public RulesetInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        RulesetInterface rulesetInterface = DTOFactory.instance().newRuleset();
-        rulesetInterface.setId(getIdFromJSONObject(jsonObject));
-        rulesetInterface.setTitle(RulesetTypeField.TITLE.getStringValue(jsonObject));
-        rulesetInterface.setFile(RulesetTypeField.FILE.getStringValue(jsonObject));
-        rulesetInterface.setOrderMetadataByRuleset(
+    public RulesetInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        RulesetInterface ruleset = DTOFactory.instance().newRuleset();
+        ruleset.setId(getIdFromJSONObject(jsonObject));
+        ruleset.setTitle(RulesetTypeField.TITLE.getStringValue(jsonObject));
+        ruleset.setFile(RulesetTypeField.FILE.getStringValue(jsonObject));
+        ruleset.setOrderMetadataByRuleset(
             RulesetTypeField.ORDER_METADATA_BY_RULESET.getBooleanValue(jsonObject));
 
-        ClientInterface clientInterface = DTOFactory.instance().newClient();
-        clientInterface.setId(RulesetTypeField.CLIENT_ID.getIntValue(jsonObject));
-        clientInterface.setName(RulesetTypeField.CLIENT_NAME.getStringValue(jsonObject));
+        ClientInterface client = DTOFactory.instance().newClient();
+        client.setId(RulesetTypeField.CLIENT_ID.getIntValue(jsonObject));
+        client.setName(RulesetTypeField.CLIENT_NAME.getStringValue(jsonObject));
 
-        rulesetInterface.setClient(clientInterface);
-        return rulesetInterface;
+        ruleset.setClient(client);
+        return ruleset;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -302,33 +302,7 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
 
     @Override
     public TaskInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        TaskInterface taskInterface = DTOFactory.instance().newTask();
-        taskInterface.setId(getIdFromJSONObject(jsonObject));
-        taskInterface.setTitle(TaskTypeField.TITLE.getStringValue(jsonObject));
-        taskInterface.setLocalizedTitle(getLocalizedTitle(taskInterface.getTitle()));
-        taskInterface.setOrdering(TaskTypeField.ORDERING.getIntValue(jsonObject));
-        int taskStatus = TaskTypeField.PROCESSING_STATUS.getIntValue(jsonObject);
-        taskInterface.setProcessingStatus(TaskStatus.getStatusFromValue(taskStatus));
-        taskInterface.setProcessingStatusTitle(Helper.getTranslation(taskInterface.getProcessingStatus().getTitle()));
-        int editType = TaskTypeField.EDIT_TYPE.getIntValue(jsonObject);
-        taskInterface.setEditType(TaskEditType.getTypeFromValue(editType));
-        taskInterface.setEditTypeTitle(Helper.getTranslation(taskInterface.getEditType().getTitle()));
-        try {
-            taskInterface.setProcessingMoment(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
-            taskInterface.setProcessingBeginTime(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
-            taskInterface.setProcessingEndTime(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
-        } catch (ParseException e) {
-            throw new DataException(e);
-        }
-        taskInterface.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
-        taskInterface.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
-        taskInterface.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));
-        taskInterface.setTypeImagesWrite(TaskTypeField.TYPE_IMAGES_WRITE.getBooleanValue(jsonObject));
-        taskInterface.setTypeImagesRead(TaskTypeField.TYPE_IMAGES_READ.getBooleanValue(jsonObject));
-        taskInterface.setBatchStep(TaskTypeField.BATCH_STEP.getBooleanValue(jsonObject));
-        taskInterface.setRoleIds(convertJSONValuesToList(TaskTypeField.ROLES.getJsonArray(jsonObject)));
-        taskInterface.setRolesSize(TaskTypeField.ROLES.getSizeOfProperty(jsonObject));
-        taskInterface.setCorrectionCommentStatus(TaskTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
+        TaskInterface taskInterface = createTaskInterface(jsonObject);
         convertTaskProjectFromJsonObjectToInterface(jsonObject, taskInterface);
 
         /*
@@ -356,13 +330,46 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
         return taskInterface;
     }
 
+    private TaskInterface createTaskInterface(Map<String, Object> jsonObject) throws DataException {
+        TaskInterface taskInterface = DTOFactory.instance().newTask();
+        taskInterface.setId(getIdFromJSONObject(jsonObject));
+        taskInterface.setTitle(TaskTypeField.TITLE.getStringValue(jsonObject));
+        taskInterface.setLocalizedTitle(getLocalizedTitle(taskInterface.getTitle()));
+        taskInterface.setOrdering(TaskTypeField.ORDERING.getIntValue(jsonObject));
+        int taskStatus = TaskTypeField.PROCESSING_STATUS.getIntValue(jsonObject);
+        taskInterface.setProcessingStatus(TaskStatus.getStatusFromValue(taskStatus));
+        taskInterface.setProcessingStatusTitle(Helper.getTranslation(taskInterface.getProcessingStatus().getTitle()));
+        int editType = TaskTypeField.EDIT_TYPE.getIntValue(jsonObject);
+        taskInterface.setEditType(TaskEditType.getTypeFromValue(editType));
+        taskInterface.setEditTypeTitle(Helper.getTranslation(taskInterface.getEditType().getTitle()));
+        try {
+            taskInterface.setProcessingMoment(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
+            taskInterface.setProcessingBeginTime(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
+            taskInterface.setProcessingEndTime(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
+        } catch (ParseException e) {
+            throw new DataException(e);
+        }
+        taskInterface.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
+        taskInterface.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
+        taskInterface.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));
+        taskInterface.setTypeImagesWrite(TaskTypeField.TYPE_IMAGES_WRITE.getBooleanValue(jsonObject));
+        taskInterface.setTypeImagesRead(TaskTypeField.TYPE_IMAGES_READ.getBooleanValue(jsonObject));
+        taskInterface.setBatchStep(TaskTypeField.BATCH_STEP.getBooleanValue(jsonObject));
+        taskInterface.setRoleIds(convertJSONValuesToList(TaskTypeField.ROLES.getJsonArray(jsonObject)));
+        taskInterface.setRolesSize(TaskTypeField.ROLES.getSizeOfProperty(jsonObject));
+        taskInterface.setCorrectionCommentStatus(TaskTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
+        return taskInterface;
+    }
+
     /**
      * Parses and adds properties related to the project of a task to the taskInterface.
      * 
      * @param jsonObject the jsonObject retrieved from the ElasticSearch index for a task
      * @param taskInterface the taskInterface
      */
-    private void convertTaskProjectFromJsonObjectToInterface(Map<String, Object> jsonObject, TaskInterface taskInterface) throws DataException {
+    private void convertTaskProjectFromJsonObjectToInterface(Map<String, Object> jsonObject,
+            TaskInterface taskInterface) throws DataException {
+
         ProjectInterface projectInterface = DTOFactory.instance().newProject();
         projectInterface.setId(TaskTypeField.PROJECT_ID.getIntValue(jsonObject));
         projectInterface.setTitle(TaskTypeField.PROJECT_TITLE.getStringValue(jsonObject));

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -51,12 +51,13 @@ import org.kitodo.data.elasticsearch.index.type.TaskType;
 import org.kitodo.data.elasticsearch.index.type.enums.TaskTypeField;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.data.interfaces.UserInterface;
 import org.kitodo.exceptions.InvalidImagesException;
 import org.kitodo.exceptions.MediaNotFoundException;
 import org.kitodo.export.ExportDms;
-import org.kitodo.production.dto.ProjectDTO;
-import org.kitodo.production.dto.TaskDTO;
-import org.kitodo.production.dto.UserDTO;
+import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.enums.GenerationMode;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
@@ -80,7 +81,7 @@ import org.primefaces.model.SortOrder;
  * functions on the task because the task itself is a database bean and
  * therefore may not include functionality.
  */
-public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
+public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskDAO> {
 
     private static final Logger logger = LogManager.getLogger(TaskService.class);
     private static volatile TaskService instance = null;
@@ -190,7 +191,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
     }
 
     @Override
-    public List<TaskDTO> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
+    public List<TaskInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
             throws DataException {
         return loadData(first, pageSize, sortField, sortOrder, filters, false, false, false,
                 Arrays.asList(TaskStatus.OPEN, TaskStatus.INWORK));
@@ -210,7 +211,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
      * @return List of loaded tasks
      * @throws DataException if tasks cannot be loaded from search index
      */
-    public List<TaskDTO> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters,
+    public List<TaskInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters,
                                   boolean onlyOwnTasks, boolean hideCorrectionTasks, boolean showAutomaticTasks,
                                   List<TaskStatus> taskStatus)
             throws DataException {
@@ -299,31 +300,31 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
     }
 
     @Override
-    public TaskDTO convertJSONObjectToDTO(Map<String, Object> jsonObject, boolean related) throws DataException {
-        TaskDTO taskDTO = new TaskDTO();
-        taskDTO.setId(getIdFromJSONObject(jsonObject));
-        taskDTO.setTitle(TaskTypeField.TITLE.getStringValue(jsonObject));
-        taskDTO.setLocalizedTitle(getLocalizedTitle(taskDTO.getTitle()));
-        taskDTO.setOrdering(TaskTypeField.ORDERING.getIntValue(jsonObject));
+    public TaskInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
+        TaskInterface taskInterface = DTOFactory.instance().newTask();
+        taskInterface.setId(getIdFromJSONObject(jsonObject));
+        taskInterface.setTitle(TaskTypeField.TITLE.getStringValue(jsonObject));
+        taskInterface.setLocalizedTitle(getLocalizedTitle(taskInterface.getTitle()));
+        taskInterface.setOrdering(TaskTypeField.ORDERING.getIntValue(jsonObject));
         int taskStatus = TaskTypeField.PROCESSING_STATUS.getIntValue(jsonObject);
-        taskDTO.setProcessingStatus(TaskStatus.getStatusFromValue(taskStatus));
-        taskDTO.setProcessingStatusTitle(Helper.getTranslation(taskDTO.getProcessingStatus().getTitle()));
+        taskInterface.setProcessingStatus(TaskStatus.getStatusFromValue(taskStatus));
+        taskInterface.setProcessingStatusTitle(Helper.getTranslation(taskInterface.getProcessingStatus().getTitle()));
         int editType = TaskTypeField.EDIT_TYPE.getIntValue(jsonObject);
-        taskDTO.setEditType(TaskEditType.getTypeFromValue(editType));
-        taskDTO.setEditTypeTitle(Helper.getTranslation(taskDTO.getEditType().getTitle()));
-        taskDTO.setProcessingTime(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
-        taskDTO.setProcessingBegin(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
-        taskDTO.setProcessingEnd(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
-        taskDTO.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
-        taskDTO.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
-        taskDTO.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));
-        taskDTO.setTypeImagesWrite(TaskTypeField.TYPE_IMAGES_WRITE.getBooleanValue(jsonObject));
-        taskDTO.setTypeImagesRead(TaskTypeField.TYPE_IMAGES_READ.getBooleanValue(jsonObject));
-        taskDTO.setBatchStep(TaskTypeField.BATCH_STEP.getBooleanValue(jsonObject));
-        taskDTO.setRoleIds(convertJSONValuesToList(TaskTypeField.ROLES.getJsonArray(jsonObject)));
-        taskDTO.setRolesSize(TaskTypeField.ROLES.getSizeOfProperty(jsonObject));
-        taskDTO.setCorrectionCommentStatus(TaskTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
-        convertTaskProjectFromJsonObjectToDTO(jsonObject, taskDTO);
+        taskInterface.setEditType(TaskEditType.getTypeFromValue(editType));
+        taskInterface.setEditTypeTitle(Helper.getTranslation(taskInterface.getEditType().getTitle()));
+        taskInterface.setProcessingTime(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
+        taskInterface.setProcessingBegin(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
+        taskInterface.setProcessingEnd(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
+        taskInterface.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
+        taskInterface.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
+        taskInterface.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));
+        taskInterface.setTypeImagesWrite(TaskTypeField.TYPE_IMAGES_WRITE.getBooleanValue(jsonObject));
+        taskInterface.setTypeImagesRead(TaskTypeField.TYPE_IMAGES_READ.getBooleanValue(jsonObject));
+        taskInterface.setBatchStep(TaskTypeField.BATCH_STEP.getBooleanValue(jsonObject));
+        taskInterface.setRoleIds(convertJSONValuesToList(TaskTypeField.ROLES.getJsonArray(jsonObject)));
+        taskInterface.setRolesSize(TaskTypeField.ROLES.getSizeOfProperty(jsonObject));
+        taskInterface.setCorrectionCommentStatus(TaskTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
+        convertTaskProjectFromJsonObjectToInterface(jsonObject, taskInterface);
 
         /*
          * We read the list of the process but not the list of templates, because only process tasks
@@ -332,35 +333,35 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
          */
         int process = TaskTypeField.PROCESS_ID.getIntValue(jsonObject);
         if (process > 0 && !related) {
-            taskDTO.setProcess(ServiceManager.getProcessService().findById(process, true));
-            taskDTO.setBatchAvailable(ServiceManager.getProcessService()
-                    .isProcessAssignedToOnlyOneBatch(taskDTO.getProcess().getBatches()));
+            taskInterface.setProcess(ServiceManager.getProcessService().findById(process, true));
+            taskInterface.setBatchAvailable(ServiceManager.getProcessService()
+                    .isProcessAssignedToOnlyOneBatch(taskInterface.getProcess().getBatches()));
         }
 
         int processingUser = TaskTypeField.PROCESSING_USER_ID.getIntValue(jsonObject);
         if (processingUser > 0) {
-            UserDTO userDTO = new UserDTO();
-            userDTO.setId(processingUser);
-            userDTO.setLogin(TaskTypeField.PROCESSING_USER_LOGIN.getStringValue(jsonObject));
-            userDTO.setName(TaskTypeField.PROCESSING_USER_NAME.getStringValue(jsonObject));
-            userDTO.setSurname(TaskTypeField.PROCESSING_USER_SURNAME.getStringValue(jsonObject));
-            userDTO.setFullName(TaskTypeField.PROCESSING_USER_FULLNAME.getStringValue(jsonObject));
-            taskDTO.setProcessingUser(userDTO);
+            UserInterface userInterface = DTOFactory.instance().newUser();
+            userInterface.setId(processingUser);
+            userInterface.setLogin(TaskTypeField.PROCESSING_USER_LOGIN.getStringValue(jsonObject));
+            userInterface.setName(TaskTypeField.PROCESSING_USER_NAME.getStringValue(jsonObject));
+            userInterface.setSurname(TaskTypeField.PROCESSING_USER_SURNAME.getStringValue(jsonObject));
+            userInterface.setFullName(TaskTypeField.PROCESSING_USER_FULLNAME.getStringValue(jsonObject));
+            taskInterface.setProcessingUser(userInterface);
         }
-        return taskDTO;
+        return taskInterface;
     }
 
     /**
-     * Parses and adds properties related to the project of a task to the taskDTO.
+     * Parses and adds properties related to the project of a task to the taskInterface.
      * 
      * @param jsonObject the jsonObject retrieved from the ElasticSearch index for a task
-     * @param taskDTO the taskDTO
+     * @param taskInterface the taskInterface
      */
-    private void convertTaskProjectFromJsonObjectToDTO(Map<String, Object> jsonObject, TaskDTO taskDTO) throws DataException {
-        ProjectDTO projectDTO = new ProjectDTO();
-        projectDTO.setId(TaskTypeField.PROJECT_ID.getIntValue(jsonObject));
-        projectDTO.setTitle(TaskTypeField.PROJECT_TITLE.getStringValue(jsonObject));
-        taskDTO.setProject(projectDTO);
+    private void convertTaskProjectFromJsonObjectToInterface(Map<String, Object> jsonObject, TaskInterface taskInterface) throws DataException {
+        ProjectInterface projectInterface = DTOFactory.instance().newProject();
+        projectInterface.setId(TaskTypeField.PROJECT_ID.getIntValue(jsonObject));
+        projectInterface.setTitle(TaskTypeField.PROJECT_TITLE.getStringValue(jsonObject));
+        taskInterface.setProject(projectInterface);
     }
 
     private List<Integer> convertJSONValuesToList(List<Map<String, Object>> jsonObject) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -301,9 +301,9 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
     }
 
     @Override
-    public TaskInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        TaskInterface taskInterface = createTaskInterface(jsonObject);
-        convertTaskProjectFromJsonObjectToInterface(jsonObject, taskInterface);
+    public TaskInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        TaskInterface task = createTask(jsonObject);
+        convertTaskProjectFromJsonObjectTo(jsonObject, task);
 
         /*
          * We read the list of the process but not the list of templates, because only process tasks
@@ -312,68 +312,68 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
          */
         int process = TaskTypeField.PROCESS_ID.getIntValue(jsonObject);
         if (process > 0 && !related) {
-            taskInterface.setProcess(ServiceManager.getProcessService().findById(process, true));
-            taskInterface.setBatchAvailable(ServiceManager.getProcessService()
-                    .isProcessAssignedToOnlyOneBatch(taskInterface.getProcess().getBatches()));
+            task.setProcess(ServiceManager.getProcessService().findById(process, true));
+            task.setBatchAvailable(ServiceManager.getProcessService()
+                    .isProcessAssignedToOnlyOneBatch(task.getProcess().getBatches()));
         }
 
         int processingUser = TaskTypeField.PROCESSING_USER_ID.getIntValue(jsonObject);
         if (processingUser > 0) {
-            UserInterface userInterface = DTOFactory.instance().newUser();
-            userInterface.setId(processingUser);
-            userInterface.setLogin(TaskTypeField.PROCESSING_USER_LOGIN.getStringValue(jsonObject));
-            userInterface.setName(TaskTypeField.PROCESSING_USER_NAME.getStringValue(jsonObject));
-            userInterface.setSurname(TaskTypeField.PROCESSING_USER_SURNAME.getStringValue(jsonObject));
-            userInterface.setFullName(TaskTypeField.PROCESSING_USER_FULLNAME.getStringValue(jsonObject));
-            taskInterface.setProcessingUser(userInterface);
+            UserInterface user = DTOFactory.instance().newUser();
+            user.setId(processingUser);
+            user.setLogin(TaskTypeField.PROCESSING_USER_LOGIN.getStringValue(jsonObject));
+            user.setName(TaskTypeField.PROCESSING_USER_NAME.getStringValue(jsonObject));
+            user.setSurname(TaskTypeField.PROCESSING_USER_SURNAME.getStringValue(jsonObject));
+            user.setFullName(TaskTypeField.PROCESSING_USER_FULLNAME.getStringValue(jsonObject));
+            task.setProcessingUser(user);
         }
-        return taskInterface;
+        return task;
     }
 
-    private TaskInterface createTaskInterface(Map<String, Object> jsonObject) throws DataException {
-        TaskInterface taskInterface = DTOFactory.instance().newTask();
-        taskInterface.setId(getIdFromJSONObject(jsonObject));
-        taskInterface.setTitle(TaskTypeField.TITLE.getStringValue(jsonObject));
-        taskInterface.setLocalizedTitle(getLocalizedTitle(taskInterface.getTitle()));
-        taskInterface.setOrdering(TaskTypeField.ORDERING.getIntValue(jsonObject));
+    private TaskInterface createTask(Map<String, Object> jsonObject) throws DataException {
+        TaskInterface task = DTOFactory.instance().newTask();
+        task.setId(getIdFromJSONObject(jsonObject));
+        task.setTitle(TaskTypeField.TITLE.getStringValue(jsonObject));
+        task.setLocalizedTitle(getLocalizedTitle(task.getTitle()));
+        task.setOrdering(TaskTypeField.ORDERING.getIntValue(jsonObject));
         int taskStatus = TaskTypeField.PROCESSING_STATUS.getIntValue(jsonObject);
-        taskInterface.setProcessingStatus(TaskStatus.getStatusFromValue(taskStatus));
-        taskInterface.setProcessingStatusTitle(Helper.getTranslation(taskInterface.getProcessingStatus().getTitle()));
+        task.setProcessingStatus(TaskStatus.getStatusFromValue(taskStatus));
+        task.setProcessingStatusTitle(Helper.getTranslation(task.getProcessingStatus().getTitle()));
         int editType = TaskTypeField.EDIT_TYPE.getIntValue(jsonObject);
-        taskInterface.setEditType(TaskEditType.getTypeFromValue(editType));
-        taskInterface.setEditTypeTitle(Helper.getTranslation(taskInterface.getEditType().getTitle()));
+        task.setEditType(TaskEditType.getTypeFromValue(editType));
+        task.setEditTypeTitle(Helper.getTranslation(task.getEditType().getTitle()));
         try {
-            taskInterface.setProcessingMoment(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
-            taskInterface.setProcessingBeginTime(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
-            taskInterface.setProcessingEndTime(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
+            task.setProcessingMoment(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
+            task.setProcessingBeginTime(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
+            task.setProcessingEndTime(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
         } catch (ParseException e) {
             throw new DataException(e);
         }
-        taskInterface.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
-        taskInterface.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
-        taskInterface.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));
-        taskInterface.setTypeImagesWrite(TaskTypeField.TYPE_IMAGES_WRITE.getBooleanValue(jsonObject));
-        taskInterface.setTypeImagesRead(TaskTypeField.TYPE_IMAGES_READ.getBooleanValue(jsonObject));
-        taskInterface.setBatchStep(TaskTypeField.BATCH_STEP.getBooleanValue(jsonObject));
-        taskInterface.setRoleIds(convertJSONValuesToList(TaskTypeField.ROLES.getJsonArray(jsonObject)));
-        taskInterface.setRolesSize(TaskTypeField.ROLES.getSizeOfProperty(jsonObject));
-        taskInterface.setCorrectionCommentStatus(TaskTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
-        return taskInterface;
+        task.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
+        task.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
+        task.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));
+        task.setTypeImagesWrite(TaskTypeField.TYPE_IMAGES_WRITE.getBooleanValue(jsonObject));
+        task.setTypeImagesRead(TaskTypeField.TYPE_IMAGES_READ.getBooleanValue(jsonObject));
+        task.setBatchStep(TaskTypeField.BATCH_STEP.getBooleanValue(jsonObject));
+        task.setRoleIds(convertJSONValuesToList(TaskTypeField.ROLES.getJsonArray(jsonObject)));
+        task.setRolesSize(TaskTypeField.ROLES.getSizeOfProperty(jsonObject));
+        task.setCorrectionCommentStatus(TaskTypeField.CORRECTION_COMMENT_STATUS.getIntValue(jsonObject));
+        return task;
     }
 
     /**
-     * Parses and adds properties related to the project of a task to the taskInterface.
+     * Parses and adds properties related to the project of a task to the task.
      * 
      * @param jsonObject the jsonObject retrieved from the ElasticSearch index for a task
-     * @param taskInterface the taskInterface
+     * @param task the task
      */
-    private void convertTaskProjectFromJsonObjectToInterface(Map<String, Object> jsonObject,
-            TaskInterface taskInterface) throws DataException {
+    private void convertTaskProjectFromJsonObjectTo(Map<String, Object> jsonObject,
+            TaskInterface task) throws DataException {
 
-        ProjectInterface projectInterface = DTOFactory.instance().newProject();
-        projectInterface.setId(TaskTypeField.PROJECT_ID.getIntValue(jsonObject));
-        projectInterface.setTitle(TaskTypeField.PROJECT_TITLE.getStringValue(jsonObject));
-        taskInterface.setProject(projectInterface);
+        ProjectInterface project = DTOFactory.instance().newProject();
+        project.setId(TaskTypeField.PROJECT_ID.getIntValue(jsonObject));
+        project.setTitle(TaskTypeField.PROJECT_TITLE.getStringValue(jsonObject));
+        task.setProject(project);
     }
 
     private List<Integer> convertJSONValuesToList(List<Map<String, Object>> jsonObject) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -13,6 +13,7 @@ package org.kitodo.production.services.data;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -312,9 +313,13 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
         int editType = TaskTypeField.EDIT_TYPE.getIntValue(jsonObject);
         taskInterface.setEditType(TaskEditType.getTypeFromValue(editType));
         taskInterface.setEditTypeTitle(Helper.getTranslation(taskInterface.getEditType().getTitle()));
-        taskInterface.setProcessingTime(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
-        taskInterface.setProcessingBegin(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
-        taskInterface.setProcessingEnd(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
+        try {
+            taskInterface.setProcessingMoment(TaskTypeField.PROCESSING_TIME.getStringValue(jsonObject));
+            taskInterface.setProcessingBeginTime(TaskTypeField.PROCESSING_BEGIN.getStringValue(jsonObject));
+            taskInterface.setProcessingEndTime(TaskTypeField.PROCESSING_END.getStringValue(jsonObject));
+        } catch (ParseException e) {
+            throw new DataException(e);
+        }
         taskInterface.setCorrection(TaskTypeField.CORRECTION.getBooleanValue(jsonObject));
         taskInterface.setTypeAutomatic(TaskTypeField.TYPE_AUTOMATIC.getBooleanValue(jsonObject));
         taskInterface.setTypeMetadata(TaskTypeField.TYPE_METADATA.getBooleanValue(jsonObject));

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -72,6 +72,7 @@ import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.command.CommandService;
 import org.kitodo.production.services.command.KitodoScriptService;
 import org.kitodo.production.services.data.base.ProjectSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseTaskServiceInterface;
 import org.kitodo.production.services.file.SubfolderFactoryService;
 import org.kitodo.production.services.image.ImageGenerator;
 import org.kitodo.production.services.workflow.WorkflowControllerService;
@@ -82,7 +83,7 @@ import org.primefaces.model.SortOrder;
  * functions on the task because the task itself is a database bean and
  * therefore may not include functionality.
  */
-public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskDAO> {
+public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskDAO> implements DatabaseTaskServiceInterface {
 
     private static final Logger logger = LogManager.getLogger(TaskService.class);
     private static volatile TaskService instance = null;
@@ -173,7 +174,7 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
         return countResults(new HashMap<String, String>(filters), false, false, false, null);
     }
 
-    public Long countResults(HashMap<String, String> filters, boolean onlyOwnTasks, boolean hideCorrectionTasks,
+    public Long countResults(Map<?, String> filters, boolean onlyOwnTasks, boolean hideCorrectionTasks,
                              boolean showAutomaticTasks, List<TaskStatus> taskStatus)
             throws DataException {
         return countDocuments(createUserTaskQuery(ServiceManager.getFilterService().parseFilterString(filters),
@@ -212,7 +213,7 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
      * @return List of loaded tasks
      * @throws DataException if tasks cannot be loaded from search index
      */
-    public List<TaskInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters,
+    public List<TaskInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map<?, String> filters,
                                   boolean onlyOwnTasks, boolean hideCorrectionTasks, boolean showAutomaticTasks,
                                   List<TaskStatus> taskStatus)
             throws DataException {
@@ -704,7 +705,7 @@ public class TaskService extends ProjectSearchService<Task, TaskInterface, TaskD
      *            of template
      * @return list of JSON objects with tasks for specific template id
      */
-    List<Map<String, Object>> findByTemplateId(Integer id) throws DataException {
+    public List<Map<String, Object>> findByTemplateId(Integer id) throws DataException {
         return findDocuments(getQueryForTemplate(id));
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -53,9 +53,11 @@ import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseTemplateServiceInterface;
 import org.primefaces.model.SortOrder;
 
-public class TemplateService extends ClientSearchService<Template, TemplateInterface, TemplateDAO> {
+public class TemplateService extends ClientSearchService<Template, TemplateInterface, TemplateDAO>
+        implements DatabaseTemplateServiceInterface {
 
     private static final Logger logger = LogManager.getLogger(TemplateService.class);
     private static volatile TemplateService instance = null;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -182,37 +182,37 @@ public class TemplateService extends ClientSearchService<Template, TemplateInter
     }
 
     @Override
-    public TemplateInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        TemplateInterface templateInterface = DTOFactory.instance().newTemplate();
-        templateInterface.setId(getIdFromJSONObject(jsonObject));
-        templateInterface.setTitle(TemplateTypeField.TITLE.getStringValue(jsonObject));
-        templateInterface.setActive(TemplateTypeField.ACTIVE.getBooleanValue(jsonObject));
+    public TemplateInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        TemplateInterface template = DTOFactory.instance().newTemplate();
+        template.setId(getIdFromJSONObject(jsonObject));
+        template.setTitle(TemplateTypeField.TITLE.getStringValue(jsonObject));
+        template.setActive(TemplateTypeField.ACTIVE.getBooleanValue(jsonObject));
         try {
-            templateInterface.setCreationTime(TemplateTypeField.CREATION_DATE.getStringValue(jsonObject));
+            template.setCreationTime(TemplateTypeField.CREATION_DATE.getStringValue(jsonObject));
         } catch (ParseException e) {
             throw new DataException(e);
         }
-        templateInterface.setDocket(
+        template.setDocket(
             ServiceManager.getDocketService().findById(TemplateTypeField.DOCKET.getIntValue(jsonObject)));
-        templateInterface.setRuleset(
+        template.setRuleset(
             ServiceManager.getRulesetService().findById(TemplateTypeField.RULESET_ID.getIntValue(jsonObject)));
-        WorkflowInterface workflowInterface = DTOFactory.instance().newWorkflow();
-        workflowInterface.setTitle(TemplateTypeField.WORKFLOW_TITLE.getStringValue(jsonObject));
-        templateInterface.setWorkflow(workflowInterface);
-        templateInterface.setTasks(convertRelatedJSONObjectToInterface(jsonObject, TemplateTypeField.TASKS.getKey(),
+        WorkflowInterface workflow = DTOFactory.instance().newWorkflow();
+        workflow.setTitle(TemplateTypeField.WORKFLOW_TITLE.getStringValue(jsonObject));
+        template.setWorkflow(workflow);
+        template.setTasks(convertRelatedJSONObjectTo(jsonObject, TemplateTypeField.TASKS.getKey(),
             ServiceManager.getTaskService()));
-        templateInterface.setCanBeUsedForProcess(hasCompleteTasks(templateInterface.getTasks()));
+        template.setCanBeUsedForProcess(hasCompleteTasks(template.getTasks()));
 
         if (!related) {
-            convertRelatedJSONObjects(jsonObject, templateInterface);
+            convertRelatedJSONObjects(jsonObject, template);
         }
 
-        return templateInterface;
+        return template;
     }
 
-    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, TemplateInterface templateInterface)
+    private void convertRelatedJSONObjects(Map<String, Object> jsonObject, TemplateInterface template)
             throws DataException {
-        templateInterface.setProjects(convertRelatedJSONObjectToInterface(jsonObject, TemplateTypeField.PROJECTS.getKey(),
+        template.setProjects(convertRelatedJSONObjectTo(jsonObject, TemplateTypeField.PROJECTS.getKey(),
             ServiceManager.getProjectService()).stream().sorted(Comparator.comparing(ProjectInterface::getTitle))
                 .collect(Collectors.toList()));
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -291,7 +291,7 @@ public class TemplateService extends ClientSearchService<Template, TemplateInter
      *            list of tasks for testing
      * @return true or false
      */
-    boolean hasCompleteTasks(List<TaskInterface> list) {
+    boolean hasCompleteTasks(List<? extends TaskInterface> list) {
         if (list.isEmpty()) {
             return false;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -188,7 +188,7 @@ public class TemplateService extends ClientSearchService<Template, TemplateInter
         templateInterface.setTitle(TemplateTypeField.TITLE.getStringValue(jsonObject));
         templateInterface.setActive(TemplateTypeField.ACTIVE.getBooleanValue(jsonObject));
         try {
-        templateInterface.setCreationTime(TemplateTypeField.CREATION_DATE.getStringValue(jsonObject));
+            templateInterface.setCreationTime(TemplateTypeField.CREATION_DATE.getStringValue(jsonObject));
         } catch (ParseException e) {
             throw new DataException(e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -16,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -186,7 +187,11 @@ public class TemplateService extends ClientSearchService<Template, TemplateInter
         templateInterface.setId(getIdFromJSONObject(jsonObject));
         templateInterface.setTitle(TemplateTypeField.TITLE.getStringValue(jsonObject));
         templateInterface.setActive(TemplateTypeField.ACTIVE.getBooleanValue(jsonObject));
-        templateInterface.setCreationDate(TemplateTypeField.CREATION_DATE.getStringValue(jsonObject));
+        try {
+        templateInterface.setCreationTime(TemplateTypeField.CREATION_DATE.getStringValue(jsonObject));
+        } catch (ParseException e) {
+            throw new DataException(e);
+        }
         templateInterface.setDocket(
             ServiceManager.getDocketService().findById(TemplateTypeField.DOCKET.getIntValue(jsonObject)));
         templateInterface.setRuleset(

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -45,8 +45,8 @@ import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.persistence.UserDAO;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.UserInterface;
 import org.kitodo.exceptions.FilterException;
-import org.kitodo.production.dto.UserDTO;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.security.SecurityUserDetails;
 import org.kitodo.production.security.password.SecurityPasswordEncoder;
@@ -325,7 +325,7 @@ public class UserService extends ClientSearchDatabaseService<User, UserDAO> impl
      *            object as UserDTo
      * @return full name of the user as String
      */
-    public String getFullName(UserDTO user) {
+    public String getFullName(UserInterface user) {
         return user.getSurname() + ", " + user.getName();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
@@ -99,12 +99,12 @@ public class WorkflowService extends ClientSearchService<Workflow, WorkflowInter
     }
 
     @Override
-    public WorkflowInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
-        WorkflowInterface workflowInterface = DTOFactory.instance().newWorkflow();
-        workflowInterface.setId(getIdFromJSONObject(jsonObject));
-        workflowInterface.setTitle(WorkflowTypeField.TITLE.getStringValue(jsonObject));
-        workflowInterface.setWorkflowStatus(WorkflowTypeField.STATUS.getStringValue(jsonObject));
-        return workflowInterface;
+    public WorkflowInterface convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException {
+        WorkflowInterface workflow = DTOFactory.instance().newWorkflow();
+        workflow.setId(getIdFromJSONObject(jsonObject));
+        workflow.setTitle(WorkflowTypeField.TITLE.getStringValue(jsonObject));
+        workflow.setWorkflowStatus(WorkflowTypeField.STATUS.getStringValue(jsonObject));
+        return workflow;
     }
 
     private QueryBuilder getWorkflowsForCurrentUserQuery() {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
@@ -32,9 +32,11 @@ import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
+import org.kitodo.production.services.data.interfaces.DatabaseWorkflowServiceInterface;
 import org.primefaces.model.SortOrder;
 
-public class WorkflowService extends ClientSearchService<Workflow, WorkflowInterface, WorkflowDAO> {
+public class WorkflowService extends ClientSearchService<Workflow, WorkflowInterface, WorkflowDAO>
+        implements DatabaseWorkflowServiceInterface {
 
     private static volatile WorkflowService instance = null;
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
@@ -27,13 +27,14 @@ import org.kitodo.data.elasticsearch.index.type.WorkflowType;
 import org.kitodo.data.elasticsearch.index.type.enums.WorkflowTypeField;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.WorkflowDTO;
+import org.kitodo.data.interfaces.WorkflowInterface;
+import org.kitodo.production.dto.DTOFactory;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.base.ClientSearchService;
 import org.primefaces.model.SortOrder;
 
-public class WorkflowService extends ClientSearchService<Workflow, WorkflowDTO, WorkflowDAO> {
+public class WorkflowService extends ClientSearchService<Workflow, WorkflowInterface, WorkflowDAO> {
 
     private static volatile WorkflowService instance = null;
 
@@ -80,7 +81,7 @@ public class WorkflowService extends ClientSearchService<Workflow, WorkflowDTO, 
     }
 
     @Override
-    public List<WorkflowDTO> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
+    public List<WorkflowInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map filters)
             throws DataException {
         return findByQuery(getWorkflowsForCurrentUserQuery(), getSortBuilder(sortField, sortOrder), first, pageSize,
             false);
@@ -98,12 +99,12 @@ public class WorkflowService extends ClientSearchService<Workflow, WorkflowDTO, 
     }
 
     @Override
-    public WorkflowDTO convertJSONObjectToDTO(Map<String, Object> jsonObject, boolean related) throws DataException {
-        WorkflowDTO workflowDTO = new WorkflowDTO();
-        workflowDTO.setId(getIdFromJSONObject(jsonObject));
-        workflowDTO.setTitle(WorkflowTypeField.TITLE.getStringValue(jsonObject));
-        workflowDTO.setStatus(WorkflowTypeField.STATUS.getStringValue(jsonObject));
-        return workflowDTO;
+    public WorkflowInterface convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException {
+        WorkflowInterface workflowInterface = DTOFactory.instance().newWorkflow();
+        workflowInterface.setId(getIdFromJSONObject(jsonObject));
+        workflowInterface.setTitle(WorkflowTypeField.TITLE.getStringValue(jsonObject));
+        workflowInterface.setStatus(WorkflowTypeField.STATUS.getStringValue(jsonObject));
+        return workflowInterface;
     }
 
     private QueryBuilder getWorkflowsForCurrentUserQuery() {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
@@ -103,7 +103,7 @@ public class WorkflowService extends ClientSearchService<Workflow, WorkflowInter
         WorkflowInterface workflowInterface = DTOFactory.instance().newWorkflow();
         workflowInterface.setId(getIdFromJSONObject(jsonObject));
         workflowInterface.setTitle(WorkflowTypeField.TITLE.getStringValue(jsonObject));
-        workflowInterface.setStatus(WorkflowTypeField.STATUS.getStringValue(jsonObject));
+        workflowInterface.setWorkflowStatus(WorkflowTypeField.STATUS.getStringValue(jsonObject));
         return workflowInterface;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/ClientSearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/ClientSearchService.java
@@ -30,10 +30,10 @@ import org.kitodo.data.elasticsearch.index.type.BaseType;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.elasticsearch.search.enums.SearchCondition;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.BaseDTO;
+import org.kitodo.data.interfaces.DataInterface;
 import org.kitodo.production.services.ServiceManager;
 
-public abstract class ClientSearchService<T extends BaseIndexedBean, S extends BaseDTO, V extends BaseDAO<T>>
+public abstract class ClientSearchService<T extends BaseIndexedBean, S extends DataInterface, V extends BaseDAO<T>>
         extends TitleSearchService<T, S, V> {
 
     private final String clientKey;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/ProjectSearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/ProjectSearchService.java
@@ -25,10 +25,10 @@ import org.kitodo.data.elasticsearch.index.Indexer;
 import org.kitodo.data.elasticsearch.index.type.BaseType;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.BaseDTO;
+import org.kitodo.data.interfaces.DataInterface;
 import org.kitodo.production.services.ServiceManager;
 
-public abstract class ProjectSearchService<T extends BaseIndexedBean, S extends BaseDTO, V extends BaseDAO<T>>
+public abstract class ProjectSearchService<T extends BaseIndexedBean, S extends DataInterface, V extends BaseDAO<T>>
         extends ClientSearchService<T, S, V> {
 
     private final String projectKey;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchDatabaseService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchDatabaseService.java
@@ -19,9 +19,11 @@ import org.kitodo.data.database.beans.BaseBean;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.persistence.BaseDAO;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.production.services.data.interfaces.SearchDatabaseServiceInterface;
 import org.primefaces.model.SortOrder;
 
-public abstract class SearchDatabaseService<T extends BaseBean, S extends BaseDAO<T>> {
+public abstract class SearchDatabaseService<T extends BaseBean, S extends BaseDAO<T>>
+        implements SearchDatabaseServiceInterface<T> {
 
     protected S dao;
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -100,7 +100,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends DataInt
      *            true or false
      * @return Interface object
      */
-    public abstract S convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException;
+    public abstract S convertJSONObjectTo(Map<String, Object> jsonObject, boolean related) throws DataException;
 
     /**
      * Count all not indexed rows in database. Not indexed means that row has index
@@ -452,7 +452,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends DataInt
      */
     public S findById(Integer id, boolean related) throws DataException {
         try {
-            return convertJSONObjectToInterface(searcher.findDocument(id), related);
+            return convertJSONObjectTo(searcher.findDocument(id), related);
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }
@@ -537,7 +537,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends DataInt
         List<S> results = new ArrayList<>();
 
         for (Map<String, Object> jsonObject : jsonObjects) {
-            results.add(convertJSONObjectToInterface(jsonObject, related));
+            results.add(convertJSONObjectTo(jsonObject, related));
         }
 
         return results;
@@ -552,9 +552,9 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends DataInt
      *            name of related property
      * @return bean object
      */
-    protected <O extends DataInterface> List<O> convertRelatedJSONObjectToInterface(Map<String, Object> jsonObject, String key,
+    protected <O extends DataInterface> List<O> convertRelatedJSONObjectTo(Map<String, Object> jsonObject, String key,
             SearchService<?, O, ?> service) throws DataException {
-        List<Integer> ids = getRelatedPropertyForInterface(jsonObject, key);
+        List<Integer> ids = getRelatedPropertyFor(jsonObject, key);
         if (ids.isEmpty()) {
             return new ArrayList<>();
         }
@@ -905,7 +905,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends DataInt
      * @return display properties as list of Integers
      */
     @SuppressWarnings("unchecked")
-    private List<Integer> getRelatedPropertyForInterface(Map<String, Object> object, String key) {
+    private List<Integer> getRelatedPropertyFor(Map<String, Object> object, String key) {
         if (Objects.nonNull(object)) {
             List<Map<String, Object>> jsonArray = (List<Map<String, Object>>) object.get(key);
             List<Integer> ids = new ArrayList<>();

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -53,7 +53,7 @@ import org.kitodo.data.elasticsearch.index.type.BaseType;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.elasticsearch.search.enums.SearchCondition;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.BaseDTO;
+import org.kitodo.data.interfaces.DataInterface;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.data.ProjectService;
 import org.primefaces.model.SortOrder;
@@ -62,7 +62,7 @@ import org.primefaces.model.SortOrder;
  * Class for implementing methods used by all service classes which search in
  * ElasticSearch index.
  */
-public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO, V extends BaseDAO<T>>
+public abstract class SearchService<T extends BaseIndexedBean, S extends DataInterface, V extends BaseDAO<T>>
         extends SearchDatabaseService<T, V> {
 
     private static final Logger logger = LogManager.getLogger(SearchService.class);
@@ -91,16 +91,16 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     }
 
     /**
-     * Method converts JSON object object to DTO. Necessary for displaying in the
+     * Method converts JSON object object to Interface. Necessary for displaying in the
      * frontend.
      *
      * @param jsonObject
      *            return from find methods
      * @param related
      *            true or false
-     * @return DTO object
+     * @return Interface object
      */
-    public abstract S convertJSONObjectToDTO(Map<String, Object> jsonObject, boolean related) throws DataException;
+    public abstract S convertJSONObjectToInterface(Map<String, Object> jsonObject, boolean related) throws DataException;
 
     /**
      * Count all not indexed rows in database. Not indexed means that row has index
@@ -133,22 +133,22 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     }
 
     /**
-     * Get all DTO objects from index an convert them for frontend with all
+     * Get all Interface objects from index an convert them for frontend with all
      * relations.
      *
-     * @return List of DTO objects
+     * @return List of Interface objects
      */
     public List<S> findAll() throws DataException {
         return findAll(false);
     }
 
     /**
-     * Get all DTO objects from index.
+     * Get all Interface objects from index.
      *
-     * @return List of DTO objects
+     * @return List of Interface objects
      */
     public List<S> findAll(boolean related) throws DataException {
-        return convertJSONObjectsToDTOs(findAllDocuments(), related);
+        return convertJSONObjectsToInterfaces(findAllDocuments(), related);
     }
 
     /**
@@ -430,54 +430,54 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     }
 
     /**
-     * Find object in ES and convert it to DTO.
+     * Find object in ES and convert it to Interface.
      *
      * @param id
      *            object id
-     * @return DTO object
+     * @return Interface object
      */
     public S findById(Integer id) throws DataException {
         return findById(id, false);
     }
 
     /**
-     * Find object related to previously found object in ES and convert it to DTO.
+     * Find object related to previously found object in ES and convert it to Interface.
      *
      * @param id
      *            related object id
      * @param related
      *            this method should ba called only with true, if false call method
      *            findById(Integer id).
-     * @return related DTO object
+     * @return related Interface object
      */
     public S findById(Integer id, boolean related) throws DataException {
         try {
-            return convertJSONObjectToDTO(searcher.findDocument(id), related);
+            return convertJSONObjectToInterface(searcher.findDocument(id), related);
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }
     }
 
     /**
-     * Find list of DTO objects by query.
+     * Find list of Interface objects by query.
      *
      * @param query
      *            as QueryBuilder object
      * @param related
      *            determines if converted object is related to some other object (if
      *            so, objects related to it are not included in conversion)
-     * @return list of found DTO objects
+     * @return list of found Interface objects
      */
     public List<S> findByQuery(QueryBuilder query, boolean related) throws DataException {
         try {
-            return convertJSONObjectsToDTOs(searcher.findDocuments(query), related);
+            return convertJSONObjectsToInterfaces(searcher.findDocuments(query), related);
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }
     }
 
     /**
-     * Find list of DTO objects by query.
+     * Find list of Interface objects by query.
      *
      * @param query
      *            as QueryBuilder object
@@ -486,18 +486,18 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      * @param related
      *            determines if converted object is related to some other object (if
      *            so, objects related to it are not included in conversion)
-     * @return list of found DTO objects
+     * @return list of found Interface objects
      */
     public List<S> findByQuery(QueryBuilder query, SortBuilder sort, boolean related) throws DataException {
         try {
-            return convertJSONObjectsToDTOs(searcher.findDocuments(query, sort), related);
+            return convertJSONObjectsToInterfaces(searcher.findDocuments(query, sort), related);
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }
     }
 
     /**
-     * Find list of sorted DTO objects by query with defined offset and size of
+     * Find list of sorted Interface objects by query with defined offset and size of
      * results.
      *
      * @param query
@@ -511,33 +511,33 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      * @param related
      *            determines if converted object is related to some other object (if
      *            so, objects related to it are not included in conversion)
-     * @return list of found DTO objects
+     * @return list of found Interface objects
      */
     public List<S> findByQuery(QueryBuilder query, SortBuilder sort, Integer offset, Integer size, boolean related)
             throws DataException {
         try {
-            return convertJSONObjectsToDTOs(searcher.findDocuments(query, sort, offset, size), related);
+            return convertJSONObjectsToInterfaces(searcher.findDocuments(query, sort, offset, size), related);
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }
     }
 
     /**
-     * Convert list of JSONObject object to list of DTO objects.
+     * Convert list of JSONObject object to list of Interface objects.
      *
      * @param jsonObjects
      *            list of SearchResult objects
      * @param related
      *            determines if converted object is related to some other object (if
      *            so, objects related to it are not included in conversion)
-     * @return list of DTO object
+     * @return list of Interface object
      */
-    protected List<S> convertJSONObjectsToDTOs(List<Map<String, Object>> jsonObjects, boolean related)
+    protected List<S> convertJSONObjectsToInterfaces(List<Map<String, Object>> jsonObjects, boolean related)
             throws DataException {
         List<S> results = new ArrayList<>();
 
         for (Map<String, Object> jsonObject : jsonObjects) {
-            results.add(convertJSONObjectToDTO(jsonObject, related));
+            results.add(convertJSONObjectToInterface(jsonObject, related));
         }
 
         return results;
@@ -552,9 +552,9 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      *            name of related property
      * @return bean object
      */
-    protected <O extends BaseDTO> List<O> convertRelatedJSONObjectToDTO(Map<String, Object> jsonObject, String key,
+    protected <O extends DataInterface> List<O> convertRelatedJSONObjectToInterface(Map<String, Object> jsonObject, String key,
             SearchService<?, O, ?> service) throws DataException {
-        List<Integer> ids = getRelatedPropertyForDTO(jsonObject, key);
+        List<Integer> ids = getRelatedPropertyForInterface(jsonObject, key);
         if (ids.isEmpty()) {
             return new ArrayList<>();
         }
@@ -905,7 +905,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      * @return display properties as list of Integers
      */
     @SuppressWarnings("unchecked")
-    private List<Integer> getRelatedPropertyForDTO(Map<String, Object> object, String key) {
+    private List<Integer> getRelatedPropertyForInterface(Map<String, Object> object, String key) {
         if (Objects.nonNull(object)) {
             List<Map<String, Object>> jsonArray = (List<Map<String, Object>>) object.get(key);
             List<Integer> ids = new ArrayList<>();

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/TitleSearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/TitleSearchService.java
@@ -25,13 +25,13 @@ import org.kitodo.data.elasticsearch.index.Indexer;
 import org.kitodo.data.elasticsearch.index.type.BaseType;
 import org.kitodo.data.elasticsearch.search.Searcher;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.BaseDTO;
+import org.kitodo.data.interfaces.DataInterface;
 
 /**
  * Class for implementing methods used by service classes which search for title
  * in ElasticSearch index.
  */
-public abstract class TitleSearchService<T extends BaseIndexedBean, S extends BaseDTO, V extends BaseDAO<T>>
+public abstract class TitleSearchService<T extends BaseIndexedBean, S extends DataInterface, V extends BaseDAO<T>>
         extends SearchService<T, S, V> {
 
     private static final String TITLE = "title";

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseBatchServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseBatchServiceInterface.java
@@ -27,7 +27,7 @@ public interface DatabaseBatchServiceInterface extends SearchDatabaseServiceInte
      * <p>
      * <b>Implementation Note:</b><br>
      * The function must get all processes from each batch and delete the
-     * batches to be deleted in each process before, it deletes the batches.
+     * batches to be deleted in each process, before it deletes the batches.
      *
      * @param batches
      *            batches to delete

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseBatchServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseBatchServiceInterface.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.util.Collection;
+
+import org.kitodo.data.database.beans.Batch;
+import org.kitodo.data.exceptions.DataException;
+
+/**
+ * Specifies the special database-related functions of the batch service.
+ */
+public interface DatabaseBatchServiceInterface extends SearchDatabaseServiceInterface<Batch> {
+
+    /**
+     * Deletes all given batches from the database.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * The function must get all processes from each batch and delete the
+     * batches to be deleted in each process before, it deletes the batches.
+     *
+     * @param batches
+     *            batches to delete
+     */
+    void removeAll(Collection<Batch> batches) throws DataException;
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseDocketServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseDocketServiceInterface.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.util.List;
+
+import org.kitodo.data.database.beans.Docket;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.DocketInterface;
+
+/**
+ * Specifies the special database-related functions of the docket service.
+ */
+public interface DatabaseDocketServiceInterface extends SearchDatabaseServiceInterface<Docket> {
+
+    /**
+     * Returns all docket configuration objects of the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * The function requires that the thread is assigned to a logged-in user.
+     * 
+     * @return all dockets for the selected client
+     */
+    List<Docket> getAllForSelectedClient();
+
+    /**
+     * Returns all docket configuration objects with the specified label. This
+     * can be used to check whether a label is still available.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * There is currently no filtering by client, so a label used by one client
+     * cannot be used by another client.
+     * 
+     * @param title
+     *            name to search for
+     * @return list of dockets
+     */
+    List<Docket> getByTitle(String title);
+
+    // === alternative functions that are no longer required ===
+
+    /**
+     * Find object in ES and convert it to Interface.
+     *
+     * @param id
+     *            object id
+     * @return Interface object
+     * @deprecated Use {@link #getById(Integer)}.
+     */
+    default DocketInterface findById(Integer id) throws DataException {
+        try {
+            return getById(id);
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseFilterServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseFilterServiceInterface.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import org.kitodo.data.database.beans.Filter;
+
+/**
+ * Specifies the special database-related functions of the filter service.
+ */
+public interface DatabaseFilterServiceInterface extends SearchDatabaseServiceInterface<Filter> {
+
+    /* nothing is needed here at the moment */
+
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProcessServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProcessServiceInterface.java
@@ -14,6 +14,7 @@ package org.kitodo.production.services.data.interfaces;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.data.FilterService;
 import org.kitodo.production.services.dataformat.MetsService;
 import org.kitodo.production.services.file.FileService;
 import org.primefaces.model.SortOrder;
@@ -303,8 +305,8 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      * @throws DataException
      *             if an error occurs
      */
-    List<Process> findSelectedProcesses(boolean showClosedProcesses, boolean showInactiveProjects, String filter,
-            Collection<Integer> excludedProcessIds) throws DataException;
+    List<ProcessInterface> findSelectedProcesses(boolean showClosedProcesses, boolean showInactiveProjects,
+            String filter, Collection<Integer> excludedProcessIds) throws DataException;
 
     /**
      * Determines the number of processes that match the specified filter
@@ -384,14 +386,14 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      * @param process
      *            process for which the data record number should be placed in
      *            the processBaseUri field
-     * @return the record number in a URI object
+     * @return the record number
      */
     /*
      * Since the moment this was introduced, I've never understood why this
      * exists. Nor why property processBaseUri exists at all. See #5856
      */
-    default URI getProcessDataDirectory(ProcessInterface process) {
-        return getProcessDataDirectory((Process) process, false);
+    default String getProcessDataDirectory(ProcessInterface process) {
+        return getProcessDataDirectory((Process) process, false).toString();
     }
 
     /**
@@ -429,8 +431,8 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      * 
      * <p>
      * <b>API Note:</b><br>
-     * This function counts the data records for the client, for which the
-     * logged in user is currently working.
+     * This function returns the processes for the client, for which the logged
+     * in user is currently working.
      * 
      * <p>
      * <b>Implementation Requirements:</b><br>
@@ -448,8 +450,11 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      * @throws DataException
      *             if an error occurs
      */
-    List<ProcessInterface> getResultsWithFilter(String filter, boolean showClosedProcesses,
-            boolean showInactiveProjects) throws DataException;
+    default List<ProcessInterface> getResultsWithFilter(String filter, boolean showClosedProcesses,
+            boolean showInactiveProjects) throws DataException {
+        return loadData(0, Integer.MAX_VALUE, "id", SortOrder.ASCENDING,
+            Collections.singletonMap(FilterService.FILTER_STRING, filter), showClosedProcesses, showInactiveProjects);
+    }
 
     /**
      * Returns processes to be offered as templates in the selection list. If a

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProcessServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProcessServiceInterface.java
@@ -85,15 +85,14 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      * If <i>batchMaxSize</i> is configured, at most the configured number of
      * processes will be returned.
      * 
+     * <!-- To replace the existing search functionality in
+     * BatchForm.filterProcesses(). -->
+     * 
      * @param processfilter
      *            substring to search
      * @return all processes whose names contain the comparison string
      * @throws DAOException
      *             in the event of a database connection error
-     */
-    /*
-     * To replace the existing search functionality in
-     * BatchForm.filterProcesses().
      */
     default List<Process> filterProcesses(String processfilter) throws DAOException {
         int batchMaxSize = ConfigCore.getIntParameter(ParameterCore.BATCH_DISPLAY_LIMIT, -1);
@@ -260,13 +259,12 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      * <b>Implementation Requirements:</b><br>
      * This function requires that the thread is assigned to a logged-in user.
      *
+     * <!-- Used to check whether a process identifier is already in use. In
+     * both places, the result is only checked for > 0. -->
+     *
      * @param title
      *            process name to be searched for
      * @return number of processes with this title
-     */
-    /*
-     * Used to check whether a process identifier is already in use. In both
-     * cases, the result is only checked for > 0.
      */
     default Long findNumberOfProcessesWithTitle(String title) throws DataException {
         int sessionClientId = ServiceManager.getUserService().getSessionClientId();
@@ -399,6 +397,9 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
     /**
      * Sets the record number of the process into the processBaseUri field. Can
      * also save the process.
+     * 
+     * <!-- Since the moment this was introduced, I've never understood why this
+     * exists. Nor why property processBaseUri exists at all. See #5856 -->
      *
      * @param process
      *            process for which the data record number should be placed in
@@ -406,10 +407,6 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      * @param forIndexingAll
      *            whether the process should <b>not</b> be saved
      * @return the record number in a URI object
-     */
-    /*
-     * Since the moment this was introduced, I've never understood why this
-     * exists. Nor why property processBaseUri exists at all. See #5856
      */
     default URI getProcessDataDirectory(Process process, boolean forIndexingAll) {
         try {
@@ -488,8 +485,7 @@ public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceIn
      *            maximum number of objects to return
      * @param sortField
      *            by which column the data should be sorted. Must not be
-     *            {@code null} or empty.
-     *            <p>
+     *            {@code null} or empty.<br>
      *            One of:<br>
      *            <ul>
      *            <li>"id": ID</li>

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProcessServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProcessServiceInterface.java
@@ -1,0 +1,577 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.kitodo.api.dataformat.LogicalDivision;
+import org.kitodo.api.dataformat.Workpiece;
+import org.kitodo.config.ConfigCore;
+import org.kitodo.config.enums.ParameterCore;
+import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.dataformat.MetsService;
+import org.kitodo.production.services.file.FileService;
+import org.primefaces.model.SortOrder;
+
+/**
+ * Specifies the special database-related functions of the process service.
+ */
+public interface DatabaseProcessServiceInterface extends SearchDatabaseServiceInterface<Process> {
+
+    /**
+     * Returns the number of objects of the implementing type that the filter
+     * matches.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts the data records for the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     *
+     * @param filters
+     *            a map with exactly one entry, only the value is important, in
+     *            which the content of the filter field is passed
+     * @param showClosedProcesses
+     *            whether completed processes should be displayed (usually not)
+     * @param showInactiveProjects
+     *            whether processes of deactivated projects should be displayed
+     *            (usually not)
+     * @return the number of matching objects
+     * @throws DAOException
+     *             that can be caused by Hibernate
+     * @throws DataException
+     *             that can be caused by ElasticSearch
+     */
+    /*
+     * Here, an additional function countResults() is specified with additional
+     * parameters, and the generally specified function from
+     * SearchDatabaseServiceInterface is not used. However, in
+     * DatabaseTemplateServiceInterface, a value is set that affects the
+     * generally specified functions countResults() and loadData() in
+     * SearchDatabaseServiceInterface. This could be equalized at some point in
+     * the future.
+     */
+    Long countResults(Map<?, String> filters, boolean showClosedProcesses, boolean showInactiveProjects)
+            throws DataException;
+
+    /**
+     * Finds all processes whose names contain the comparison string.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * If <i>batchMaxSize</i> is configured, at most the configured number of
+     * processes will be returned.
+     * 
+     * @param processfilter
+     *            substring to search
+     * @return all processes whose names contain the comparison string
+     * @throws DAOException
+     *             in the event of a database connection error
+     */
+    /*
+     * To replace the existing search functionality in
+     * BatchForm.filterProcesses().
+     */
+    default List<Process> filterProcesses(String processfilter) throws DAOException {
+        int batchMaxSize = ConfigCore.getIntParameter(ParameterCore.BATCH_DISPLAY_LIMIT, -1);
+        String query = "FROM Process WHERE title LIKE '%" + processfilter + "%'"
+                + (batchMaxSize > 0 ? " LIMIT " + batchMaxSize : "");
+        return getByQuery(query);
+    }
+
+    /**
+     * Finds processes by searchQuery for a number of fields.
+     *
+     * @param searchQuery
+     *            the query word or phrase
+     * @return a List of found ProcessInterfaces
+     * @throws DataException
+     *             when accessing the elasticsearch server fails
+     */
+    /*
+     * Only used in SearchResultForm. SearchResultForm is thrown out in further
+     * development. No new implementation required here. (However, the
+     * functionality must be provided in countResults() and loadData().)
+     */
+    default List<ProcessInterface> findByAnything(String searchQuery) throws DataException {
+        throw new UnsupportedOperationException("no longer provided this way");
+    }
+
+    /**
+     * Determines all processes with a specific docket.
+     *
+     * @param docketId
+     *            record number of the docket
+     * @return list that is not empty if something was found, otherwise empty
+     *         list
+     */
+    /*
+     * Used in DocketForm to find out whether a docket is used in a process.
+     * (Then it may not be deleted.) Is only checked for isEmpty().
+     */
+    Collection<?> findByDocket(int docketId) throws DataException;
+
+    /**
+     * Finds all processes with specific metadata entries.
+     *
+     * @param metadata
+     *            metadata entries that the process must have
+     * @param exactMatch
+     *            whether all metadata entries must be found in the process,
+     *            otherwise at least one
+     * @return all found processes
+     * @throws DataException
+     *             if there was an error during the search, or if the metadata
+     *             is not indexed
+     */
+    /*
+     * Used in the import service to locate parent processes. The map contains
+     * exactly one entry: a metadata key which is use="recordIdentifier", and as
+     * value the remote ID of the parent process (for example its PPN).
+     * exactMatch is always true here.
+     */
+    default List<ProcessInterface> findByMetadata(Map<String, String> metadata, boolean exactMatch)
+            throws DataException {
+        throw new DataException("index currently not available");
+    }
+
+    /**
+     * Determines all processes with a specific ruleset.
+     *
+     * @param rulesetId
+     *            record number of the ruleset
+     * @return list that is not empty if something was found, otherwise empty
+     *         list
+     */
+    /*
+     * Used in RulesetForm to find out whether a ruleset is used in a process.
+     * (Then it may not be deleted.) Is only checked for isEmpty().
+     */
+    Collection<?> findByRuleset(int rulesetId) throws DataException;
+
+    /**
+     * Determines all processes with a specific production template.
+     *
+     * @param templateId
+     *            record number of the production template
+     * @return list that is not empty if something was found, otherwise empty
+     *         list
+     * @throws DataException
+     *             if an error occurred during the search
+     */
+    /*
+     * Used in TemplateForm to find out whether a production template is used in
+     * a process. (Then it may not be deleted.) Is only checked for isEmpty().
+     */
+    public Collection<?> findByTemplate(int templateId) throws DataException;
+
+    /**
+     * Finds all processes with the specified name.
+     *
+     * @param title
+     *            process name to search for
+     * @return all processes with the specified name
+     * @throws DataException
+     *             when there is an error on conversation
+     */
+    /*
+     * Only used in NewspaperProcessesGenerator and only checked there on
+     * .isEmpty(), to see if a process title already exists.
+     */
+    @SuppressWarnings("unchecked")
+    default List<ProcessInterface> findByTitle(String title) throws DataException {
+        return (List<ProcessInterface>) (List<?>) getByQuery("FROM Process WHERE title = '" + title + "'");
+    }
+
+    /**
+     * Searches for linkable processes based on user input. A process can be
+     * linked if it has the samerule set, belongs to the same client, and the
+     * topmost element of the logical outline below the selected parent element
+     * is an allowed child.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * For the latter, the data file must be read at the moment. This will be
+     * aborted after a timeout so that the user gets an answer (which may be
+     * incomplete) in finite time.
+     *
+     * @param searchInput
+     *            user input
+     * @param rulesetId
+     *            the id of the allowed ruleset
+     * @param allowedStructuralElementTypes
+     *            allowed topmost logical structural elements
+     * @return found processes
+     * @throws DataException
+     *             if the search engine fails
+     */
+    List<ProcessInterface> findLinkableChildProcesses(String searchInput, int rulesetId,
+            Collection<String> allowedStructuralElementTypes) throws DataException;
+
+    /**
+     * Searches for linkable processes based on user input. A process can be
+     * linked if it belongs to the same project and has the same ruleset.
+     *
+     * @param searchInput
+     *            user input
+     * @param projectId
+     *            the id of the allowed project
+     * @param rulesetId
+     *            the id of the allowed ruleset
+     * @return found processes
+     * @throws DataException
+     *             if the search engine fails
+     */
+    List<ProcessInterface> findLinkableParentProcesses(String searchInput, int projectId, int rulesetId)
+            throws DataException;
+
+    /**
+     * Determines how many processes have a specific identifier.
+     *
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts the data records for the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     *
+     * @param title
+     *            process name to be searched for
+     * @return number of processes with this title
+     */
+    /*
+     * Used to check whether a process identifier is already in use. In both
+     * cases, the result is only checked for > 0.
+     */
+    default Long findNumberOfProcessesWithTitle(String title) throws DataException {
+        int sessionClientId = ServiceManager.getUserService().getSessionClientId();
+        String query = "FROM Process process WHERE process.title = '" + title + "' "
+                + "AND process.project.client.id = " + sessionClientId;
+        return (long) getByQuery(query).size();
+    }
+
+    /**
+     * Returns all selected processes. This refers to when a user has ticked
+     * "select all", and then optionally deselected individual processes. The
+     * function then returns a list of all <i>remaining</i> processes.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts the data records for the client, for which the
+     * logged in user is currently working. <b>Use it with caution, only if the
+     * number of objects is manageable.</b>
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     * 
+     * 
+     * @param showClosedProcesses
+     *            whether completed processes should also be displayed (usually
+     *            not)
+     * @param showInactiveProjects
+     *            whether processes from projects that are no longer active
+     *            should also be displayed (usually not)
+     * @param filter
+     *            user input in the filter input field
+     * @param excludedProcessIds
+     *            IDs of processes individually deselected after "select all"
+     * @return the processes found
+     * @throws DataException
+     *             if an error occurs
+     */
+    List<Process> findSelectedProcesses(boolean showClosedProcesses, boolean showInactiveProjects, String filter,
+            Collection<Integer> excludedProcessIds) throws DataException;
+
+    /**
+     * Determines the number of processes that match the specified filter
+     * criteria.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts the data records for the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     * 
+     * @param showClosedProcesses
+     *            whether completed processes should also be displayed (usually
+     *            not)
+     * @param showInactiveProjects
+     *            whether processes from projects that are no longer active
+     *            should also be displayed (usually not)
+     * @param filter
+     *            user input in the filter input field
+     * @return the number of matching processes
+     * @throws DataException
+     *             if an error occurs
+     */
+    default Integer getAmountForFilter(boolean showClosedProcesses, boolean showInactiveProjects, String filter)
+            throws DataException {
+        return getResultsWithFilter(filter, showClosedProcesses, showInactiveProjects).size();
+    }
+
+    /**
+     * Returns the type of the top element of the logical structure, and thus
+     * the type of the workpiece of the process.
+     *
+     * @param processId
+     *            id of the process whose root type is to be determined
+     * @return the type of root element of the logical structure of the
+     *         workpiece
+     * @throws DataException
+     *             if the type cannot be found in the index (e.g. because the
+     *             process cannot be found in the index)
+     */
+    default String getBaseType(int processId) throws DataException {
+
+        final FileService fileService = ServiceManager.getFileService();
+        final MetsService metsService = ServiceManager.getMetsService();
+
+        try {
+            URI path = fileService.getMetadataFilePath(getById(processId), true, false);
+            Workpiece workpiece = metsService.loadWorkpiece(path);
+            String baseType = metsService.getBaseType(workpiece);
+            return baseType;
+
+        } catch (DAOException | IOException e) {
+            throw new DataException(e);
+        }
+    }
+
+    /**
+     * Gets the number of immediate children of the given process.
+     * 
+     * @param processId
+     *            id of the process
+     * @return number of immediate children
+     * @throws DAOException
+     *             when query to database fails
+     */
+    default int getNumberOfChildren(int processId) throws DAOException {
+        return getById(processId).getChildren().size();
+    }
+
+    /**
+     * Sets the record number of the process into the processBaseUri field. Can
+     * also save the process.
+     *
+     * @param process
+     *            process for which the data record number should be placed in
+     *            the processBaseUri field
+     * @return the record number in a URI object
+     */
+    /*
+     * Since the moment this was introduced, I've never understood why this
+     * exists. Nor why property processBaseUri exists at all. See #5856
+     */
+    default URI getProcessDataDirectory(ProcessInterface process) {
+        return getProcessDataDirectory((Process) process, false);
+    }
+
+    /**
+     * Sets the record number of the process into the processBaseUri field. Can
+     * also save the process.
+     *
+     * @param process
+     *            process for which the data record number should be placed in
+     *            the processBaseUri field
+     * @param forIndexingAll
+     *            whether the process should <b>not</b> be saved
+     * @return the record number in a URI object
+     */
+    /*
+     * Since the moment this was introduced, I've never understood why this
+     * exists. Nor why property processBaseUri exists at all. See #5856
+     */
+    default URI getProcessDataDirectory(Process process, boolean forIndexingAll) {
+        try {
+            Integer id = process.getId();
+            URI uri = URI.create(id.toString());
+            process.setProcessBaseUri(uri);
+            if (!forIndexingAll) {
+                saveToDatabase(process);
+            }
+            return uri;
+        } catch (DAOException e) {
+            LogManager.getLogger(DatabaseProcessServiceInterface.class).error(e.getMessage(), e);
+            return URI.create("");
+        }
+    }
+
+    /**
+     * Returns the processes that match the specified filter criteria.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts the data records for the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     * 
+     * @param filter
+     *            user input in the filter input field
+     * @param showClosedProcesses
+     *            whether completed processes should also be displayed (usually
+     *            not)
+     * @param showInactiveProjects
+     *            whether processes from projects that are no longer active
+     *            should also be displayed (usually not)
+     * @return the matching processes
+     * @throws DataException
+     *             if an error occurs
+     */
+    List<ProcessInterface> getResultsWithFilter(String filter, boolean showClosedProcesses,
+            boolean showInactiveProjects) throws DataException;
+
+    /**
+     * Returns processes to be offered as templates in the selection list. If a
+     * user wants to create a larger number of processes that are the same in
+     * many metadata, they can create one sample process and then create copies
+     * of it.
+     * 
+     * @return processes to be offered in the choice list
+     */
+    default List<Process> getTemplateProcesses() throws DataException, DAOException {
+        return getByQuery("FROM Process WHERE inChoiceListShown IS true ORDER BY title ASC");
+    }
+
+    /**
+     * Provides a window onto the process objects. This makes it possible to
+     * navigate through the processes page by page, without having to load all
+     * objects into memory.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function filters the data according to the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     * 
+     * @param offset
+     *            number of objects to be skipped at the list head
+     * @param limit
+     *            maximum number of objects to return
+     * @param sortField
+     *            by which column the data should be sorted. Must not be
+     *            {@code null} or empty.
+     *            <p>
+     *            One of:<br>
+     *            <ul>
+     *            <li>"id": ID</li>
+     *            <li>"title.keyword": Process title</li>
+     *            <li>"progressCombined": Status</li>
+     *            <li>"lastEditingUser": Last editing user</li>
+     *            <li>"processingBeginLastTask": Processing begin of last
+     *            task</li>
+     *            <li>"processingEndLastTask": Processing end of last task</li>
+     *            <li>"correctionCommentStatus": Comments</li>
+     *            <li>"project.title.keyword": Project</li>
+     *            <li>"creationDate": Duration [sic!]</li>
+     *            </ul>
+     * @param sortOrder
+     *            sort ascending or descending?
+     * @param filters
+     *            a map with exactly one entry, only the value is important, in
+     *            which the content of the filter field is passed
+     * @param showClosedProcesses
+     *            whether completed processes should be displayed (usually not)
+     * @param showInactiveProjects
+     *            whether processes of deactivated projects should be displayed
+     *            (usually not)
+     * @return the data objects to be displayed
+     * @throws DataException
+     *             if processes cannot be loaded from search index
+     */
+    /*
+     * Here, an additional function loadData() is specified with additional
+     * parameters, and the generally specified function from
+     * SearchDatabaseServiceInterface is not used. However, in
+     * DatabaseTemplateServiceInterface, a value is set that affects the
+     * generally specified functions countResults() and loadData() in
+     * SearchDatabaseServiceInterface. This could be equalized at some point in
+     * the future.
+     */
+    List<ProcessInterface> loadData(int offset, int limit, String sortField, SortOrder sortOrder,
+            Map<?, String> filters, boolean showClosedProcesses, boolean showInactiveProjects) throws DataException;
+
+    /**
+     * Saves multiple processes in the database.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * Each object is stored in its own database transaction.
+     *
+     * @param list
+     *            processes to save
+     */
+    void saveList(List<Process> list) throws DAOException;
+
+    /**
+     * Updates the children linked in the database to those specified in the
+     * logical structure. Processes linked in the logical structure are linked
+     * in the database. For processes that are not linked in the logical
+     * structure, the link in the database is removed.
+     *
+     * @param process
+     *            parent process
+     * @param logicalStructure
+     *            the current state of the logical structure
+     * @throws DAOException
+     *             if a process is referenced with a URI whose ID does not
+     *             appear in the database
+     * @throws DataException
+     *             if the process cannot be saved
+     */
+    void updateChildrenFromLogicalStructure(Process process, LogicalDivision logicalStructure)
+            throws DAOException, DataException;
+
+    // === alternative functions that are no longer required ===
+
+    /**
+     * Find object in ES and convert it to Interface.
+     *
+     * @param id
+     *            object id
+     * @return Interface object
+     * @deprecated Use {@link #getById(Integer)}.
+     */
+    @Deprecated
+    default ProcessInterface findById(Integer id) throws DataException {
+        try {
+            return getById(id);
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProjectServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseProjectServiceInterface.java
@@ -1,0 +1,137 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import static org.kitodo.constants.StringConstants.COMMA_DELIMITER;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.kitodo.data.database.beans.Project;
+import org.kitodo.data.database.beans.User;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.ProjectInterface;
+import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.security.SecurityAccessService;
+
+/**
+ * Specifies the special database-related functions of the projects service.
+ */
+public interface DatabaseProjectServiceInterface extends SearchDatabaseServiceInterface<Project> {
+
+    /**
+     * Returns all projects that can still be assigned to a user. Returns the
+     * projects that are not already assigned to the user to be edited, and that
+     * belong to the client for which the logged-in user is currently working.
+     * These are displayed in the addProjectsPopup.
+     * 
+     * <p>
+     * {P} := currentUser.currentClient.projects - userAccount.projects
+     *
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * The function requires that the thread is assigned to a logged-in user.
+     * 
+     * @param user
+     *            user being edited
+     * @return projects that can be assigned
+     */
+    List<ProjectInterface> findAllAvailableForAssignToUser(User user) throws DataException;
+
+    /**
+     * Returns all projects the user is assigned to for the current client. This
+     * returns all projects, that the user, identified by the current session,
+     * is assigned to, and that belong to the client, that they are currently
+     * working for.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * The function requires that the thread is assigned to a logged-in user.
+     * 
+     * @return all projects the user is assigned to for the current client
+     * @throws DataException
+     *             on errors
+     */
+    List<ProjectInterface> findAllProjectsForCurrentUser() throws DataException;
+
+    /**
+     * Returns all projects of the client, for which the logged in user is
+     * currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * The function requires that the thread is assigned to a logged-in user.
+     * 
+     * @return all projects for the selected client
+     */
+    List<Project> getAllForSelectedClient();
+
+    /**
+     * Returns the names of the projects the user is allowed to see. If the user
+     * has the {@code AuthorityToViewProjectList} and
+     * {@link AuthorityToViewClientList} permissions, the list is returned
+     * unfiltered. Otherwise it will be limited to those projects that belong to
+     * the client for which the user is currently working and to which the user
+     * is assigned.
+     * 
+     * @param projects
+     *            projects to filter if necessary
+     * @return Returns a string with the names, separated by ", "
+     */
+    default String getProjectTitles(List<Project> projects) throws DataException {
+        final SecurityAccessService permissions = ServiceManager.getSecurityAccessService();
+
+        Stream<Project> projectsStream = projects.stream();
+        if (permissions.hasAuthorityToViewProjectList() && permissions.hasAuthorityToViewClientList()) {
+            List<Integer> permitted = findAllProjectsForCurrentUser().stream().map(ProjectInterface::getId)
+                    .collect(Collectors.toList());
+            projectsStream = projectsStream.filter(project -> permitted.contains(project.getId()));
+        }
+        return projectsStream.map(Project::getTitle).collect(Collectors.joining(COMMA_DELIMITER));
+    }
+
+    /**
+     * Returns all projects of the specified client and name.
+     *
+     * @param title
+     *            naming of the projects
+     * @param clientId
+     *            record number of the client whose projects are queried
+     * @return all projects of the specified client and name
+     */
+    List<Project> getProjectsWithTitleAndClient(String title, Integer clientId);
+
+    // === alternative functions that are no longer required ===
+
+    /**
+     * Returns all projects from the database.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This method actually returns all objects of all clients and is therefore
+     * more suitable for operational purposes, rather not for display purposes.
+     *
+     * @return all objects of the implementing type
+     * @deprecated Use {@link #getAll()}.
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    default List<ProjectInterface> findAll() throws DataException {
+        try {
+            return (List<ProjectInterface>) (List<?>) getAll();
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseRulesetServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseRulesetServiceInterface.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.util.List;
+
+import org.kitodo.data.database.beans.Ruleset;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.RulesetInterface;
+
+/**
+ * Specifies the special database-related functions of the ruleset service.
+ */
+public interface DatabaseRulesetServiceInterface extends SearchDatabaseServiceInterface<Ruleset> {
+
+    /**
+     * Returns all business domain models of the client, for which the logged in
+     * user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * The function requires that the thread is assigned to a logged-in user.
+     * 
+     * @return all dockets for the selected client
+     */
+    List<Ruleset> getAllForSelectedClient();
+
+    /**
+     * Returns all business domain models with the specified label. This can be
+     * used to check whether a label is still available.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * There is currently no filtering by client, so a label used by one client
+     * cannot be used by another client.
+     * 
+     * @param title
+     *            name to search for
+     * @return list of dockets
+     */
+    List<Ruleset> getByTitle(String title);
+
+    // === alternative functions that are no longer required ===
+
+    /**
+     * Find object in ES and convert it to Interface.
+     *
+     * @param id
+     *            object id
+     * @return Interface object
+     * @deprecated Use {@link #getById(Integer)}.
+     */
+    @Deprecated
+    default RulesetInterface findById(Integer id) throws DataException {
+        try {
+            return getById(id);
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseTaskServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseTaskServiceInterface.java
@@ -227,8 +227,7 @@ public interface DatabaseTaskServiceInterface extends SearchDatabaseServiceInter
      *            maximum number of objects to return
      * @param sortField
      *            by which column the data should be sorted. Must not be
-     *            {@code null} or empty.
-     *            <p>
+     *            {@code null} or empty.<br>
      *            One of:<br>
      *            <ul>
      *            <li>"title.keyword": Title</li>

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseTaskServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseTaskServiceInterface.java
@@ -1,0 +1,297 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.kitodo.data.database.beans.Task;
+import org.kitodo.data.database.enums.TaskStatus;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.TaskInterface;
+import org.kitodo.production.helper.tasks.EmptyTask;
+import org.primefaces.model.SortOrder;
+
+public interface DatabaseTaskServiceInterface extends SearchDatabaseServiceInterface<Task> {
+
+    /**
+     * Returns the number of objects of the implementing type that the filter
+     * matches.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts the data records for the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     *
+     * @param filters
+     *            a map with exactly one entry, only the value is important, in
+     *            which the content of the filter field is passed
+     * @param onlyOwnTasks
+     *            whether only tasks, to which the current user is already
+     *            assigned as processor (usually not)
+     * @param hideCorrectionTasks
+     *            whether tasks in correction runs should be hidden (usually
+     *            not)
+     * @param showAutomaticTasks
+     *            whether automatic tasks should be included (usually not)
+     * @param taskStatus
+     *            tasks in what status Tasks in what status. Must not be
+     *            {@code} null. One of: [OPEN, INWORK], [OPEN], [INWORK] or [].
+     * @return the number of matching objects
+     * @throws DAOException
+     *             database access error
+     * @throws DataException
+     *             index access error
+     */
+    /*
+     * Here, an additional function countResults() is specified with additional
+     * parameters, and the generally specified function from
+     * SearchDatabaseServiceInterface is not used. However, in
+     * DatabaseTemplateServiceInterface, a value is set that affects the
+     * generally specified functions countResults() and loadData() in
+     * SearchDatabaseServiceInterface. This could be equalized at some point in
+     * the future.
+     */
+    Long countResults(Map<?, String> filters, boolean onlyOwnTasks, boolean hideCorrectionTasks,
+            boolean showAutomaticTasks, List<TaskStatus> taskStatus) throws DataException;
+
+    /**
+     * Runs a script for a task. The script can be a programmatic branch into
+     * the application, a so-called Kitodo Script, or a command line call. If it
+     * is an automatic task, depending on the result of the script, the task is
+     * completed or set to open and the changed state is immediately saved to
+     * the database.
+     *
+     * @param task
+     *            task in which the script is executed
+     * @param automatic
+     *            if so, the task is set to completed if the outcome is positive
+     *            (without errors, for a command line call with the return code
+     *            0), and if the outcome is negative it is set to open; and the
+     *            object is then immediately updated in the database.
+     */
+    void executeScript(Task task, boolean automatic) throws DataException;
+
+    /**
+     * Runs a script for a task. The script can be a programmatic branch into
+     * the application, a so-called Kitodo Script, or a command line call. If it
+     * is an automatic task, depending on the result of the script, the task is
+     * completed or set to open and the changed state is immediately saved to
+     * the database.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * In previous versions, up to five scripts could be available in a task,
+     * and the operator would then start one or another of them manually.
+     * Therefore, the script can still be passed here (because there were
+     * several of them). Actually, this is no longer necessary, since there is
+     * only one script per task remaining, and that can be cleaned up one day.
+     *
+     * @param task
+     *            task in which the script is executed
+     * @param script
+     *            The command to be executed. If it starts with "action:", it is
+     *            an internal function call, otherwise a command line that the
+     *            JVM executes with the user it runs under.
+     * @param automatic
+     *            if so, the task is set to completed if the outcome is positive
+     *            (without errors, for a command line call with the return code
+     *            0), and if the outcome is negative it is set to open; and the
+     *            object is then immediately updated in the database.
+     * @return whether it had a successful outcome
+     */
+    boolean executeScript(Task task, String script, boolean automatic) throws DataException;
+
+    /**
+     * Determines all processes with a specific production template.
+     *
+     * @param templateId
+     *            record number of the production template
+     * @return list that is not empty if something was found, otherwise empty
+     *         list
+     * @throws DataException
+     *             if an error occurred during the search
+     */
+    /*
+     * Used in TemplateForm to find out whether a production template is used in
+     * a process. (Then it may not be deleted.) Is only checked for isEmpty().
+     */
+    public Collection<?> findByTemplateId(Integer id) throws DataException;
+
+    /**
+     * Finds all task names that each differ from any other. That means, no
+     * doubles.
+     *
+     * <p>
+     * <b>API Note:</b><br>
+     * This method actually returns all task names of all clients and is
+     * therefore more suitable for operational purposes, rather not for display
+     * purposes.
+     *
+     * @return all different task names
+     */
+    List<String> findTaskTitlesDistinct() throws DataException, DAOException;
+
+    /**
+     * Generates browser-friendly images. (thumbnails, or even full images in
+     * any format used by browsers)
+     *
+     * @param executingThread
+     *            Background thread that controls image generation. In this
+     *            thread, display fields are updated so that the user can see
+     *            the progress.
+     * @param task
+     *            task whose status should be set upon completion
+     * @param automatic
+     *            if so, the task is set to completed if the processing was
+     *            completed without errors, and else it is set to open; and the
+     *            object is then immediately updated in the database.
+     * @throws DataException
+     *             if the task cannot be saved
+     */
+    void generateImages(EmptyTask executingThread, Task task, boolean automatic) throws DataException;
+
+    /**
+     * Returns all tasks that lie between the two specified tasks in the
+     * processing sequence.
+     *
+     * @param previousOrdering
+     *            processing sequence number of the previous task, that is the
+     *            task in which the error can be corrected
+     * @param laterOrdering
+     *            processing sequence number of the later task, that is the task
+     *            in which the error was discovered
+     * @param processId
+     *            record number of the process whose tasks are being searched
+     * @return the tasks in between
+     */
+    List<Task> getAllTasksInBetween(Integer previousOrdering, Integer laterOrdering, Integer processId);
+
+    /**
+     * Returns all tasks in the batch with the specified name.
+     *
+     * @param title
+     *            task title
+     * @param batchId
+     *            batch number
+     * @return all identified tasks
+     */
+    List<Task> getCurrentTasksOfBatch(String title, Integer batchId);
+
+    /**
+     * Finds all tasks that preceded the current one. This is used when a user
+     * wants to send an error message to a previous task, so the user can choose
+     * which task they want to send the message to.
+     *
+     * @param ordering
+     *            processing sequence number of the task in which the error was
+     *            discovered
+     * @param processId
+     *            record number of the process whose tasks are being searched
+     * @return list of Task objects
+     */
+    List<Task> getPreviousTasksForProblemReporting(Integer ordering, Integer processId);
+
+    /**
+     * Provides a window onto the task objects. This makes it possible to
+     * navigate through the tasks page by page, without having to load all
+     * objects into memory.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function filters the data according to the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     * 
+     * @param offset
+     *            number of objects to be skipped at the list head
+     * @param limit
+     *            maximum number of objects to return
+     * @param sortField
+     *            by which column the data should be sorted. Must not be
+     *            {@code null} or empty.
+     *            <p>
+     *            One of:<br>
+     *            <ul>
+     *            <li>"title.keyword": Title</li>
+     *            <li>"processForTask.id": Process ID</li>
+     *            <li>"processForTask.title.keyword": Process</li>
+     *            <li>"processingStatus": Status</li>
+     *            <li>"processingUser.name.keyword": Last editing user</li>
+     *            <li>"processingBegin": Start of work</li>
+     *            <li>"processingEnd": End of work</li>
+     *            <li>"correctionCommentStatus": Comments</li>
+     *            <li>"projectForTask.title.keyword": Project</li>
+     *            <li>"processForTask.creationDate": Duration (Process)
+     *            [sic!]</li>
+     *            </ul>
+     * @param sortOrder
+     *            sort ascending or descending?
+     * @param filters
+     *            a map with exactly one entry, only the value is important, in
+     *            which the content of the filter field is passed
+     * @param onlyOwnTasks
+     *            whether only tasks, to which the current user is already
+     *            assigned as processor (usually not)
+     * @param hideCorrectionTasks
+     *            whether tasks in correction runs should be hidden (usually
+     *            not)
+     * @param showAutomaticTasks
+     *            whether automatic tasks should be included (usually not)
+     * @param taskStatus
+     *            Tasks in what status. Must not be {@code} null. One of: [OPEN,
+     *            INWORK], [OPEN], [INWORK] or [].
+     * @return the data objects to be displayed
+     * @throws DataException
+     *             if processes cannot be loaded from search index
+     */
+    /*
+     * Here, an additional function loadData() is specified with additional
+     * parameters, and the generally specified function from
+     * SearchDatabaseServiceInterface is not used. However, in
+     * DatabaseTemplateServiceInterface, a value is set that affects the
+     * generally specified functions countResults() and loadData() in
+     * SearchDatabaseServiceInterface. This could be equalized at some point in
+     * the future.
+     */
+    List<TaskInterface> loadData(int first, int pageSize, String sortField, SortOrder sortOrder, Map<?, String> filters,
+            boolean onlyOwnTasks, boolean hideCorrectionTasks, boolean showAutomaticTasks, List<TaskStatus> taskStatus)
+            throws DataException;
+
+    // === alternative functions that are no longer required ===
+
+    /**
+     * Find object in ES and convert it to Interface.
+     *
+     * @param id
+     *            object id
+     * @return Interface object
+     * @deprecated Use {@link #getById(Integer)}.
+     */
+    @Deprecated
+    default TaskInterface findById(Integer id) throws DataException {
+        try {
+            return getById(id);
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseTemplateServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseTemplateServiceInterface.java
@@ -1,0 +1,118 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.kitodo.data.database.beans.Template;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.interfaces.TemplateInterface;
+import org.primefaces.model.SortOrder;
+
+/**
+ * Specifies the special database-related functions of the template service.
+ */
+public interface DatabaseTemplateServiceInterface extends SearchDatabaseServiceInterface<Template> {
+
+    /**
+     * Determines all process templates with a specific docket.
+     *
+     * @param docketId
+     *            record number of the docket
+     * @return list that is not empty if something was found, otherwise empty
+     *         list
+     */
+    public Collection<?> findByDocket(int docketId) throws DataException;
+
+    /**
+     * Returns all process templates that can still be assigned to a project.
+     * Returns the process templates that
+     * <ul>
+     * <li>are active</li>
+     * <li>and that are not already assigned to the project to be
+     * edited<sup>✻</sup>,</li>
+     * <li>and that belong to the client for which the logged-in user is
+     * currently working.</li>
+     * </ul>
+     * These are displayed in the templateAddPopup.
+     * 
+     * <p>
+     * {T} := currentUser.currentClient.processTemplates[active] -
+     * projectEdited.processTemplates
+     *
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * The function requires that the thread is assigned to a logged-in user.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * ✻) If the project has already been saved. If not, if {@code projectID} is
+     * {@code null}, returns all active process templates for the current
+     * client.
+     * 
+     * @param projectId
+     *            ID of project which is going to be edited. May be
+     *            {@code null}.
+     * @return process templates that can be assigned
+     */
+    List<TemplateInterface> findAllAvailableForAssignToProject(Integer projectId) throws DataException;
+
+    /**
+     * Determines all process templates with a specific ruleset.
+     *
+     * @param rulesetId
+     *            record number of the ruleset
+     * @return list that is not empty if something was found, otherwise empty
+     *         list
+     */
+    /*
+     * Used in RulesetForm to find out whether a ruleset is used in a process
+     * template. (Then it may not be deleted.) Is only checked for isEmpty().
+     */
+    Collection<?> findByRuleset(int rulesetId) throws DataException;
+
+    /**
+     * Sets whether to display non-active production templates in the list.
+     *
+     * <p>
+     * <b>API Note:</b><br>
+     * Affects the results of functions {@link #countDatabaseRows()} and
+     * {@link #loadData(int, int, String, SortOrder, Map)} in
+     * {@link SearchDatabaseServiceInterface}.
+     * 
+     * @param showInactiveTemplates
+     *            as boolean
+     */
+    /*
+     * Here, a value is set that affects the generally specified functions
+     * countResults() and loadData() in SearchDatabaseServiceInterface. However,
+     * in DatabaseProjectServiceInterface and DatabaseTaskServiceInterface, an
+     * additional functions countResults() and loadData() are specified with
+     * additional parameters, and the generally specified functions
+     * countResults() and loadData() from SearchDatabaseServiceInterface are not
+     * used. This could be equalized at some point in the future.
+     */
+    void setShowInactiveTemplates(boolean showInactiveTemplates);
+
+    /**
+     * Returns all process templates of the specified client and name.
+     *
+     * @param title
+     *            naming of the projects
+     * @param clientId
+     *            record number of the client whose projects are queried
+     * @return all process templates of the specified client and name
+     */
+    List<Template> getTemplatesWithTitleAndClient(String title, Integer clientId);
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseWorkflowServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/DatabaseWorkflowServiceInterface.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.util.List;
+
+import org.kitodo.data.database.beans.Workflow;
+import org.kitodo.data.database.enums.WorkflowStatus;
+
+/**
+ * Specifies the special database-related functions of the workflow service.
+ */
+public interface DatabaseWorkflowServiceInterface extends SearchDatabaseServiceInterface<Workflow> {
+
+    /**
+     * Returns all available workflows. These are all workflows that are in
+     * {@link WorkflowStatus} {@code ACTIVE} for the client for which the
+     * current user is working at the moment.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * The function requires that the thread is assigned to a logged-in user.
+     *
+     * @return all available workflows
+     */
+    List<Workflow> getAvailableWorkflows();
+
+    /**
+     * Returns all active workflows. These are all workflows that are in
+     * {@link WorkflowStatus} {@code ACTIVE}.
+     *
+     * <p>
+     * <b>API Note:</b><br>
+     * This method actually returns all objects of all clients and is therefore
+     * more suitable for operational purposes, rather not for display purposes.
+     * 
+     * @return all active workflows
+     */
+    List<Workflow> getAllActiveWorkflows();
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/SearchDatabaseServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/SearchDatabaseServiceInterface.java
@@ -1,0 +1,373 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data.interfaces;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.kitodo.data.database.beans.BaseBean;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
+import org.kitodo.data.exceptions.DataException;
+import org.primefaces.model.SortOrder;
+
+/**
+ * Specifies the functions of the Search Database Service
+ * 
+ * @param <T>
+ *            type of database objects
+ */
+public interface SearchDatabaseServiceInterface<T extends BaseBean> {
+    /**
+     * Returns the number of objects of the implementing type in the database.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts all data records in the database for all clients.
+     *
+     * @return the number of objects
+     */
+    Long countDatabaseRows() throws DAOException;
+
+    /**
+     * Returns the number of objects of the implementing type that the filter
+     * matches.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function counts the data records for the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * For {@code SearchDatabaseServiceInterface<Template>}, this must take into
+     * account the value from
+     * {@link DatabaseTemplateServiceInterface#setShowInactiveTemplates(boolean)}.
+     * For {@link DatabaseProcessServiceInterface} and
+     * {@link DatabaseTaskServiceInterface}, this function is unused. They
+     * declare their own {@code countResults()} with additional parameters.
+     * 
+     * @param filters
+     *            a map with exactly one entry, only the value is important, in
+     *            which the content of the filter field is passed
+     * @return the number of matching objects
+     * @throws DAOException
+     *             that can be caused by Hibernate
+     * @throws DataException
+     *             that can be caused by ElasticSearch
+     */
+    Long countResults(Map<?, String> filters) throws DAOException, DataException;
+
+    /**
+     * Unlinks the object from the primary Hibernate cache, so it can be garbage
+     * collected.
+     *
+     * @param baseBean
+     *            bean to evict
+     */
+    void evict(T baseBean);
+
+    /**
+     * Returns all objects of the implementing type from the database.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This method actually returns all objects of all clients and is therefore
+     * more suitable for operational purposes, rather not for display purposes.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * Use this with caution, only if the number of objects is manageable.
+     *
+     * @return all objects of the implementing type
+     */
+    List<T> getAll() throws DAOException;
+
+    /**
+     * Returns a range of all objects of the implementing type from the
+     * database. In this way the objects can be fetched in groups.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This method actually returns all objects of all clients and is therefore
+     * more suitable for operational purposes, rather not for display purposes.
+     *
+     * @param offset
+     *            number of objects to be skipped at the head
+     * @param size
+     *            maximum number of objects to return
+     * @return objects in the given range
+     */
+    public List<T> getAll(int offset, int size) throws DAOException;
+
+    /**
+     * Gets an object by its database record number.
+     *
+     * @param id
+     *            record number
+     * @return object
+     */
+    T getById(Integer id) throws DAOException;
+
+    /**
+     * Gets a set of objects based on a search query.
+     *
+     * @param query
+     *            search query
+     *            <!-- TODO: clarify what exactly is passed here -->
+     * @return list of exact bean objects
+     */
+    public List<T> getByQuery(String query);
+
+    /**
+     * Provides a window onto the data objects of the implementing type. This
+     * makes it possible to navigate through the data objects page by page,
+     * without having to load <i>all</i> objects into memory.
+     * 
+     * <p>
+     * <b>API Note:</b><br>
+     * This function filters the data according to the client, for which the
+     * logged in user is currently working.
+     * 
+     * <p>
+     * <b>Implementation Requirements:</b><br>
+     * This function requires that the thread is assigned to a logged-in user.
+     * 
+     * <p>
+     * <b>Implementation Note:</b><br>
+     * For {@code SearchDatabaseServiceInterface<Template>}, this must take into
+     * account the value from
+     * {@link DatabaseTemplateServiceInterface#setShowInactiveTemplates(boolean)}.
+     * For {@link DatabaseProcessServiceInterface} and
+     * {@link DatabaseTaskServiceInterface}, this function is unused. They
+     * declare their own {@code loadData()} with additional parameters.
+     * 
+     * @param offset
+     *            number of objects to be skipped at the list head
+     * @param limit
+     *            maximum number of objects to return
+     * @param sortField
+     *            by which column the data should be sorted
+     *            <!-- TODO: clarify what is passed here, what if no sorting is selected -->
+     * @param sortOrder
+     *            sort ascending or descending?
+     * @param filters
+     *            a map with exactly one entry, only the value is important, in
+     *            which the content of the filter field is passed
+     *
+     * @return the data objects to be displayed
+     * @throws DataException
+     *             if processes cannot be loaded from search index
+     */
+    List<T> loadData(int offset, int limit, String sortField, SortOrder sortOrder, Map<?, String> filters)
+            throws DataException;
+
+    /**
+     * Removes an object from the database.
+     *
+     * @param baseIndexedBean
+     *            object to remove
+     */
+    public void removeFromDatabase(T baseIndexedBean) throws DAOException;
+
+    /**
+     * Stores an object in the database.
+     *
+     * @param baseIndexedBean
+     *            object to save
+     */
+    void saveToDatabase(T baseIndexedBean) throws DAOException;
+
+    // === alternative functions that are no longer required ===
+
+    /**
+     * Count all objects in index.
+     *
+     * @return amount of all objects
+     * @deprecated Use {@link #countDatabaseRows()}.
+     */
+    @Deprecated
+    default Long count() throws DataException {
+        try {
+            return countDatabaseRows();
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+
+    /**
+     * Get all not indexed objects from database in given range. Not indexed
+     * means that row has index action INDEX or NULL.
+     *
+     * @param offset
+     *            result - important, numeration starts since 0
+     * @param size
+     *            amount of results
+     * @return list of all not indexed objects from database in given range
+     * @deprecated Use {@link #getAll(int, int)}.
+     */
+    @Deprecated
+    default List<T> getAllNotIndexed(int offset, int size) throws DAOException {
+        return getAll(offset, size);
+    }
+
+    /**
+     * Method removes object from database and document from the index of
+     * Elastic Search.
+     *
+     * @param baseIndexedBean
+     *            object
+     * @deprecated Use {@link #removeFromDatabase(BaseBean)}.
+     */
+    @Deprecated
+    default void remove(T baseIndexedBean) throws DataException {
+        try {
+            removeFromDatabase(baseIndexedBean);
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+
+    /**
+     * calls save method with default updateRelatedObjectsInIndex=false.
+     * 
+     * @param object
+     *            the object to save
+     * @deprecated Use {@link #saveToDatabase(BaseBean)}.
+     */
+    @Deprecated
+    public default void save(T object) throws DataException {
+        try {
+            saveToDatabase(object);
+        } catch (DAOException e) {
+            throw new DataException(e);
+        }
+    }
+
+    /**
+     * Method saves object to database and document to the index of Elastic
+     * Search. This method binds three other methods: save to database, save to
+     * index and save dependencies to index.
+     *
+     * <p>
+     * First step sets up the flag indexAction to state Index and saves to
+     * database. It informs that object was updated in database but not yet in
+     * index. If this step fails, method breaks. If it is successful, method
+     * saves changes to index, first document and next its dependencies. If one
+     * of this steps fails, method retries up to 5 times operations on index. If
+     * it continues to fail, method breaks. If save to index was successful,
+     * indexAction flag is changed to Done and database is again updated. There
+     * is possibility that last step fails and in that case, even if index is up
+     * to date, in some point of the future it will be reindexed by
+     * administrator.
+     *
+     * @param baseIndexedBean
+     *            object
+     *
+     * @param updateRelatedObjectsInIndex
+     *            if relatedObjects need to be updated in Index
+     * @deprecated Use {@link #saveToDatabase(BaseBean)}.
+     */
+    @Deprecated
+    default void save(T baseIndexedBean, boolean updateRelatedObjectsInIndex) throws DataException {
+        save(baseIndexedBean);
+    }
+
+    // === functions no longer used ===
+
+    /**
+     * Method adds all object found in database to Elastic Search index.
+     *
+     * @param baseIndexedBeans
+     *            List of BaseIndexedBean objects
+     * @deprecated Does nothing anymore and can be deleted.
+     */
+    @Deprecated
+    default void addAllObjectsToIndex(List<T> baseIndexedBeans)
+            throws CustomResponseException, DAOException, IOException {
+    }
+
+    /**
+     * Get all ids from index in a given range.
+     *
+     * @return List of ids in given range
+     * @deprecated The function was only used in the context of the no longer
+     *             existing function {@link #removeLooseIndexData(List)} and can
+     *             therefore now also be omitted.
+     */
+    @Deprecated
+    default List<Integer> findAllIDs(Long startIndex, int limit) throws DataException {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Method removes document from the index of Elastic Search.
+     *
+     * @param baseIndexedBean
+     *            object
+     * @param forceRefresh
+     *            force index refresh - if true, time of execution is longer but
+     *            object is right after that available for display
+     * @deprecated Does nothing anymore and can be deleted.
+     */
+    @Deprecated
+    default void removeFromIndex(T baseIndexedBean, boolean forceRefresh)
+            throws CustomResponseException, DataException, IOException {
+    }
+
+    /**
+     * Method removes document from the index of Elastic Search by given id.
+     *
+     * @param id
+     *            of object
+     * @param forceRefresh
+     *            force index refresh - if true, time of execution is longer but
+     *            object is right after that available for display
+     * @deprecated Does nothing anymore and can be deleted.
+     */
+    @Deprecated
+    default void removeFromIndex(Integer id, boolean forceRefresh) throws CustomResponseException, DataException {
+    }
+
+    /**
+     * Removes all objects from index, which are no longer in Database.
+     * 
+     * @param baseIndexedBeansId
+     *            the list of beans to check for missing db eintries.
+     *
+     * @deprecated Does nothing anymore and can be deleted.
+     */
+    @Deprecated
+    default void removeLooseIndexData(List<Integer> baseIndexedBeansId) {
+    }
+
+    /**
+     * Method saves document to the index of Elastic Search.
+     *
+     * @param baseIndexedBean
+     *            object
+     * @param forceRefresh
+     *            force index refresh - if true, time of execution is longer but
+     *            object is right after that available for display
+     * @deprecated Does nothing anymore and can be deleted.
+     */
+    @Deprecated
+    default void saveToIndex(T baseIndexedBean, boolean forceRefresh)
+            throws CustomResponseException, DataException, IOException {
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/SearchDatabaseServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/SearchDatabaseServiceInterface.java
@@ -353,7 +353,7 @@ public interface SearchDatabaseServiceInterface<T extends BaseBean> {
      * @deprecated Does nothing anymore and can be deleted.
      */
     @Deprecated
-    default void removeLooseIndexData(List<Integer> baseIndexedBeansId) {
+    default void removeLooseIndexData(List<Integer> baseIndexedBeansId) throws DataException, CustomResponseException {
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/SearchDatabaseServiceInterface.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/interfaces/SearchDatabaseServiceInterface.java
@@ -23,7 +23,7 @@ import org.kitodo.data.exceptions.DataException;
 import org.primefaces.model.SortOrder;
 
 /**
- * Specifies the functions of the Search Database Service
+ * Specifies the functions of the Search Database Service.
  * 
  * @param <T>
  *            type of database objects
@@ -162,8 +162,20 @@ public interface SearchDatabaseServiceInterface<T extends BaseBean> {
      * @param limit
      *            maximum number of objects to return
      * @param sortField
-     *            by which column the data should be sorted
-     *            <!-- TODO: clarify what is passed here, what if no sorting is selected -->
+     *            by which column the data should be sorted. Must not be
+     *            {@code null} or empty.<br>
+     *            One of:<br>
+     *            <ul>
+     *            <li>"title.keyword": Title [docket, ruleset, process template,
+     *            and workflow]</li>
+     *            <li>"file.keyword": File [docket, and ruleset]</li>
+     *            <li>"orderMetadataByRuleset": Order metadata as in ruleset
+     *            (otherwise alphabetically) [only ruleset]</li>
+     *            <li>"ruleset.title.keyword": Ruleset [only process
+     *            template]</li>
+     *            <li>"active": Active [only process template]</li>
+     *            <li>"status": Status [only workflow]</li>
+     *            </ul>
      * @param sortOrder
      *            sort ascending or descending?
      * @param filters

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
@@ -213,9 +213,9 @@ public class DataEditorService {
                                                                          Collection<Metadata> existingMetadata,
                                                                          Collection<String> additionalFields, Ruleset ruleset) {
         List<SelectItem> addableMetadata = new ArrayList<>();
-        Collection<MetadataViewInterface> viewInterfaces = structureView
+        Collection<MetadataViewInterface> views = structureView
                 .getAddableMetadata(existingMetadata, additionalFields);
-        for (MetadataViewInterface keyView : viewInterfaces) {
+        for (MetadataViewInterface keyView : views) {
             addableMetadata.add(
                     new SelectItem(keyView.getId(), keyView.getLabel(),
                             keyView instanceof SimpleMetadataViewInterface

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -724,14 +724,14 @@ public class FileService {
     }
 
     /**
-     * Gets the URI of the metadata.xml of a given processInterface.
+     * Gets the URI of the metadata.xml of a given process.
      *
-     * @param processInterface
+     * @param process
      *            the process to get the metadata.xml for.
      * @return The URI to the metadata.xml
      */
-    public URI getMetadataFilePath(ProcessInterface processInterface) throws IOException {
-        return getMetadataFilePath(processInterface, true);
+    public URI getMetadataFilePath(ProcessInterface process) throws IOException {
+        return getMetadataFilePath(process, true);
     }
 
     /**
@@ -752,16 +752,16 @@ public class FileService {
     }
 
     /**
-     * Gets the URI of the metadata.xml of a given processInterface.
+     * Gets the URI of the metadata.xml of a given process.
      *
-     * @param processInterface
+     * @param process
      *            the process to get the metadata.xml for.
      * @param mustExist
      *            whether the file must exist
      * @return The URI to the metadata.xml
      */
-    public URI getMetadataFilePath(ProcessInterface processInterface, boolean mustExist) throws IOException {
-        URI metadataFilePath = getProcessSubTypeURI(processInterface, ProcessSubType.META_XML, null);
+    public URI getMetadataFilePath(ProcessInterface process, boolean mustExist) throws IOException {
+        URI metadataFilePath = getProcessSubTypeURI(process, ProcessSubType.META_XML, null);
         if (mustExist && !fileExist(metadataFilePath)) {
             throw new IOException(Helper.getTranslation("metadataFileNotFound", metadataFilePath.getPath()));
         }
@@ -901,17 +901,17 @@ public class FileService {
      * to the correct URI. File.separator doesn't work because on Windows it
      * appends backslash to URI.
      *
-     * @param processInterface
+     * @param process
      *            the process, the uri is needed for.
      * @return the URI.
      */
-    public String getProcessBaseUriForExistingProcess(ProcessInterface processInterface) {
-        String processBaseUri = processInterface.getProcessBase();
-        if (Objects.isNull(processBaseUri) && Objects.nonNull(processInterface.getId())) {
-            processInterface.setProcessBase(
-                fileManagementModule.createUriForExistingProcess(processInterface.getId().toString()).toString());
+    public String getProcessBaseUriForExistingProcess(ProcessInterface process) {
+        String processBaseUri = process.getProcessBase();
+        if (Objects.isNull(processBaseUri) && Objects.nonNull(process.getId())) {
+            process.setProcessBase(
+                fileManagementModule.createUriForExistingProcess(process.getId().toString()).toString());
         }
-        return processInterface.getProcessBase();
+        return process.getProcessBase();
     }
 
     /**
@@ -996,7 +996,7 @@ public class FileService {
      * Gets the URI for a Process Sub-location. Possible Locations are listed
      * in ProcessSubType
      *
-     * @param processInterface
+     * @param process
      *            the process to get the sublocation for.
      * @param processSubType
      *            The subType.
@@ -1005,15 +1005,15 @@ public class FileService {
      *            folder of the sublocation is returned
      * @return The URI of the requested location
      */
-    private URI getProcessSubTypeURI(ProcessInterface processInterface, ProcessSubType processSubType, String resourceName) {
+    private URI getProcessSubTypeURI(ProcessInterface process, ProcessSubType processSubType, String resourceName) {
 
-        String processDataDirectory = ServiceManager.getProcessService().getProcessDataDirectory(processInterface);
+        String processDataDirectory = ServiceManager.getProcessService().getProcessDataDirectory(process);
 
         if (Objects.isNull(resourceName)) {
             resourceName = "";
         }
         return fileManagementModule.getProcessSubTypeUri(URI.create(processDataDirectory),
-                Helper.getNormalizedTitle(processInterface.getTitle()), processSubType, resourceName);
+                Helper.getNormalizedTitle(process.getTitle()), processSubType, resourceName);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -906,11 +906,11 @@ public class FileService {
      * @return the URI.
      */
     public String getProcessBaseUriForExistingProcess(ProcessInterface processInterface) {
-        String processBaseUri = processInterface.getProcessBaseUri();
+        String processBaseUri = processInterface.getProcessBase();
         if (Objects.isNull(processBaseUri) && Objects.nonNull(processInterface.getId())) {
-            processInterface.setProcessBaseUri(fileManagementModule.createUriForExistingProcess(processInterface.getId().toString()).toString());
+            processInterface.setProcessBase(fileManagementModule.createUriForExistingProcess(processInterface.getId().toString()).toString());
         }
-        return processInterface.getProcessBaseUri();
+        return processInterface.getProcessBase();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -908,7 +908,8 @@ public class FileService {
     public String getProcessBaseUriForExistingProcess(ProcessInterface processInterface) {
         String processBaseUri = processInterface.getProcessBase();
         if (Objects.isNull(processBaseUri) && Objects.nonNull(processInterface.getId())) {
-            processInterface.setProcessBase(fileManagementModule.createUriForExistingProcess(processInterface.getId().toString()).toString());
+            processInterface.setProcessBase(
+                fileManagementModule.createUriForExistingProcess(processInterface.getId().toString()).toString());
         }
         return processInterface.getProcessBase();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -57,10 +57,10 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.InvalidImagesException;
 import org.kitodo.exceptions.MediaNotFoundException;
-import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.file.BackupFileRotation;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.ImageHelper;
@@ -724,14 +724,14 @@ public class FileService {
     }
 
     /**
-     * Gets the URI of the metadata.xml of a given processDTO.
+     * Gets the URI of the metadata.xml of a given processInterface.
      *
-     * @param processDTO
+     * @param processInterface
      *            the process to get the metadata.xml for.
      * @return The URI to the metadata.xml
      */
-    public URI getMetadataFilePath(ProcessDTO processDTO) throws IOException {
-        return getMetadataFilePath(processDTO, true);
+    public URI getMetadataFilePath(ProcessInterface processInterface) throws IOException {
+        return getMetadataFilePath(processInterface, true);
     }
 
     /**
@@ -752,16 +752,16 @@ public class FileService {
     }
 
     /**
-     * Gets the URI of the metadata.xml of a given processDTO.
+     * Gets the URI of the metadata.xml of a given processInterface.
      *
-     * @param processDTO
+     * @param processInterface
      *            the process to get the metadata.xml for.
      * @param mustExist
      *            whether the file must exist
      * @return The URI to the metadata.xml
      */
-    public URI getMetadataFilePath(ProcessDTO processDTO, boolean mustExist) throws IOException {
-        URI metadataFilePath = getProcessSubTypeURI(processDTO, ProcessSubType.META_XML, null);
+    public URI getMetadataFilePath(ProcessInterface processInterface, boolean mustExist) throws IOException {
+        URI metadataFilePath = getProcessSubTypeURI(processInterface, ProcessSubType.META_XML, null);
         if (mustExist && !fileExist(metadataFilePath)) {
             throw new IOException(Helper.getTranslation("metadataFileNotFound", metadataFilePath.getPath()));
         }
@@ -901,16 +901,16 @@ public class FileService {
      * to the correct URI. File.separator doesn't work because on Windows it
      * appends backslash to URI.
      *
-     * @param processDTO
+     * @param processInterface
      *            the process, the uri is needed for.
      * @return the URI.
      */
-    public String getProcessBaseUriForExistingProcess(ProcessDTO processDTO) {
-        String processBaseUri = processDTO.getProcessBaseUri();
-        if (Objects.isNull(processBaseUri) && Objects.nonNull(processDTO.getId())) {
-            processDTO.setProcessBaseUri(fileManagementModule.createUriForExistingProcess(processDTO.getId().toString()).toString());
+    public String getProcessBaseUriForExistingProcess(ProcessInterface processInterface) {
+        String processBaseUri = processInterface.getProcessBaseUri();
+        if (Objects.isNull(processBaseUri) && Objects.nonNull(processInterface.getId())) {
+            processInterface.setProcessBaseUri(fileManagementModule.createUriForExistingProcess(processInterface.getId().toString()).toString());
         }
-        return processDTO.getProcessBaseUri();
+        return processInterface.getProcessBaseUri();
     }
 
     /**
@@ -995,7 +995,7 @@ public class FileService {
      * Gets the URI for a Process Sub-location. Possible Locations are listed
      * in ProcessSubType
      *
-     * @param processDTO
+     * @param processInterface
      *            the process to get the sublocation for.
      * @param processSubType
      *            The subType.
@@ -1004,15 +1004,15 @@ public class FileService {
      *            folder of the sublocation is returned
      * @return The URI of the requested location
      */
-    private URI getProcessSubTypeURI(ProcessDTO processDTO, ProcessSubType processSubType, String resourceName) {
+    private URI getProcessSubTypeURI(ProcessInterface processInterface, ProcessSubType processSubType, String resourceName) {
 
-        String processDataDirectory = ServiceManager.getProcessService().getProcessDataDirectory(processDTO);
+        String processDataDirectory = ServiceManager.getProcessService().getProcessDataDirectory(processInterface);
 
         if (Objects.isNull(resourceName)) {
             resourceName = "";
         }
         return fileManagementModule.getProcessSubTypeUri(URI.create(processDataDirectory),
-                Helper.getNormalizedTitle(processDTO.getTitle()), processSubType, resourceName);
+                Helper.getNormalizedTitle(processInterface.getTitle()), processSubType, resourceName);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/ocr/OcrdWorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/ocr/OcrdWorkflowService.java
@@ -63,7 +63,7 @@ public class OcrdWorkflowService {
      */
     public List<Pair<?, ?>> getOcrdWorkflows() {
         String ocrdWorkflowsDirectoryConfig = ConfigCore.getParameterOrDefaultValue(ParameterCore.OCRD_WORKFLOWS_DIR);
-        if (StringUtils.isNotEmpty(ocrdWorkflowsDirectoryConfig)) {
+        if (StringUtils.isNotBlank(ocrdWorkflowsDirectoryConfig)) {
             Path ocrdWorkflowsDirectory = Path.of(ocrdWorkflowsDirectoryConfig);
             if (Files.isDirectory(ocrdWorkflowsDirectory)) {
                 try (Stream<Path> ocrProfilePaths = Files.walk(ocrdWorkflowsDirectory, FileVisitOption.FOLLOW_LINKS)) {
@@ -92,7 +92,7 @@ public class OcrdWorkflowService {
      * @return The OCR-D workflow
      */
     public Pair<?, ?> getOcrdWorkflow(String ocrdWorkflowId) {
-        if (StringUtils.isNotEmpty(ocrdWorkflowId)) {
+        if (StringUtils.isNotBlank(ocrdWorkflowId)) {
             return getOcrdWorkflows().stream().filter(pair -> pair.getKey().equals(ocrdWorkflowId)).findFirst()
                     .orElse(null);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/schema/SchemaService.java
@@ -114,7 +114,7 @@ public class SchemaService {
     }
 
     private void set(Workpiece workpiece, MdSec domain, String key, String value) {
-        if (StringUtils.isNotEmpty(value)) {
+        if (StringUtils.isNotBlank(value)) {
             MetadataEntry entry = new MetadataEntry();
             entry.setKey(key);
             entry.setDomain(domain);

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/desktop/projectsWidget.xhtml
@@ -33,10 +33,10 @@
         <p:column headerText="#{msgs.actions}" styleClass="actionsColumn">
             <h:form id="projectActionForm">
                 <h:panelGroup styleClass="action"
-                              title="#{project.templates.size() gt 0 ? msgs['createNewProcess'] : msgs['noTemplatesConfigured']}">
+                              title="#{project.activeTemplates.size() gt 0 ? msgs['createNewProcess'] : msgs['noTemplatesConfigured']}">
                     <p:commandLink id="createProcessFromTemplate"
                                    action="#{SelectTemplateDialogView.createProcessForProject()}"
-                                   disabled="#{project.templates.size() lt 1}"
+                                   disabled="#{project.activeTemplates.size() lt 1}"
                                    rendered="#{SecurityAccessController.hasAuthorityToAddProcess()}">
                         <f:setPropertyActionListener target="#{SelectTemplateDialogView.selectedTemplateId}" value="0"/>
                         <f:setPropertyActionListener target="#{SelectTemplateDialogView.project}" value="#{project}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/selectTemplate.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/selectTemplate.xhtml
@@ -37,7 +37,7 @@
                         <f:selectItem itemValue="#{null}"
                                       itemLabel="#{msgs['selectTemplate']}"
                                       noSelectionOption="true"/>
-                        <f:selectItems value="#{SelectTemplateDialogView.project.templates}"
+                        <f:selectItems value="#{SelectTemplateDialogView.project.activeTemplates}"
                                        var="template"
                                        itemLabel="#{template.title}"
                                        itemValue="#{template.id}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/templateList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/templateList.xhtml
@@ -17,7 +17,7 @@
         xmlns:p="http://primefaces.org/ui"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
-    <p:dataTable id="templateTable" var="template" value="#{ProjectForm.project.templates}" sortBy="#{template.title}">
+    <p:dataTable id="templateTable" var="template" value="#{ProjectForm.project.activeTemplates}" sortBy="#{template.title}">
         <p:column headerText="#{msgs.template}" id="taskTitle">
             <h:outputText value="#{template.title}"/>
         </p:column>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/projectList.xhtml
@@ -78,10 +78,10 @@
             <h:form id="projectActionForm">
 
                 <h:panelGroup styleClass="action"
-                              title="#{item.templates.size() gt 0 ? msgs['createNewProcess'] : msgs['noTemplatesConfigured']}">
+                              title="#{item.activeTemplates.size() gt 0 ? msgs['createNewProcess'] : msgs['noTemplatesConfigured']}">
                     <p:commandLink id="createProcessFromTemplate"
                                    action="#{SelectTemplateDialogView.createProcessForProject()}"
-                                   disabled="#{item.templates.size() lt 1}"
+                                   disabled="#{item.activeTemplates.size() lt 1}"
                                    rendered="#{SecurityAccessController.hasAuthorityToAddProcess()}">
                         <f:setPropertyActionListener target="#{SelectTemplateDialogView.selectedTemplateId}" value="0"/>
                         <f:setPropertyActionListener target="#{SelectTemplateDialogView.project}" value="#{item}"/>
@@ -133,10 +133,10 @@
                 </h:commandLink>
 
                 <h:panelGroup styleClass="action"
-                              title="#{item.templates.size() gt 0 ? msgs['massImport'] : msgs['noTemplatesConfigured']}">
+                              title="#{item.activeTemplates.size() gt 0 ? msgs['massImport'] : msgs['noTemplatesConfigured']}">
                     <p:commandLink id="massImport"
                                    action="#{SelectTemplateDialogView.openMassImportForProject()}"
-                                   disabled="#{item.templates.size() lt 1}"
+                                   disabled="#{item.activeTemplates.size() lt 1}"
                                    rendered="#{SecurityAccessController.hasAuthorityToAddProcess()}">
                         <f:setPropertyActionListener target="#{SelectTemplateDialogView.selectedTemplateId}" value="0"/>
                         <f:setPropertyActionListener target="#{SelectTemplateDialogView.project}" value="#{item}"/>
@@ -182,7 +182,7 @@
                                          columns="2"
                                          columnClasses="label, actionsColumn" >
                                 <p:repeat id="templates"
-                                          value="#{item.templates}"
+                                          value="#{item.activeTemplates}"
                                           var="template">
                                     <div class="project-template-action">
                                         <h:outputText value="#{template.title}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
@@ -197,7 +197,7 @@
                 <o:graphicImage title="#{item.workflow.title}"
                                 styleClass="workflow-diagram"
                                 rendered="#{item.workflow ne null}"
-                                value="#{item.diagramImage}"
+                                value="#{TemplateForm.getDiagramImage(item.workflow.title)}"
                                 dataURI="true" />
             </div>
         </p:rowExpansion>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/workflowList.xhtml
@@ -81,11 +81,11 @@
                     </h:commandLink>
 
                     <h:panelGroup styleClass="action"
-                                  title="#{item.status eq 'active' ? msgs['archive'] : msgs['workflowUnableToArchive']}">
+                                  title="#{item.status eq 'ACTIVE' ? msgs['archive'] : msgs['workflowUnableToArchive']}">
                         <p:commandLink id="archiveWorkflow"
                                        action="#{WorkflowForm.archive}"
-                                       disabled="#{item.status ne 'active'}"
-                                       styleClass="#{item.status ne 'active' ? 'disabled' : ''}"
+                                       disabled="#{item.status ne 'ACTIVE'}"
+                                       styleClass="#{item.status ne 'ACTIVE' ? 'disabled' : ''}"
                                        rendered="#{SecurityAccessController.hasAuthorityToEditWorkflow()}"
                                        update="workflowTable">
                             <h:outputText title="#{msgs.archive}"><i class="fa fa-archive"/></h:outputText>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -101,16 +101,16 @@
                       styleClass="numeric"
                       sortBy="#{item.processingBegin}"
                       rendered="#{CurrentTaskForm.showColumn('task.processingBegin')}">
-                <h:outputText value="#{item.processingBegin}"
-                              title="#{item.processingBegin}"/>
+                <h:outputText value="#{ProcessForm.getFormattedDate(item.processingBegin)}"
+                              title="#{ProcessForm.getFormattedDate(item.processingBegin)}"/>
             </p:column>
             <p:column id="processingEndColumn"
                       headerText="#{msgs.processingEnd}"
                       styleClass="numeric"
                       sortBy="#{item.processingEnd}"
                       rendered="#{CurrentTaskForm.showColumn('task.processingEnd')}">
-                <h:outputText value="#{item.processingEnd}"
-                              title="#{item.processingEnd}"/>
+                <h:outputText value="#{ProcessForm.getFormattedDate(item.processingEnd)}"
+                              title="#{ProcessForm.getFormattedDate(item.processingEnd)}"/>
             </p:column>
 
             <p:column styleClass="comment-column genericSortIcon"
@@ -253,16 +253,16 @@
                                           value="#{item.correction}"/>
 
                             <h:outputText value="#{msgs.processingBegin}:"/>
-                            <h:outputText title="#{item.processingBegin}"
-                                          value="#{item.processingBegin}"/>
+                            <h:outputText title="#{ProcessForm.getFormattedDate(item.processingBegin)}"
+                                          value="#{ProcessForm.getFormattedDate(item.processingBegin)}"/>
                         </p:panelGrid>
                         <p:panelGrid id="taskDetailTableSecond"
                                      styleClass="expansion-column"
                                      columns="2"
                                      columnClasses="label, value">
                             <h:outputText value="#{msgs.lastEdited}:"/>
-                            <h:outputText title="#{item.processingTime}"
-                                          value="#{item.processingTime}"/>
+                            <h:outputText title="#{ProcessForm.getFormattedDate(item.processingTime)}"
+                                          value="#{ProcessForm.getFormattedDate(item.processingTime)}"/>
 
                             <h:outputText value="#{msgs.lastUpdatedBy}:"/>
                             <h:outputText title="#{item.processingUser.fullName}"

--- a/Kitodo/src/test/java/org/kitodo/DataFactoryProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/DataFactoryProvider.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo;
+
+import org.kitodo.data.interfaces.DataFactoryInterface;
+import org.kitodo.production.dto.DTOFactory;
+
+/**
+ * Provider for the data factory used in the tests. This way, if you change the
+ * implementation, only one location in the code needs to be changed.
+ */
+public class DataFactoryProvider {
+
+    DataFactoryInterface instance = DTOFactory.instance();
+
+    /**
+     * Returns the data factory.
+     * 
+     * @return the data factory
+     */
+    DataFactoryInterface getDataFactory() {
+        return instance;
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/forms/IndexingFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/IndexingFormIT.java
@@ -28,7 +28,7 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.enums.IndexAction;
-import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.services.ServiceManager;
 
 public class IndexingFormIT {
@@ -78,7 +78,7 @@ public class IndexingFormIT {
 
         indexingForm.countDatabaseObjects();
 
-        ProcessDTO processOne = ServiceManager.getProcessService().findById(1);
+        ProcessInterface processOne = ServiceManager.getProcessService().findById(1);
         Assert.assertNull("process should not be found in index", processOne.getTitle());
         IndexAction indexAction = ServiceManager.getProcessService().getById(1).getIndexAction();
         Assert.assertEquals("Index Action should be Index", IndexAction.INDEX, indexAction);

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ProcessFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ProcessFormIT.java
@@ -104,7 +104,7 @@ public class ProcessFormIT {
         Assert.assertEquals(new ArrayList<>(Arrays.asList(1, 2, 5)), selectedIds);
 
         processForm.setAllSelected(false);
-        processForm.selectedProcessesOrProcessDTOs = ServiceManager.getProcessService().findByAnything("SelectionTest");
+        processForm.selectedProcesses = ServiceManager.getProcessService().findByAnything("SelectionTest");
         selectedIds = processForm.getSelectedProcesses()
                 .stream().map(Process::getId).sorted().collect(Collectors.toList());
         Assert.assertEquals(new ArrayList<>(Arrays.asList(4, 5)), selectedIds);

--- a/Kitodo/src/test/java/org/kitodo/production/forms/SearchResultFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/SearchResultFormIT.java
@@ -19,7 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
-import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.services.ServiceManager;
 
 public class SearchResultFormIT {
@@ -50,7 +50,7 @@ public class SearchResultFormIT {
     public void testSearch() {
         searchResultForm.setSearchQuery("es");
         searchResultForm.searchForProcessesBySearchQuery();
-        List<ProcessDTO> resultList = searchResultForm.getFilteredList();
+        List<ProcessInterface> resultList = searchResultForm.getFilteredList();
 
         Assert.assertEquals(3, resultList.size());
 
@@ -104,7 +104,7 @@ public class SearchResultFormIT {
         searchResultForm.searchForProcessesBySearchQuery();
         searchResultForm.setCurrentProjectFilter(1000);
         searchResultForm.filterList();
-        List<ProcessDTO> resultList = searchResultForm.getFilteredList();
+        List<ProcessInterface> resultList = searchResultForm.getFilteredList();
         Assert.assertEquals(0, resultList.size());
 
         searchResultForm.setCurrentProjectFilter(1);
@@ -138,7 +138,7 @@ public class SearchResultFormIT {
         searchResultForm.setCurrentTaskFilter("notExistent");
         searchResultForm.setCurrentTaskStatusFilter(0);
         searchResultForm.filterList();
-        List<ProcessDTO> resultList = searchResultForm.getFilteredList();
+        List<ProcessInterface> resultList = searchResultForm.getFilteredList();
         Assert.assertEquals(0, resultList.size());
 
         searchResultForm.setCurrentTaskFilter("Progress");
@@ -159,7 +159,7 @@ public class SearchResultFormIT {
         searchResultForm.searchForProcessesBySearchQuery();
         searchResultForm.setCurrentProjectFilter(1);
         searchResultForm.filterList();
-        List<ProcessDTO> resultList = searchResultForm.getFilteredList();
+        List<ProcessInterface> resultList = searchResultForm.getFilteredList();
         Assert.assertEquals(2, resultList.size());
 
         searchResultForm.setCurrentTaskFilter("");

--- a/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/TaskActionProcessorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/TaskActionProcessorIT.java
@@ -273,7 +273,7 @@ public class TaskActionProcessorIT {
         MapMessageObjectReader mapMessageObjectReader = mock(MapMessageObjectReader.class);
         when(mapMessageObjectReader.getMandatoryInteger(TaskActionProcessor.KEY_TASK_ID)).thenReturn(taskId);
         when(mapMessageObjectReader.getMandatoryString(TaskActionProcessor.KEY_TASK_ACTION)).thenReturn(action);
-        if (StringUtils.isNotEmpty(message)) {
+        if (StringUtils.isNotBlank(message)) {
             when(mapMessageObjectReader.hasField(TaskActionProcessor.KEY_MESSAGE)).thenReturn(Boolean.TRUE);
             when(mapMessageObjectReader.getMandatoryString(TaskActionProcessor.KEY_MESSAGE)).thenReturn(message);
         }

--- a/Kitodo/src/test/java/org/kitodo/production/model/LazyDTOModelIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/model/LazyDTOModelIT.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.Client;
-import org.kitodo.production.dto.DocketDTO;
+import org.kitodo.data.interfaces.DocketInterface;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ClientService;
 import org.primefaces.model.SortOrder;
@@ -80,11 +80,11 @@ public class LazyDTOModelIT {
         List dockets = lazyDTOModelDocket.load(0, 2, "title", SortOrder.ASCENDING, null);
         assertEquals(2, dockets.size());
 
-        DocketDTO docket = (DocketDTO) dockets.get(0);
+        DocketInterface docket = (DocketInterface) dockets.get(0);
         assertEquals("default", docket.getTitle());
 
         dockets = lazyDTOModelDocket.load(0, 2, "title", SortOrder.DESCENDING, null);
-        docket = (DocketDTO) dockets.get(0);
+        docket = (DocketInterface) dockets.get(0);
         assertEquals("tester", docket.getTitle());
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/process/NewspaperProcessesGeneratorIT.java
@@ -45,7 +45,7 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.helper.tasks.GeneratesNewspaperProcessesThread;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.kitodo.production.model.bibliography.course.Granularity;
@@ -242,7 +242,7 @@ public class NewspaperProcessesGeneratorIT {
         GeneratesNewspaperProcessesThread generatesNewspaperProcessesThread = new GeneratesNewspaperProcessesThread(completeEdition, course);
         generatesNewspaperProcessesThread.start();
 
-        ProcessDTO byId = ServiceManager.getProcessService().findById(11);
+        ProcessInterface byId = ServiceManager.getProcessService().findById(11);
         Assert.assertNull("Process should not have been created", byId.getTitle());
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -46,7 +46,7 @@ import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.tasks.EmptyTask;
 import org.kitodo.production.helper.tasks.TaskManager;
@@ -236,7 +236,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "PDM1.0");
 
-        final List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        final List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should not contain metadata beforehand", 0, processByMetadata.size() );
 
         String script = "action:addData " + "key:" + metadataKey + " value:PDM1.0";
@@ -245,7 +245,7 @@ public class KitodoScriptServiceIT {
         KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
-        final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
+        final List<ProcessInterface> processByMetadataAfter = ServiceManager.getProcessService()
                 .findByMetadata(metadataSearchMap);
         Assert.assertEquals("does not contain metadata", 1, processByMetadataAfter.size() );
     }
@@ -354,7 +354,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "Kollektion2");
 
-        final List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        final List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should not contain metadata beforehand", 1, processByMetadata.size() );
 
         String script = "action:copyDataToChildren " + "key:" + metadataKey + " source:" + metadataKey;
@@ -363,7 +363,7 @@ public class KitodoScriptServiceIT {
         KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
-        final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
+        final List<ProcessInterface> processByMetadataAfter = ServiceManager.getProcessService()
                 .findByMetadata(metadataSearchMap);
         Assert.assertEquals("does not contain metadata", 3, processByMetadataAfter.size() );
         ProcessTestUtils.removeTestProcess(testProcessIds.get(MockDatabase.HIERARCHY_PARENT));
@@ -376,7 +376,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "legal note");
 
-        final List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap, true);
+        final List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap, true);
         Assert.assertEquals("should not contain metadata beforehand", 0, processByMetadata.size() );
 
         String script = "action:addData " + "key:" + metadataKey + " \"value:legal note\"";
@@ -385,7 +385,7 @@ public class KitodoScriptServiceIT {
         KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
-        final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
+        final List<ProcessInterface> processByMetadataAfter = ServiceManager.getProcessService()
                 .findByMetadata(metadataSearchMap, true);
         Assert.assertEquals("does not contain metadata", 1, processByMetadataAfter.size() );
     }
@@ -399,7 +399,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> secondMetadataSearchMap = new HashMap<>();
         secondMetadataSearchMap.put(metadataKey, "secondNote");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should not contain metadata beforehand", 0, processByMetadata.size() );
 
         processByMetadata = ServiceManager.getProcessService().findByMetadata(secondMetadataSearchMap);
@@ -412,7 +412,7 @@ public class KitodoScriptServiceIT {
         KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
         Thread.sleep(2000);
-        List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadataAfter = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("does not contain metadata", 1, processByMetadataAfter.size());
         processByMetadataAfter = ServiceManager.getProcessService().findByMetadata(secondMetadataSearchMap);
         Assert.assertEquals("does not contain metadata", 1, processByMetadataAfter.size());
@@ -425,7 +425,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "Proc");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("does not contain metadata", 0, processByMetadata.size() );
 
         String script = "action:addData " + "key:" + metadataKey + " source:TSL_ATS";
@@ -446,7 +446,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, String.valueOf(kitodoScriptTestProcessId));
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("does not contain metadata", 0, processByMetadata.size() );
 
         String script = "action:addData " + "key:" + metadataKey + " variable:(processid)";
@@ -467,7 +467,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         String script = "action:deleteData " + "key:" + metadataKey;
@@ -488,7 +488,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         String script = "action:deleteData " + "key:" + metadataKey + " value:SecondMetaShort";
@@ -508,7 +508,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "Proc");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         String script = "action:deleteData " + "key:" + metadataKey;
@@ -529,7 +529,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         String script = "action:deleteData " + "key:" + metadataKey + " source:TitleDocMainShort";
@@ -550,7 +550,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         String script = "action:deleteData" + " key:" + metadataKey + " value:SecondMetaLong";
@@ -573,7 +573,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> newMetadataSearchMap = new HashMap<>();
         newMetadataSearchMap.put(metadataKey, "Overwritten");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(oldMetadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(oldMetadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
@@ -603,7 +603,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> newMetadataSearchMap = new HashMap<>();
         newMetadataSearchMap.put(metadataKey, "Second process");
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(oldMetadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(oldMetadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
@@ -633,7 +633,7 @@ public class KitodoScriptServiceIT {
         HashMap<String, String> newMetadataSearchMap = new HashMap<>();
         newMetadataSearchMap.put(metadataKey, String.valueOf(kitodoScriptTestProcessId));
 
-        List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(oldMetadataSearchMap);
+        List<ProcessInterface> processByMetadata = ServiceManager.getProcessService().findByMetadata(oldMetadataSearchMap);
         Assert.assertEquals("should contain metadata", 1, processByMetadata.size() );
 
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/FilterServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/FilterServiceIT.java
@@ -33,7 +33,7 @@ import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.Filter;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.TaskDTO;
+import org.kitodo.data.interfaces.TaskInterface;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.services.ServiceManager;
 
@@ -348,9 +348,9 @@ public class FilterServiceIT {
 
         // TODO: why "step" creates something called historical filter?
         QueryBuilder query = filterService.queryBuilder("\"step:Finished\"", ObjectType.TASK, false, false);
-        List<TaskDTO> taskDTOS = taskService.findByQuery(query, true);
+        List<TaskInterface> taskInterfaceS = taskService.findByQuery(query, true);
         // assertEquals("Incorrect amount of tasks with title containing
-        // 'Testing'!", 1, taskDTOS.size());
+        // 'Testing'!", 1, taskInterfaceS.size());
 
         QueryBuilder firstQuery = filterService.queryBuilder("\"stepopen:Open\"", ObjectType.TASK, false, false);
         assertEquals("Incorrect amount of tasks with title containing 'Open'!", 1,
@@ -553,8 +553,8 @@ public class FilterServiceIT {
 
         // empty condition is not allowed and returns no results
         QueryBuilder query = filterService.queryBuilder("\"steplocked:\"", ObjectType.TASK, false, false);
-        List<TaskDTO> taskDTOS = taskService.findByQuery(query, true);
-        assertEquals("Incorrect amount of closed tasks with no ordering!", 0, taskDTOS.size());
+        List<TaskInterface> taskInterfaceS = taskService.findByQuery(query, true);
+        assertEquals("Incorrect amount of closed tasks with no ordering!", 0, taskInterfaceS.size());
 
         // empty condition is not allowed and throws Exception in ElasticSearch 7
         query = filterService.queryBuilder("\"id:\"", ObjectType.PROCESS, false, false);

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
@@ -353,14 +353,14 @@ public class ImportServiceIT {
             InvalidMetadataValueException, NoSuchMetadataFieldException, ParserConfigurationException, SAXException,
             TransformerException {
         Ruleset ruleset = ServiceManager.getRulesetService().getById(RULESET_ID);
-        RulesetManagementInterface managementInterface = ServiceManager.getRulesetService().openRuleset(ruleset);
+        RulesetManagementInterface management = ServiceManager.getRulesetService().openRuleset(ruleset);
         ImportConfiguration importConfiguration = MockDatabase.getK10PlusImportConfiguration();
         try (InputStream inputStream = Files.newInputStream(Paths.get(TEST_KITODO_METADATA_FILE_PATH))) {
             String fileContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
             Document xmlDocument = XMLUtils.parseXMLString(fileContent);
             TempProcess tempProcess = ServiceManager.getImportService().createTempProcessFromDocument(
                     importConfiguration, xmlDocument, TEMPLATE_ID, PROJECT_ID);
-            ImportService.processTempProcess(tempProcess, managementInterface,
+            ImportService.processTempProcess(tempProcess, management,
                     ImportService.ACQUISITION_STAGE_CREATE, ServiceManager.getUserService()
                             .getCurrentMetadataLanguage(), null);
             Assert.assertFalse("Process should have some properties",
@@ -507,13 +507,13 @@ public class ImportServiceIT {
             NoSuchMetadataFieldException, ParserConfigurationException, SAXException {
         ImportConfiguration importConfiguration = MockDatabase.getK10PlusImportConfiguration();
         Ruleset ruleset = ServiceManager.getRulesetService().getById(RULESET_ID);
-        RulesetManagementInterface managementInterface = ServiceManager.getRulesetService().openRuleset(ruleset);
+        RulesetManagementInterface management = ServiceManager.getRulesetService().openRuleset(ruleset);
         try (InputStream inputStream = Files.newInputStream(Paths.get(filepath))) {
             String fileContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
             Document xmlDocument = XMLUtils.parseXMLString(fileContent);
             TempProcess tempProcess = ServiceManager.getImportService().createTempProcessFromDocument(
                     importConfiguration, xmlDocument, TEMPLATE_ID, PROJECT_ID);
-            return ProcessHelper.transformToProcessDetails(tempProcess, managementInterface,
+            return ProcessHelper.transformToProcessDetails(tempProcess, management,
                     ImportService.ACQUISITION_STAGE_CREATE, ServiceManager.getUserService()
                             .getCurrentMetadataLanguage());
         }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -597,14 +597,14 @@ public class ProcessServiceIT {
 
     @Test
     public void shouldBeProcessAssignedToOnlyOneBatch() throws Exception {
-        ProcessInterface processInterface = processService.findById(2);
-        assertTrue(processService.isProcessAssignedToOnlyOneBatch(processInterface.getBatches()));
+        ProcessInterface process = processService.findById(2);
+        assertTrue(processService.isProcessAssignedToOnlyOneBatch(process.getBatches()));
     }
 
     @Test
     public void shouldNotBeProcessAssignedToOnlyOneBatch() throws Exception {
-        ProcessInterface processInterface = processService.findById(1);
-        assertFalse(processService.isProcessAssignedToOnlyOneBatch(processInterface.getBatches()));
+        ProcessInterface process = processService.findById(1);
+        assertFalse(processService.isProcessAssignedToOnlyOneBatch(process.getBatches()));
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -58,7 +58,7 @@ import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.elasticsearch.index.converter.ProcessConverter;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.data.interfaces.ProcessInterface;
 import org.kitodo.production.enums.ProcessState;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
@@ -261,7 +261,7 @@ public class ProcessServiceIT {
         process.setTitle(processTitle);
         ServiceManager.getProcessService().save(process);
 
-        List<ProcessDTO> byAnything = processService.findByAnything("ith-hyphen_an");
+        List<ProcessInterface> byAnything = processService.findByAnything("ith-hyphen_an");
         assertFalse("nothing found", byAnything.isEmpty());
         assertEquals("wrong process found", processTitle, byAnything.get(0).getTitle());
 
@@ -288,31 +288,31 @@ public class ProcessServiceIT {
 
     @Test
     public void shouldFindByProperty() throws DataException {
-        List<ProcessDTO> processByProperty = processService.findByProperty("Process Property", "first value");
+        List<ProcessInterface> processByProperty = processService.findByProperty("Process Property", "first value");
         assertEquals(1, processByProperty.size());
     }
 
     @Test
     public void shouldNotFindByWrongPropertyTitle() throws DataException {
-        List<ProcessDTO> processByProperty = processService.findByProperty("test Property", "first value");
+        List<ProcessInterface> processByProperty = processService.findByProperty("test Property", "first value");
         assertTrue(processByProperty.isEmpty());
     }
 
     @Test
     public void shouldNotFindByWrongPropertyTitleAndValue() throws DataException {
-        List<ProcessDTO> processByProperty = processService.findByProperty("test Property", "test value");
+        List<ProcessInterface> processByProperty = processService.findByProperty("test Property", "test value");
         assertTrue(processByProperty.isEmpty());
     }
 
     @Test
     public void shouldNotFindByTokenizedPropertyTitle() throws DataException {
-        List<ProcessDTO> processByProperty = processService.findByProperty("Property", "first value");
+        List<ProcessInterface> processByProperty = processService.findByProperty("Property", "first value");
         assertTrue(processByProperty.isEmpty());
     }
 
     @Test
     public void shouldNotFindByTokenizedPropertyTitleAndWrongValue() throws DataException {
-        List<ProcessDTO> processByProperty = processService.findByProperty("Property", "test value");
+        List<ProcessInterface> processByProperty = processService.findByProperty("Property", "test value");
         assertTrue(processByProperty.isEmpty());
     }
 
@@ -434,7 +434,7 @@ public class ProcessServiceIT {
 
     @Test
     public void shouldGetBatchId() throws Exception {
-        ProcessDTO process = processService.findById(1);
+        ProcessInterface process = processService.findById(1);
         String batchId = processService.getBatchID(process);
         boolean condition = batchId.equals("First batch, Third batch");
         assertTrue("BatchId doesn't match to given plain text!", condition);
@@ -480,7 +480,7 @@ public class ProcessServiceIT {
         processService.save(secondProcess);
 
         QueryBuilder querySortHelperStatusTrue = processService.getQueryForClosedProcesses();
-        List<ProcessDTO> byQuery = processService.findByQuery(querySortHelperStatusTrue, true);
+        List<ProcessInterface> byQuery = processService.findByQuery(querySortHelperStatusTrue, true);
 
         Assert.assertEquals("Found the wrong amount of Processes", 1 ,byQuery.size());
         secondProcess.setSortHelperStatus(sortHelperStatusOld);
@@ -597,14 +597,14 @@ public class ProcessServiceIT {
 
     @Test
     public void shouldBeProcessAssignedToOnlyOneBatch() throws Exception {
-        ProcessDTO processDTO = processService.findById(2);
-        assertTrue(processService.isProcessAssignedToOnlyOneBatch(processDTO.getBatches()));
+        ProcessInterface processInterface = processService.findById(2);
+        assertTrue(processService.isProcessAssignedToOnlyOneBatch(processInterface.getBatches()));
     }
 
     @Test
     public void shouldNotBeProcessAssignedToOnlyOneBatch() throws Exception {
-        ProcessDTO processDTO = processService.findById(1);
-        assertFalse(processService.isProcessAssignedToOnlyOneBatch(processDTO.getBatches()));
+        ProcessInterface processInterface = processService.findById(1);
+        assertFalse(processService.isProcessAssignedToOnlyOneBatch(processInterface.getBatches()));
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.services.data;
 
 import java.net.URI;
+import java.text.ParseException;
 import java.util.List;
 
 import org.junit.Assert;
@@ -26,38 +27,38 @@ import org.kitodo.production.services.ServiceManager;
 public class ProcessServiceTest {
 
     @Test
-    public void shouldGetSortedCorrectionSolutionMessages() {
+    public void shouldGetSortedCorrectionSolutionMessages() throws ParseException {
         final ProcessInterface processInterface = new ProcessDTO();
 
         PropertyInterface firstPropertyInterface = new PropertyDTO();
         firstPropertyInterface.setId(1);
         firstPropertyInterface.setTitle("Korrektur notwendig");
         firstPropertyInterface.setValue("Fix it");
-        firstPropertyInterface.setCreationDate(null);
+        firstPropertyInterface.setCreationTime(null);
 
         PropertyInterface secondPropertyInterface = new PropertyDTO();
         secondPropertyInterface.setId(2);
         secondPropertyInterface.setTitle("Korrektur notwendig");
         secondPropertyInterface.setValue("Fix it also");
-        secondPropertyInterface.setCreationDate(null);
+        secondPropertyInterface.setCreationTime(null);
 
         PropertyInterface thirdPropertyInterface = new PropertyDTO();
         thirdPropertyInterface.setId(3);
         thirdPropertyInterface.setTitle("Other title");
         thirdPropertyInterface.setValue("Other value");
-        thirdPropertyInterface.setCreationDate("2017-12-01");
+        thirdPropertyInterface.setCreationTime("2017-12-01");
 
         PropertyInterface fourthPropertyInterface = new PropertyDTO();
         fourthPropertyInterface.setId(4);
         fourthPropertyInterface.setTitle("Korrektur durchgef\u00FChrt");
         fourthPropertyInterface.setValue("Fixed second");
-        fourthPropertyInterface.setCreationDate("2017-12-05");
+        fourthPropertyInterface.setCreationTime("2017-12-05");
 
         PropertyInterface fifthPropertyInterface = new PropertyDTO();
         fifthPropertyInterface.setId(5);
         fifthPropertyInterface.setTitle("Korrektur durchgef\u00FChrt");
         fifthPropertyInterface.setValue("Fixed first");
-        fifthPropertyInterface.setCreationDate("2017-12-03");
+        fifthPropertyInterface.setCreationTime("2017-12-03");
 
         @SuppressWarnings("unchecked")
         List<PropertyInterface> properties = (List<PropertyInterface>) processInterface.getProperties();

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
@@ -16,6 +16,8 @@ import java.net.URI;
 import org.junit.Assert;
 import org.junit.Test;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.interfaces.ProcessInterface;
+import org.kitodo.data.interfaces.PropertyInterface;
 import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.dto.PropertyDTO;
 import org.kitodo.production.services.ServiceManager;
@@ -24,43 +26,43 @@ public class ProcessServiceTest {
 
     @Test
     public void shouldGetSortedCorrectionSolutionMessages() {
-        final ProcessDTO processDTO = new ProcessDTO();
+        final ProcessInterface processInterface = new ProcessDTO();
 
-        PropertyDTO firstPropertyDTO = new PropertyDTO();
-        firstPropertyDTO.setId(1);
-        firstPropertyDTO.setTitle("Korrektur notwendig");
-        firstPropertyDTO.setValue("Fix it");
-        firstPropertyDTO.setCreationDate(null);
+        PropertyInterface firstPropertyInterface = new PropertyDTO();
+        firstPropertyInterface.setId(1);
+        firstPropertyInterface.setTitle("Korrektur notwendig");
+        firstPropertyInterface.setValue("Fix it");
+        firstPropertyInterface.setCreationDate(null);
 
-        PropertyDTO secondPropertyDTO = new PropertyDTO();
-        secondPropertyDTO.setId(2);
-        secondPropertyDTO.setTitle("Korrektur notwendig");
-        secondPropertyDTO.setValue("Fix it also");
-        secondPropertyDTO.setCreationDate(null);
+        PropertyInterface secondPropertyInterface = new PropertyDTO();
+        secondPropertyInterface.setId(2);
+        secondPropertyInterface.setTitle("Korrektur notwendig");
+        secondPropertyInterface.setValue("Fix it also");
+        secondPropertyInterface.setCreationDate(null);
 
-        PropertyDTO thirdPropertyDTO = new PropertyDTO();
-        thirdPropertyDTO.setId(3);
-        thirdPropertyDTO.setTitle("Other title");
-        thirdPropertyDTO.setValue("Other value");
-        thirdPropertyDTO.setCreationDate("2017-12-01");
+        PropertyInterface thirdPropertyInterface = new PropertyDTO();
+        thirdPropertyInterface.setId(3);
+        thirdPropertyInterface.setTitle("Other title");
+        thirdPropertyInterface.setValue("Other value");
+        thirdPropertyInterface.setCreationDate("2017-12-01");
 
-        PropertyDTO fourthPropertyDTO = new PropertyDTO();
-        fourthPropertyDTO.setId(4);
-        fourthPropertyDTO.setTitle("Korrektur durchgef\u00FChrt");
-        fourthPropertyDTO.setValue("Fixed second");
-        fourthPropertyDTO.setCreationDate("2017-12-05");
+        PropertyInterface fourthPropertyInterface = new PropertyDTO();
+        fourthPropertyInterface.setId(4);
+        fourthPropertyInterface.setTitle("Korrektur durchgef\u00FChrt");
+        fourthPropertyInterface.setValue("Fixed second");
+        fourthPropertyInterface.setCreationDate("2017-12-05");
 
-        PropertyDTO fifthPropertyDTO = new PropertyDTO();
-        fifthPropertyDTO.setId(5);
-        fifthPropertyDTO.setTitle("Korrektur durchgef\u00FChrt");
-        fifthPropertyDTO.setValue("Fixed first");
-        fifthPropertyDTO.setCreationDate("2017-12-03");
+        PropertyInterface fifthPropertyInterface = new PropertyDTO();
+        fifthPropertyInterface.setId(5);
+        fifthPropertyInterface.setTitle("Korrektur durchgef\u00FChrt");
+        fifthPropertyInterface.setValue("Fixed first");
+        fifthPropertyInterface.setCreationDate("2017-12-03");
 
-        processDTO.getProperties().add(firstPropertyDTO);
-        processDTO.getProperties().add(secondPropertyDTO);
-        processDTO.getProperties().add(thirdPropertyDTO);
-        processDTO.getProperties().add(fourthPropertyDTO);
-        processDTO.getProperties().add(fifthPropertyDTO);
+        processInterface.getProperties().add(firstPropertyInterface);
+        processInterface.getProperties().add(secondPropertyInterface);
+        processInterface.getProperties().add(thirdPropertyInterface);
+        processInterface.getProperties().add(fourthPropertyInterface);
+        processInterface.getProperties().add(fifthPropertyInterface);
 
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
@@ -28,45 +28,45 @@ public class ProcessServiceTest {
 
     @Test
     public void shouldGetSortedCorrectionSolutionMessages() throws ParseException {
-        final ProcessInterface processInterface = new ProcessDTO();
+        final ProcessInterface process = new ProcessDTO();
 
-        PropertyInterface firstPropertyInterface = new PropertyDTO();
-        firstPropertyInterface.setId(1);
-        firstPropertyInterface.setTitle("Korrektur notwendig");
-        firstPropertyInterface.setValue("Fix it");
-        firstPropertyInterface.setCreationTime(null);
+        PropertyInterface firstProperty = new PropertyDTO();
+        firstProperty.setId(1);
+        firstProperty.setTitle("Korrektur notwendig");
+        firstProperty.setValue("Fix it");
+        firstProperty.setCreationTime(null);
 
-        PropertyInterface secondPropertyInterface = new PropertyDTO();
-        secondPropertyInterface.setId(2);
-        secondPropertyInterface.setTitle("Korrektur notwendig");
-        secondPropertyInterface.setValue("Fix it also");
-        secondPropertyInterface.setCreationTime(null);
+        PropertyInterface secondProperty = new PropertyDTO();
+        secondProperty.setId(2);
+        secondProperty.setTitle("Korrektur notwendig");
+        secondProperty.setValue("Fix it also");
+        secondProperty.setCreationTime(null);
 
-        PropertyInterface thirdPropertyInterface = new PropertyDTO();
-        thirdPropertyInterface.setId(3);
-        thirdPropertyInterface.setTitle("Other title");
-        thirdPropertyInterface.setValue("Other value");
-        thirdPropertyInterface.setCreationTime("2017-12-01");
+        PropertyInterface thirdProperty = new PropertyDTO();
+        thirdProperty.setId(3);
+        thirdProperty.setTitle("Other title");
+        thirdProperty.setValue("Other value");
+        thirdProperty.setCreationTime("2017-12-01");
 
-        PropertyInterface fourthPropertyInterface = new PropertyDTO();
-        fourthPropertyInterface.setId(4);
-        fourthPropertyInterface.setTitle("Korrektur durchgef\u00FChrt");
-        fourthPropertyInterface.setValue("Fixed second");
-        fourthPropertyInterface.setCreationTime("2017-12-05");
+        PropertyInterface fourthProperty = new PropertyDTO();
+        fourthProperty.setId(4);
+        fourthProperty.setTitle("Korrektur durchgef\u00FChrt");
+        fourthProperty.setValue("Fixed second");
+        fourthProperty.setCreationTime("2017-12-05");
 
-        PropertyInterface fifthPropertyInterface = new PropertyDTO();
-        fifthPropertyInterface.setId(5);
-        fifthPropertyInterface.setTitle("Korrektur durchgef\u00FChrt");
-        fifthPropertyInterface.setValue("Fixed first");
-        fifthPropertyInterface.setCreationTime("2017-12-03");
+        PropertyInterface fifthProperty = new PropertyDTO();
+        fifthProperty.setId(5);
+        fifthProperty.setTitle("Korrektur durchgef\u00FChrt");
+        fifthProperty.setValue("Fixed first");
+        fifthProperty.setCreationTime("2017-12-03");
 
         @SuppressWarnings("unchecked")
-        List<PropertyInterface> properties = (List<PropertyInterface>) processInterface.getProperties();
-        properties.add(firstPropertyInterface);
-        properties.add(secondPropertyInterface);
-        properties.add(thirdPropertyInterface);
-        properties.add(fourthPropertyInterface);
-        properties.add(fifthPropertyInterface);
+        List<PropertyInterface> properties = (List<PropertyInterface>) process.getProperties();
+        properties.add(firstProperty);
+        properties.add(secondProperty);
+        properties.add(thirdProperty);
+        properties.add(fourthProperty);
+        properties.add(fifthProperty);
 
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceTest.java
@@ -12,6 +12,7 @@
 package org.kitodo.production.services.data;
 
 import java.net.URI;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,11 +59,13 @@ public class ProcessServiceTest {
         fifthPropertyInterface.setValue("Fixed first");
         fifthPropertyInterface.setCreationDate("2017-12-03");
 
-        processInterface.getProperties().add(firstPropertyInterface);
-        processInterface.getProperties().add(secondPropertyInterface);
-        processInterface.getProperties().add(thirdPropertyInterface);
-        processInterface.getProperties().add(fourthPropertyInterface);
-        processInterface.getProperties().add(fifthPropertyInterface);
+        @SuppressWarnings("unchecked")
+        List<PropertyInterface> properties = (List<PropertyInterface>) processInterface.getProperties();
+        properties.add(firstPropertyInterface);
+        properties.add(secondPropertyInterface);
+        properties.add(thirdPropertyInterface);
+        properties.add(fourthPropertyInterface);
+        properties.add(fifthPropertyInterface);
 
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProjectServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProjectServiceIT.java
@@ -32,7 +32,7 @@ import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.dto.ProjectDTO;
+import org.kitodo.data.interfaces.ProjectInterface;
 import org.kitodo.production.services.ServiceManager;
 
 /**
@@ -88,7 +88,7 @@ public class ProjectServiceIT {
         assertTrue(projectNotFound,
             projectService.findById(1).getTitle().equals(firstProject) && projectService.findById(1).getId().equals(1));
         assertTrue(projectNotFound, projectService.findById(1).isActive());
-        assertEquals(projectNotFound, 2, projectService.findById(1).getTemplates().size());
+        assertEquals(projectNotFound, 2, projectService.findById(1).getActiveTemplates().size());
 
         assertFalse(projectNotFound, projectService.findById(3).isActive());
     }
@@ -178,7 +178,7 @@ public class ProjectServiceIT {
     public void findByIds() throws DataException {
         ProjectService projectService = ServiceManager.getProjectService();
         QueryBuilder projectsForCurrentUserQuery = projectService.getProjectsForCurrentUserQuery();
-        List<ProjectDTO> byQuery = projectService.findByQuery(projectsForCurrentUserQuery, true);
+        List<ProjectInterface> byQuery = projectService.findByQuery(projectsForCurrentUserQuery, true);
         assertEquals("Wrong amount of projects found",2,byQuery.size());
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
@@ -92,12 +92,12 @@ public class TemplateServiceIT {
 
     @Test
     public void shouldHasCompleteTasks() throws Exception {
-        TemplateInterface templateInterface = templateService.findById(1);
-        boolean condition = templateService.hasCompleteTasks(templateInterface.getTasks());
+        TemplateInterface template = templateService.findById(1);
+        boolean condition = templateService.hasCompleteTasks(template.getTasks());
         assertTrue("Process Interface doesn't have complete tasks!", condition);
 
-        templateInterface = templateService.findById(3);
-        condition = templateService.hasCompleteTasks(templateInterface.getTasks());
+        template = templateService.findById(3);
+        condition = templateService.hasCompleteTasks(template.getTasks());
         assertFalse("Process Interface has complete tasks!", condition);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
@@ -11,6 +11,10 @@
 
 package org.kitodo.production.services.data;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -19,13 +23,9 @@ import org.junit.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.Template;
+import org.kitodo.data.interfaces.TemplateInterface;
 import org.kitodo.exceptions.ProcessGenerationException;
-import org.kitodo.production.dto.TemplateDTO;
 import org.kitodo.production.services.ServiceManager;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class TemplateServiceIT {
 
@@ -52,7 +52,7 @@ public class TemplateServiceIT {
 
     @Test
     public void shouldFindAll() throws Exception {
-        List<TemplateDTO> templates = templateService.findAll();
+        List<TemplateInterface> templates = templateService.findAll();
         assertEquals("Found incorrect amount of templates!", 4, templates.size());
     }
 
@@ -92,12 +92,12 @@ public class TemplateServiceIT {
 
     @Test
     public void shouldHasCompleteTasks() throws Exception {
-        TemplateDTO templateDTO = templateService.findById(1);
-        boolean condition = templateService.hasCompleteTasks(templateDTO.getTasks());
-        assertTrue("Process DTO doesn't have complete tasks!", condition);
+        TemplateInterface templateInterface = templateService.findById(1);
+        boolean condition = templateService.hasCompleteTasks(templateInterface.getTasks());
+        assertTrue("Process Interface doesn't have complete tasks!", condition);
 
-        templateDTO = templateService.findById(3);
-        condition = templateService.hasCompleteTasks(templateDTO.getTasks());
-        assertFalse("Process DTO has complete tasks!", condition);
+        templateInterface = templateService.findById(3);
+        condition = templateService.hasCompleteTasks(templateInterface.getTasks());
+        assertFalse("Process Interface has complete tasks!", condition);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
@@ -94,10 +94,10 @@ public class TemplateServiceIT {
     public void shouldHasCompleteTasks() throws Exception {
         TemplateInterface template = templateService.findById(1);
         boolean condition = templateService.hasCompleteTasks(template.getTasks());
-        assertTrue("Process Interface doesn't have complete tasks!", condition);
+        assertTrue("Process doesn't have complete tasks!", condition);
 
         template = templateService.findById(3);
         condition = templateService.hasCompleteTasks(template.getTasks());
-        assertFalse("Process Interface has complete tasks!", condition);
+        assertFalse("Process has complete tasks!", condition);
     }
 }


### PR DESCRIPTION
Issue #5760 1c) -- part 2

1c) part 2 introduces interfaces for the database- and search-related functionality of the data services, that by now still use the search index. The data services implement _a lot_ of functionality, some of which is thoroughly covered by tests, but otherwise is not used in the code.

The aim of this step was to clarify and document which of these functions are actually used in the source code—and you can see that there isn't that much—and how they work, in particular to clarify the implicit functionality: Does a function search on _all_ data? Or does it access the user session in the background, and look _only for the data for the client_, for which the logged-in user is currently working? _Or are there other criteria_, if so, which ones, and where are they passed?

You can see that this is not implemented uniformly everywhere, and not every function name describes exactly, what the function actually does. Clarifying this was a prerequisite for a re-implementation with identical functionality, which will follow in the next step.

For better reviewability, this part is provided as a separate pull request.

Follow-up pull request to #6032 ([immediate diff](/matthias-ronge/kitodo-production/compare/5760_1c_1...5760_1c_2))