### PR TITLE
Fix the disappearance of collapsed metadata 

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -42,6 +42,13 @@
                  styleClass="no-header"
                  widgetVar="metadataTable"
                  id="metadataTable">
+        <p:ajax event="expand"
+                process="@this"
+                update="@(.ui-tree, .stripe.selected)" />
+
+        <p:ajax event="collapse"
+                process="@this"
+                update="@(.ui-tree, .stripe.selected)"/>
         <p:column>
             <span class="input-wrapper">
                 <!-- field label

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -42,13 +42,8 @@
                  styleClass="no-header"
                  widgetVar="metadataTable"
                  id="metadataTable">
-        <p:ajax event="expand"
-                process="@this"
-                update="@(.ui-tree, .stripe.selected)" />
-
         <p:ajax event="collapse"
-                process="@this"
-                update="@(.ui-tree, .stripe.selected)"/>
+                onstart="return #{request.requestURI.contains('metadataEditor')};"/>
         <p:column>
             <span class="input-wrapper">
                 <!-- field label


### PR DESCRIPTION
Enhanced version of https://github.com/kitodo/kitodo-production/pull/6232
Fixes https://github.com/kitodo/kitodo-production/issues/6231

@solth I followed your suggestion to only "activate" the ajax tag in the metadata editor by using the onstart functionality for checking a passed in context value, which makes it possible to decide what the rendering context is.

Edit: I can probably inspect the URI directly to not having to introduce an addional renderContext.