### PR TITLE
Create xlsx Excel file

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -18,7 +18,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.kitodo.data.elasticsearch.index.type.enums.ProcessTypeField;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.dto.ProcessDTO;
@@ -56,7 +56,7 @@ public class SearchResultGeneration {
      *
      * @return HSSFWorkbook
      */
-    public XSSFWorkbook getResult() {
+    public SXSSFWorkbook getResult() {
         return getWorkbook();
     }
 
@@ -96,8 +96,8 @@ public class SearchResultGeneration {
         return query;
     }
 
-    private XSSFWorkbook getWorkbook() {
-        XSSFWorkbook workbook = new XSSFWorkbook();
+    private SXSSFWorkbook getWorkbook() {
+        SXSSFWorkbook workbook = new SXSSFWorkbook();
         Sheet sheet = workbook.createSheet("Search results");
 
         Row title = sheet.createRow(0);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -16,9 +16,9 @@ import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.poi.hssf.usermodel.HSSFRow;
-import org.apache.poi.hssf.usermodel.HSSFSheet;
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.kitodo.data.elasticsearch.index.type.enums.ProcessTypeField;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.production.dto.ProcessDTO;
@@ -56,7 +56,7 @@ public class SearchResultGeneration {
      *
      * @return HSSFWorkbook
      */
-    public HSSFWorkbook getResult() {
+    public XSSFWorkbook getResult() {
         return getWorkbook();
     }
 
@@ -96,11 +96,11 @@ public class SearchResultGeneration {
         return query;
     }
 
-    private HSSFWorkbook getWorkbook() {
-        HSSFWorkbook workbook = new HSSFWorkbook();
-        HSSFSheet sheet = workbook.createSheet("Search results");
+    private XSSFWorkbook getWorkbook() {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("Search results");
 
-        HSSFRow title = sheet.createRow(0);
+        Row title = sheet.createRow(0);
         title.createCell(0).setCellValue(this.filter);
         for (int i = 1; i < 8; i++) {
             title.createCell(i).setCellValue("");
@@ -113,7 +113,7 @@ public class SearchResultGeneration {
         return workbook;
     }
 
-    private void insertRowData(HSSFSheet sheet) {
+    private void insertRowData(Sheet sheet) {
         int rowCounter = 2;
         long numberOfProcessedProcesses = 0;
         int elasticsearchLimit = 9999;
@@ -149,8 +149,8 @@ public class SearchResultGeneration {
         }
     }
 
-    private void setRowHeader(HSSFSheet sheet) {
-        HSSFRow rowHeader = sheet.createRow(1);
+    private void setRowHeader(Sheet sheet) {
+        Row rowHeader = sheet.createRow(1);
         rowHeader.createCell(0).setCellValue(Helper.getTranslation("title"));
         rowHeader.createCell(1).setCellValue(Helper.getTranslation("ID"));
         rowHeader.createCell(2).setCellValue(Helper.getTranslation("Datum"));
@@ -161,8 +161,8 @@ public class SearchResultGeneration {
         rowHeader.createCell(7).setCellValue(Helper.getTranslation("Status"));
     }
 
-    private void prepareRow(int rowCounter, HSSFSheet sheet, ProcessDTO processDTO) {
-        HSSFRow row = sheet.createRow(rowCounter);
+    private void prepareRow(int rowCounter, Sheet sheet, ProcessDTO processDTO) {
+        Row row = sheet.createRow(rowCounter);
         row.createCell(0).setCellValue(processDTO.getTitle());
         row.createCell(1).setCellValue(processDTO.getId());
         row.createCell(2).setCellValue(processDTO.getCreationDate());

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -82,7 +82,7 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.XML;
@@ -1559,7 +1559,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             try (OutputStream out = response.getResponseOutputStream()) {
                 SearchResultGeneration sr = new SearchResultGeneration(filter, showClosedProcesses,
                         showInactiveProjects);
-                XSSFWorkbook wb = sr.getResult();
+                SXSSFWorkbook wb = sr.getResult();
                 List<List<Cell>> rowList = new ArrayList<>();
                 Sheet mySheet = wb.getSheetAt(0);
                 Iterator<Row> rowIter = mySheet.rowIterator();
@@ -1585,6 +1585,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
                 }
 
                 document.close();
+                wb.close();
                 out.flush();
                 facesContext.responseComplete();
             }
@@ -1605,8 +1606,9 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             try (OutputStream out = response.getResponseOutputStream()) {
                 SearchResultGeneration sr = new SearchResultGeneration(filter, showClosedProcesses,
                         showInactiveProjects);
-                XSSFWorkbook wb = sr.getResult();
+                SXSSFWorkbook wb = sr.getResult();
                 wb.write(out);
+                wb.close();
                 out.flush();
                 facesContext.responseComplete();
             }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -78,13 +78,11 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.join.ScoreMode;
-import org.apache.poi.hssf.usermodel.HSSFCell;
-import org.apache.poi.hssf.usermodel.HSSFRow;
-import org.apache.poi.hssf.usermodel.HSSFSheet;
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.XML;
@@ -1561,16 +1559,16 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             try (OutputStream out = response.getResponseOutputStream()) {
                 SearchResultGeneration sr = new SearchResultGeneration(filter, showClosedProcesses,
                         showInactiveProjects);
-                HSSFWorkbook wb = sr.getResult();
-                List<List<HSSFCell>> rowList = new ArrayList<>();
-                HSSFSheet mySheet = wb.getSheetAt(0);
+                XSSFWorkbook wb = sr.getResult();
+                List<List<Cell>> rowList = new ArrayList<>();
+                Sheet mySheet = wb.getSheetAt(0);
                 Iterator<Row> rowIter = mySheet.rowIterator();
                 while (rowIter.hasNext()) {
-                    HSSFRow myRow = (HSSFRow) rowIter.next();
+                    Row myRow = (Row) rowIter.next();
                     Iterator<Cell> cellIter = myRow.cellIterator();
-                    List<HSSFCell> row = new ArrayList<>();
+                    List<Cell> row = new ArrayList<>();
                     while (cellIter.hasNext()) {
-                        HSSFCell myCell = (HSSFCell) cellIter.next();
+                        Cell myCell = (Cell) cellIter.next();
                         row.add(myCell);
                     }
                     rowList.add(row);
@@ -1603,11 +1601,11 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             throws IOException {
         FacesContext facesContext = FacesContext.getCurrentInstance();
         if (!facesContext.getResponseComplete()) {
-            ExternalContext response = prepareHeaderInformation(facesContext, "search.xls");
+            ExternalContext response = prepareHeaderInformation(facesContext, "search.xlsx");
             try (OutputStream out = response.getResponseOutputStream()) {
                 SearchResultGeneration sr = new SearchResultGeneration(filter, showClosedProcesses,
                         showInactiveProjects);
-                HSSFWorkbook wb = sr.getResult();
+                XSSFWorkbook wb = sr.getResult();
                 wb.write(out);
                 out.flush();
                 facesContext.responseComplete();
@@ -1649,15 +1647,15 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         return externalContext;
     }
 
-    private PdfPTable getPdfTable(List<List<HSSFCell>> rowList) throws DocumentException {
+    private PdfPTable getPdfTable(List<List<Cell>> rowList) throws DocumentException {
         // create formatter for cells with default locale
         DataFormatter formatter = new DataFormatter();
 
         PdfPTable table = new PdfPTable(8);
         table.setSpacingBefore(20);
         table.setWidths(new int[] {4, 1, 2, 1, 1, 1, 2, 2 });
-        for (List<HSSFCell> row : rowList) {
-            for (HSSFCell hssfCell : row) {
+        for (List<Cell> row : rowList) {
+            for (Cell hssfCell : row) {
                 String stringCellValue = formatter.formatCellValue(hssfCell);
                 table.addCell(stringCellValue);
             }


### PR DESCRIPTION
resolves https://github.com/kitodo/kitodo-production/issues/6172
This PR changes the used classes in order to create xlsx files when exporting an Excel file to be compatible with newer Excel versions.  

I am using SXSSFWorkbook to generate Excel and PDF files, which has a lower memory footprint by flushing intermediary files to disk. See: https://www.baeldung.com/java-apache-poi-workbook-evaluation 

This will hopefully enable exporting even longer lists of processes to Excel in the future.

The dependency issues described in this PR were resolved by https://github.com/kitodo/kitodo-production/pull/6362
