### PR TITLE
Add flyway-maven-plugin to plugins and update flyway related configuration

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
+++ b/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
@@ -1,4 +1,4 @@
 flyway.user=kitodo
 flyway.password=kitodo
-flyway.url=jdbc:mysql://localhost/kitodo?useSSL=false
-flyway.locations=filesystem:../Kitodo-DataManagement/src/main/resources/db/migration
+flyway.url=jdbc:mysql://localhost/kitodo
+flyway.locations=filesystem:Kitodo-DataManagement/src/main/resources/db/migration

--- a/pom.xml
+++ b/pom.xml
@@ -843,6 +843,37 @@ from system library in Java 11+ -->
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.5</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.flywaydb</groupId>
+                    <artifactId>flyway-maven-plugin</artifactId>
+                    <version>${flyway-maven-plugin.version}</version>
+                    <configuration>
+                        <configFiles>
+                            <!-- local configuration file -->
+                            <!--<configFile>${main.basedir}/config-local/flyway.properties</configFile>-->
+                            <configFile>
+                                ${main.basedir}/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
+                            </configFile>
+                        </configFiles>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.mysql</groupId>
+                            <artifactId>mysql-connector-j</artifactId>
+                            <version>${mysql.version}</version>
+                        </dependency>
+                       <dependency>
+                           <groupId>org.flywaydb</groupId>
+                          <artifactId>flyway-mysql</artifactId>
+                          <version>${flyway-maven-plugin.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mariadb.jdbc</groupId>
+                            <artifactId>mariadb-java-client</artifactId>
+                            <version>${mariadb-java-client.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -1016,16 +1047,16 @@ from system library in Java 11+ -->
                         <configuration>
                             <configFiles>
                                 <!-- local configuration file -->
-                                <!--<configFile>${basedir}/config-local/flyway.properties</configFile>-->
+                                <!--<configFile>${main.basedir}/config-local/flyway.properties</configFile>-->
                                 <configFile>
-                                    ${basedir}/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
+                                    ${main.basedir}/Kitodo-DataManagement/src/main/resources/db/config/flyway.properties
                                 </configFile>
                             </configFiles>
                         </configuration>
                         <dependencies>
                             <dependency>
-                                <groupId>mysql</groupId>
-                                <artifactId>mysql-connector-java</artifactId>
+                                <groupId>com.mysql</groupId>
+                                <artifactId>mysql-connector-j</artifactId>
                                 <version>${mysql.version}</version>
                             </dependency>
                             <dependency>


### PR DESCRIPTION
- fix dependency
- use main.basedir instead of basedir in path of flyway.properties and update url

This allows running `mvn flyway:migrate` from the source root directory.