### PR TITLE
[3.7] Execute the CI workflow on the 3.7.x release branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,8 @@ name: "CodeQL"
 on:
   push:
   pull_request:
-    branches: [ master ]
+    branches:
+      - 3.7.x
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,11 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push and pull request events but only for pull_requests on the master branch
+  # Triggers the workflow on push and pull request events but only for pull_requests on the 3.7.x release branch
   push:
   pull_request:
-    branches: [ master ]
+    branches:
+      - 3.7.x
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This change should activate the CI workflow execution on the 3.7.x release branch. This was discussed with @solth .