### PR TITLE
Disabled elements should not be focused, extends PR #6063

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -30,7 +30,7 @@ metadataEditor.metadataTree = {
             event.preventDefault();
             let form = element.form;
             let focusableElements = Array.from(form.elements).filter((element) => {
-                return element.tabIndex >= 0;
+                return element.tabIndex >= 0 && !element.disabled;
             });
             let index = focusableElements.indexOf(element);
             let nextInput = focusableElements[index + 1];


### PR DESCRIPTION
This PR modifies the logic introduced by [6063](https://github.com/kitodo/kitodo-production/pull/6063). Without this change disabled elements might receive focus which is inconsistent with the behaviour of the tab key.