### PR TITLE
Add missing declaration of 'groupDisplayLabel' to test ruleset.xsd

### DIFF
--- a/Kitodo-DataEditor/src/test/resources/ruleset.xsd
+++ b/Kitodo-DataEditor/src/test/resources/ruleset.xsd
@@ -466,6 +466,9 @@
                     imported metadata entries from the data source can be updated later.
 
                 'title' This field is used as the title to form the author-title key.
+
+                'groupDisplayLabel' keys of this type are displayed in the metadata update dialog of the metadata
+                    editor.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction>
@@ -481,6 +484,7 @@
                             <xs:enumeration value="higherlevelIdentifier"/>
                             <xs:enumeration value="processTitle"/>
                             <xs:enumeration value="recordIdentifier"/>
+                            <xs:enumeration value="groupDisplayLabel"/>
                             <xs:enumeration value="title"/>
                         </xs:restriction>
                     </xs:simpleType>


### PR DESCRIPTION
This PR adds `groupDisplayLabel` to the ruleset schema definition used for tests.