### PR TITLE
Remove unused dependency org.apache.pdfbox:pdfbox

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -145,18 +145,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-web</artifactId>
         </dependency>
-        <!-- overwrite parent dependency -->
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox</artifactId>
-            <version>2.0.32</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>


### PR DESCRIPTION
It's only used in Kitodo-Docket which has its own dependency entry.