### PR TITLE
pom.xml: Replace maven.compiler.{source,target} by maven.compiler.release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
         <phase.prop>none</phase.prop>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.debug>true</maven.compiler.debug>
         <maven.compiler.debuglevel>lines,vars,source</maven.compiler.debuglevel>
         <maxAllowedViolations>0</maxAllowedViolations>


### PR DESCRIPTION
This fixes a lot of build warnings with Java compilers newer than version 11.

As the change is supported since Java 9, it also works with Java 11.