### PR TITLE
Adjust titles of some tabs containing lists

### DIFF
--- a/Kitodo/src/main/webapp/pages/tasks.xhtml
+++ b/Kitodo/src/main/webapp/pages/tasks.xhtml
@@ -59,7 +59,7 @@
 
     <ui:define name="pageTabView">
         <p:tabView id="tasksTabView">
-            <p:tab id="tasksTab" title="#{msgs.taskList}">
+            <p:tab id="tasksTab" title="#{msgs.tasks}">
                 <ui:include src="/WEB-INF/templates/includes/tasks/taskList.xhtml"/>
             </p:tab>
         </p:tabView>

--- a/Kitodo/src/main/webapp/pages/userEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/userEdit.xhtml
@@ -100,14 +100,14 @@
                 </ui:include>
             </p:tab>
 
-            <p:tab id="projectTab" title="#{msgs.projectList}">
+            <p:tab id="projectTab" title="#{msgs.projects}">
                 <ui:include src="/WEB-INF/templates/includes/userEdit/projectList.xhtml">
                     <ui:param name="isEditMode" value="#{isEditMode}" />
                     <ui:param name="isCreateMode" value="#{isCreateMode}" />
                 </ui:include>
             </p:tab>
 
-            <p:tab id="clientTab" title="#{msgs.clientList}" rendered="#{SecurityAccessController.hasAuthorityGlobal('editUser')}">
+            <p:tab id="clientTab" title="#{msgs.clients}" rendered="#{SecurityAccessController.hasAuthorityGlobal('editUser')}">
                 <ui:include src="/WEB-INF/templates/includes/userEdit/clientList.xhtml">
                     <ui:param name="isEditMode" value="#{isEditMode}" />
                     <ui:param name="isCreateMode" value="#{isCreateMode}" />


### PR DESCRIPTION
Most tabs containing lists have the list entry type as a title. This pull request adjust some remaining lists titles that differ from that pattern.