### PR TITLE
Use FileUtils.deleteDirectory instead of FileSystemUtils.deleteSubDirectories

### DIFF
--- a/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/MockEntity.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/data/elasticsearch/MockEntity.java
@@ -21,9 +21,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 
+import org.apache.commons.io.FileUtils;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.transport.Netty4Plugin;
@@ -54,7 +54,7 @@ public class MockEntity {
     private static void removeOldDataDirectories(String dataDirectory) throws Exception {
         File dataDir = new File(dataDirectory);
         if (dataDir.exists()) {
-            FileSystemUtils.deleteSubDirectories(dataDir.toPath());
+            FileUtils.deleteDirectory(dataDir);
         }
     }
 

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -43,12 +43,12 @@ import javax.json.JsonReader;
 
 import com.xebialabs.restito.semantics.Action;
 import com.xebialabs.restito.server.StubServer;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.InternalSettingsPreparer;
 import org.elasticsearch.node.Node;
@@ -293,7 +293,7 @@ public class MockDatabase {
     private static void removeOldDataDirectories(String dataDirectory) throws Exception {
         File dataDir = new File(dataDirectory);
         if (dataDir.exists()) {
-            FileSystemUtils.deleteSubDirectories(dataDir.toPath());
+            FileUtils.deleteDirectory(dataDir);
         }
     }
 


### PR DESCRIPTION
This eliminates an Elasticsearch dependency and replaces it by an already existing dependency.