### PR TITLE
Update doc type in form before searching potential parent processes

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -192,8 +192,8 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                 } else {
                     createProcessForm.setProcesses(processes);
                     TempProcess currentTempProcess = processes.getFirst();
-                    attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
                     createProcessForm.fillCreateProcessForm(currentTempProcess);
+                    attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
                     showMessageAndRecord(importConfiguration, processes);
                 }
             } catch (IOException | ProcessGenerationException | XPathExpressionException | URISyntaxException


### PR DESCRIPTION
This pull request changes the code so that the frontend is updated _before_ potential parent processes are determined, because that is based - additional to other criteria - on the doc type of the new child process, which is taken from the updated frontend.

Thus fixes #5596 