### PR TITLE
Change groupId of Kitodo-Validation

### DIFF
--- a/Kitodo-Validation/pom.xml
+++ b/Kitodo-Validation/pom.xml
@@ -23,7 +23,7 @@
     </parent>
 
     <name>Kitodo - Validation</name>
-    <groupId>org.kitodo.validation</groupId>
+    <groupId>org.kitodo</groupId>
     <artifactId>kitodo-validation</artifactId>
 
     <properties>


### PR DESCRIPTION
~No other module has a groupId, and there is no obvious reason for one here.~

The other modules have no explicit groupId, but use `org.kitodo` implicitly.