### PR TITLE
Correction comment state

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -405,6 +405,10 @@ public class WorkflowControllerService {
             taskService.replaceProcessingUser(currentTask, getCurrentUser());
             taskService.save(currentTask);
         }
+        // "currentTask" and "process" are re-added to the comment object without saving it to database, again, because
+        // comment is further used in calling method, hence we make use of a side effect here (without requiring to save
+        // the comment again, because process ID and current task ID remain the same)
+        // TODO: refactor to improve readability and maintainability
         comment.setCurrentTask(ServiceManager.getTaskService().getById(comment.getCurrentTask().getId()));
         if (Objects.nonNull(comment.getProcess())) {
             comment.setProcess(ServiceManager.getProcessService().getById(comment.getProcess().getId()));

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -386,6 +386,13 @@ public class WorkflowControllerService {
      */
     public void solveProblem(Comment comment, TaskEditType taskEditType)
             throws DataException, DAOException, IOException {
+        comment.setCorrected(Boolean.TRUE);
+        comment.setCorrectionDate(new Date());
+        try {
+            ServiceManager.getCommentService().saveToDatabase(comment);
+        } catch (DAOException e) {
+            Helper.setErrorMessage("errorSaving", new Object[] {"comment"}, logger, e);
+        }
         if (Objects.nonNull(comment.getCorrectionTask())) {
             closeTaskByUser(comment.getCorrectionTask());
             comment.setCorrectionTask(ServiceManager.getTaskService().getById(comment.getCorrectionTask().getId()));
@@ -399,12 +406,8 @@ public class WorkflowControllerService {
             taskService.save(currentTask);
         }
         comment.setCurrentTask(ServiceManager.getTaskService().getById(comment.getCurrentTask().getId()));
-        comment.setCorrected(Boolean.TRUE);
-        comment.setCorrectionDate(new Date());
-        try {
-            ServiceManager.getCommentService().saveToDatabase(comment);
-        } catch (DAOException e) {
-            Helper.setErrorMessage("errorSaving", new Object[] {"comment"}, logger, e);
+        if (Objects.nonNull(comment.getProcess())) {
+            comment.setProcess(ServiceManager.getProcessService().getById(comment.getProcess().getId()));
         }
     }
 


### PR DESCRIPTION
This pull request slightly adjusts the `WorkflowControllerService.solveProblem` function so that a comment's `corrected` flag with value `TRUE` is saved to the database _before_ `closeTaskByUser` is called. That method loads the comment from the database and requires the updated `corrected` state to work properly. 

The updated `corrected` state is then saved to the index field `correctionCommentStatus` which in turn is used to determine whether the grey or red exclamation mark icon should be displayed in the process and task lists. Thereby fixes #5676 