### PR TITLE
Require global role editing permission to see global authorities

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/controller/SecurityAccessController.java
+++ b/Kitodo/src/main/java/org/kitodo/production/controller/SecurityAccessController.java
@@ -957,6 +957,24 @@ public class SecurityAccessController {
     }
 
     /**
+     * Checks if current user has global authority for editing roles.
+     *
+     * @return true if current user has global authority for editing roles
+     */
+    public boolean hasAuthorityGlobalToEditRole() {
+        return securityAccessService.hasAuthorityGlobalToEditRole();
+    }
+
+    /**
+     * Checks if current user has global authority for viewing a role.
+     *
+     * @return true if current user has global authority for editing a role
+     */
+    public boolean hasAuthorityGlobalToViewRole() {
+        return securityAccessService.hasAuthorityGlobalToViewRole();
+    }
+
+    /**
      * Checks if current user has authority to configure displayed columns in list
      * views.
      *

--- a/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/security/SecurityAccessService.java
@@ -890,6 +890,25 @@ public class SecurityAccessService extends SecurityAccess {
     }
 
     /**
+     * Checks if current user has global authority for editing a role.
+     *
+     * @return true if current user has global authority for editing a role
+     */
+    public boolean hasAuthorityGlobalToEditRole() {
+        return hasAnyAuthorityGlobal("editRole");
+    }
+
+    /**
+     * Checks if current user has global authority for viewing a role.
+     * Having the authority to edit a role also grants permission to view it inherently.
+     *
+     * @return true if current user has global authority for editing a role
+     */
+    public boolean hasAuthorityGlobalToViewRole() {
+        return hasAnyAuthorityGlobal("viewRole, editRole");
+    }
+
+    /**
      * Check if current user has global authority to view role list. It returns true
      * if user has "viewAllRoles" authority globally.
      *

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/roleEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/roleEdit/details.xhtml
@@ -42,18 +42,20 @@
             </p:row>
             <p:row rendered="#{not SecurityAccessController.hasAuthorityGlobalToAddOrEditRole()}" />
         </p:panelGrid>
-        <p:panelGrid columns="2" layout="grid">
-            <p:row>
+        <p:panelGrid columns="#{SecurityAccessController.hasAuthorityGlobalToViewRole() ? 2 : 1}"
+                     layout="grid">
+            <p:row rendered="#{SecurityAccessController.hasAuthorityGlobalToViewRole()}">
                 <!--global authorities-->
                 <h:panelGroup>
                     <h3 style="margin-bottom: 20px">
                         <h:outputText value="#{msgs.globalAssignable}"/>
                     </h3>
+                    <!--@elvariable id="authority" type="org.kitodo.data.database.beans.Authority"-->
                     <p:pickList id="authoritiesGlobalPick"
                                 showSourceFilter="true" showTargetFilter="true"
                                 filterMatchMode="contains"
                                 responsive="true"
-                                disabled="#{isViewMode}"
+                                disabled="#{not SecurityAccessController.hasAuthorityGlobalToEditRole() or isViewMode}"
                                 value="#{RoleForm.globalAssignableAuthorities}"
                                 converter="#{authorityConverter}"
                                 var="authority"
@@ -70,7 +72,7 @@
                 <!--client authorities-->
                 <h:panelGroup>
                     <h3 style="margin-bottom: 20px">
-                        <h:outputText value="#{msgs.clientAssignable}"/>
+                        <h:outputText value="#{SecurityAccessController.hasAuthorityGlobalToViewRole() ? msgs.clientAssignable : msgs.authorities}"/>
                     </h3>
                     <p:pickList id="authoritiesClientPick"
                                 value="#{RoleForm.clientAssignableAuthorities}"


### PR DESCRIPTION
This pull request adds the check suggested in #5837 and hides the "Global authorities" on the "Role edit" page when the user does not have the permission to globally edit a role:

<img width="1445" alt="Bildschirmfoto 2024-10-31 um 08 38 25" src="https://github.com/user-attachments/assets/70b179c4-0a80-44f3-bac4-58774a3dc436">

@pontus-osterdahl does this work for you?

Fixes #5837 