### PR TITLE
[3.7] Fix property not found exception in metadata editor with physical structure tree

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
@@ -83,7 +83,7 @@
                         a:data-order="#{physicalNode.order}"/>
                 <h:outputText value=" 🔗" rendered="#{physicalNode.linked}"/>
             </p:treeNode>
-            <p:treeNode type="#{DataEditorForm.structurePanel.MEDIA_PARTIAL_NODE_TYPE}"
+            <p:treeNode type="#{StructurePanel.MEDIA_PARTIAL_NODE_TYPE}"
                         icon="ui-icon-media-partial">
                 <h:outputText
                         value="#{physicalNode.label}"


### PR DESCRIPTION
Same as #6268 for 3.7.x