### PR TITLE
Do not reset the ORDERLABEL if division is a page

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -44,6 +44,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.Division;
+import org.kitodo.api.dataformat.PhysicalDivision;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.production.services.dataeditor.DataEditorService;
@@ -672,7 +673,9 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
         try {
             if (Objects.nonNull(division)) {
                 division.getContentIds().clear();
-                division.setOrderlabel(null);
+                if (!division.getType().equals(PhysicalDivision.TYPE_PAGE)) {
+                    division.setOrderlabel(null);
+                }
                 division.setLabel(null);
             }
             metadata.clear();


### PR DESCRIPTION
fixes https://github.com/kitodo/kitodo-production/issues/5220
alternative: https://github.com/kitodo/kitodo-production/pull/6244
We should not reset the ORDERLABEL of a page during metadata preservation since this breaks the pagination when the ORDERLABEL is set to excluded.
While this fixes the pagination issue there are other potential problems. I did an alternative pull request which tries to adress them all:
https://github.com/kitodo/kitodo-production/pull/6244