### PR TITLE
Refactor preservation logic and include hidden metadata

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
@@ -96,19 +96,6 @@ public class ProcessBooleanMetadata extends ProcessSimpleMetadata implements Ser
         return Collections.emptyList();
     }
 
-    @Override
-    Pair<BiConsumer<Division<?>, String>, String> getStructureFieldValue()
-            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
-
-        if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
-            if (!isValid()) {
-                throw new InvalidMetadataValueException(label, settings.convertBoolean(active).orElse(""));
-            }
-            return Pair.of(super.getStructureFieldSetters(settings), settings.convertBoolean(active).orElse(null));
-        } else {
-            return null;
-        }
-    }
 
     /**
      * Returns whether the switch is on.

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
@@ -16,17 +16,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
-import org.kitodo.api.dataformat.Division;
 import org.kitodo.exceptions.InvalidMetadataValueException;
-import org.kitodo.exceptions.NoSuchMetadataFieldException;
 
 /**
  * A row on the metadata panel that contains an on/off switch.
@@ -68,6 +64,11 @@ public class ProcessBooleanMetadata extends ProcessSimpleMetadata implements Ser
     @Override
     public String getMetadataID() {
         return settings.getId();
+    }
+
+    @Override
+    public String extractSimpleValue() {
+        return settings.convertBoolean(active).orElse(null);
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDetail.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDetail.java
@@ -124,21 +124,6 @@ public abstract class ProcessDetail implements Serializable {
     public abstract Collection<Metadata> getMetadata(boolean skipEmpty) throws InvalidMetadataValueException;
 
     /**
-     * If the metadata entry addresses a property of the structure, returns a
-     * pair of the setter and the value to set; else {@code null}. This method
-     * it to be called when saving the data.
-     *
-     * @return if data is to be written a pair of the setter of the
-     *         {@link LogicalDivision} and the value to set, else null
-     * @throws InvalidMetadataValueException
-     *             if the metadata form contains syntactically wrong input
-     * @throws NoSuchMetadataFieldException
-     *             if the field configured in the rule set does not exist
-     */
-    abstract Pair<BiConsumer<Division<?>, String>, String> getStructureFieldValue()
-            throws InvalidMetadataValueException, NoSuchMetadataFieldException;
-
-    /**
      * Returns whether this metadata entry is leading for options of other
      * metadata entries. If true, the application must refresh the metadata
      * panel after this entry was changed to reflect the option changes in other

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -686,12 +686,12 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                     metadata.addAll(row.getMetadataWithFilledValues());
                 }
             }
-            if (Objects.nonNull(hiddenMetadata)) {
-                if (!hiddenMetadata.isEmpty()) {
-                    for (Metadata hiddenmetadatum : hiddenMetadata) {
-                        if (hiddenmetadatum instanceof MetadataEntry
-                                && specialFields.contains(hiddenmetadatum.getKey())) {
-                            updateDivision(hiddenmetadatum.getKey(), ((MetadataEntry) hiddenmetadatum).getValue());
+            if (!Objects.isNull(hiddenMetadata) && !hiddenMetadata.isEmpty()) {
+                for (Metadata hidden : hiddenMetadata) {
+                    if (hidden instanceof MetadataEntry) {
+                        MetadataEntry entry = (MetadataEntry) hidden;
+                        if (specialFields.contains(entry.getKey())) {
+                            updateDivision(entry.getKey(), entry.getValue());
                         }
                     }
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -686,7 +686,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                     metadata.addAll(row.getMetadataWithFilledValues());
                 }
             }
-            if (!Objects.isNull(hiddenMetadata) && !hiddenMetadata.isEmpty()) {
+            if (Objects.nonNull(hiddenMetadata) && !hiddenMetadata.isEmpty()) {
                 for (Metadata hidden : hiddenMetadata) {
                     if (hidden instanceof MetadataEntry) {
                         MetadataEntry entry = (MetadataEntry) hidden;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -65,6 +65,8 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
      * Fields the user has selected to show in addition, with no data yet.
      */
     private final Collection<String> additionallySelectedFields = new ArrayList<>();
+    private static final Set<String> specialFields = Set.of(METADATA_KEY_LABEL, METADATA_KEY_ORDERLABEL,
+            METADATA_KEY_CONTENTIDS);
 
     private boolean copy;
 
@@ -672,8 +674,6 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                 division.setLabel(null);
             }
             metadata.clear();
-            Set<String> specialFields = new HashSet<>(Set.of(METADATA_KEY_LABEL, METADATA_KEY_ORDERLABEL,
-                    METADATA_KEY_CONTENTIDS));
 
             for (TreeNode child : treeNode.getChildren()) {
                 ProcessDetail row = (ProcessDetail) child.getData();
@@ -715,7 +715,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     }
 
     private void updateDivisionFromProcessDetail(String key, ProcessSimpleMetadata processDetail) throws InvalidMetadataValueException {
-        String simpleValue = extractSimpleValue(processDetail);
+        String simpleValue = processDetail.extractSimpleValue();
         if (!processDetail.getSettings().isValid(simpleValue, getListForLeadingMetadataFields())) {
             throw new InvalidMetadataValueException(key, simpleValue);
         };
@@ -723,15 +723,6 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
             return;
         }
         updateDivision(key, simpleValue);
-    }
-
-    private String extractSimpleValue(ProcessDetail value) {
-        if (value instanceof ProcessTextMetadata) {
-            return ((ProcessTextMetadata) value).getValue();
-        } else if (value instanceof ProcessSelectMetadata) {
-            return String.join(" ", ((ProcessSelectMetadata) value).getSelectedItems());
-        }
-        return null;
     }
 
     private void updateDivision(String key, String value) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -192,6 +192,11 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     }
 
     @Override
+    public String extractSimpleValue() {
+        return String.join(" ", getSelectedItems());
+    }
+
+    @Override
     public boolean isValid() {
         for (String selectedItem : selectedItems) {
             if (!settings.isValid(selectedItem, container.getListForLeadingMetadataFields())) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -192,20 +192,6 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     }
 
     @Override
-    Pair<BiConsumer<Division<?>, String>, String> getStructureFieldValue()
-            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
-        if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
-            String value = String.join(" ", selectedItems);
-            if (!settings.isValid(value, container.getListForLeadingMetadataFields())) {
-                throw new InvalidMetadataValueException(label, value);
-            }
-            return Pair.of(super.getStructureFieldSetters(settings), value);
-        } else {
-            return null;
-        }
-    }
-
-    @Override
     public boolean isValid() {
         for (String selectedItem : selectedItems) {
             if (!settings.isValid(selectedItem, container.getListForLeadingMetadataFields())) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -52,6 +52,11 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
      */
     abstract ProcessSimpleMetadata getClone();
 
+    /**
+     * Returns a simpler string representation of the Metadata.
+     *
+     * @return A string representation of the Metadata
+     */
     abstract String extractSimpleValue();
 
     public SimpleMetadataViewInterface getSettings() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -72,6 +72,10 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
         }
     }
 
+    public SimpleMetadataViewInterface getSettings() {
+        return settings;
+    }
+
     /**
      * Returns if the field may be edited. Some fields may be disallowed to be
      * edit from the rule set.

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -56,22 +56,6 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
      */
     abstract ProcessSimpleMetadata getClone();
 
-    protected BiConsumer<Division<?>, String> getStructureFieldSetters(MetadataViewInterface field)
-            throws NoSuchMetadataFieldException {
-        String key = field.getId();
-
-        switch (key.toUpperCase()) {
-            case "LABEL":
-                return Division::setLabel;
-            case "ORDERLABEL":
-                return Division::setOrderlabel;
-            case "CONTENTIDS":
-                return (division, value) -> division.getContentIds().add(URI.create(value));
-            default:
-                throw new NoSuchMetadataFieldException(key, field.getLabel());
-        }
-    }
-
     public SimpleMetadataViewInterface getSettings() {
         return settings;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -12,20 +12,16 @@
 package org.kitodo.production.forms.createprocess;
 
 import java.io.Serializable;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
-import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.Division;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.PhysicalDivision;
-import org.kitodo.exceptions.NoSuchMetadataFieldException;
 
 abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializable {
 
@@ -55,6 +51,8 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
      * @return an independently mutable copy
      */
     abstract ProcessSimpleMetadata getClone();
+
+    abstract String extractSimpleValue();
 
     public SimpleMetadataViewInterface getSettings() {
         return settings;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -15,17 +15,12 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.Metadata;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.InputType;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
-import org.kitodo.api.dataformat.Division;
-import org.kitodo.exceptions.InvalidMetadataValueException;
-import org.kitodo.exceptions.NoSuchMetadataFieldException;
 
 public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serializable {
 
@@ -120,6 +115,11 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
      */
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public String extractSimpleValue() {
+        return getValue();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -106,20 +106,6 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
     }
 
     @Override
-    Pair<BiConsumer<Division<?>, String>, String> getStructureFieldValue()
-            throws InvalidMetadataValueException, NoSuchMetadataFieldException {
-
-        if (settings.getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
-            if (!settings.isValid(value, container.getListForLeadingMetadataFields())) {
-                throw new InvalidMetadataValueException(label, value);
-            }
-            return Pair.of(super.getStructureFieldSetters(settings), value);
-        } else {
-            return null;
-        }
-    }
-
-    @Override
     public boolean isValid() {
         if (Objects.isNull(value) || value.isEmpty()) {
             return false;


### PR DESCRIPTION
fixes https://github.com/kitodo/kitodo-production/issues/5220
alternative to https://github.com/kitodo/kitodo-production/pull/6238

This pull request addresses an issue where the special metadata fields "LABEL", "ORDERLABEL", and "CONTENTIDS" are lost when they are set as excluded metadata. When opening a process in the metadata editor and saving it, this loss can occur. A special problem is, that an excluded "ORDERLABEL" will result in broken pagination (https://github.com/kitodo/kitodo-production/issues/5220).

Pull request [#6238](https://github.com/kitodo/kitodo-production/pull/6238) specifically resolves the issue of preserving pagination even when the ORDERLABEL is excluded by not resetting the ORDERLABEL in case of a page. However, in order to fully address the broader problem of losing the special metada fields when they are excluded, we must also ensure that the division data is updated based on hidden/excluded metadata.

This pull request not only resolves the issue of losing excluded metadata but also refactors the existing logic. The goal of the refactoring is to make the logic more explicit, improving both readability and maintainability. The current BiConsumer logic is difficult to follow, so I’ve aimed to preserve the functionality while making the code more understandable.

If this approach is rejected or introduces new problems, we should seek an alternative solution to properly handle hidden metadata.