### PR TITLE
Enrich process with LABEL and ORDERLABEL during mass import

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -1216,6 +1216,7 @@ public class ImportService {
             processTempProcess(tempProcess, ServiceManager.getRulesetService().openRuleset(template.getRuleset()),
                     "create", Locale.LanguageRange.parse(metadataLanguage.isEmpty() ? "en" : metadataLanguage),
                     parentTempProcess);
+            setLabelAndOrderLabelOfImportedProcess(tempProcess, presetMetadata);
             String title = tempProcess.getProcess().getTitle();
             String validateRegEx = ConfigCore.getParameterOrDefaultValue(ParameterCore.VALIDATE_PROCESS_TITLE_REGEX);
             if (StringUtils.isBlank(title)) {
@@ -1290,6 +1291,19 @@ public class ImportService {
             }
         }
         return metadata;
+    }
+
+    private void setLabelAndOrderLabelOfImportedProcess(TempProcess tempProcess, Map<String, List<String>> presetMetadata) {
+        List<String> labelList = presetMetadata.get(ProcessFieldedMetadata.METADATA_KEY_LABEL);
+        List<String> orderLabelList = presetMetadata.get(ProcessFieldedMetadata.METADATA_KEY_ORDERLABEL);
+
+        if (Objects.nonNull(labelList) && !labelList.isEmpty() && !labelList.get(0).isBlank()) {
+            tempProcess.getWorkpiece().getLogicalStructure().setLabel(labelList.get(0));
+        }
+
+        if (Objects.nonNull(orderLabelList) && !orderLabelList.isEmpty() && !orderLabelList.get(0).isBlank()) {
+            tempProcess.getWorkpiece().getLogicalStructure().setOrderlabel(orderLabelList.get(0));
+        }
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
@@ -44,7 +44,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kitodo.ExecutionPermission;
@@ -227,16 +226,11 @@ public class ImportServiceIT {
         String processLabel = workpiece.getLogicalStructure().getLabel();
         String processOrderlabel = workpiece.getLogicalStructure().getOrderlabel();
         try {
-            Assert.assertTrue("Process does not contain correct metadata",
-                    assertMetadataSetContainsMetadata(metadata, TITLE, "Band 1"));
-            Assert.assertTrue("Process does not contain correct metadata",
-                    assertMetadataSetContainsMetadata(metadata, PLACE, "Hamburg"));
-            Assert.assertTrue("Process does not contain correct metadata",
-                    assertMetadataSetContainsMetadata(metadata, PLACE, "Berlin"));
-            Assert.assertEquals("Process does not have the correct LABEL",
-                    processLabel, "TEST-LABEL");
-            Assert.assertEquals("Process does not have the correct ORDERLABEL",
-                    processOrderlabel, "TEST-ORDERLABEL");
+            assertTrue(assertMetadataSetContainsMetadata(metadata, TITLE, "Band 1"), "Process does not contain correct metadata");
+            assertTrue(assertMetadataSetContainsMetadata(metadata, PLACE, "Hamburg"), "Process does not contain correct metadata");
+            assertTrue(assertMetadataSetContainsMetadata(metadata, PLACE, "Berlin"), "Process does not contain correct metadata");
+            assertEquals("TEST-LABEL", processLabel,"Process does not have the correct LABEL");
+            assertEquals("TEST-ORDERLABEL", processOrderlabel,"Process does not have the correct ORDERLABEL");
         } finally {
             ProcessTestUtils.removeTestProcess(processWithAdditionalMetadata.getId());
         }


### PR DESCRIPTION
Because of the way Kitodo production works, it is important to have the LABEL and the ORDERLABEL before the data is exported and partially enriched via XSL. 
https://github.com/kitodo/kitodo-production/issues/5016#issuecomment-1378852324
This is especially a problem when providing LABELs during mass import, because an import XSL does not take into consideration fields provided via csv upload.

This PR explicitely adds LABEL and ORDERLABEL to the logical root, when they are provided during mass import.