### PR TITLE
Add option to set default client for each user

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/User.java
@@ -117,6 +117,10 @@ public class User extends BaseBean {
     @Column(name = "show_physical_page_number_below_thumbnail")
     private boolean showPhysicalPageNumberBelowThumbnail;
 
+    @ManyToOne
+    @JoinColumn(name = "default_client_id", foreignKey = @ForeignKey(name = "FK_user_default_client_id"))
+    private Client defaultClient;
+
     /**
      * Constructor for User Entity.
      */
@@ -160,6 +164,7 @@ public class User extends BaseBean {
         this.projects = Objects.isNull(user.projects) ? new ArrayList<>() : user.projects;
         this.clients = Objects.isNull(user.clients) ? new ArrayList<>() : user.clients;
         this.filters = Objects.isNull(user.filters) ? new ArrayList<>() : user.filters;
+        this.defaultClient = Objects.isNull(user.defaultClient) ? null : user.defaultClient;
 
         if (Objects.nonNull(user.tableSize)) {
             this.tableSize = user.tableSize;
@@ -515,6 +520,24 @@ public class User extends BaseBean {
      */
     public void setShowPhysicalPageNumberBelowThumbnail(boolean showPhysicalPageNumberBelowThumbnail) {
         this.showPhysicalPageNumberBelowThumbnail = showPhysicalPageNumberBelowThumbnail;
+    }
+
+    /**
+     * Get default client.
+     *
+     * @return default client
+     */
+    public Client getDefaultClient() {
+        return defaultClient;
+    }
+
+    /**
+     * Set default client.
+     *
+     * @param defaultClient default client
+     */
+    public void setDefaultClient(Client defaultClient) {
+        this.defaultClient = defaultClient;
     }
 
     /**

--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_136__Add_default_client_to_user.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_136__Add_default_client_to_user.sql
@@ -1,0 +1,13 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+-- Add column "default_client_id" to "user" table
+ALTER TABLE user ADD default_client_id INT;

--- a/Kitodo/src/main/java/org/kitodo/production/controller/SessionClientController.java
+++ b/Kitodo/src/main/java/org/kitodo/production/controller/SessionClientController.java
@@ -80,10 +80,14 @@ public class SessionClientController {
      * Display client selection dialog if user is logged in and has multiple clients.
      */
     public void showClientSelectDialog() {
-        if (Objects.isNull(getCurrentSessionClient()) && !userHasOnlyOneClient()) {
-            PrimeFaces.current().executeScript("PF('selectClientDialog').show();");
+        User currentUser = ServiceManager.getUserService().getCurrentUser();
+        Client defaultClient = currentUser.getDefaultClient();
+        if (Objects.nonNull(defaultClient)) {
+            setSessionClient(defaultClient);
         } else if (userHasOnlyOneClient()) {
             setSessionClient(getFirstClientOfCurrentUser());
+        } else if (Objects.isNull(getCurrentSessionClient()) && !userHasOnlyOneClient()) {
+            PrimeFaces.current().executeScript("PF('selectClientDialog').show();");
         }
     }
 
@@ -160,6 +164,15 @@ public class SessionClientController {
             }
         }
         return clients;
+    }
+
+    /**
+     * Get default client of current user.
+     *
+     * @return default client of current user
+     */
+    public Client getDefaultClientOfCurrentUser() {
+        return ServiceManager.getUserService().getCurrentUser().getDefaultClient();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -364,6 +364,9 @@ public class UserForm extends BaseForm {
                 for (Client client : this.userObject.getClients()) {
                     if (client.getId().equals(clientId)) {
                         this.userObject.getClients().remove(client);
+                        if (client.equals(this.userObject.getDefaultClient())) {
+                            this.userObject.setDefaultClient(null);
+                        }
                         break;
                     }
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/security/CustomLoginSuccessHandler.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/CustomLoginSuccessHandler.java
@@ -48,7 +48,8 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         try {
             SessionClientController controller = new SessionClientController();
             if (ServiceManager.getIndexingService().isIndexCorrupted()
-                    || controller.getAvailableClientsOfCurrentUser().size() > 1) {
+                    || (controller.getAvailableClientsOfCurrentUser().size() > 1
+                    && Objects.isNull(controller.getDefaultClientOfCurrentUser()))) {
                 // redirect to empty landing page, where dialogs are displayed depending on both checks!
                 redirectStrategy.sendRedirect(httpServletRequest, httpServletResponse, EMPTY_LANDING_PAGE);
             } else {

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -363,6 +363,7 @@ databaseStatistic=Datenbankstatistik
 day=Tag
 days=Tage
 deactivatedTemplates=Deaktivierte Produktionsvorlagen
+defaultClient=Standardmandant
 defaults=Vorgaben
 delete=L\u00F6schen
 deleteAfterMove=Nach dem Export l\u00F6schen

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -363,6 +363,7 @@ databaseStatistic=Database statistics
 day=day
 days=days
 deactivatedTemplates=Deactivated templates
+defaultClient=Default client
 defaults=Defaults
 delete=Delete
 deleteAfterMove=Delete after export

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
@@ -123,7 +123,9 @@
                             onchange="toggleSave()" required="#{empty param['editForm:saveButtonToggler']}"
                             redisplay="true"/>
             </h:panelGroup>
-            <div>
+            <h:panelGroup layout="block"
+                          id="defaultClientWrapper"
+                          rendered="#{UserForm.userObject.clients.size() gt 1}">
                 <p:outputLabel for="defaultClient"
                                value="#{msgs['defaultClient']}"
                                title="#{msgs['defaultClient']}"/>
@@ -139,7 +141,7 @@
                     <p:ajax event="change"
                             oncomplete="toggleSave()"/>
                 </p:selectOneMenu>
-            </div>
+            </h:panelGroup>
             <div>
                 <!-- table size -->
                 <p:outputLabel for="table-size" value="#{msgs.tableSize}" />

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
@@ -124,6 +124,23 @@
                             redisplay="true"/>
             </h:panelGroup>
             <div>
+                <p:outputLabel for="defaultClient"
+                               value="#{msgs['defaultClient']}"
+                               title="#{msgs['defaultClient']}"/>
+                <p:selectOneMenu id="defaultClient"
+                                 converter="#{clientConverter}"
+                                 value="#{UserForm.userObject.defaultClient}"
+                                 disabled="#{isViewMode}">
+                    <f:selectItem noSelectionOption="true"
+                                  itemLabel="#{msgs['notSelected']}"/>
+                    <f:selectItems value="#{UserForm.userObject.clients}"
+                                   var="client"
+                                   itemLabel="#{client.name}"/>
+                    <p:ajax event="change"
+                            oncomplete="toggleSave()"/>
+                </p:selectOneMenu>
+            </div>
+            <div>
                 <!-- table size -->
                 <p:outputLabel for="table-size" value="#{msgs.tableSize}" />
                 <p:inputText id="table-size" value="#{UserForm.userObject.tableSize}" disabled="#{isViewMode}"

--- a/Kitodo/src/test/java/org/kitodo/selenium/LoginST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/LoginST.java
@@ -11,27 +11,26 @@
 
 package org.kitodo.selenium;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kitodo.data.elasticsearch.exceptions.CustomResponseException;
-import org.kitodo.data.exceptions.DataException;
+import org.kitodo.data.database.beans.Client;
+import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.beans.User;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.selenium.testframework.BaseTestSelenium;
 import org.kitodo.selenium.testframework.Browser;
 import org.kitodo.selenium.testframework.Pages;
 
-public class LoginST extends BaseTestSelenium {
+import java.util.Collections;
 
-    @BeforeAll
-    public static void manipulateIndex() throws DataException, CustomResponseException {
-        // remove one process from index but not from DB to provoke index warning
-        ServiceManager.getProcessService().removeFromIndex(1, true);
-    }
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LoginST extends BaseTestSelenium {
 
     @Test
     public void indexWarningTest() throws Exception {
+        // remove one process from index but not from DB to provoke index warning
+        ServiceManager.getProcessService().removeFromIndex(1, true);
+
         // log into Kitodo with non-admin user to be redirected to 'checks' page
         Pages.getLoginPage().goTo().performLogin(ServiceManager.getUserService().getById(2));
         assertEquals("http://localhost:8080/kitodo/pages/checks.jsf", Browser.getCurrentUrl());
@@ -41,5 +40,36 @@ public class LoginST extends BaseTestSelenium {
         Pages.getLoginPage().goTo().performLoginAsAdmin();
         assertEquals("http://localhost:8080/kitodo/pages/system.jsf?tabIndex=2", Browser.getCurrentUrl());
         Pages.getTopNavigation().logout();
+
+        // restore deleted process to index
+        Process unindexedProcess = ServiceManager.getProcessService().getById(1);
+        ServiceManager.getProcessService().addAllObjectsToIndex(Collections.singletonList(unindexedProcess));
+    }
+
+    @Test
+    public void defaultClientTest() throws Exception {
+        User userNowak = ServiceManager.getUserService().getByLogin("nowak");
+        assertTrue(userNowak.getClients().size() > 1, "Test user should have more than one client");
+        Client defaultClient = userNowak.getDefaultClient();
+        assertNull(defaultClient, "Default client should be null.");
+
+        Pages.getLoginPage().goTo().performLogin(userNowak);
+        assertEquals("http://localhost:8080/kitodo/pages/checks.jsf", Browser.getCurrentUrl(),
+                "User with multiple clients but no default client should get redirected to 'checks' page.");
+        Pages.getTopNavigation().cancelClientSelection();
+
+        // set default client of user
+        Client firstClient = ServiceManager.getClientService().getById(1);
+        userNowak.setDefaultClient(firstClient);
+        ServiceManager.getUserService().saveToDatabase(userNowak);
+
+        Pages.getLoginPage().goTo().performLogin(userNowak);
+        assertEquals("http://localhost:8080/kitodo/pages/desktop.jsf", Browser.getCurrentUrl(),
+                "User with default client should get redirected to 'desktop' page.");
+        Pages.getTopNavigation().logout();
+
+        // restore users original settings
+        userNowak.setDefaultClient(null);
+        ServiceManager.getUserService().saveToDatabase(userNowak);
     }
 }


### PR DESCRIPTION
This pull request adds the option to set a default client in the user settings. This default client will be selected automatically upon login, skipping the "Select client" dialog for users with multiple clients. 

This functionality is optional which means the system will work exactly the same as before when no default client is set.

Fixes #6262 