### PR TITLE
Add relation between import configurations and clients

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Client.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Client.java
@@ -40,6 +40,9 @@ public class Client extends BaseBean {
                     foreignKey = @ForeignKey(name = "FK_column_id"))})
     private List<ListColumn> listColumns;
 
+    @ManyToMany(mappedBy = "clients", cascade = CascadeType.PERSIST)
+    private List<ImportConfiguration> importConfigurations;
+
     /**
      * Gets name.
      *
@@ -98,5 +101,27 @@ public class Client extends BaseBean {
      */
     public void setListColumns(List<ListColumn> columns) {
         this.listColumns = columns;
+    }
+
+    /**
+     * Get import configuration.
+     *
+     * @return import configurations
+     */
+    public List<ImportConfiguration> getImportConfigurations() {
+        initialize(new ClientDAO(), this.importConfigurations);
+        if (Objects.isNull(this.importConfigurations)) {
+            this.importConfigurations = new ArrayList<>();
+        }
+        return importConfigurations;
+    }
+
+    /**
+     * Set import configurations.
+     *
+     * @param configurations import configurations
+     */
+    public void setImportConfigurations(List<ImportConfiguration> configurations) {
+        this.importConfigurations = configurations;
     }
 }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ImportConfiguration.java
@@ -29,7 +29,10 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
+import org.kitodo.data.database.persistence.ImportConfigurationDAO;
 import org.kitodo.data.database.persistence.MappingFileDAO;
 import org.kitodo.data.database.persistence.SearchFieldDAO;
 import org.kitodo.data.database.persistence.UrlParameterDAO;
@@ -157,6 +160,16 @@ public class ImportConfiguration extends BaseBean {
 
     @Column(name = "metadata_record_title_xpath")
     private String metadataRecordTitleXPath;
+
+    @ManyToMany(cascade = CascadeType.PERSIST)
+    @LazyCollection(LazyCollectionOption.FALSE)
+    @JoinTable(name = "client_x_importconfiguration", joinColumns = {
+        @JoinColumn(name = "importconfiguration_id",
+                foreignKey = @ForeignKey(name = "FK_client_x_importconfiguration_importconfiguration_id")) },
+            inverseJoinColumns = {
+                @JoinColumn(name = "client_id",
+                    foreignKey = @ForeignKey(name = "FK_client_x_importconfiguration_client_id")) })
+    private List<Client> clients;
 
     /**
      * Default constructor.
@@ -842,6 +855,28 @@ public class ImportConfiguration extends BaseBean {
         return "";
     }
 
+    /**
+     * Get clients.
+     *
+     * @return value of clients
+     */
+    public List<Client> getClients() {
+        initialize(new ImportConfigurationDAO(), this.clients);
+        if (Objects.isNull(this.clients)) {
+            this.clients = new ArrayList<>();
+        }
+        return clients;
+    }
+
+    /**
+     * Set clients.
+     *
+     * @param clients List of Client
+     */
+    public void setClients(List<Client> clients) {
+        this.clients = clients;
+    }
+
     @Override
     public boolean equals(Object object) {
         if (this == object) {
@@ -898,7 +933,8 @@ public class ImportConfiguration extends BaseBean {
                 sruRecordSchema,
                 oaiMetadataPrefix,
                 metadataRecordIdXPath,
-                metadataRecordTitleXPath
+                metadataRecordTitleXPath,
+                clients
         );
     }
 }

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_130__Add_relation_between_importconfiguration_and_client.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_130__Add_relation_between_importconfiguration_and_client.sql
@@ -1,0 +1,29 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+--
+-- Migration: Create relation between ImportConfigurations and Clients
+--
+
+-- 1. creating cross table
+CREATE TABLE IF NOT EXISTS client_x_importconfiguration (
+    client_id INT(11) NOT NULL,
+    importconfiguration_id INT(11) NOT NULL,
+    PRIMARY KEY ( client_id, importconfiguration_id ),
+    KEY FK_client_x_importconfiguration_client_id (client_id),
+    KEY FK_client_x_importconfiguration_importconfiguration_id (importconfiguration_id),
+    CONSTRAINT FK_client_x_importconfiguration_client_id FOREIGN KEY (client_id) REFERENCES client(id),
+    CONSTRAINT FK_client_x_importconfiguration_importconfiguration_id FOREIGN KEY (importconfiguration_id) REFERENCES importconfiguration(id)
+) DEFAULT CHARACTER SET = utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+-- 2. initially map all clients to all import configurations to retain status quo
+INSERT INTO client_x_importconfiguration SELECT client.id, importconfiguration.id FROM client, importconfiguration;

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_130__Add_relation_between_importconfiguration_and_client.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_130__Add_relation_between_importconfiguration_and_client.sql
@@ -13,7 +13,9 @@
 -- Migration: Create relation between ImportConfigurations and Clients
 --
 
--- 1. creating cross table
+SET SQL_SAFE_UPDATES = 0;
+
+-- 1. create cross table
 CREATE TABLE IF NOT EXISTS client_x_importconfiguration (
     client_id INT(11) NOT NULL,
     importconfiguration_id INT(11) NOT NULL,
@@ -27,3 +29,8 @@ CREATE TABLE IF NOT EXISTS client_x_importconfiguration (
 
 -- 2. initially map all clients to all import configurations to retain status quo
 INSERT INTO client_x_importconfiguration SELECT client.id, importconfiguration.id FROM client, importconfiguration;
+
+-- 3. add new special permission to allow users to map import configuration to clients
+INSERT IGNORE INTO authority (title) VALUES ('assignImportConfigurationToClient_globalAssignable');
+
+SET SQL_SAFE_UPDATES = 1;

--- a/Kitodo/src/main/java/org/kitodo/constants/StringConstants.java
+++ b/Kitodo/src/main/java/org/kitodo/constants/StringConstants.java
@@ -15,6 +15,6 @@ public class StringConstants {
 
     public static final String COMMA_DELIMITER = ", ";
     public static final String SEMICOLON_DELIMITER = "; ";
-    public static final String SAVE = "editForm:save";
+    public static final String EDIT_FORM_SAVE = "editForm:save";
 
 }

--- a/Kitodo/src/main/java/org/kitodo/constants/StringConstants.java
+++ b/Kitodo/src/main/java/org/kitodo/constants/StringConstants.java
@@ -15,5 +15,6 @@ public class StringConstants {
 
     public static final String COMMA_DELIMITER = ", ";
     public static final String SEMICOLON_DELIMITER = "; ";
+    public static final String SAVE = "editForm:save";
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/controller/SecurityAccessController.java
+++ b/Kitodo/src/main/java/org/kitodo/production/controller/SecurityAccessController.java
@@ -1099,4 +1099,13 @@ public class SecurityAccessController {
     public boolean hasAuthorityToRenameMediaFiles() {
         return securityAccessService.hasAuthorityToRenameMediaFiles();
     }
+
+    /**
+     * Check if the current user has the permission to assign import configurations to clients.
+     *
+     * @return true if the current user has the permission to assign import configurations to clients.
+     */
+    public boolean hasAuthorityToAssignImportConfigurationToClient() {
+        return securityAccessService.hasAuthorityToAssignImportConfigurationToClient();
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/controller/SessionClientController.java
+++ b/Kitodo/src/main/java/org/kitodo/production/controller/SessionClientController.java
@@ -11,8 +11,10 @@
 
 package org.kitodo.production.controller;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.RequestScoped;
 import javax.faces.context.FacesContext;
@@ -149,7 +151,7 @@ public class SessionClientController {
      *
      * @return The list of clients.
      */
-    public List<Client> getAvailableClientsOfCurrentUser()  {
+    public List<Client> getAvailableClientsOfCurrentUser() {
         User currentUser = ServiceManager.getUserService().getCurrentUser();
         List<Client> clients = currentUser.getClients();
         for (Project project : currentUser.getProjects()) {
@@ -158,5 +160,14 @@ public class SessionClientController {
             }
         }
         return clients;
+    }
+
+    /**
+     * Get list of available clients of current user sorted by name.
+     * @return list of available clients of current user sorted by name
+     */
+    public List<Client> getAvailableClientsOfCurrentUserSortedByName() {
+        return getAvailableClientsOfCurrentUser().stream().sorted(Comparator.comparing(Client::getName))
+                .collect(Collectors.toList());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
@@ -38,7 +38,6 @@ import org.kitodo.data.database.beans.SearchField;
 import org.kitodo.data.database.beans.UrlParameter;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.production.controller.SessionClientController;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
@@ -463,8 +462,12 @@ public class ImportConfigurationEditView extends BaseForm {
      */
     public List<Client> getAvailableClients() {
         if (Objects.isNull(availableClients) || availableClients.isEmpty()) {
-            SessionClientController controller = new SessionClientController();
-            availableClients =  controller.getAvailableClientsOfCurrentUserSortedByName();
+            try {
+                availableClients = ServiceManager.getClientService().getAllSortedByName();
+            } catch (DAOException e) {
+                Helper.setErrorMessage(e);
+                availableClients = new ArrayList<>();
+            }
         }
         return availableClients;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
@@ -30,6 +30,7 @@ import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.api.externaldatamanagement.SearchInterfaceType;
 import org.kitodo.api.schemaconverter.FileFormat;
 import org.kitodo.api.schemaconverter.MetadataFormat;
+import org.kitodo.data.database.beans.Client;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.beans.MappingFile;
 import org.kitodo.data.database.beans.Process;
@@ -37,6 +38,7 @@ import org.kitodo.data.database.beans.SearchField;
 import org.kitodo.data.database.beans.UrlParameter;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.production.controller.SessionClientController;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
@@ -49,6 +51,7 @@ public class ImportConfigurationEditView extends BaseForm {
     private static final Logger logger = LogManager.getLogger(ImportConfigurationEditView.class);
     private ImportConfiguration importConfiguration = new ImportConfiguration();
     private List<SelectItem> searchFields = new ArrayList<>();
+    private List<Client> availableClients = new ArrayList<>();
     private static final List<String> SRU_VERSIONS = List.of("1.1", "1.2", "2.0");
     private static final List<String> SCHEMES = List.of("https", "http", "ftp");
     private static final List<String> PARENT_ELEMENT_TYPES = Collections.singletonList("reference");
@@ -434,5 +437,35 @@ public class ImportConfigurationEditView extends BaseForm {
      */
     public void setParentIdSearchField(String parentIdSearchField) {
         importConfiguration.setParentSearchField(getSearchFieldMap().get(parentIdSearchField));
+    }
+
+    /**
+     * Get assigned clients.
+     *
+     * @return assigned clients
+     */
+    public List<Client> getAssignedClients() {
+        return new ArrayList<>(importConfiguration.getClients());
+    }
+
+    /**
+     * Set assigned clients.
+     *
+     * @param clients assigned clients
+     */
+    public void setAssignedClients(List<Client> clients) {
+        this.importConfiguration.setClients(clients);
+    }
+
+    /**
+     * Get list of available clients.
+     * @return list of available clients
+     */
+    public List<Client> getAvailableClients() {
+        if (Objects.isNull(availableClients) || availableClients.isEmpty()) {
+            SessionClientController controller = new SessionClientController();
+            availableClients =  controller.getAvailableClientsOfCurrentUserSortedByName();
+        }
+        return availableClients;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
@@ -105,6 +105,8 @@ public class ImportConfigurationEditView extends BaseForm {
                 importConfiguration = ServiceManager.getImportConfigurationService().getById(id);
             } else {
                 importConfiguration = new ImportConfiguration();
+                importConfiguration.setClients(Collections.singletonList(ServiceManager.getUserService()
+                        .getSessionClientOfAuthenticatedUser()));
             }
             setSaveDisabled(true);
         } catch (DAOException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationListView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationListView.java
@@ -28,7 +28,6 @@ import org.kitodo.exceptions.ConfigException;
 import org.kitodo.exceptions.ImportConfigurationInUseException;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.helper.Helper;
-import org.kitodo.production.model.LazyDTOModel;
 import org.kitodo.production.services.ServiceManager;
 import org.primefaces.PrimeFaces;
 
@@ -44,7 +43,6 @@ public class ImportConfigurationListView extends BaseForm {
      */
     public ImportConfigurationListView() {
         super();
-        super.setLazyDTOModel(new LazyDTOModel(ServiceManager.getImportConfigurationService()));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/validators/AbsolutePathValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/validators/AbsolutePathValidator.java
@@ -30,7 +30,7 @@ public class AbsolutePathValidator implements Validator<String> {
     public void validate(FacesContext facesContext, UIComponent uiComponent, String pathString)
             throws ValidatorException {
         // only validate when saving
-        if (!facesContext.getExternalContext().getRequestParameterMap().containsKey(StringConstants.SAVE)) {
+        if (!facesContext.getExternalContext().getRequestParameterMap().containsKey(StringConstants.EDIT_FORM_SAVE)) {
             return;
         }
         if (StringUtils.isNotBlank(pathString) && !pathString.startsWith("/")) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/validators/ImportConfigurationClientValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/validators/ImportConfigurationClientValidator.java
@@ -29,7 +29,7 @@ public class ImportConfigurationClientValidator implements Validator<ArrayList<?
     public void validate(FacesContext context, UIComponent component, ArrayList<?> clientList)
             throws ValidatorException {
         // only validate when saving
-        if (!context.getExternalContext().getRequestParameterMap().containsKey(StringConstants.SAVE)) {
+        if (!context.getExternalContext().getRequestParameterMap().containsKey(StringConstants.EDIT_FORM_SAVE)) {
             return;
         }
         if (clientList.isEmpty()) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/validators/ImportConfigurationClientValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/validators/ImportConfigurationClientValidator.java
@@ -11,7 +11,7 @@
 
 package org.kitodo.production.forms.validators;
 
-import org.kitodo.constants.StringConstants;
+import java.util.ArrayList;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.component.UIComponent;
@@ -19,7 +19,8 @@ import javax.faces.context.FacesContext;
 import javax.faces.validator.FacesValidator;
 import javax.faces.validator.Validator;
 import javax.faces.validator.ValidatorException;
-import java.util.ArrayList;
+
+import org.kitodo.constants.StringConstants;
 
 @FacesValidator("ImportConfigurationClientValidator")
 public class ImportConfigurationClientValidator implements Validator<ArrayList<?>> {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/validators/ImportConfigurationClientValidator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/validators/ImportConfigurationClientValidator.java
@@ -11,31 +11,29 @@
 
 package org.kitodo.production.forms.validators;
 
+import org.kitodo.constants.StringConstants;
+
 import javax.faces.application.FacesMessage;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.validator.FacesValidator;
 import javax.faces.validator.Validator;
 import javax.faces.validator.ValidatorException;
+import java.util.ArrayList;
 
-import org.apache.commons.lang3.StringUtils;
-import org.kitodo.constants.StringConstants;
-
-@FacesValidator("AbsolutePathValidator")
-public class AbsolutePathValidator implements Validator<String> {
-
-
+@FacesValidator("ImportConfigurationClientValidator")
+public class ImportConfigurationClientValidator implements Validator<ArrayList<?>> {
 
     @Override
-    public void validate(FacesContext facesContext, UIComponent uiComponent, String pathString)
+    public void validate(FacesContext context, UIComponent component, ArrayList<?> clientList)
             throws ValidatorException {
         // only validate when saving
-        if (!facesContext.getExternalContext().getRequestParameterMap().containsKey(StringConstants.SAVE)) {
+        if (!context.getExternalContext().getRequestParameterMap().containsKey(StringConstants.SAVE)) {
             return;
         }
-        if (StringUtils.isNotBlank(pathString) && !pathString.startsWith("/")) {
+        if (clientList.isEmpty()) {
             throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR,
-                    "Non empty URL path must be absolute, e.g. start with a '/'!", null));
+                    "The import configuration must be assigned to at least one client", null));
         }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/CatalogConfigurationImporter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/CatalogConfigurationImporter.java
@@ -18,6 +18,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -105,6 +106,8 @@ public class CatalogConfigurationImporter {
             }
             importConfiguration.setMappingFiles(getMappingFiles(importConfiguration));
             importConfiguration.setPrestructuredImport(OPACConfig.isPrestructuredImport(catalogName));
+            importConfiguration.setClients(Collections.singletonList(ServiceManager.getUserService()
+                    .getSessionClientOfAuthenticatedUser()));
         }
         ServiceManager.getImportConfigurationService().saveToDatabase(importConfiguration);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
@@ -13,6 +13,7 @@ package org.kitodo.production.services.data;
 
 import static org.kitodo.constants.StringConstants.COMMA_DELIMITER;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -119,5 +120,15 @@ public class ClientService extends SearchDatabaseService<Client, ClientDAO> {
             return clients.stream().filter(client -> ServiceManager.getUserService().getAuthenticatedUser().getClients()
                     .contains(client)).map(Client::getName).collect(Collectors.joining(COMMA_DELIMITER));
         }
+    }
+
+    /**
+     * Get all clients sorted by name.
+     * @return all clients, sorted by name
+     * @throws DAOException when retrieving clients from the database fails
+     */
+    public List<Client> getAllSortedByName() throws DAOException {
+        return getAll().stream().sorted(Comparator.comparing(Client::getName))
+                .collect(Collectors.toList());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
@@ -11,6 +11,7 @@
 
 package org.kitodo.production.services.data;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,7 @@ import java.util.stream.Collectors;
 import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.beans.Project;
+import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.persistence.ImportConfigurationDAO;
 import org.kitodo.data.exceptions.DataException;
@@ -145,12 +147,17 @@ public class ImportConfigurationService extends SearchDatabaseService<ImportConf
      * @throws DAOException when ImportConfigurations could not be loaded
      */
     public List<ImportConfiguration> getAll() throws DAOException {
-        return super.getAll().stream().sorted(Comparator.comparing(ImportConfiguration::getTitle))
+        User currentUser = ServiceManager.getUserService().getCurrentUser();
+        return super.getAll().stream()
+                .filter(importConfiguration -> !Collections.disjoint(importConfiguration.getClients(), currentUser.getClients()))
+                .sorted(Comparator.comparing(ImportConfiguration::getTitle))
                 .collect(Collectors.toList());
     }
 
     private List<ImportConfiguration> getAllImportConfigurations(ImportConfigurationType type) throws DAOException {
+        User currentUser = ServiceManager.getUserService().getCurrentUser();
         return super.getAll().stream()
+                .filter(importConfiguration -> !Collections.disjoint(importConfiguration.getClients(), currentUser.getClients()))
                 .filter(importConfiguration -> type.name()
                         .equals(importConfiguration.getConfigurationType()))
                 .sorted(Comparator.comparing(ImportConfiguration::getTitle))

--- a/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
@@ -1086,4 +1086,13 @@ public class SecurityAccessService extends SecurityAccess {
     public boolean hasAuthorityToRenameMediaFiles() {
         return hasAnyAuthorityForClient("renameMedia");
     }
+
+    /**
+     * Check if the current user has the permission to assign import configurations to clients.
+     *
+     * @return true if the current user has the permission to assign import configurations to clients.
+     */
+    public boolean hasAuthorityToAssignImportConfigurationToClient() {
+        return hasAuthorityGlobal("assignImportConfigurationToClient");
+    }
 }

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -1245,6 +1245,7 @@ addTemplateProperty=Vorlageneigenschaft hinzuf\u00FCgen
 addUser=Benutzer hinzuf\u00FCgen
 addWorkflow=Workflow hinzuf\u00FCgen
 addWorkpieceProperty=Werkst\u00FCckeigenschaft hinzuf\u00FCgen
+assignImportConfigurationToClient=Importkonfiguration zu Mandanten zuweisen
 assignTasks=Aufgaben zuweisen
 overrideTasks=Aufgaben \u00FCberschreiben
 superviseTasks=Aufgaben \u00FCberwachen

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -1246,6 +1246,7 @@ addTemplateProperty=Add template property
 addUser=Add user
 addWorkflow=Add workflow
 addWorkpieceProperty=Add workpiece property
+assignImportConfigurationToClient=Assign import configuration to client
 assignTasks=Assign tasks
 overrideTasks=Override tasks
 superviseTasks=Supervise tasks

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/importConfigurations.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/importConfigurations.xhtml
@@ -19,7 +19,7 @@
 
     <!--@elvariable id="item" type="org.kitodo.data.database.beans.ImportConfiguration"-->
     <p:dataTable id="configurationTable"
-                 value="#{ImportConfigurationListView.lazyDTOModel}"
+                 value="#{ImportConfigurationListView.importConfigurations}"
                  var="item"
                  styleClass="default-layout"
                  first="#{ImportConfigurationListView.firstRow}"

--- a/Kitodo/src/main/webapp/pages/importConfigurationEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/importConfigurationEdit.xhtml
@@ -176,12 +176,15 @@
                 </p:panelGrid>
             </p:tab>
 
-            <p:tab id="clientsTab" title="#{msgs.clients}">
+            <p:tab id="clientsTab"
+                   title="#{msgs.clients}"
+                   rendered="#{SecurityAccessController.hasAuthorityToAssignImportConfigurationToClient()}">
                 <p:panelGrid columns="1"
                              layout="grid"
                              id="clients-grid">
                     <p:selectManyCheckbox id="clientsList"
                                           layout="grid"
+                                          validator="ImportConfigurationClientValidator"
                                           columns="1"
                                           collectionType="java.util.ArrayList"
                                           value="#{importConfigurationEditView.assignedClients}"

--- a/Kitodo/src/main/webapp/pages/importConfigurationEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/importConfigurationEdit.xhtml
@@ -175,6 +175,26 @@
                     </p:row>
                 </p:panelGrid>
             </p:tab>
+
+            <p:tab id="clientsTab" title="#{msgs.clients}">
+                <p:panelGrid columns="1"
+                             layout="grid"
+                             id="clients-grid">
+                    <p:selectManyCheckbox id="clientsList"
+                                          layout="grid"
+                                          columns="1"
+                                          collectionType="java.util.ArrayList"
+                                          value="#{importConfigurationEditView.assignedClients}"
+                                          converter="#{clientConverter}">
+                        <f:selectItems value="#{importConfigurationEditView.availableClients}"
+                                       var="client"
+                                       itemLabel="#{client.name}"
+                                       itemValue="#{client}"/>
+                        <p:ajax event="change"
+                                oncomplete="toggleSave()"/>
+                    </p:selectManyCheckbox>
+                </p:panelGrid>
+            </p:tab>
         </p:tabView>
     </ui:define>
 

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -449,6 +449,9 @@ public class MockDatabase {
         authorities.add(new Authority("renameMedia" + GLOBAL_ASSIGNABLE));
         authorities.add(new Authority("renameMedia" + CLIENT_ASSIGNABLE));
 
+        // Assign import configurations to clients
+        authorities.add(new Authority("assignImportConfigurationToClient" + GLOBAL_ASSIGNABLE));
+
         for (Authority authority : authorities) {
             ServiceManager.getAuthorityService().saveToDatabase(authority);
         }
@@ -1442,6 +1445,7 @@ public class MockDatabase {
         Role metadataRole = ServiceManager.getRoleService().getById(6);
         Role databaseRole = ServiceManager.getRoleService().getById(7);
         Role renameMediaRole = ServiceManager.getRoleService().getById(8);
+        Role clientAdminRole = ServiceManager.getRoleService().getById(9);
 
         User firstUser = new User();
         firstUser.setName("Jan");
@@ -1484,6 +1488,8 @@ public class MockDatabase {
         thirdUser.setLanguage("de");
         thirdUser.setActive(false);
         thirdUser.getRoles().add(adminRole);
+        thirdUser.getRoles().add(clientAdminRole);
+        thirdUser.getClients().add(secondClient);
         ServiceManager.getUserService().saveToDatabase(thirdUser);
 
         User fourthUser = new User();
@@ -1522,11 +1528,12 @@ public class MockDatabase {
 
     private static void insertRoles() throws DAOException {
         List<Authority> allAuthorities = ServiceManager.getAuthorityService().getAll();
-        Client client = ServiceManager.getClientService().getById(1);
+        Client firstClient = ServiceManager.getClientService().getById(1);
+        Client secondClient = ServiceManager.getClientService().getById(2);
 
         Role firstRole = new Role();
         firstRole.setTitle("Admin");
-        firstRole.setClient(client);
+        firstRole.setClient(firstClient);
 
         // insert administration authorities
         for (int i = 0; i < 34; i++) {
@@ -1537,7 +1544,7 @@ public class MockDatabase {
 
         Role secondRole = new Role();
         secondRole.setTitle("General");
-        secondRole.setClient(client);
+        secondRole.setClient(firstClient);
 
         // insert general authorities
         for (int i = 34; i < allAuthorities.size(); i++) {
@@ -1548,7 +1555,7 @@ public class MockDatabase {
 
         Role thirdRole = new Role();
         thirdRole.setTitle("Random for first");
-        thirdRole.setClient(client);
+        thirdRole.setClient(firstClient);
 
         // insert authorities for view on projects page
         List<Authority> userAuthoritiesForFirst = new ArrayList<>();
@@ -1578,12 +1585,12 @@ public class MockDatabase {
 
         Role fifthUserGroup = new Role();
         fifthUserGroup.setTitle("Without authorities");
-        fifthUserGroup.setClient(client);
+        fifthUserGroup.setClient(firstClient);
         ServiceManager.getRoleService().saveToDatabase(fifthUserGroup);
 
         Role sixthRole = new Role();
         sixthRole.setTitle("With partial metadata editor authorities");
-        sixthRole.setClient(client);
+        sixthRole.setClient(firstClient);
 
         // insert authorities to view metadata and gallery in metadata editor, but not structure data
         List<Authority> userMetadataAuthorities = new ArrayList<>();
@@ -1597,7 +1604,7 @@ public class MockDatabase {
         // insert database authority
         Role databaseStatisticsRole = new Role();
         databaseStatisticsRole.setTitle("Database management role");
-        databaseStatisticsRole.setClient(client);
+        databaseStatisticsRole.setClient(firstClient);
 
         List<Authority> databaseStatisticAuthorities = new ArrayList<>();
         databaseStatisticAuthorities.add(ServiceManager.getAuthorityService().getByTitle("viewDatabaseStatistic" + GLOBAL_ASSIGNABLE));
@@ -1608,11 +1615,19 @@ public class MockDatabase {
         // insert media renaming role
         Role renameMediaRole = new Role();
         renameMediaRole.setTitle("Rename process media files");
-        renameMediaRole.setClient(client);
+        renameMediaRole.setClient(firstClient);
         renameMediaRole.setAuthorities(Collections.singletonList(ServiceManager.getAuthorityService().getByTitle("renameMedia" + GLOBAL_ASSIGNABLE)));
         renameMediaRole.setAuthorities(Collections.singletonList(ServiceManager.getAuthorityService().getByTitle("renameMedia" + CLIENT_ASSIGNABLE)));
 
         ServiceManager.getRoleService().saveToDatabase(renameMediaRole);
+
+        // insert client admin role
+        Role clientAdminRole = new Role();
+        clientAdminRole.setTitle("Client administrator");
+        clientAdminRole.setClient(secondClient);
+        clientAdminRole.setAuthorities(Collections.singletonList(ServiceManager.getAuthorityService().getByTitle("assignImportConfigurationToClient" + GLOBAL_ASSIGNABLE)));
+
+        ServiceManager.getRoleService().saveToDatabase(clientAdminRole);
     }
 
     private static void insertUserFilters() throws DAOException, DataException {
@@ -1707,6 +1722,8 @@ public class MockDatabase {
 
     public static void insertImportConfigurations() throws DAOException, DataException {
         Client firstClient = ServiceManager.getClientService().getById(1);
+        Client secondClient = ServiceManager.getClientService().getById(2);
+        List<Client> clients = Arrays.asList(firstClient, secondClient);
 
         // add GBV import configuration, including id and default search fields
         ImportConfiguration gbvConfiguration = new ImportConfiguration();
@@ -1730,7 +1747,7 @@ public class MockDatabase {
         gbvConfiguration.setSearchFields(Collections.singletonList(ppnField));
         gbvConfiguration.setIdSearchField(gbvConfiguration.getSearchFields().get(0));
         gbvConfiguration.setDefaultSearchField(gbvConfiguration.getSearchFields().get(0));
-        gbvConfiguration.setClients(Collections.singletonList(firstClient));
+        gbvConfiguration.setClients(clients);
         ServiceManager.getImportConfigurationService().saveToDatabase(gbvConfiguration);
 
         // add Kalliope import configuration, including id search field
@@ -1809,7 +1826,7 @@ public class MockDatabase {
 
         k10plusConfiguration.setIdSearchField(k10plusConfiguration.getSearchFields().get(0));
         k10plusConfiguration.setParentSearchField(k10plusConfiguration.getSearchFields().get(1));
-        k10plusConfiguration.setClients(Collections.singletonList(firstClient));
+        k10plusConfiguration.setClients(clients);
         ServiceManager.getImportConfigurationService().saveToDatabase(k10plusConfiguration);
 
         for (Project project : ServiceManager.getProjectService().getAll()) {

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -1706,6 +1706,7 @@ public class MockDatabase {
     }
 
     public static void insertImportConfigurations() throws DAOException, DataException {
+        Client firstClient = ServiceManager.getClientService().getById(1);
 
         // add GBV import configuration, including id and default search fields
         ImportConfiguration gbvConfiguration = new ImportConfiguration();
@@ -1729,6 +1730,7 @@ public class MockDatabase {
         gbvConfiguration.setSearchFields(Collections.singletonList(ppnField));
         gbvConfiguration.setIdSearchField(gbvConfiguration.getSearchFields().get(0));
         gbvConfiguration.setDefaultSearchField(gbvConfiguration.getSearchFields().get(0));
+        gbvConfiguration.setClients(Collections.singletonList(firstClient));
         ServiceManager.getImportConfigurationService().saveToDatabase(gbvConfiguration);
 
         // add Kalliope import configuration, including id search field
@@ -1767,6 +1769,7 @@ public class MockDatabase {
 
         kalliopeConfiguration.setIdSearchField(kalliopeConfiguration.getSearchFields().get(0));
         kalliopeConfiguration.setParentSearchField(kalliopeConfiguration.getSearchFields().get(1));
+        kalliopeConfiguration.setClients(Collections.singletonList(firstClient));
         ServiceManager.getImportConfigurationService().saveToDatabase(kalliopeConfiguration);
 
         // add K10Plus import configuration, including id search field
@@ -1806,6 +1809,7 @@ public class MockDatabase {
 
         k10plusConfiguration.setIdSearchField(k10plusConfiguration.getSearchFields().get(0));
         k10plusConfiguration.setParentSearchField(k10plusConfiguration.getSearchFields().get(1));
+        k10plusConfiguration.setClients(Collections.singletonList(firstClient));
         ServiceManager.getImportConfigurationService().saveToDatabase(k10plusConfiguration);
 
         for (Project project : ServiceManager.getProjectService().getAll()) {

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ClientFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ClientFormIT.java
@@ -21,7 +21,7 @@ import org.kitodo.production.services.ServiceManager;
 
 public class ClientFormIT {
 
-    private ClientForm clientForm = new ClientForm();
+    private final ClientForm clientForm = new ClientForm();
 
     /**
      * Setup Database and start elasticsearch.
@@ -64,7 +64,7 @@ public class ClientFormIT {
                 .size();
         int numberOfNewAuthorities = ServiceManager.getRoleService().getAllRolesByClientId(1).get(8).getAuthorities()
                 .size();
-        Assert.assertEquals("Role was not added", 9, numberOfRolesForFirstClient);
+        Assert.assertEquals("Role was not added", 10, numberOfRolesForFirstClient);
         Assert.assertEquals("Authorities were not added", numberOfOldAuthorities, numberOfNewAuthorities);
         Assert.assertEquals("Authorities were removed from second client", numberOfAuthoritiesToCopy,
                 numberOfOldAuthorities);

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/AuthorityServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/AuthorityServiceIT.java
@@ -28,7 +28,7 @@ import org.kitodo.production.services.ServiceManager;
 public class AuthorityServiceIT {
 
     private static final AuthorityService authorityService = ServiceManager.getAuthorityService();
-    private static final int EXPECTED_AUTHORITIES_COUNT = 99;
+    private static final int EXPECTED_AUTHORITIES_COUNT = 100;
 
     @BeforeClass
     public static void prepareDatabase() throws Exception {

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
@@ -52,7 +52,7 @@ public class ImportConfigurationIT {
         User userOne = ServiceManager.getUserService().getById(1);
         SecurityTestUtils.addUserDataToSecurityContext(userOne, 1);
         List<ImportConfiguration> configs = ServiceManager.getImportConfigurationService().getAll();
-        assertEquals("Wrong number of import configurations", Long.valueOf(3), Long.valueOf(configs.size()));
+        assertEquals("Wrong number of import configurations", 3, configs.size());
         assertEquals("Wrong first import configuration", GBV, configs.get(0).getTitle());
         assertEquals("Wrong last import configuration", KALLIOPE, configs.get(2).getTitle());
     }
@@ -67,7 +67,7 @@ public class ImportConfigurationIT {
         User userThree = ServiceManager.getUserService().getById(3);
         SecurityTestUtils.addUserDataToSecurityContext(userThree, 2);
         List<ImportConfiguration> configs = ServiceManager.getImportConfigurationService().getAll();
-        assertEquals("Wrong number of import configurations", Long.valueOf(2), Long.valueOf(configs.size()));
+        assertEquals("Wrong number of import configurations",2, configs.size());
         assertFalse("User should not have access to import configuration 'Kalliope' of unassigned client",
                 configs.stream().anyMatch(config -> KALLIOPE.equals(config.getTitle())));
     }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportConfigurationIT.java
@@ -19,7 +19,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitodo.MockDatabase;
+import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.ImportConfiguration;
+import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
 
@@ -31,9 +33,12 @@ public class ImportConfigurationIT {
     @BeforeClass
     public static void prepareDatabase() throws Exception {
         MockDatabase.startNode();
+        MockDatabase.insertRolesFull();
         MockDatabase.insertMappingFiles();
         MockDatabase.insertImportConfigurations();
         MockDatabase.setUpAwaitility();
+        User userOne = ServiceManager.getUserService().getById(1);
+        SecurityTestUtils.addUserDataToSecurityContext(userOne, 1);
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
@@ -125,11 +125,11 @@ public class ImportServiceIT {
     @BeforeClass
     public static void prepareDatabase() throws Exception {
         MockDatabase.startNode();
+        MockDatabase.insertProcessesFull();
+        MockDatabase.insertProcessesForHierarchyTests();
         MockDatabase.insertMappingFiles();
         MockDatabase.insertImportConfigurations();
         MockDatabase.insertImportconfigurationWithCustomUrlParameters();
-        MockDatabase.insertProcessesFull();
-        MockDatabase.insertProcessesForHierarchyTests();
         MockDatabase.setUpAwaitility();
         User userOne = ServiceManager.getUserService().getById(1);
         SecurityTestUtils.addUserDataToSecurityContext(userOne, 1);

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/RoleServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/RoleServiceIT.java
@@ -35,7 +35,7 @@ public class RoleServiceIT {
 
     private static final RoleService roleService = ServiceManager.getRoleService();
 
-    private static final int EXPECTED_ROLES_COUNT = 8;
+    private static final int EXPECTED_ROLES_COUNT = 9;
 
     private static final String WRONG_NUMBER_OF_ROLES = "Amount of roles assigned to client is incorrect!";
 
@@ -78,7 +78,7 @@ public class RoleServiceIT {
     @Test
     public void shouldGetAllRolesInGivenRange() throws Exception {
         List<Role> roles = roleService.getAll(1, 10);
-        assertEquals("Not all user's roles were found in database!", 7, roles.size());
+        assertEquals("Not all user's roles were found in database!", 8, roles.size());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class RoleServiceIT {
         assertEquals(WRONG_NUMBER_OF_ROLES, 7, roles.size());
 
         roles = roleService.getAllRolesByClientId(2);
-        assertEquals(WRONG_NUMBER_OF_ROLES, 1, roles.size());
+        assertEquals(WRONG_NUMBER_OF_ROLES, 2, roles.size());
     }
 
     @Test
@@ -185,6 +185,6 @@ public class RoleServiceIT {
 
         user = ServiceManager.getUserService().getById(2);
         roles = roleService.getAllAvailableForAssignToUser(user);
-        assertEquals(WRONG_NUMBER_OF_ROLES, 6, roles.size());
+        assertEquals(WRONG_NUMBER_OF_ROLES, 7, roles.size());
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/security/SecurityAccessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/security/SecurityAccessServiceIT.java
@@ -51,7 +51,7 @@ public class SecurityAccessServiceIT {
         SecurityTestUtils.addUserDataToSecurityContext(user, 1);
         Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext().getAuthentication()
                 .getAuthorities();
-        Assert.assertEquals("Security context holder does not hold the corresponding authorities", 171,
+        Assert.assertEquals("Security context holder does not hold the corresponding authorities", 172,
             authorities.size());
     }
 

--- a/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
@@ -152,7 +152,6 @@ public class ImportingST extends BaseTestSelenium {
         List<String> importConfigurationNames = importPage.getImportConfigurationsTitles();
         assertEquals("Wrong title of first import configuration", TestConstants.GBV, importConfigurationNames.get(1));
         assertEquals("Wrong title of second import configuration", TestConstants.K10PLUS, importConfigurationNames.get(2));
-        assertEquals("Wrong title of third import configuration", TestConstants.KALLIOPE, importConfigurationNames.get(3));
     }
 
     /**


### PR DESCRIPTION
Since import configurations can contain sensitive data like FTP credentials, they shouldn't be freely shared between clients. This pull request adds a relation between clients and import configurations similar to that between clients and projects, so that import configurations are explicitely mapped to specific lists of clients and users can only see and use those import configurations that are mapped to at least one of their assigned clients.

(since XSLT mapping files normally do _not_ contain such sensitive data and are - like rulesets - available to all users via the file system anyway, a relation between clients and mapping files does not seem necessary and therefore has not been added)

The mapping between import configurations and clients can be edited via a new third tab named "Mandanten" ("Clients") on the import configuration edit page:

<img width="437" alt="Bildschirmfoto 2024-07-12 um 14 05 53" src="https://github.com/user-attachments/assets/4c87051e-3450-4d58-b1f5-8dcdf5729397">

The SQL migration file in this pull request that adds the corresponding cross table also assigns _all_ existing import configurations to _all_ existing clients by default to maintain the current status quo. An admin can then make use of the new functionality instroduced in this pull request and restrict access to specific configurations using the import configuration edit formular shown above.

Fixes #6059