### PR TITLE
Revert "Use special property `revision` to set the version only once"

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - API</name>

--- a/Kitodo-Command/pom.xml
+++ b/Kitodo-Command/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Command</name>

--- a/Kitodo-DataEditor/pom.xml
+++ b/Kitodo-DataEditor/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Data Editor</name>

--- a/Kitodo-DataFormat/pom.xml
+++ b/Kitodo-DataFormat/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Data Format</name>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Data Management</name>

--- a/Kitodo-Docket/pom.xml
+++ b/Kitodo-Docket/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Docket</name>

--- a/Kitodo-FileManagement/pom.xml
+++ b/Kitodo-FileManagement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - File Management</name>

--- a/Kitodo-ImageManagement/pom.xml
+++ b/Kitodo-ImageManagement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Image Management</name>

--- a/Kitodo-LongTermPreservationValidation/pom.xml
+++ b/Kitodo-LongTermPreservationValidation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Long Term Preservation Validation</name>

--- a/Kitodo-PersistentIdentifier/pom.xml
+++ b/Kitodo-PersistentIdentifier/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Persistent Identifier</name>

--- a/Kitodo-Query-URL-Import/pom.xml
+++ b/Kitodo-Query-URL-Import/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Query URL Import</name>

--- a/Kitodo-Validation/pom.xml
+++ b/Kitodo-Validation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Validation</name>

--- a/Kitodo-XML-SchemaConverter/pom.xml
+++ b/Kitodo-XML-SchemaConverter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - XML SchemaConverter</name>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.kitodo</groupId>
         <artifactId>kitodo-production</artifactId>
-        <version>${revision}</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <name>Kitodo - Core</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.kitodo</groupId>
     <artifactId>kitodo-production</artifactId>
-    <version>${revision}</version>
+    <version>3.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <organization>
@@ -30,8 +30,7 @@
     <url>https://github.com/kitodo/kitodo-production</url>
 
     <properties>
-        <revision>3.7.0-SNAPSHOT</revision>
-        <kitodo.version>${revision}</kitodo.version>
+        <kitodo.version>3.7.0-SNAPSHOT</kitodo.version>
         <checkstyle.config.location>config/checkstyle.xml</checkstyle.config.location>
         <main.basedir>${project.basedir}</main.basedir>
         <phase.prop>none</phase.prop>


### PR DESCRIPTION
Reverts kitodo/kitodo-production#6127

Fixes #6153 

As this pull request creates POM files for every module and the whole project with wrong artifact version information. 

With this wrong artifact version information `$revision` which can not be resolved inside the project by Maven itself and even not if you want to re-use a Kitodo.Production module in an other context (maybe currently only a future view) or want to develop an extended module which is basing on an existing Kitodo.Production module (which may already happen).

The issue is, that `$revision` is set as a placeholder inside the needed artifact but is read by maven not as a placeholder but as as string value. This is mismatching while resolving the artifact version.

Using the `revision` as a special property may not be bad but is current usage is wrong or at least not right. Until this is fixed the changes should be reverted and should be re-applied after this issue itself is fixed.