### PR TITLE
Fix mets file id check including an option for use of this check

### DIFF
--- a/Kitodo-DataFormat/pom.xml
+++ b/Kitodo-DataFormat/pom.xml
@@ -44,6 +44,14 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -461,7 +461,7 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
                 for (FileType file : fileGrp.getFile()) {
                     if (strictCheck && usedFileId.contains(file.getID())) {
                         throw new IllegalArgumentException(
-                            "Corrupt file: file with id " + file.getID() + " is part of multiple groups"
+                            "Corrupt file: each METS file ID has to be unique but " + file.getID() + " is used multiple times!"
                         );
                     } else {
                         usedFileId.add(file.getID());

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -44,6 +44,7 @@ import org.kitodo.api.dataformat.PhysicalDivision;
 import org.kitodo.api.dataformat.ProcessingNote;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.dataformat.mets.MetsXmlElementAccessInterface;
+import org.kitodo.config.KitodoConfig;
 import org.kitodo.dataformat.metskitodo.DivType;
 import org.kitodo.dataformat.metskitodo.FileType;
 import org.kitodo.dataformat.metskitodo.Mets;
@@ -452,19 +453,21 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
     private Map<FileType, String> createFileUseByFileCache(Mets mets) {
         HashMap<FileType, String> fileUseMap = new HashMap<>();
         FileSec fileSec = mets.getFileSec();
+        Set<String> usedFileId = new HashSet<>();
+        boolean strictCheck = KitodoConfig.getConfig().getBoolean("useStrictMetsFileIdCheck", false);
         if (Objects.nonNull(fileSec)) {
             for (FileGrp fileGrp : fileSec.getFileGrp()) {
                 String use = fileGrp.getUSE();
                 for (FileType file : fileGrp.getFile()) {
-                    if (fileUseMap.containsKey(file)) {
+                    if (strictCheck && usedFileId.contains(file.getID())) {
                         throw new IllegalArgumentException(
                             "Corrupt file: file with id " + file.getID() + " is part of multiple groups"
                         );
                     } else {
+                        usedFileId.add(file.getID());
                         fileUseMap.put(file, use);
                     }
                 }
-                
             }
         }
         return fileUseMap;

--- a/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
+++ b/Kitodo-DataFormat/src/test/java/org/kitodo/dataformat/access/MetsXmlElementAccessIT.java
@@ -303,7 +303,7 @@ public class MetsXmlElementAccessIT {
                 )
             );
 
-        assertEquals("Corrupt file: file with id FILE_0001 is part of multiple groups", exception.getMessage());
+        assertEquals("Corrupt file: each METS file ID has to be unique but FILE_0001 is used multiple times!", exception.getMessage());
     }
 
     @Test

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -419,6 +419,10 @@ issue.colours=#f94a15;#0071bc;#42ba37;#ee7e5b;#1e3946;#ca2f00;#AAAAFF;#000055;#0
 # Minimal average number of pages per process in newspaper process creation
 numberOfPages.minimum=1
 
+# Use strict mets:fileId check or not. Property is used inside the Kitodo-DataFormat module.
+# For more information see German GitHub discussion https://github.com/kitodo/kitodo-production/discussions/6087
+# On default check is disabled
+useStrictMetsFileIdCheck=false
 
 # -----------------------------------
 # Batch processing

--- a/pom.xml
+++ b/pom.xml
@@ -588,6 +588,12 @@ from system library in Java 11+ -->
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.omnifaces</groupId>
                 <artifactId>omnifaces</artifactId>
                 <version>3.13.3</version>


### PR DESCRIPTION
It is a solution for an issue explained in discussion https://github.com/kitodo/kitodo-production/discussions/6087 . By default this check is disabled or not in use and can be enabled.