### PR TITLE
Remove junit4 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -542,12 +542,6 @@ from system library in Java 11+ -->
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.jvnet.jaxb2_commons</groupId>
                 <artifactId>jaxb2-basics-runtime</artifactId>
                 <version>${jaxb2-basics-runtime.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
                 <groupId>com.xebialabs.restito</groupId>
                 <artifactId>restito</artifactId>
                 <version>0.9.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This is the last pull request to remove the old needed dependency to execute Junit 4 based tests inside a Junit 5 test system. If this pull request is merged then all tests should be written / created as Junit 5 based tests.

The pull request include an optional commit to remove the transitive dependency to an old junit 4  from a used dependency. If this transitive dependency is not removed it is still possible to create or write Junit 4 code but the execution of this code should fail. So far as I could I discovered no issues with removing this transitive dependency.