### PR TITLE
Update version of flyway-maven-plugin (required for newer MariaDB)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <selenium.version>3.141.59</selenium.version>
         <spring.security.version>5.7.13</spring.security.version>
-        <flyway-maven-plugin.version>8.4.4</flyway-maven-plugin.version>
+        <flyway-maven-plugin.version>9.22.3</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.3.0</spotbugs-maven-plugin.version>
         <pitest.version>1.4.10</pitest.version>
         <mariadb-java-client.version>2.7.12</mariadb-java-client.version>


### PR DESCRIPTION
The latest version 10.15.2 cannot be used:
```
Error:  Failed to execute goal org.flywaydb:flyway-maven-plugin:10.15.2:baseline (default) on project kitodo-data-management: Execution default of goal org.flywaydb:flyway-maven-plugin:10.15.2:baseline failed: Unable to load the mojo 'baseline' in the plugin 'org.flywaydb:flyway-maven-plugin:10.15.2' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/flywaydb/maven/BaselineMojo has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

Therefore the update only updates to 9.22.3.