### PR TITLE
Update ActiveMQ client to latest stable version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
-                <version>5.17.6</version>
+                <version>5.18.5</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Updating to latest stable version of ActiveMQ with Java 11 support. ActiveMQ at version 6 needs at least Java 17 for running.

See current support table of ActiveMQ: https://activemq.apache.org/components/classic/download/