### PR TITLE
Correct version in dockets xsl

### DIFF
--- a/Kitodo-Docket/src/test/resources/docket.xsl
+++ b/Kitodo-Docket/src/test/resources/docket.xsl
@@ -12,7 +12,7 @@
  *
 -->
 
-<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:kitodo="http://www.kitodo.org/logfile" exclude-result-prefixes="fo">
     <xsl:output method="xml" indent="yes"/>

--- a/Kitodo-Docket/src/test/resources/docket_multipage.xsl
+++ b/Kitodo-Docket/src/test/resources/docket_multipage.xsl
@@ -12,7 +12,7 @@
  *
 -->
 
-<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:kitodo="http://www.kitodo.org/logfile" exclude-result-prefixes="fo">
     <xsl:output method="xml" indent="yes"/>

--- a/Kitodo/src/main/resources/docket.xsl
+++ b/Kitodo/src/main/resources/docket.xsl
@@ -12,7 +12,7 @@
  *
 -->
 
-<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:kitodo="http://www.kitodo.org/logfile" exclude-result-prefixes="fo">
     <xsl:output method="xml" indent="yes"/>

--- a/Kitodo/src/main/resources/docket_multipage.xsl
+++ b/Kitodo/src/main/resources/docket_multipage.xsl
@@ -12,7 +12,7 @@
  *
 -->
 
-<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:kitodo="http://www.kitodo.org/logfile" exclude-result-prefixes="fo">
     <xsl:output method="xml" indent="yes"/>

--- a/Kitodo/src/test/resources/xslt/docket.xsl
+++ b/Kitodo/src/test/resources/xslt/docket.xsl
@@ -12,7 +12,7 @@
  *
 -->
 
-<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:kitodo="http://www.kitodo.org/logfile" exclude-result-prefixes="fo">
     <xsl:output method="xml" indent="yes"/>


### PR DESCRIPTION
While running tests locally (which takes very long -https://github.com/kitodo/kitodo-production/pull/6121) i noticed a message that the xsl files have the wrong version number 1.1 which automatically gets downgraded to 1.0. I replaced all the version numbers with 1.0.