### PR TITLE
Speed up display of parent processes

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
@@ -105,15 +105,16 @@ public class Searcher extends Index {
     }
 
     /**
-     * Get documents by id.
+     * Retrieves a mapping of document IDs to their corresponding base type for the given list of IDs.
+     * Delegates to the `SearchRestClient`.
      *
      * @param ids
-     *            of searched document as List
-     * @return JSONObject
+     *            the list of document IDs to search for.
+     * @return a map where each key is a document ID and the value is the corresponding base type of the document.
      */
-    public List<Map<String, Object>> getDocuments(List<Integer> ids) throws CustomResponseException, DataException {
+    public Map<Integer, String> fetchIdToBaseTypeMap(List<Integer> ids) throws CustomResponseException, DataException {
         SearchRestClient restClient = initiateRestClient();
-        return restClient.getDocuments(this.type,ids);
+        return restClient.fetchIdToBaseTypeMap(this.type,ids);
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/search/Searcher.java
@@ -105,6 +105,18 @@ public class Searcher extends Index {
     }
 
     /**
+     * Get documents by id.
+     *
+     * @param ids
+     *            of searched document as List
+     * @return JSONObject
+     */
+    public List<Map<String, Object>> getDocuments(List<Integer> ids) throws CustomResponseException, DataException {
+        SearchRestClient restClient = initiateRestClient();
+        return restClient.getDocuments(this.type,ids);
+    }
+
+    /**
      * Find document by id.
      *
      * @param id

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -601,8 +601,10 @@ public class StructurePanel implements Serializable {
     /**
      * Build a StructureTreeNode for a logical division, which is then visualized in the logical structure tree.
      *
-     * @param structure the logical division
-     * @return the StructureTreeNode instance
+     * @param structure the logical division for which the tree node is being constructed
+     * @param idTypeMap the mapping of process id to basetype
+     * @param viewCache a cache for storing and retrieving already processed StructuralElementViews
+     * @return the constructed {@link StructureTreeNode} instance representing the given logical division
      */
     private StructureTreeNode buildStructureTreeNode(LogicalDivision structure,  Map<Integer, String> idTypeMap,
                                                      Map<String, StructuralElementViewInterface> viewCache) {
@@ -640,6 +642,7 @@ public class StructurePanel implements Serializable {
      * @param structure the current logical structure
      * @param result the current corresponding primefaces tree node
      * @param processTypeMap the mapping of process id to basetype
+     * @param viewCache a cache for storing and retrieving already processed StructuralElementViews
      * @return a collection of views that contains all views of the full sub-tree
      */
     private Collection<View> buildStructureTreeRecursively(LogicalDivision structure, TreeNode result, Map<Integer,

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1730,6 +1730,13 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         return "";
     }
 
+    /**
+     * Retrieves a mapping of process IDs to their corresponding base types.
+     *
+     * @param processIds
+     *            list of document IDs to retrieve and process.
+     * @return a map where the keys are document IDs and the values are their associated base types
+     */
     public Map<Integer, String> getIdBaseTypeMap(List<Integer> processIds) throws DataException {
         return fetchIdToBaseTypeMap(processIds);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1730,6 +1730,10 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
         return "";
     }
 
+    public Map<Integer, String> getIdBaseTypeMap(List<Integer> processIds) throws DataException {
+        return getIdTypeMap(processIds);
+    }
+
     /**
      * Filter for correction / solution messages.
      *

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1731,7 +1731,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     }
 
     public Map<Integer, String> getIdBaseTypeMap(List<Integer> processIds) throws DataException {
-        return getIdTypeMap(processIds);
+        return fetchIdToBaseTypeMap(processIds);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -20,6 +20,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -453,6 +454,29 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     public S findById(Integer id, boolean related) throws DataException {
         try {
             return convertJSONObjectToDTO(searcher.findDocument(id), related);
+        } catch (CustomResponseException e) {
+            throw new DataException(e);
+        }
+    }
+
+    /**
+     * Retrieves documents for the given list of IDs, extracts the "id" and "baseType" fields,
+     * and maps each ID to its corresponding base type.
+     *
+     * @param ids
+     *            list of document IDs to retrieve and process.
+     * @return a map where the keys are document IDs and the values are their associated base types.
+     */
+    public Map<Integer, String> getIdTypeMap(List<Integer> ids) throws DataException {
+        try {
+            List<Map<String, Object>> documents = searcher.getDocuments(ids);
+            Map<Integer, String> idToBaseTypeMap = new HashMap<>();
+            for (Map<String, Object> document : documents) {
+                Integer id = Integer.parseInt((String) document.get("id"));
+                String baseType = (String) document.get("baseType");
+                idToBaseTypeMap.put(id, baseType);
+            }
+            return idToBaseTypeMap;
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -460,23 +460,15 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
     }
 
     /**
-     * Retrieves documents for the given list of IDs, extracts the "id" and "baseType" fields,
-     * and maps each ID to its corresponding base type.
+     * Retrieves a mapping of document IDs to their corresponding base types for the given list of IDs.
      *
      * @param ids
      *            list of document IDs to retrieve and process.
      * @return a map where the keys are document IDs and the values are their associated base types.
      */
-    public Map<Integer, String> getIdTypeMap(List<Integer> ids) throws DataException {
+    public Map<Integer, String> fetchIdToBaseTypeMap(List<Integer> ids) throws DataException {
         try {
-            List<Map<String, Object>> documents = searcher.getDocuments(ids);
-            Map<Integer, String> idToBaseTypeMap = new HashMap<>();
-            for (Map<String, Object> document : documents) {
-                Integer id = Integer.parseInt((String) document.get("id"));
-                String baseType = (String) document.get("baseType");
-                idToBaseTypeMap.put(id, baseType);
-            }
-            return idToBaseTypeMap;
+            return searcher.fetchIdToBaseTypeMap(ids);
         } catch (CustomResponseException e) {
             throw new DataException(e);
         }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/dataeditor/StructurePanelTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/dataeditor/StructurePanelTest.java
@@ -17,6 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.kitodo.DummyRulesetManagement;
@@ -25,6 +27,7 @@ import org.kitodo.api.dataformat.mets.LinkedMetsResource;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.beans.Workflow;
+import org.kitodo.production.services.ServiceManager;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
 
@@ -47,12 +50,14 @@ public class StructurePanelTest {
         LinkedMetsResource link = new LinkedMetsResource();
         link.setUri(URI.create("database://?process.id=42"));
         structure.setLink(link);
+        Map<Integer, String> processTypeMap = new HashMap<>();
+        processTypeMap.put(ServiceManager.getProcessService().processIdFromUri(link.getUri()), "Monograph");
         TreeNode result = new DefaultTreeNode();
 
         Method buildStructureTreeRecursively = StructurePanel.class.getDeclaredMethod("buildStructureTreeRecursively",
-            LogicalDivision.class, TreeNode.class);
+            LogicalDivision.class, TreeNode.class, Map.class);
         buildStructureTreeRecursively.setAccessible(true);
-        buildStructureTreeRecursively.invoke(underTest, structure, result);
+        buildStructureTreeRecursively.invoke(underTest, structure, result, processTypeMap);
 
         assertTrue(((StructureTreeNode) result.getChildren().get(0).getData()).isLinked());
     }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/dataeditor/StructurePanelTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/dataeditor/StructurePanelTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.kitodo.DummyRulesetManagement;
+import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.mets.LinkedMetsResource;
 import org.kitodo.data.database.beans.Process;
@@ -51,13 +52,14 @@ public class StructurePanelTest {
         link.setUri(URI.create("database://?process.id=42"));
         structure.setLink(link);
         Map<Integer, String> processTypeMap = new HashMap<>();
+        Map<String, StructuralElementViewInterface> viewCache = new HashMap<>();
         processTypeMap.put(ServiceManager.getProcessService().processIdFromUri(link.getUri()), "Monograph");
         TreeNode result = new DefaultTreeNode();
 
         Method buildStructureTreeRecursively = StructurePanel.class.getDeclaredMethod("buildStructureTreeRecursively",
-            LogicalDivision.class, TreeNode.class, Map.class);
+            LogicalDivision.class, TreeNode.class, Map.class, Map.class);
         buildStructureTreeRecursively.setAccessible(true);
-        buildStructureTreeRecursively.invoke(underTest, structure, result, processTypeMap);
+        buildStructureTreeRecursively.invoke(underTest, structure, result, processTypeMap, viewCache);
 
         assertTrue(((StructureTreeNode) result.getChildren().get(0).getData()).isLinked());
     }


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/5934

As outlined in issue https://github.com/kitodo/kitodo-production/issues/5934, we currently face performance problems when working with parent processes in the editor, which contain a lot of children elements. In the issue discussion i thought that the problem lies in opening a lot of XML files for detection of the base type, but we are already using the index. I discovered that the problem seems to stem from accessing the index hundreds of times.
I tried to correct that and was able to bring the time to show a parent process with 600 files from more than 30 seconds to around 3 seconds.
My implementation does four things:
- Instead of retrieving the base types for the linked processes when the structure tree is constructed recursively, i fetch all the base types before the structure tree is constructed
- Instead of retrieving the documents from the Elasticsearch index one by one i fetch them in one go using the Mget operation. (https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docs-multi-get.html)
- We do not have to convert the document to a DTO since we only need the basetype, which we can fetch directly from the Elasticsearch response, which is reduced in size by specifiying the only source field we need: "baseType"
- We can use a view cache for already derived views


