### PR TITLE
Fix vertical alignment of gallery placeholder images

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -3444,6 +3444,7 @@ Column content
 .thumbnail + .thumbnail-container video {
     background: var(--carbon-blue);
     border: solid calc(2 * var(--default-border-width)) var(--carbon-blue);
+    box-sizing: border-box;
 }
 
 .thumbnail.selected + .thumbnail-container .mediaListIconItem,
@@ -3606,6 +3607,7 @@ Column content
 #imagePreviewForm\:unstructuredMedia ul li > .ui-panel.ui-draggable {
     display: inline-block;
     position: relative;
+    vertical-align: top;
 }
 
 .page-drop-area {


### PR DESCRIPTION
Fixes CSS issue in gallery, see:

Before:

![Screenshot from 2024-10-08 11-07-30](https://github.com/user-attachments/assets/eb027fe9-f3f7-493c-8783-1e00ab537a84)


After (with #6239):

![Screenshot from 2024-10-08 11-03-25](https://github.com/user-attachments/assets/1047fc01-0dff-443d-a7e0-ebc764e5c4e3)

Tested with Firefox and Chrome.