### PR TITLE
[3.7] Submit filters with numpad enter

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
@@ -131,6 +131,7 @@ function handleKeydown(event) {
             }
             break;
         case "Enter":
+        case "NumpadEnter":
             if ($(FILTER_OPTIONS_FORM_WRAPPER).is(':visible') && $(SELECTED_SUGGESTION_ITEM).length === 1) {
                 selectConfirm();
             } else {


### PR DESCRIPTION
When a filter was entered and the enter key on the numpad is pressed, the filter is not submitted but the page will be reloaded.
This pr adds the code for the numpad enter key, so filters can be submitted correctly when pressing this key.