### PR TITLE
Add small horizontal padding to context menu text

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -122,6 +122,10 @@ html.progressCursor * {
     display: none;
 }
 
+div.ui-contextmenu .ui-menuitem .ui-menuitem-text {
+    padding: 0 0.5em;
+}
+
 /*----------------------------------------------------------------------
 Header
 ----------------------------------------------------------------------*/


### PR DESCRIPTION
This pull request improves the CSS styling of all context menus by adding a small horizontal padding to the text. Icons and text do not collide any more.

Before:
![image](https://github.com/user-attachments/assets/2268383c-642d-414c-881a-50757ea688d6)


After:
![image](https://github.com/user-attachments/assets/dbc6ba8e-3a08-4002-8dea-baa3c7d6f535)
