### PR TITLE
Improve suggestions for properties in filter menu

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
@@ -220,14 +220,24 @@ public class FilterMenu {
                 suggestions.addAll(createStringSuggestionsMatchingInput(input, filterService.initProjects(), FilterPart.VALUE));
                 break;
             case PROPERTY:
-                suggestions.addAll(createStringSuggestionsMatchingInput(input,
-                    filterService.initProcessPropertyTitles(), FilterPart.VALUE));
+                suggestions.addAll(createStringSuggestionsMatchingInput(input, initProcessPropertyTitles(), FilterPart.VALUE));
                 break;
             default:
                 // Do nothing
                 break;
         }
         return suggestions;
+    }
+
+    /**
+     * Get list of process properties and format them with a trailing colon.
+     *
+     * @return List of formatted process property keys
+     */
+    private List<String> initProcessPropertyTitles() {
+        return ServiceManager.getFilterService().initProcessPropertyTitles().stream()
+                .map(propertyTitle -> propertyTitle + ":")
+                .collect(Collectors.toList());
     }
 
     private List<Suggestion> createSuggestionsForTaskValue(FilterString category, String input) {
@@ -246,8 +256,7 @@ public class FilterMenu {
                 suggestions.addAll(createStringSuggestionsMatchingInput(input, filterService.initProjects(), FilterPart.VALUE));
                 break;
             case PROPERTY:
-                suggestions.addAll(createStringSuggestionsMatchingInput(input,
-                    filterService.initProcessPropertyTitles(), FilterPart.VALUE));
+                suggestions.addAll(createStringSuggestionsMatchingInput(input, initProcessPropertyTitles(), FilterPart.VALUE));
                 break;
             default:
                 // Do nothing


### PR DESCRIPTION
Filtering for a property uses the following syntax: `property:KEY:VALUE`.
Currently the strings `property:` and `KEY` (dynamic value) can be taken from the suggestions. The user has to type the second colon by hand every time, before typing the actual, wanted value.

This pull request adds the colon to the suggestion, so the user only has to type the value manually.