### PR TITLE
Sort list for correct test comparing

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/production/services/calendar/CalendarServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/calendar/CalendarServiceIT.java
@@ -132,7 +132,7 @@ public class CalendarServiceIT {
 
         List<String> actualMetadataSummary = CalendarService.getMetadataSummary(block).stream()
                 .map(entry -> entry.getKey().getLabel() + " - " + entry.getValue().toString())
-                .collect(Collectors.toList());
+                .sorted().collect(Collectors.toList());
         List<String> expectedMetadataSummary = Arrays.asList("Process title - 2024-03-04", "Signatur - 2024-03-05");
         assertEquals(expectedMetadataSummary, actualMetadataSummary);
     }


### PR DESCRIPTION
The test method shouldGetMetadataSummary() in class CalendarServiceIT is expecting a list of string entries in a sorted way but the actual getting list entries are not sorted. So the test execution is randomly successfull or failing. 

This PR is adding a sorting call while the list of meta data entries is generated.