### PR TITLE
[Kitodo DataFormat] Replace Junit4 with Junit5

### DIFF
--- a/Kitodo-DataFormat/pom.xml
+++ b/Kitodo-DataFormat/pom.xml
@@ -44,10 +44,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/DataFormatVersionProviderTest.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/DataFormatVersionProviderTest.java
@@ -11,15 +11,16 @@
 
 package org.kitodo.dataformat;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class DataFormatVersionProviderTest {
 
-    private DataFormatVersionProvider versionProvider = new DataFormatVersionProvider();
+    private final DataFormatVersionProvider versionProvider = new DataFormatVersionProvider();
 
     @Test
     public void getDataFormatVersionTest() {
-        Assert.assertEquals("Data format version was not correct", "1.0", versionProvider.getDataFormatVersion());
+        assertEquals("1.0", versionProvider.getDataFormatVersion(), "Data format version was not correct");
     }
 }

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -11,8 +11,9 @@
 
 package org.kitodo.dataformat.access;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,13 +29,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.kitodo.api.MdSec;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.MetadataGroup;
 import org.kitodo.api.dataformat.LogicalDivision;
-import org.kitodo.api.dataformat.PhysicalDivision;
 import org.kitodo.api.dataformat.MediaVariant;
+import org.kitodo.api.dataformat.PhysicalDivision;
 import org.kitodo.api.dataformat.ProcessingNote;
 import org.kitodo.api.dataformat.View;
 import org.kitodo.api.dataformat.Workpiece;
@@ -252,41 +254,41 @@ public class MetsXmlElementAccessIT {
     @Test
     public void missingMetsHeaderCreationDateDidNotThrowNullPointerException() throws IOException {
         Workpiece workpiece = new MetsXmlElementAccess()
-                .read(new FileInputStream(new File("src/test/resources/meta_missing_createdate.xml")));
+            .read(new FileInputStream("src/test/resources/meta_missing_createdate.xml"));
         assertNotNull(workpiece.getCreationDate());
     }
 
     @Test
-    public void missingMetsFileForPointer() throws Exception {
-        try {
-            new MetsXmlElementAccess().read(new FileInputStream(new File("src/test/resources/meta_missing_file.xml")));
-        } catch (IllegalArgumentException e) {
-            assertEquals("Corrupt file: file id for <mets:fptr> not found for div PHYS_0001", e.getMessage());
-        };
+    public void missingMetsFileForPointer() {
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> new MetsXmlElementAccess().read(
+                        new FileInputStream("src/test/resources/meta_missing_file.xml")
+                )
+            );
+
+        assertEquals("Corrupt file: file id for <mets:fptr> not found for div PHYS_0001", exception.getMessage());
     }
 
     @Test
-    public void duplicateMetsFileDefinition() throws Exception {
-        try {
-            new MetsXmlElementAccess().read(
-                new FileInputStream(new File("src/test/resources/meta_duplicate_file.xml"))
+    @Disabled("See GitHub discussion https://github.com/kitodo/kitodo-production/discussions/6087")
+    public void duplicateMetsFileDefinition() {
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> new MetsXmlElementAccess().read(
+                        new FileInputStream("src/test/resources/meta_duplicate_file.xml")
+                )
             );
-        } catch (IllegalArgumentException e) {
-            assertEquals("Corrupt file: file with id FILE_0001 is part of multiple groups", e.getMessage());
-        };
+
+        assertEquals("Corrupt file: file with id FILE_0001 is part of multiple groups", exception.getMessage());
     }
 
     @Test
-    public void missingMetsFileGroupUse() throws Exception {
-        try {
-            new MetsXmlElementAccess().read(
-                new FileInputStream(new File("src/test/resources/meta_missing_file_use.xml"))
+    public void missingMetsFileGroupUse() {
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> new MetsXmlElementAccess().read(
+                    new FileInputStream("src/test/resources/meta_missing_file_use.xml")
+                )
             );
-        } catch (IllegalArgumentException e) {
-            assertEquals(
-                "Corrupt file: file use for <mets:fptr> with id FILE_0001 not found in <mets:fileGrp>",
-                e.getMessage()
-            );
-        };
+
+        assertEquals("Corrupt file: file use for <mets:fptr> with id FILE_0001 not found in <mets:fileGrp>", exception.getMessage());
     }
 }

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Files;
@@ -253,9 +254,11 @@ public class MetsXmlElementAccessIT {
 
     @Test
     public void missingMetsHeaderCreationDateDidNotThrowNullPointerException() throws IOException {
-        Workpiece workpiece = new MetsXmlElementAccess()
-            .read(new FileInputStream("src/test/resources/meta_missing_createdate.xml"));
-        assertNotNull(workpiece.getCreationDate());
+        try (InputStream fileContent = new FileInputStream("src/test/resources/meta_missing_createdate.xml")) {
+            Workpiece workpiece = new MetsXmlElementAccess()
+                    .read(fileContent);
+            assertNotNull(workpiece.getCreationDate());
+        }
     }
 
     @Test


### PR DESCRIPTION
Part of a pull request series to replace Junit4 with Junit5 based tests. Changed made by module and are independent of the other parts.

One test must be disabled, see discussion https://github.com/kitodo/kitodo-production/discussions/6087. Test will be re-enabled in a separate later pull request.