### PR TITLE
Translate metadata keys in mass import record table header

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
@@ -110,7 +110,7 @@ public class MassImportForm extends BaseForm {
             resetValues();
             if (!csvLines.isEmpty()) {
                 importedCsvHeaderLine = csvLines.get(0);
-                metadataKeys = new LinkedList<>(Arrays.asList(csvLines.get(0).split(csvSeparator, -1)));
+                updateMetadataKeys();
                 if (csvLines.size() > 1) {
                     importedCsvLines = csvLines.subList(1, csvLines.size());
                     records = massImportService.parseLines(importedCsvLines, csvSeparator);
@@ -133,12 +133,17 @@ public class MassImportForm extends BaseForm {
      * Event listender function called when user switches CSV separator character used to split text lines into cells.
      */
     public void changeSeparator() {
-        metadataKeys = new LinkedList<>(Arrays.asList(importedCsvHeaderLine.split(csvSeparator, -1)));
+        updateMetadataKeys();
         try {
             records = massImportService.parseLines(importedCsvLines, csvSeparator);
         } catch (IOException | CsvException e) {
             Helper.setErrorMessage(e);
         }
+    }
+
+    private void updateMetadataKeys() {
+        metadataKeys = Arrays.stream(importedCsvHeaderLine.split(csvSeparator, -1)).map(String::trim)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -215,7 +220,7 @@ public class MassImportForm extends BaseForm {
      */
     public String getColumnHeader(Integer columnIndex) {
         if (columnIndex < metadataKeys.size()) {
-            return metadataKeys.get(columnIndex);
+            return Helper.getTranslation(metadataKeys.get(columnIndex));
         }
         return "";
     }


### PR DESCRIPTION
While writing the documentation for the [mass import](https://github.com/kitodo/kitodo-production/wiki/Massenimport) I noticed that the column headers in the record table only contain the keys, not the translated labels, of each metadata. This pull request changes that so that now the correct translation of the metadata keys are displayed in the column headers. (if the CSV file contains unknown metadata keys that are not defined in the current ruleset, the verbatim strings from the CSV are displayed instead)