### PR TITLE
Fix wrong checks of empty string in LdapUser context

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
+++ b/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
@@ -279,7 +279,7 @@ public class LdapUser implements DirContext {
 
     @Override
     public Attributes getAttributes(String name) throws NamingException {
-        if (StringUtils.isBlank(name)) {
+        if (!StringUtils.isBlank(name)) {
             throw new NameNotFoundException();
         }
         return (Attributes) this.attributes.clone();
@@ -292,7 +292,7 @@ public class LdapUser implements DirContext {
 
     @Override
     public Attributes getAttributes(String name, String[] ids) throws NamingException {
-        if (StringUtils.isBlank(name)) {
+        if (!StringUtils.isBlank(name)) {
             throw new NameNotFoundException();
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
+++ b/Kitodo/src/main/java/org/kitodo/production/ldap/LdapUser.java
@@ -279,7 +279,7 @@ public class LdapUser implements DirContext {
 
     @Override
     public Attributes getAttributes(String name) throws NamingException {
-        if (!StringUtils.isBlank(name)) {
+        if (StringUtils.isNotBlank(name)) {
             throw new NameNotFoundException();
         }
         return (Attributes) this.attributes.clone();
@@ -292,7 +292,7 @@ public class LdapUser implements DirContext {
 
     @Override
     public Attributes getAttributes(String name, String[] ids) throws NamingException {
-        if (!StringUtils.isBlank(name)) {
+        if (StringUtils.isNotBlank(name)) {
             throw new NameNotFoundException();
         }
 

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -680,7 +680,7 @@ lastPage=Last page
 lastUpdatedBy=Last updated by
 later=Please try again in a few minutes.
 ldapKonfigurationSchreiben=Write LDAP configuration
-ldapWritten=LDAP configuration successfully written for user\: ????
+ldapWritten=LDAP configuration successfully written for user\:
 # ldapgroupSaving is used in ldapgroupEdit.xhtml - line 39
 ldapGroupSaving=Saving LDAP group...
 ldapGroup=LDAP group


### PR DESCRIPTION
In the following [commit](https://github.com/kitodo/kitodo-production/commit/b598388abce560b44a69f8aa0a76f43a3ec41cfa?diff=split&w=0) ".isEmpty()" was replaced with "StringUtils.isBlank".
But unfortunately the negation of the calls has been lost which is why they are now testing the opposite of what they should.
This merge request should fix the error.
fix #6210 