### PR TITLE
[3.7] Update process when assigning task

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -148,7 +148,7 @@ public class CurrentTaskForm extends BaseForm {
                     return tasksPath;
                 } else {
                     this.workflowControllerService.assignTaskToUser(this.currentTask);
-                    ServiceManager.getTaskService().save(this.currentTask);
+                    ServiceManager.getTaskService().save(this.currentTask, true);
                 }
             } catch (DataException | IOException | DAOException e) {
                 Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.TASK.getTranslationSingular() }, logger,


### PR DESCRIPTION
When a task is assigned to a user the tasks status changes from "open" to "in work". This change is not saved properly in the related process object resulting in an outdated progress bar in the process list.
This change saves the tasks related objects to address this issue.