### PR TITLE
Handle exception during Kitodo Script execution

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/exceptions/KitodoScriptExecutionException.java
+++ b/Kitodo/src/main/java/org/kitodo/exceptions/KitodoScriptExecutionException.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.exceptions;
+
+public class KitodoScriptExecutionException extends Exception {
+
+    /**
+     * Constructor with given exception message.
+     * @param message as String
+     */
+    public KitodoScriptExecutionException(String message) {
+        super(message);
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
@@ -18,6 +18,7 @@ import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.exceptions.KitodoScriptExecutionException;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 
 public class AddDataScript extends EditDataScript {
@@ -29,7 +30,7 @@ public class AddDataScript extends EditDataScript {
      * @param metadataScript the script to execute
      */
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
-            MetadataScript metadataScript) {
+            MetadataScript metadataScript) throws KitodoScriptExecutionException {
         Workpiece workpiece = metadataFile.getWorkpiece();
         Collection<Metadata> metadataCollection = getMetadataCollection(metadataScript, workpiece);
         generateValueForMetadataScript(metadataScript, metadataCollection, process, metadataFile);

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
@@ -19,6 +19,7 @@ import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.exceptions.KitodoScriptExecutionException;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 
 public class DeleteDataScript extends EditDataScript {
@@ -30,7 +31,7 @@ public class DeleteDataScript extends EditDataScript {
      * @param metadataScript the script to execute
      */
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
-                               MetadataScript metadataScript) {
+                               MetadataScript metadataScript) throws KitodoScriptExecutionException {
         Workpiece workpiece = metadataFile.getWorkpiece();
 
         Collection<Metadata> metadataCollection = getMetadataCollection(metadataScript, workpiece);

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -37,6 +37,7 @@ import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
 import org.kitodo.exceptions.InvalidImagesException;
+import org.kitodo.exceptions.KitodoScriptExecutionException;
 import org.kitodo.exceptions.MediaNotFoundException;
 import org.kitodo.export.ExportDms;
 import org.kitodo.production.enums.GenerationMode;
@@ -253,10 +254,10 @@ public class KitodoScriptService {
 
     private void deleteData(List<Process> processes, String script) {
         String currentProcessTitle = null;
-        try {
-            script = script.replaceFirst("\\s*action:deleteData\\s+(.*?)[\r\n\\s]*", "$1");
-            DeleteDataScript deleteDataScript = new DeleteDataScript();
-            for (Process process : processes) {
+        script = script.replaceFirst("\\s*action:deleteData\\s+(.*?)[\r\n\\s]*", "$1");
+        DeleteDataScript deleteDataScript = new DeleteDataScript();
+        for (Process process : processes) {
+            try {
                 currentProcessTitle = process.getTitle();
                 LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                         .readMetadataFile(process);
@@ -264,20 +265,20 @@ public class KitodoScriptService {
                 ServiceManager.getMetsService().saveWorkpiece(metadataFile.getWorkpiece(),
                         ServiceManager.getProcessService().getMetadataFileUri(process));
                 Helper.setMessage("deleteDataOk", currentProcessTitle);
+            } catch (IOException | KitodoScriptExecutionException e) {
+                Helper.setErrorMessage("deleteDataError", currentProcessTitle + ": " + e.getMessage(), logger, e);
             }
-        } catch (IOException e) {
-            Helper.setErrorMessage("deleteDataError", currentProcessTitle + ":" + e.getMessage(), logger, e);
         }
     }
 
     private void copyDataToChildren(List<Process> processes, String script) {
-        String currentProcessTitle = null;
-        try {
-            script = script.replaceFirst("\\s*action:copyDataToChildren\\s+(.*?)[\r\n\\s]*", "$1");
-            AddDataScript addDataScript = new AddDataScript();
-            for (Process parentProcess : processes) {
-                currentProcessTitle = parentProcess.getTitle();
-                List<MetadataScript> metadataScripts = addDataScript.parseScript(script);
+        String currentProcessTitle;
+        script = script.replaceFirst("\\s*action:copyDataToChildren\\s+(.*?)[\r\n\\s]*", "$1");
+        AddDataScript addDataScript = new AddDataScript();
+        for (Process parentProcess : processes) {
+            currentProcessTitle = parentProcess.getTitle();
+            List<MetadataScript> metadataScripts = addDataScript.parseScript(script);
+            try {
                 generateScriptValues(addDataScript, metadataScripts, parentProcess);
                 for (Process child : parentProcess.getChildren()) {
                     LegacyMetsModsDigitalDocumentHelper childMetadataFile = ServiceManager.getProcessService()
@@ -287,9 +288,9 @@ public class KitodoScriptService {
                     }
                 }
                 Helper.setMessage("addDataOk", currentProcessTitle);
+            } catch (IOException | KitodoScriptExecutionException e) {
+                Helper.setErrorMessage("addDataError", currentProcessTitle + ": " + e.getMessage(), logger, e);
             }
-        } catch (IOException e) {
-            Helper.setErrorMessage("addDataOk", currentProcessTitle + ":" + e.getMessage(), logger, e);
         }
     }
 
@@ -302,10 +303,10 @@ public class KitodoScriptService {
 
     private void overwriteData(List<Process> processes, String script) {
         String currentProcessTitle = null;
-        try {
-            script = script.replaceFirst("\\s*action:overwriteData\\s+(.*?)[\r\n\\s]*", "$1");
-            OverwriteDataScript overwriteDataScript = new OverwriteDataScript();
-            for (Process process : processes) {
+        script = script.replaceFirst("\\s*action:overwriteData\\s+(.*?)[\r\n\\s]*", "$1");
+        OverwriteDataScript overwriteDataScript = new OverwriteDataScript();
+        for (Process process : processes) {
+            try {
                 currentProcessTitle = process.getTitle();
                 LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                         .readMetadataFile(process);
@@ -313,9 +314,9 @@ public class KitodoScriptService {
                 ServiceManager.getMetsService().saveWorkpiece(metadataFile.getWorkpiece(),
                         ServiceManager.getProcessService().getMetadataFileUri(process));
                 Helper.setMessage("overwriteDataOk", currentProcessTitle);
+            } catch (IOException | KitodoScriptExecutionException e) {
+                Helper.setErrorMessage("overwriteDataError", currentProcessTitle + ": " + e.getMessage(), logger, e);
             }
-        } catch (IOException e) {
-            Helper.setErrorMessage("overwriteDataError", currentProcessTitle + ":" + e.getMessage(), logger, e);
         }
     }
 
@@ -373,10 +374,10 @@ public class KitodoScriptService {
 
     private void addData(List<Process> processes, String script) {
         String currentProcessTitle = null;
-        try {
-            script = script.replaceFirst("\\s*action:addData\\s+(.*?)[\r\n\\s]*", "$1");
-            AddDataScript addDataScript = new AddDataScript();
-            for (Process process : processes) {
+        script = script.replaceFirst("\\s*action:addData\\s+(.*?)[\r\n\\s]*", "$1");
+        AddDataScript addDataScript = new AddDataScript();
+        for (Process process : processes) {
+            try {
                 currentProcessTitle = process.getTitle();
                 LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                         .readMetadataFile(process);
@@ -384,9 +385,9 @@ public class KitodoScriptService {
                 ServiceManager.getMetsService().saveWorkpiece(metadataFile.getWorkpiece(),
                         ServiceManager.getProcessService().getMetadataFileUri(process));
                 Helper.setMessage("addDataOk", currentProcessTitle);
+            } catch (IOException | KitodoScriptExecutionException e) {
+                Helper.setErrorMessage("addDataError", currentProcessTitle + ": " + e.getMessage(), logger, e);
             }
-        } catch (IOException e) {
-            Helper.setErrorMessage("addDataError", currentProcessTitle + ":" + e.getMessage(), logger, e);
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/OverwriteDataScript.java
@@ -18,13 +18,14 @@ import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.MetadataGroup;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.exceptions.KitodoScriptExecutionException;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
 
 public class OverwriteDataScript extends EditDataScript {
 
     @Override
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
-            MetadataScript metadataScript) {
+            MetadataScript metadataScript) throws KitodoScriptExecutionException {
         Workpiece workpiece = metadataFile.getWorkpiece();
 
         Collection<Metadata> metadataCollection = getMetadataCollection(metadataScript, workpiece);

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -104,6 +104,7 @@ kitodoScript.importProcesses.project.noProjectWithID=Ein solches Projekt existie
 kitodoScript.importProcesses.template.isNull=Parameter ''template'' fehlt!
 kitodoScript.importProcesses.template.isNoTemplateID=''template'' ist keine g\u00F6ltige Vorlagen-ID
 kitodoScript.importProcesses.template.noTemplateWithID=Eine solche Produktionsvorlage existiert nicht!
+kitodoScript.noStructureOfTypeFound=Kein Strukturelement vom Typ "{0}" gefunden
 
 # L
 errorLoadingDocTypes=Regelsatz Konfigurationsfehler: Kein DocType ('division') gefunden

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -104,6 +104,7 @@ kitodoScript.importProcesses.project.noProjectWithID=There is no project with th
 kitodoScript.importProcesses.template.isNull=Missing value for ''template''!
 kitodoScript.importProcesses.template.isNoTemplateID=''template'' is not int!
 kitodoScript.importProcesses.template.noTemplateWithID=There is no production template with that ID
+kitodoScript.noStructureOfTypeFound=No structure element with type "{0}" found
 
 # L
 errorLoadingDocTypes=Ruleset configuration error: No DocType ('division') found

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1734,6 +1734,13 @@ Popup dialogs
     color: var(--pure-white);
 }
 
+.ui-messages-error.ui-corner-all ul,
+.ui-messages-warn.ui-corner-all ul,
+.ui-messages-info.ui-corner-all ul {
+    max-height: 80px;
+    overflow-y: auto;
+}
+
 .ui-messages-error.ui-corner-all span.ui-icon-close,
 .ui-messages-warn.ui-corner-all span.ui-icon-close,
 .ui-messages-info.ui-corner-all span.ui-icon-close {


### PR DESCRIPTION
Fixes #5976 

Also makes the "error-messages" list scrollable since it might contain many errors for many processes selected in the process list:

<img width="1487" alt="Bildschirmfoto 2024-05-16 um 15 01 38" src="https://github.com/kitodo/kitodo-production/assets/19183925/dd271a08-85b0-4276-8f75-79ce18785abc">
