### PR TITLE
Make user project list sortable by client

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/projectList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/projectList.xhtml
@@ -25,7 +25,7 @@
         <p:column headerText="#{msgs.projectList}" sortBy="#{item.title}">
             <h:outputText value="#{item.title}"/>
         </p:column>
-        <p:column headerText="#{msgs.client}">
+        <p:column headerText="#{msgs.client}" sortBy="#{item.client.name}">
             <h:outputText value="#{item.client.name}"/>
         </p:column>
         <p:column styleClass="actionsColumn" headerText="#{msgs.actions}">


### PR DESCRIPTION
List of projects assigned to user in user edit page is now sortable by clients (as is already the case for roles):

<img width="605" alt="Bildschirmfoto 2024-05-16 um 11 37 31" src="https://github.com/kitodo/kitodo-production/assets/19183925/c19dcbd7-0a68-4248-97cb-9db5fd832b32">
