### PR TITLE
Add missing `Override` annotation

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportConfigurationService.java
@@ -146,6 +146,7 @@ public class ImportConfigurationService extends SearchDatabaseService<ImportConf
      * @return list of all ImportConfigurations sorted by title
      * @throws DAOException when ImportConfigurations could not be loaded
      */
+    @Override
     public List<ImportConfiguration> getAll() throws DAOException {
         User currentUser = ServiceManager.getUserService().getCurrentUser();
         return super.getAll().stream()


### PR DESCRIPTION
CodeQL reported:

> Java enables you to annotate methods that are intended to override a method in a superclass. Compilers are required to generate an error if such an annotated method does not override a method in a superclass, which provides increased protection from potential defects. An annotated method also improves code readability.

This PR adds the missing annotation.