### PR TITLE
Improve main

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.production.security.SecurityUserDetails;
 import org.kitodo.production.services.ServiceManager;
+import org.springframework.security.core.context.SecurityContextImpl;
 
 /**
  * Kitodo.Production is the workflow management module of the Kitodo suite. It
@@ -49,16 +50,16 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
     public void contextInitialized(ServletContextEvent sce) {
         // Retrieve Manifest file as Stream
         context = sce.getServletContext();
-        InputStream rs = context.getResourceAsStream("/META-INF/MANIFEST.MF");
-        // Use Manifest to setup version information
-        if (Objects.nonNull(rs)) {
-            try {
+        try (InputStream rs = context.getResourceAsStream("/META-INF/MANIFEST.MF")){
+            // Use Manifest to setup version information
+            if (Objects.nonNull(rs)) {
                 Manifest m = new Manifest(rs);
                 manifest = Optional.of(m);
                 KitodoVersion.setupFromManifest(m);
-            } catch (IOException e) {
-                context.log(e.getMessage());
             }
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+            context.log(e.getMessage());
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -49,6 +49,7 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
     private static CompletableFuture<KitodoProduction> instance = new CompletableFuture<>();
     private ServletContext context;
     private Optional<Manifest> manifest = Optional.empty();
+    private KitodoVersion version = new KitodoVersion();
     private ActiveMQDirector activeMQDirector;
 
     @Override
@@ -60,7 +61,7 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
             if (Objects.nonNull(rs)) {
                 Manifest m = new Manifest(rs);
                 manifest = Optional.of(m);
-                KitodoVersion.setupFromManifest(m);
+                version.setupFromManifest(m);
             }
         } catch (IOException e) {
             logger.error(e.getMessage(), e);
@@ -115,6 +116,15 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
      */
     public Optional<Manifest> getManifest() {
         return manifest;
+    }
+
+    /**
+     * Returns application version information.
+     * 
+     * @return version information
+     */
+    public KitodoVersion getVersionInformation() {
+        return version;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
+import org.kitodo.production.helper.tasks.TaskManager;
 import org.kitodo.production.interfaces.activemq.ActiveMQDirector;
 import org.kitodo.production.security.SecurityUserDetails;
 import org.kitodo.production.services.ServiceManager;
@@ -118,6 +119,7 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
+        TaskManager.shutdownNow();
         if(Objects.nonNull(activeMQDirector)) {
             activeMQDirector.shutDown();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.production.version;
+package org.kitodo.production;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,7 +34,7 @@ import org.springframework.security.core.context.SecurityContextImpl;
  * startup.
  */
 @WebListener
-public class KitodoVersionListener implements ServletContextListener, HttpSessionListener, HttpSessionAttributeListener {
+public class KitodoProduction implements ServletContextListener, HttpSessionListener, HttpSessionAttributeListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.jar.Manifest;
@@ -41,16 +42,19 @@ import org.kitodo.production.services.ServiceManager;
 public class KitodoProduction implements ServletContextListener, HttpSessionListener, HttpSessionAttributeListener {
     private static final Logger logger = LogManager.getLogger(KitodoProduction.class);
     private static CompletableFuture<KitodoProduction> instance = new CompletableFuture<>();
+    private ServletContext context;
+    private Optional<Manifest> manifest = Optional.empty();
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         // Retrieve Manifest file as Stream
-        ServletContext context = sce.getServletContext();
+        context = sce.getServletContext();
         InputStream rs = context.getResourceAsStream("/META-INF/MANIFEST.MF");
         // Use Manifest to setup version information
         if (Objects.nonNull(rs)) {
             try {
                 Manifest m = new Manifest(rs);
+                manifest = Optional.of(m);
                 KitodoVersion.setupFromManifest(m);
             } catch (IOException e) {
                 context.log(e.getMessage());
@@ -73,6 +77,24 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
             logger.fatal(e);
             throw new UndeclaredThrowableException(e);
         }
+    }
+
+    /**
+     * Returns the servlet context.
+     * 
+     * @return the servlet context
+     */
+    public ServletContext getServletContext() {
+        return context;
+    }
+
+    /**
+     * Returns the manifest. If there is one. Otherwise, it can also be empty.
+     * 
+     * @return the manifest
+     */
+    public Optional<Manifest> getManifest() {
+        return manifest;
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -13,7 +13,10 @@ package org.kitodo.production;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.jar.Manifest;
 
 import javax.servlet.ServletContext;
@@ -25,9 +28,10 @@ import javax.servlet.http.HttpSessionBindingEvent;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kitodo.production.security.SecurityUserDetails;
 import org.kitodo.production.services.ServiceManager;
-import org.springframework.security.core.context.SecurityContextImpl;
 
 /**
  * Kitodo.Production is the workflow management module of the Kitodo suite. It
@@ -35,6 +39,8 @@ import org.springframework.security.core.context.SecurityContextImpl;
  */
 @WebListener
 public class KitodoProduction implements ServletContextListener, HttpSessionListener, HttpSessionAttributeListener {
+    private static final Logger logger = LogManager.getLogger(KitodoProduction.class);
+    private static CompletableFuture<KitodoProduction> instance = new CompletableFuture<>();
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
@@ -49,6 +55,23 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
             } catch (IOException e) {
                 context.log(e.getMessage());
             }
+        }
+    }
+
+    /**
+     * Returns the application’s main class.
+     * 
+     * @return the main class
+     * @throws UndeclaredThrowableException
+     *             if the servlet container is shut down before the web
+     *             application is started
+     */
+    public static KitodoProduction getInstance() {
+        try {
+            return instance.get();
+        } catch (InterruptedException | ExecutionException e) {
+            logger.fatal(e);
+            throw new UndeclaredThrowableException(e);
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -56,7 +56,7 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
     public void contextInitialized(ServletContextEvent sce) {
         // Retrieve Manifest file as Stream
         context = sce.getServletContext();
-        try (InputStream rs = context.getResourceAsStream("/META-INF/MANIFEST.MF")){
+        try (InputStream rs = context.getResourceAsStream("/META-INF/MANIFEST.MF")) {
             // Use Manifest to setup version information
             if (Objects.nonNull(rs)) {
                 Manifest m = new Manifest(rs);
@@ -130,7 +130,7 @@ public class KitodoProduction implements ServletContextListener, HttpSessionList
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
         TaskManager.shutdownNow();
-        if(Objects.nonNull(activeMQDirector)) {
+        if (Objects.nonNull(activeMQDirector)) {
             activeMQDirector.shutDown();
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoProduction.java
@@ -30,8 +30,8 @@ import org.kitodo.production.services.ServiceManager;
 import org.springframework.security.core.context.SecurityContextImpl;
 
 /**
- * Listener to set up Kitodo versioning information from Manifest on application
- * startup.
+ * Kitodo.Production is the workflow management module of the Kitodo suite. It
+ * supports the digitization process of various types of materials.
  */
 @WebListener
 public class KitodoProduction implements ServletContextListener, HttpSessionListener, HttpSessionAttributeListener {

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoVersion.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoVersion.java
@@ -17,30 +17,21 @@ import java.util.jar.Manifest;
 public class KitodoVersion {
 
     private static String version = "N/A";
-    private static String buildVersion = "N/A";
     private static String buildDate = "N/A";
-
-    /**
-     * Private constructor to hide the implicit public one.
-     */
-    private KitodoVersion() {
-
-    }
 
     /**
      * Setup KitodoVersion form manifest.
      *
      * @param manifest as Manifest
      */
-    public static void setupFromManifest(Manifest manifest) {
+    void setupFromManifest(Manifest manifest) {
         Attributes mainAttributes = manifest.getMainAttributes();
 
         version = getValueOrThrowException(mainAttributes, "Implementation-Version");
-        buildVersion = version;
         buildDate = getValueOrThrowException(mainAttributes, "Implementation-Build-Date");
     }
 
-    private static String getValueOrThrowException(Attributes attributes, String attributeName) {
+    private String getValueOrThrowException(Attributes attributes, String attributeName) {
         String value = attributes.getValue(attributeName);
         if (null == value) {
             throw new IllegalArgumentException(
@@ -49,15 +40,11 @@ public class KitodoVersion {
         return value;
     }
 
-    public static String getVersion() {
+    public String getVersion() {
         return version;
     }
 
-    public static String getBuildVersion() {
-        return buildVersion;
-    }
-
-    public static String getBuildDate() {
+    public String getBuildDate() {
         return buildDate;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/KitodoVersion.java
+++ b/Kitodo/src/main/java/org/kitodo/production/KitodoVersion.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.production.version;
+package org.kitodo.production;
 
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/HelperForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/HelperForm.java
@@ -18,8 +18,8 @@ import javax.inject.Named;
 
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
+import org.kitodo.production.KitodoVersion;
 import org.kitodo.production.helper.Helper;
-import org.kitodo.production.version.KitodoVersion;
 
 /**
  * Helper form - used for some single methods which don't match yet to other

--- a/Kitodo/src/main/java/org/kitodo/production/forms/HelperForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/HelperForm.java
@@ -18,7 +18,7 @@ import javax.inject.Named;
 
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
-import org.kitodo.production.KitodoVersion;
+import org.kitodo.production.KitodoProduction;
 import org.kitodo.production.helper.Helper;
 
 /**
@@ -30,7 +30,7 @@ import org.kitodo.production.helper.Helper;
 public class HelperForm implements Serializable {
 
     public String getVersion() {
-        return KitodoVersion.getBuildVersion();
+        return KitodoProduction.getInstance().getVersionInformation().getVersion();
     }
 
     public boolean getAnonymized() {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/TaskManager.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/TaskManager.java
@@ -223,7 +223,7 @@ public class TaskManager {
      * exit the task manager as well as its managed threads during container
      * shutdown.
      */
-    static void shutdownNow() {
+    public static void shutdownNow() {
         stopAndDeleteAllTasks();
         singleton().taskSitter.shutdownNow();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/TaskSitter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/TaskSitter.java
@@ -41,8 +41,7 @@ import org.kitodo.production.helper.tasks.EmptyTask.Behaviour;
  * constructor is private) a caring class is needed which will be available for
  * instantiation to the servlet container.
  */
-@WebListener
-public class TaskSitter implements Runnable, ServletContextListener {
+public class TaskSitter implements Runnable {
     /**
      * The field autoRunLimit holds the number of threads which at most are
      * allowed to be started automatically. It is by default initialised by the
@@ -53,27 +52,6 @@ public class TaskSitter implements Runnable, ServletContextListener {
 
     static {
         setAutoRunningThreads(true);
-    }
-
-    /**
-     * When the servlet is unloaded, i.e. on container shutdown, the TaskManager
-     * shall be shut down gracefully.
-     *
-     * @see javax.servlet.ServletContextListener#contextDestroyed(javax.servlet.ServletContextEvent)
-     */
-    @Override
-    public void contextDestroyed(ServletContextEvent arg) {
-        TaskManager.shutdownNow();
-    }
-
-    /**
-     * Currently, there is nothing to do when the servlet is loading.
-     *
-     * @see javax.servlet.ServletContextListener#contextInitialized(javax.servlet.ServletContextEvent)
-     */
-    @Override
-    public void contextInitialized(ServletContextEvent argument) {
-        // nothing is done here
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
@@ -49,8 +49,7 @@ import org.kitodo.config.enums.ParameterCore;
  * The class ActiveMQDirector also provides a basic ExceptionListener
  * implementation as required for the connection.
  */
-@WebListener
-public class ActiveMQDirector implements Runnable, ServletContextListener {
+public class ActiveMQDirector implements Runnable {
     private static final Logger logger = LogManager.getLogger(ActiveMQDirector.class);
 
     // When implementing new services, add them to this list
@@ -63,21 +62,6 @@ public class ActiveMQDirector implements Runnable, ServletContextListener {
     private static Connection connection = null;
     private static Session session = null;
     private static MessageProducer resultsTopic;
-
-    /**
-     * The method is called by the web container on startup
-     * and is used to start up the active MQ connection. All processors from
-     * {@link #services} are registered.
-     */
-    @Override
-    public void contextInitialized(ServletContextEvent initialisation) {
-        if (ConfigCore.getOptionalString(ParameterCore.ACTIVE_MQ_HOST_URL).isPresent()) {
-            Thread connectAsynchronously = new Thread(new ActiveMQDirector());
-            connectAsynchronously.setName(ActiveMQDirector.class.getSimpleName());
-            connectAsynchronously.setDaemon(true);
-            connectAsynchronously.start();
-        }
-    }
 
     @Override
     public void run() {
@@ -226,8 +210,7 @@ public class ActiveMQDirector implements Runnable, ServletContextListener {
      * The method contextDestroyed is called by the web container on shutdown.
      * It shuts down all listeners, the session and last, the connection.
      */
-    @Override
-    public void contextDestroyed(ServletContextEvent destruction) {
+    public void shutDown() {
         // Shut down all message consumers on any queues
         for (ActiveMQProcessor service : services) {
             MessageConsumer messageConsumer = service.getMessageConsumer();

--- a/Kitodo/src/test/java/org/kitodo/production/KitodoVersionTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/KitodoVersionTest.java
@@ -24,36 +24,28 @@ public class KitodoVersionTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionIfKitodoSectionIsMissingInManifest() {
-        KitodoVersion.setupFromManifest(new Manifest());
+        new KitodoVersion().setupFromManifest(new Manifest());
     }
 
     @Test
     public void attributeVersionShouldBeEqualToImplementationVersion() {
         Manifest manifest = createManifestWithValues();
-        KitodoVersion.setupFromManifest(manifest);
+        KitodoVersion version = new KitodoVersion();
+        version.setupFromManifest(manifest);
 
         assertEquals("Version attribute should be equal to Implementation-Version as specified in the given Manifest.",
-                VERSION, KitodoVersion.getVersion());
-    }
-
-    @Test
-    public void attributeBuildVersionShouldBeEqualToImplementationVersion() {
-        Manifest manifest = createManifestWithValues();
-        KitodoVersion.setupFromManifest(manifest);
-
-        assertEquals(
-                "BuildVersion attribute should be equal to Implementation-Version as specified in the given Manifest.",
-                VERSION, KitodoVersion.getBuildVersion());
+                VERSION, version.getVersion());
     }
 
     @Test
     public void attributeBuildDateShouldBeEqualToImplementationBuildDate() {
         Manifest manifest = createManifestWithValues();
-        KitodoVersion.setupFromManifest(manifest);
+        KitodoVersion version = new KitodoVersion();
+        version.setupFromManifest(manifest);
 
         assertEquals(
                 "BuildDate attribute should be equal to Implementation-Build-Date as specified in the given Manifest.",
-                BUILD_DATE, KitodoVersion.getBuildDate());
+                BUILD_DATE, version.getBuildDate());
     }
 
     private Manifest createManifestWithValues() {

--- a/Kitodo/src/test/java/org/kitodo/production/KitodoVersionTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/KitodoVersionTest.java
@@ -9,7 +9,7 @@
  * GPL3-License.txt file that was distributed with this source code.
  */
 
-package org.kitodo.production.version;
+package org.kitodo.production;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
The main class was well hidden as `KitodoVersionListener`. I renamed it to `KitodoProduction` and moved it. (Git doesn't get this on top of each other and show them as new, but it is from the previous class `KitodoVersionListener`. If you look at the individual commits, it becomes more understandable.) The instance exposes its essential properties, and the main class now handles essential functions of starting and stopping Active MQ and stopping the task manager, that was previously scattered throughout the application. The version is now no longer returned statically, but rather out of the main class.

I find it tidier this way.