### PR TITLE
Replace old commons-collections:commons-collections by org.apache.commons:commons-collections4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
             cp $GITHUB_WORKSPACE/config/database.yml.actions $GITHUB_WORKSPACE/config/database.yml
             cp $GITHUB_WORKSPACE/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.actions $GITHUB_WORKSPACE/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
             mkdir -p $GITHUB_WORKSPACE/config-local
-            cp $GITHUB_WORKSPACE/Kitodo/src/main/resources/kitodo_config.properties $GITHUB_WORKSPACE/config-local
-            cp $GITHUB_WORKSPACE/Kitodo/src/main/resources/kitodo_projects.xml $GITHUB_WORKSPACE/config-local
+            # cp $GITHUB_WORKSPACE/Kitodo/src/main/resources/kitodo_config.properties $GITHUB_WORKSPACE/config-local
+            # cp $GITHUB_WORKSPACE/Kitodo/src/main/resources/kitodo_projects.xml $GITHUB_WORKSPACE/config-local
 
       # Runs a set of commands using the runners shell
       - name: start mysql
@@ -76,15 +76,15 @@ jobs:
             mvn --version
       - name: Run dependency:analyze
         run:
-            mvn -B dependency:analyze
+            mvn -B '-P!development' dependency:analyze
       - name: Run production build (required for dependency tree)
         run: |
-            sudo mkdir -p /usr/local/kitodo/modules
-            ls -l /usr/local/kitodo $GITHUB_WORKSPACE
-            mvn -B clean install
+            # sudo mkdir -p /usr/local/kitodo/modules
+            # ls -l /usr/local/kitodo $GITHUB_WORKSPACE
+            mvn -B '-P!development' clean install
       - name: Run dependency:tree
         run:
-            mvn -B dependency:tree
+            mvn -B '-P!development' dependency:tree
       - name: run build
         run:
             mvn clean install -B '-Pall-tests,flyway,checkstyle,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,8 +71,12 @@ jobs:
       - name: check maven version
         run:
             mvn --version
+      - name: Run dependency:analyze
+        run:
+            mvn -B dependency:analyze
+      - name: Run dependency:tree
+        run:
+            mvn -B dependency:tree
       - name: run build
         run:
             mvn clean install -B '-Pall-tests,flyway,checkstyle,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
-
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
             cp $GITHUB_WORKSPACE/config/database.yml.actions $GITHUB_WORKSPACE/config/database.yml
             cp $GITHUB_WORKSPACE/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.actions $GITHUB_WORKSPACE/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
+            mkdir -p $GITHUB_WORKSPACE/config-local
+            cp $GITHUB_WORKSPACE/Kitodo/src/main/resources/kitodo_projects.xml $GITHUB_WORKSPACE/config-local
 
       # Runs a set of commands using the runners shell
       - name: start mysql

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
             cp $GITHUB_WORKSPACE/config/database.yml.actions $GITHUB_WORKSPACE/config/database.yml
             cp $GITHUB_WORKSPACE/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties.actions $GITHUB_WORKSPACE/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
             mkdir -p $GITHUB_WORKSPACE/config-local
+            cp $GITHUB_WORKSPACE/Kitodo/src/main/resources/kitodo_config.properties $GITHUB_WORKSPACE/config-local
             cp $GITHUB_WORKSPACE/Kitodo/src/main/resources/kitodo_projects.xml $GITHUB_WORKSPACE/config-local
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,9 @@ jobs:
         run:
             mvn -B dependency:analyze
       - name: Run production build (required for dependency tree)
-        run:
+        run: |
+            sudo mkdir -p /usr/local/kitodo/modules
+            ls -l /usr/local/kitodo $GITHUB_WORKSPACE
             mvn -B clean install
       - name: Run dependency:tree
         run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Run dependency:analyze
         run:
             mvn -B dependency:analyze
+      - name: Run production build (required for dependency tree)
+        run:
+            mvn -B clean install
       - name: Run dependency:tree
         run:
             mvn -B dependency:tree

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -35,6 +35,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+	</dependency>
+        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-servlet-api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,9 +164,9 @@
                 <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -352,10 +352,6 @@ from system library in Java 11+ -->
                     <exclusion>
                         <groupId>commons-beanutils</groupId>
                         <artifactId>commons-beanutils</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-collections</groupId>
-                        <artifactId>commons-collections</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
commons-collections4 was already pulled in by other dependencies, and having two packages can cause conflicts and increases the size of the war file.