### PR TITLE
Replace outdated org.codehaus.jackson:* by com.fasterxml.jackson.core:*

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -52,9 +52,13 @@
             <groupId>com.itextpdf</groupId>
             <artifactId>itextpdf</artifactId>
         </dependency>
+	<dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-xc</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -11,6 +11,9 @@
 
 package org.kitodo.production.forms;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
@@ -42,8 +45,6 @@ import javax.validation.ValidatorFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Client;

--- a/pom.xml
+++ b/pom.xml
@@ -416,10 +416,15 @@ from system library in Java 11+ -->
                 <artifactId>camunda-bpmn-model</artifactId>
                 <version>7.17.0</version>
             </dependency>
+	    <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.17.1</version>
+            </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-xc</artifactId>
-                <version>1.9.13</version>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.17.1</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
[org.codehaus.jackson:*](https://github.com/codehaus/jackson) is archived (= unmaintained) legacy code which should be [replaced](https://www.google.com/search?q=replace+org.codehaus.jackson).