### PR TITLE
Don't run CodeQL if only minimized JavaScript was changed and fix some issues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,8 @@ on:
   push:
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**/*_min.js'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessListBaseView.java
@@ -613,6 +613,7 @@ public class ProcessListBaseView extends BaseForm {
      * Update selection and first row to show in datatable on PageEvent.
      * @param pageEvent PageEvent triggered by data tables paginator
      */
+    @Override
     public void onPageChange(PageEvent pageEvent) {
         this.setFirstRow(((DataTable) pageEvent.getSource()).getFirst());
         if (allSelected) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -713,6 +713,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
      * @param treeNode treeNode to be added
      * @return whether the given ProcessDetail can be added or not
      */
+    @Override
     public boolean canBeAdded(TreeNode treeNode) throws InvalidMetadataValueException {
         if (Objects.isNull(treeNode.getParent().getParent())) {
             if (Objects.nonNull(currentProcess.getProcessMetadata().getSelectedMetadataTreeNode())
@@ -746,6 +747,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
      * @param metadataNode TreeNode for which the check is performed
      * @return whether given TreeNode contains ProcessFieldedMetadata and if any further metadata can be added to it
      */
+    @Override
     public boolean metadataAddableToGroup(TreeNode metadataNode) {
         if (metadataNode.getData() instanceof ProcessFieldedMetadata) {
             return !(DataEditorService.getAddableMetadataForGroup(getMainProcess().getRuleset(), metadataNode).isEmpty());
@@ -757,6 +759,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
      * Prepare addable metadata for metadata group.
      * @param treeNode metadataGroup treeNode
      */
+    @Override
     public void prepareAddableMetadataForGroup(TreeNode treeNode) {
         addMetadataDialog.prepareAddableMetadataForGroup(getMainProcess().getRuleset(), treeNode);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -668,6 +668,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
      *             there is no setter corresponding to the name configured in
      *             the rule set
      */
+    @Override
     public void preserve() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         try {
             if (Objects.nonNull(division)) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -87,6 +87,7 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
         return Objects.isNull(settings) || settings.isUndefined();
     }
 
+    @Override
     public boolean isRequired() {
         ComplexMetadataViewInterface containerSettings = container.getMetadataView();
         if (!(containerSettings instanceof StructuralElementViewInterface) && container.getChildMetadata().isEmpty()

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -84,6 +84,7 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
      * @param skipEmpty boolean
      * @return the metadata from this row
      */
+    @Override
     public Collection<Metadata> getMetadata(boolean skipEmpty) {
         value = value.trim();
         if (skipEmpty && value.isEmpty()) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -973,6 +973,7 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
      * @param treeNode treeNode to be added
      * @return whether the given ProcessDetail can be added or not
      */
+    @Override
     public boolean canBeAdded(TreeNode treeNode) {
         if (Objects.isNull(treeNode.getParent().getParent())) {
             if (Objects.nonNull(metadataPanel.getSelectedMetadataTreeNode()) || Objects.isNull(addMetadataDialog.getAddableMetadata())) {
@@ -1116,6 +1117,7 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
      *
      * @return whether given TreeNode contains ProcessFieldedMetadata and if any further metadata can be added to it
      */
+    @Override
     public boolean metadataAddableToGroup(TreeNode metadataNode) {
         return metadataPanel.metadataAddableToGroup(metadataNode);
     }
@@ -1123,6 +1125,7 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
     /**
      * Prepare addable metadata for metadata group.
      */
+    @Override
     public void prepareAddableMetadataForGroup(TreeNode treeNode) {
         addMetadataDialog.prepareAddableMetadataForGroup(treeNode);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/AddDataScript.java
@@ -29,6 +29,7 @@ public class AddDataScript extends EditDataScript {
      * @param process the related process
      * @param metadataScript the script to execute
      */
+    @Override
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
             MetadataScript metadataScript) throws KitodoScriptExecutionException {
         Workpiece workpiece = metadataFile.getWorkpiece();

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/DeleteDataScript.java
@@ -30,6 +30,7 @@ public class DeleteDataScript extends EditDataScript {
      * @param process the related process
      * @param metadataScript the script to execute
      */
+    @Override
     public void executeScript(LegacyMetsModsDigitalDocumentHelper metadataFile, Process process,
                                MetadataScript metadataScript) throws KitodoScriptExecutionException {
         Workpiece workpiece = metadataFile.getWorkpiece();

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -283,6 +283,7 @@ public class IndexingService {
     private ExecutorService createDeamonizedExecutorService(int threads) {
         return Executors.newFixedThreadPool(threads,
             new ThreadFactory() {
+                @Override
                 public Thread newThread(Runnable r) {
                     Thread t = Executors.defaultThreadFactory().newThread(r);
                     t.setDaemon(true);

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProjectsPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProjectsPage.java
@@ -195,6 +195,7 @@ public class ProjectsPage extends Page<ProjectsPage> {
      *
      * @return The projects page.
      */
+    @Override
     public ProjectsPage goTo() throws Exception {
         Pages.getTopNavigation().gotoProjects();
         await("Wait for execution of link click").pollDelay(Browser.getDelayMinAfterLinkClick(), TimeUnit.MILLISECONDS)

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UsersPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/UsersPage.java
@@ -117,6 +117,7 @@ public class UsersPage extends Page<UsersPage> {
      * 
      * @return The users page.
      */
+    @Override
     public UsersPage goTo() throws Exception {
         Pages.getTopNavigation().gotoUsers();
         await("Wait for execution of link click").pollDelay(Browser.getDelayMinAfterLinkClick(), TimeUnit.MILLISECONDS)


### PR DESCRIPTION
It's not necessary to run CodeQL (and spend related resources like energy and time) for all kinds of file changes. Here changes of minimized JavaScript are ignored.

In addition some missing `@Override` tags are added to fix related CodeQL issues.