### PR TITLE
Fix property not found exception in metadata editor with physical structure tree

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
@@ -83,7 +83,7 @@
                         a:data-order="#{physicalNode.order}"/>
                 <h:outputText value=" 🔗" rendered="#{physicalNode.linked}"/>
             </p:treeNode>
-            <p:treeNode type="#{DataEditorForm.structurePanel.MEDIA_PARTIAL_NODE_TYPE}"
+            <p:treeNode type="#{StructurePanel.MEDIA_PARTIAL_NODE_TYPE}"
                         icon="ui-icon-media-partial">
                 <h:outputText
                         value="#{physicalNode.label}"


### PR DESCRIPTION
When opening the metadata editor in "extended structure"-mode (with both a logical and physical tree), the following exception occurs:

![Screenshot from 2024-10-14 17-33-03](https://github.com/user-attachments/assets/f3bcc109-4323-44f1-aefb-50cc10fc9b5c)

This pull request fixes the exception (without any detailed investigation what exactly is going on). With this fix, the metadata editor loads again for me.