### PR TITLE
Include necessary Javascript dependency in processFromTemplate page

### DIFF
--- a/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
+++ b/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
@@ -134,4 +134,9 @@
         <p:menuitem value="#{msgs.createNewProcessFromTemplate}" rendered="#{empty ProcessForm.process.title}" icon="fa fa-clipboard"/>
     </ui:define>
 
+    <ui:define name="page-scripts">
+        <h:outputScript name="js/defaultScript.js" target="body"/>
+        <h:outputScript name="js/metadata_editor.js" target="body"/>
+    </ui:define>
+
 </ui:composition>


### PR DESCRIPTION
While fiddling around with https://github.com/kitodo/kitodo-production/pull/6232 i noticed that the process creation page does not have the necessary Javascript to handle keydown-events. 

Keydown events are not working on this page which breaks the logic for catching "return"-events in the metadataTreeTable.
![image](https://github.com/user-attachments/assets/f04ffec9-80e1-4e89-a877-190a868b751f)

This PR adds the script to the template.
