### PR TITLE
Optimize the update of the workflow state of processes

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -806,6 +806,31 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
     }
 
     /**
+     * Checks whether all child processes of the given parent process are in a completed state.
+     *
+     * @param parentProcess The parent process whose child processes are being checked.
+     * @return true if all child processes are in a completed state, false otherwise.
+     */
+    public boolean areAllChildProcessesInCompletedState(Process parentProcess) {
+        String hql = "SELECT count(p) FROM Process p WHERE p.parent = :parent "
+                + "AND p.sortHelperStatus NOT IN (:completedStates)";
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("parent", parentProcess);
+        parameters.put("completedStates", List.of(
+                ProcessState.COMPLETED20.getValue(),
+                ProcessState.COMPLETED.getValue()
+        ));
+        try {
+            Long count = countDatabaseRows(hql, parameters);
+            return count == 0;  // If count is 0, all child processes are completed
+        } catch (DAOException e) {
+            logger.error(e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
      * Searches for linkable processes based on user input. A process can be
      * linked if it has the same rule set, belongs to the same client, and the
      * topmost element of the logical outline below the selected parent element

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -474,11 +474,14 @@ public class WorkflowControllerService {
             TaskManager.addTask(thread);
         }
 
-        closeParent(process);
+        if (closedTask.isLast()) {
+            closeParent(process);
+        }
     }
 
     private void closeParent(Process process) throws DataException {
-        if (Objects.nonNull(process.getParent()) && allChildrenClosed(process.getParent())) {
+        if (Objects.nonNull(process.getParent()) && ServiceManager.getProcessService()
+                .areAllChildProcessesInCompletedState(process.getParent())) {
             process.getParent().setSortHelperStatus(ProcessState.COMPLETED.getValue());
             ServiceManager.getProcessService().save(process.getParent());
             closeParent(process.getParent());


### PR DESCRIPTION
Adresses https://github.com/kitodo/kitodo-production/discussions/6177

As discussed in GitHub discussion #6177, there is potential to optimize the update of the workflow state of processes. Currently, whenever a task within a child process is closed, we check whether all other child processes under the same parent are also closed. If they are, the parent process can be marked as complete as well.

However, this check seems necessary only when the task being closed is the final task in the process. If the process is not yet complete, there is no need to verify the status of other sibling processes. Additionally, if checking whether the other processes are completed is required, we can delegate this to the database to improve performance.