### PR TITLE
Add org.codehaus.mojo:flatten-maven-plugin (fixes #6153)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /javadoc
 # local build of docs with mkdocs
 /site
+# flatten-maven-plugin
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -867,6 +867,31 @@ from system library in Java 11+ -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>flatten-maven-plugin</artifactId>
+              <version>1.1.0</version>
+              <configuration>
+                <updatePomFile>true</updatePomFile>
+                <flattenMode>resolveCiFriendliesOnly</flattenMode>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>flatten</id>
+                  <phase>process-resources</phase>
+                  <goals>
+                    <goal>flatten</goal>
+                  </goals>
+                </execution>
+                <execution>
+                  <id>flatten.clean</id>
+                  <phase>clean</phase>
+                  <goals>
+                    <goal>clean</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This plugin is required for the Maven CI friendly multi module setup, see
https://maven.apache.org/maven-ci-friendly.html#install-deploy.

Fixes: #6153 