### PR TITLE
Add option to show last comment directly in comment column

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -573,6 +573,11 @@ public enum ParameterCore implements ParameterInterface {
     OCR_URL(new Parameter<UndefinedParameter>("ocrUrl")),
 
     /**
+     * Show most recent comment in process list and task list.
+     */
+    SHOW_LAST_COMMENT(new Parameter<>("showLastComment", false)),
+
+    /**
      * Process properties to display in process list.
      */
     PROCESS_PROPERTIES(new Parameter<>("processPropertyColumns")),

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
@@ -80,7 +80,7 @@ public class CommentTooltipView {
         if (comments.isEmpty()) {
             return "";
         }
-        return comments.get(0).getMessage();
+        return comments.get(comments.size() - 1).getMessage();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CommentTooltipView.java
@@ -68,4 +68,28 @@ public class CommentTooltipView {
     public List<Comment> getComments(TaskDTO taskDTO) {
         return getComments(taskDTO.getProcess());
     }
+
+    /**
+     * Get the most recent comment of the given process.
+     *
+     * @param processDTO process as ProcessDTO
+     * @return message of the comment
+     */
+    public String getLastComment(ProcessDTO processDTO) {
+        List<Comment> comments = getComments(processDTO);
+        if (comments.isEmpty()) {
+            return "";
+        }
+        return comments.get(0).getMessage();
+    }
+
+    /**
+     * Get the most recent comment of process containing the given task.
+     *
+     * @param taskDTO task as TaskDTO
+     * @return message of the comment
+     */
+    public String getLastComment(TaskDTO taskDTO) {
+        return getLastComment(taskDTO.getProcess());
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -28,6 +28,8 @@ import javax.inject.Named;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kitodo.config.ConfigCore;
+import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Batch;
 import org.kitodo.data.database.beans.Folder;
 import org.kitodo.data.database.beans.Process;
@@ -817,4 +819,14 @@ public class CurrentTaskForm extends BaseForm {
     public FilterMenu getFilterMenu() {
         return filterMenu;
     }
+
+    /**
+     * Determine whether the last comment should be displayed in the comments column.
+     *
+     * @return boolean
+     */
+    public boolean showLastComment() {
+        return ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.SHOW_LAST_COMMENT);
+    }
+
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -1190,4 +1190,13 @@ public class ProcessForm extends TemplateBaseForm {
         }
         return false;
     }
+
+    /**
+     * Determine whether the last comment should be displayed in the comments column.
+     *
+     * @return boolean
+     */
+    public boolean showLastComment() {
+        return ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.SHOW_LAST_COMMENT);
+    }
 }

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -568,6 +568,13 @@ showOcrButton=false
 ocrUrl=
 
 # -----------------------------------
+# Show last comment
+# -----------------------------------
+# Display the most recent comment of a process in the comments column.
+# It will be displayed next to the comments icon in the process and task list.
+showLastComment=false
+
+# -----------------------------------
 # Display process properties
 # -----------------------------------
 

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1800,8 +1800,8 @@ Mass import
     padding-right: var(--default-half-size);
 }
 
-.comment-column {
-    text-align: center;
+.comment-column .fa {
+    margin-right: var(--default-half-size);
 }
 
 .comment-column .fa-comment {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -116,6 +116,8 @@
                         #{process.correctionCommentStatus gt 0 ? 'fa-exclamation-circle correction' : 'fa-comment'}
                         #{process.correctionCommentStatus eq 1 ? 'corrected' : ''}"
                                   rendered="#{process.hasComments()}"/>
+                    <h:outputText value="#{commentTooltipView.getLastComment(process)}"
+                                  rendered="#{ProcessForm.showLastComment() and process.hasComments()}"/>
                 </h:panelGroup>
                 <p:tooltip for="commentIcon" styleClass="comments" trackMouse="true" rendered="#{process.hasComments()}">
                     <ui:include src="/WEB-INF/templates/includes/base/commentTooltip.xhtml">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/taskList.xhtml
@@ -123,6 +123,8 @@
                         #{item.correctionCommentStatus gt 0 ? 'fa-exclamation-circle correction' : 'fa-comment'}
                         #{item.correctionCommentStatus eq 1 ? 'corrected' : ''}"
                                   rendered="#{item.getProcess().hasComments()}"/>
+                    <h:outputText value="#{commentTooltipView.getLastComment(item)}"
+                                  rendered="#{CurrentTaskForm.showLastComment() and item.getProcess().hasComments()}"/>
                 </h:panelGroup>
                 <p:tooltip for="commentIcon" styleClass="comments" trackMouse="true">
                     <ui:include src="/WEB-INF/templates/includes/base/commentTooltip.xhtml">


### PR DESCRIPTION
This pull request adds the option `showLastComment` to the kitodo-config.properties file.
When set to true this will display the most recent comment in the  comments column in the task list and the process list.
This increases the informations the user can retrieve at a glance, without the need to hover over every comment icon.
![Bildschirmfoto 2024-07-26 um 09 55 31](https://github.com/user-attachments/assets/8b7e222f-547e-4f15-b291-e2ea793f4f54)
This change does not affect the functionality of the enhanced tooltip implemented in #5403. The new option is deactivated by default (the new parameter `showLastComment` defaults to `false` if not present).

