### PR TITLE
Fix the disappearance of collapsed metadata

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -42,6 +42,13 @@
                  styleClass="no-header"
                  widgetVar="metadataTable"
                  id="metadataTable">
+        <p:ajax event="expand"
+                process="@this"
+                update="@(.ui-tree, .stripe.selected)" />
+
+        <p:ajax event="collapse"
+                process="@this"
+                update="@(.ui-tree, .stripe.selected)"/>
         <p:column>
             <span class="input-wrapper">
                 <!-- field label


### PR DESCRIPTION
fixes https://github.com/kitodo/kitodo-production/issues/6231
fixes https://github.com/kitodo/kitodo-production/issues/5932

Before collapsing or expanding elements in our metadata tree, we should make sure that the state is persisted to not get lost while collapsing/expanding the tree.