### PR TITLE
Handle enter event in input fields

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -16,6 +16,33 @@
 
 var metadataEditor = {};
 
+metadataEditor.metadataTree = {
+
+    /**
+     * Key down event for all inputText elements in the metadata tree.
+     * If the key is "enter", handle it like a "tab"-event.
+     * @param event the corresponding key down event
+     * @param element the corresponding element
+     */
+    handleKeyDown(event, element) {
+        // Check if the pressed key is 'Enter'
+        if (event.keyCode === 13 || event.key === "Enter") {
+            event.preventDefault();
+            let form = element.form;
+            let focusableElements = Array.from(form.elements).filter(element => {
+                return element.tabIndex >= 0;
+            });
+            let index = focusableElements.indexOf(element);
+            let nextInput = focusableElements[index + 1];
+            if (nextInput) {
+                // Focus on the next input element
+                nextInput.focus();
+            }
+        }
+    },
+
+};
+
 /**
  * Methods and events related to the gallery section of the meta data editor.
  */

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -29,7 +29,7 @@ metadataEditor.metadataTree = {
         if (event.keyCode === 13 || event.key === "Enter") {
             event.preventDefault();
             let form = element.form;
-            let focusableElements = Array.from(form.elements).filter(element => {
+            let focusableElements = Array.from(form.elements).filter((element) => {
                 return element.tabIndex >= 0;
             });
             let index = focusableElements.indexOf(element);

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -63,7 +63,8 @@
                                  value="#{item.value}"
                                  disabled="#{not item.editable or readOnly}"
                                  required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
-                                 styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
+                                 styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
+                                 onkeydown="metadataEditor.metadataTree.handleKeyDown(event, this)">
                         <p:ajax event="change"
                                 oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
                     </p:inputText>


### PR DESCRIPTION
During the recent Community meeting ( https://github.com/kitodo/kitodo-production/wiki/2024%E2%80%9004%E2%80%9019-%E2%80%90-Programm-Community-Treffen-(Kitodo.Production) ), a bug was reported regarding the behavior when pressing the "Enter" key within an input field in the metadata tab of the metadata editor. This action could potentially result in the disappearance of the first form field and metadata values already recorded there. To mitigate this issue, one proposed solution is to intercept "Enter" key events within input fields (excluding textareas) in the metadata editor and handle them similarly to tab events, causing the focus to jump to the next input field. This pull request aims to implement this solution.
