### PR TITLE
Add EAD collection import

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormat.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormat.java
@@ -15,6 +15,7 @@ public enum MetadataFormat {
     MODS,
     MARC,
     PICA,
+    EAD,
     OTHER,
     KITODO;
 

--- a/Kitodo-API/src/main/java/org/kitodo/constants/StringConstants.java
+++ b/Kitodo-API/src/main/java/org/kitodo/constants/StringConstants.java
@@ -21,5 +21,17 @@ public class StringConstants {
     public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     // acquisition stages
+    public static final String CREATE = "create";
     public static final String EDIT = "edit";
+
+    // EAD string constants
+    public static final String EAD = "ead";
+    public static final String LEVEL = "level";
+    public static final String C_TAG_NAME = "c";
+    // EAD levels
+    public static final String COLLECTION = "collection";
+    public static final String CLASS = "class";
+    public static final String SERIES = "series";
+    public static final String FILE = "file";
+    public static final String ITEM = "item";
 }

--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -655,7 +655,13 @@ public enum ParameterCore implements ParameterInterface {
     /* Optional parameter can be used to limit the number of processes for which media renaming can be conducted as a
      * list function. Values different from positive integers are interpreted as "unlimited".
      */
-    MAX_NUMBER_OF_PROCESSES_FOR_MEDIA_RENAMING(new Parameter<>("maxNumberOfProcessesForMediaRenaming", -1));
+    MAX_NUMBER_OF_PROCESSES_FOR_MEDIA_RENAMING(new Parameter<>("maxNumberOfProcessesForMediaRenaming", -1)),
+
+    /*
+     * Optional parameter controlling how many processes are to be displayed and processed in the metadata import mask.
+     * When more data records are imported the import process is moved to a background task. Default value is 5.
+     */
+    MAX_NUMBER_OF_PROCESSES_FOR_IMPORT_MASK(new Parameter<>("maxNumberOfProcessesForImportMask", 5));
 
     private final Parameter<?> parameter;
 

--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -661,7 +661,13 @@ public enum ParameterCore implements ParameterInterface {
      * Optional parameter controlling how many processes are to be displayed and processed in the metadata import mask.
      * When more data records are imported the import process is moved to a background task. Default value is 5.
      */
-    MAX_NUMBER_OF_PROCESSES_FOR_IMPORT_MASK(new Parameter<>("maxNumberOfProcessesForImportMask", 5));
+    MAX_NUMBER_OF_PROCESSES_FOR_IMPORT_MASK(new Parameter<>("maxNumberOfProcessesForImportMask", 5)),
+
+    /*
+     * Optional parameter controlling whether the import of all elements from an uploaded EAD XML file should be
+     * canceled when an exception occurs or not. Defaults to 'false'.
+     */
+    STOP_EAD_COLLECTION_IMPORT_ON_EXCEPTION(new Parameter<>("stopEadCollectionImportOnException", false));
 
     private final Parameter<?> parameter;
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import javax.faces.context.FacesContext;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
@@ -29,7 +30,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.externaldatamanagement.SingleHit;
+import org.kitodo.api.schemaconverter.DataRecord;
 import org.kitodo.api.schemaconverter.ExemplarRecord;
+import org.kitodo.api.schemaconverter.MetadataFormat;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.exceptions.CatalogException;
@@ -53,7 +56,7 @@ import org.xml.sax.SAXException;
 
 public class CatalogImportDialog  extends MetadataImportDialog implements Serializable {
     private static final Logger logger = LogManager.getLogger(CatalogImportDialog.class);
-    private final LazyHitModel hitModel = new LazyHitModel();
+    private final LazyHitModel hitModel;
 
     private static final String ID_PARAMETER_NAME = "ID";
     private static final String HITSTABLE_NAME = "hitlistDialogForm:hitlistDialogTable";
@@ -64,6 +67,10 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
     private int numberOfChildren = 0;
     private String opacErrorMessage = "";
     private boolean additionalImport = false;
+    private String selectedField = "";
+    private String searchTerm = "";
+    private int importDepth = 2;
+
 
     /**
      * Standard constructor.
@@ -72,6 +79,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      */
     CatalogImportDialog(CreateProcessForm createProcessForm) {
         super(createProcessForm);
+        this.hitModel = new LazyHitModel(this);
     }
 
     /**
@@ -87,11 +95,11 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      * @return list of search fields
      */
     public List<String> getSearchFields() {
-        if (Objects.isNull(hitModel.getImportConfiguration())) {
+        if (Objects.isNull(createProcessForm.getCurrentImportConfiguration())) {
             return new LinkedList<>();
         } else {
             try {
-                return ServiceManager.getImportService().getAvailableSearchFields(hitModel.getImportConfiguration());
+                return ServiceManager.getImportService().getAvailableSearchFields(createProcessForm.getCurrentImportConfiguration());
             } catch (IllegalArgumentException e) {
                 Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
                 return new LinkedList<>();
@@ -104,8 +112,8 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      */
     public void search() {
         try {
-            if (skipHitList(hitModel.getImportConfiguration(), hitModel.getSelectedField())) {
-                getRecordById(hitModel.getSearchTerm());
+            if (skipHitList(createProcessForm.getCurrentImportConfiguration(), getSelectedField())) {
+                getRecordById(getSearchTerm());
             } else {
                 List<?> hits = hitModel.load(0, 10, null, SortOrder.ASCENDING, Collections.EMPTY_MAP);
                 if (hits.size() == 1) {
@@ -175,16 +183,21 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                 createProcessForm.setChildProcesses(new LinkedList<>());
                 int projectId = this.createProcessForm.getProject().getId();
                 int templateId = this.createProcessForm.getTemplate().getId();
-                ImportConfiguration importConfiguration = this.hitModel.getImportConfiguration();
+                ImportConfiguration importConfiguration = createProcessForm.getCurrentImportConfiguration();
 
-                // import current and ancestors
-                LinkedList<TempProcess> processes = ServiceManager.getImportService().importProcessHierarchy(
-                        currentRecordId, importConfiguration, projectId, templateId, hitModel.getImportDepth(),
-                        createProcessForm.getRulesetManagement().getFunctionalKeys(
-                                FunctionalMetadata.HIGHERLEVEL_IDENTIFIER));
-                // import children
-                if (this.importChildren) {
-                    importChildren(projectId, templateId, importConfiguration, processes);
+                LinkedList<TempProcess> processes;
+                if (MetadataFormat.EAD.name().equals(importConfiguration.getMetadataFormat())) {
+                    processes = createEadProcesses(importConfiguration);
+                } else {
+                    // import current and ancestors
+                    processes = ServiceManager.getImportService().importProcessHierarchy(currentRecordId,
+                            importConfiguration, projectId, templateId, getImportDepth(),
+                            createProcessForm.getRulesetManagement().getFunctionalKeys(
+                                    FunctionalMetadata.HIGHERLEVEL_IDENTIFIER));
+                    // import children
+                    if (this.importChildren) {
+                        importChildren(projectId, templateId, importConfiguration, processes);
+                    }
                 }
 
                 if (!createProcessForm.getProcesses().isEmpty() && additionalImport) {
@@ -196,13 +209,37 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                     attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
                     showMessageAndRecord(importConfiguration, processes);
                 }
+
             } catch (IOException | ProcessGenerationException | XPathExpressionException | URISyntaxException
-                    | ParserConfigurationException | UnsupportedFormatException | SAXException | DAOException
-                    | ConfigException | TransformerException | NoRecordFoundException | InvalidMetadataValueException
-                    | NoSuchMetadataFieldException e) {
+                     | ParserConfigurationException | UnsupportedFormatException | SAXException | DAOException
+                     | ConfigException | TransformerException | NoRecordFoundException | InvalidMetadataValueException
+                     | NoSuchMetadataFieldException | XMLStreamException e) {
                 throw new CatalogException(e.getLocalizedMessage());
             }
         }
+    }
+
+    private LinkedList<TempProcess> createEadProcesses(ImportConfiguration importConfiguration) throws NoRecordFoundException,
+            XPathExpressionException, IOException, ParserConfigurationException, SAXException, XMLStreamException,
+            UnsupportedFormatException, ProcessGenerationException, URISyntaxException, InvalidMetadataValueException,
+            TransformerException, NoSuchMetadataFieldException {
+        LinkedList<TempProcess> processes = new LinkedList<>();
+        DataRecord externalRecord = ServiceManager.getImportService()
+                .importExternalDataRecord(importConfiguration, this.currentRecordId, false);
+        createProcessForm.setXmlString(externalRecord.getOriginalData().toString());
+        if (createProcessForm.limitExceeded(externalRecord.getOriginalData().toString())) {
+            createProcessForm.calculateNumberOfEadElements();
+            Ajax.update("maxNumberOfRecordsExceededDialog");
+            PrimeFaces.current().executeScript("PF('maxNumberOfRecordsExceededDialog').show();");
+        } else {
+            LinkedList<TempProcess> eadProcesses = ServiceManager.getImportService()
+                    .parseImportedEADCollection(externalRecord, importConfiguration,
+                            createProcessForm.getProject().getId(), createProcessForm.getTemplate().getId(),
+                            createProcessForm.getSelectedEadLevel(), createProcessForm.getSelectedParentEadLevel());
+            createProcessForm.setChildProcesses(new LinkedList<>(eadProcesses.subList(1, eadProcesses.size() - 1)));
+            processes = new LinkedList<>(Collections.singletonList(eadProcesses.get(0)));
+        }
+        return processes;
     }
 
     private void showMessageAndRecord(ImportConfiguration importConfiguration, LinkedList<TempProcess> processes) {
@@ -238,7 +275,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
         try {
             if (this.importChildren) {
                 this.numberOfChildren = ServiceManager.getImportService().getNumberOfChildren(
-                        this.hitModel.getImportConfiguration(), this.currentRecordId);
+                        createProcessForm.getCurrentImportConfiguration(), this.currentRecordId);
             }
             if (this.importChildren && this.numberOfChildren > NUMBER_OF_CHILDREN_WARNING_THRESHOLD) {
                 Ajax.update("manyChildrenWarningDialog");
@@ -294,7 +331,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      */
     public void setSelectedExemplarRecord(ExemplarRecord selectedExemplarRecord) {
         try {
-            ImportService.setSelectedExemplarRecord(selectedExemplarRecord, this.hitModel.getImportConfiguration(),
+            ImportService.setSelectedExemplarRecord(selectedExemplarRecord, createProcessForm.getCurrentImportConfiguration(),
                     this.createProcessForm.getProcessMetadata().getProcessDetailsElements());
             String summary = Helper.getTranslation("newProcess.catalogueSearch.exemplarRecordSelectedSummary");
             String detail = Helper.getTranslation("newProcess.catalogueSearch.exemplarRecordSelectedDetail",
@@ -303,7 +340,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
             Ajax.update(FORM_CLIENTID);
         } catch (ParameterNotFoundException e) {
             Helper.setErrorMessage("newProcess.catalogueSearch.exemplarRecordParameterNotFoundError",
-                    new Object[] {e.getMessage(), this.hitModel.getImportConfiguration().getTitle() });
+                    new Object[] {e.getMessage(), createProcessForm.getCurrentImportConfiguration().getTitle() });
         }
     }
 
@@ -314,8 +351,8 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      */
     public boolean isParentIdSearchFieldConfigured() {
         try {
-            return Objects.nonNull(this.hitModel.getImportConfiguration()) && ServiceManager.getImportService()
-                    .isParentIdSearchFieldConfigured(this.hitModel.getImportConfiguration());
+            return Objects.nonNull(createProcessForm.getCurrentImportConfiguration()) && ServiceManager.getImportService()
+                    .isParentIdSearchFieldConfigured(createProcessForm.getCurrentImportConfiguration());
         } catch (ConfigException e) {
             return false;
         }
@@ -358,6 +395,61 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
      */
     public void setAdditionalImport(boolean additionalImport) {
         this.additionalImport = additionalImport;
+    }
+
+
+    /**
+     * Get searchTerm.
+     *
+     * @return value of searchTerm
+     */
+    public String getSearchTerm() {
+        return this.searchTerm;
+    }
+
+    /**
+     * Set searchTerm.
+     *
+     * @param searchTerm as java.lang.String
+     */
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    /**
+     * Get selectedField.
+     *
+     * @return value of selectedField
+     */
+    public String getSelectedField() {
+        return this.selectedField;
+    }
+
+    /**
+     * Set selectedField.
+     *
+     * @param field as java.lang.String
+     */
+    public void setSelectedField(String field) {
+        this.selectedField = field;
+    }
+
+    /**
+     * Get import depth.
+     *
+     * @return import depth
+     */
+    public int getImportDepth() {
+        return importDepth;
+    }
+
+    /**
+     * Set import depth.
+     *
+     * @param depth import depth
+     */
+    public void setImportDepth(int depth) {
+        importDepth = depth;
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -428,7 +428,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
     /**
      * Set selectedField.
      *
-     * @param field as java.lang.String
+     * @param field as String
      */
     public void setSelectedField(String field) {
         this.selectedField = field;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -129,7 +129,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
      * @throws XMLStreamException when retrieving EAD from XML data fails
      */
     public void calculateNumberOfEadElements() throws XMLStreamException {
-        numberOfEadElements = XMLUtils.getNumberOfElements(xmlString, selectedEadLevel);
+        numberOfEadElements = XMLUtils.getNumberOfEADElements(xmlString, selectedEadLevel);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -122,6 +122,12 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
         this.priorityList = priorityList;
     }
 
+    /**
+     * Calculate number of EAD elements of selected level (e.g. "item", "file" etc.) from "xmlString", containing
+     * content of currently imported XML file.
+     *
+     * @throws XMLStreamException when retrieving EAD from XML data fails
+     */
     public void calculateNumberOfEadElements() throws XMLStreamException {
         numberOfEadElements = XMLUtils.getNumberOfElements(xmlString, selectedEadLevel);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -12,7 +12,6 @@
 package org.kitodo.production.forms.createprocess;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -30,24 +29,26 @@ import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
+import javax.xml.stream.XMLStreamException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.MetadataEntry;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
-import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
-import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
-import org.kitodo.api.dataformat.Division;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
+import org.kitodo.api.schemaconverter.MetadataFormat;
+import org.kitodo.constants.StringConstants;
+import org.kitodo.data.database.beans.Client;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.Template;
+import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.CommandException;
@@ -60,7 +61,10 @@ import org.kitodo.production.dto.ProcessDTO;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.forms.BaseForm;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.helper.ProcessHelper;
 import org.kitodo.production.helper.TempProcess;
+import org.kitodo.production.helper.XMLUtils;
+import org.kitodo.production.helper.tasks.TaskManager;
 import org.kitodo.production.interfaces.MetadataTreeTableInterface;
 import org.kitodo.production.interfaces.RulesetSetupInterface;
 import org.kitodo.production.metadata.MetadataEditor;
@@ -69,6 +73,7 @@ import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ImportService;
 import org.kitodo.production.services.data.ProcessService;
 import org.kitodo.production.services.dataeditor.DataEditorService;
+import org.kitodo.production.thread.ImportEadProcessesThread;
 import org.primefaces.PrimeFaces;
 import org.primefaces.model.TreeNode;
 
@@ -97,8 +102,17 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
     private int progress;
     private TempProcess currentProcess;
     private Boolean rulesetConfigurationForOpacImportComplete = null;
-    private String defaultConfigurationType;
+    private ImportConfiguration currentImportConfiguration;
     static final int TITLE_RECORD_LINK_TAB_INDEX = 1;
+
+    private final List<String> eadLevels = Arrays.asList(StringConstants.FILE, StringConstants.ITEM);
+    private final List<String> eadParentLevels = Arrays.asList(StringConstants.COLLECTION, StringConstants.CLASS,
+            StringConstants.SERIES);
+    private String selectedEadLevel = StringConstants.FILE;
+    private String selectedParentEadLevel = StringConstants.COLLECTION;
+    private String xmlString;
+    private String filename;
+    protected int numberOfEadElements;
 
     public CreateProcessForm() {
         priorityList = ServiceManager.getUserService().getCurrentMetadataLanguage();
@@ -106,6 +120,10 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
 
     CreateProcessForm(List<Locale.LanguageRange> priorityList) {
         this.priorityList = priorityList;
+    }
+
+    public void calculateNumberOfEadElements() throws XMLStreamException {
+        numberOfEadElements = XMLUtils.getNumberOfElements(xmlString, selectedEadLevel);
     }
 
     /**
@@ -429,10 +447,8 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                 project = processGenerator.getProject();
                 template = processGenerator.getTemplate();
                 updateRulesetAndDocType(getMainProcess().getRuleset());
-                if (Objects.nonNull(project) && Objects.nonNull(project.getDefaultImportConfiguration())) {
-                    setDefaultImportConfiguration(project.getDefaultImportConfiguration());
-                } else {
-                    defaultConfigurationType = null;
+                if (Objects.nonNull(project)) {
+                    setCurrentImportConfiguration(project.getDefaultImportConfiguration());
                 }
                 if (Objects.nonNull(parentId) && parentId != 0) {
                     ProcessDTO parentProcess = ServiceManager.getProcessService().findById(parentId);
@@ -448,43 +464,29 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                     titleRecordLinkTab.setChosenParentProcess(String.valueOf(parentId));
                     titleRecordLinkTab.chooseParentProcess();
                     if (Objects.nonNull(project.getDefaultChildProcessImportConfiguration())) {
-                        setDefaultImportConfiguration(project.getDefaultChildProcessImportConfiguration());
-                    } else {
-                        defaultConfigurationType = null;
+                        setCurrentImportConfiguration(project.getDefaultChildProcessImportConfiguration());
                     }
                     if (setChildCount(titleRecordLinkTab.getTitleRecordProcess(), rulesetManagement, workpiece)) {
                         updateRulesetAndDocType(getMainProcess().getRuleset());
                     }
                 }
                 processDataTab.prepare();
-                showDefaultImportConfigurationDialog();
+                showDialogForImportConfiguration(currentImportConfiguration);
             }
         } catch (ProcessGenerationException | DataException | DAOException | IOException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
     }
 
-    private void showDefaultImportConfigurationDialog() {
-        if (ImportConfigurationType.OPAC_SEARCH.name().equals(defaultConfigurationType)) {
-            checkRulesetConfiguration();
-        } else if (ImportConfigurationType.FILE_UPLOAD.name().equals(defaultConfigurationType)) {
-            PrimeFaces.current().executeScript("PF('fileUploadDialog').show()");
-        } else if (ImportConfigurationType.PROCESS_TEMPLATE.name().equals(defaultConfigurationType)) {
-            PrimeFaces.current().executeScript("PF('searchEditDialog').show()");
-        }
-    }
-
-    private void setDefaultImportConfiguration(ImportConfiguration importConfiguration) {
-        defaultConfigurationType = importConfiguration.getConfigurationType();
-        if (ImportConfigurationType.OPAC_SEARCH.name().equals(importConfiguration.getConfigurationType())) {
-            catalogImportDialog.getHitModel().setImportConfiguration(importConfiguration);
-            PrimeFaces.current().ajax().update("catalogSearchDialog");
-        } else if (ImportConfigurationType.PROCESS_TEMPLATE.name().equals(importConfiguration.getConfigurationType())) {
-            searchDialog.setOriginalProcess(importConfiguration.getDefaultTemplateProcess());
-            PrimeFaces.current().ajax().update("searchEditDialog");
-        } else if (ImportConfigurationType.FILE_UPLOAD.name().equals(importConfiguration.getConfigurationType())) {
-            fileUploadDialog.setImportConfiguration(importConfiguration);
-            PrimeFaces.current().ajax().update("fileUploadDialog");
+    private void showDialogForImportConfiguration(ImportConfiguration importConfiguration) {
+        if (Objects.nonNull(importConfiguration)) {
+            if (ImportConfigurationType.OPAC_SEARCH.name().equals(importConfiguration.getConfigurationType())) {
+                PrimeFaces.current().executeScript("PF('catalogSearchDialog').show();");
+            } else if (ImportConfigurationType.PROCESS_TEMPLATE.name().equals(importConfiguration.getConfigurationType())) {
+                PrimeFaces.current().executeScript("PF('searchEditDialog').show();");
+            } else if (ImportConfigurationType.FILE_UPLOAD.name().equals(importConfiguration.getConfigurationType())) {
+                PrimeFaces.current().executeScript("PF('fileUploadDialog').show();");
+            }
         }
     }
 
@@ -524,7 +526,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
             throw new IOException("Unable to create directories for process hierarchy!");
         }
 
-        if (this.catalogImportDialog.isImportChildren() && !createProcessesLocation(this.childProcesses)) {
+        if (saveChildProcesses() && !createProcessesLocation(this.childProcesses)) {
             throw new IOException("Unable to create directories for child processes!");
         }
         saveProcessHierarchyMetadata();
@@ -625,49 +627,11 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
             if (this.processes.indexOf(tempProcess) == 0) {
                 tempProcess.getProcessMetadata().preserve();
             }
-            saveTempProcessMetadata(tempProcess);
+            ProcessHelper.saveTempProcessMetadata(tempProcess, rulesetManagement, acquisitionStage, priorityList);
         }
         // save child processes meta.xml files
         for (TempProcess tempProcess : this.childProcesses) {
-            saveTempProcessMetadata(tempProcess);
-        }
-    }
-
-    private void saveTempProcessMetadata(TempProcess tempProcess) {
-        try (OutputStream out = ServiceManager.getFileService()
-                .write(ServiceManager.getProcessService().getMetadataFileUri(tempProcess.getProcess()))) {
-            Workpiece workpiece = tempProcess.getWorkpiece();
-            workpiece.setId(tempProcess.getProcess().getId().toString());
-            if (Objects.nonNull(rulesetManagement)) {
-                setProcessTitleMetadata(workpiece, tempProcess.getProcess().getTitle());
-            }
-            ServiceManager.getMetsService().save(workpiece, out);
-        } catch (IOException e) {
-            Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
-        }
-    }
-
-    private void setProcessTitleMetadata(Workpiece workpiece, String processTitle) {
-        Collection<String> keysForProcessTitle = rulesetManagement.getFunctionalKeys(FunctionalMetadata.PROCESS_TITLE);
-        if (!keysForProcessTitle.isEmpty()) {
-            addAllowedMetadataRecursive(workpiece.getLogicalStructure(), keysForProcessTitle, processTitle);
-            addAllowedMetadataRecursive(workpiece.getPhysicalStructure(), keysForProcessTitle, processTitle);
-        }
-    }
-
-    private void addAllowedMetadataRecursive(Division<?> division, Collection<String> keys, String value) {
-        StructuralElementViewInterface divisionView = rulesetManagement.getStructuralElementView(division.getType(),
-            acquisitionStage, priorityList);
-        for (MetadataViewInterface metadataView : divisionView.getAllowedMetadata()) {
-            if (metadataView instanceof SimpleMetadataViewInterface && keys.contains(metadataView.getId())
-                    && division.getMetadata().parallelStream()
-                            .filter(metadata -> metadataView.getId().equals(metadata.getKey()))
-                            .count() < metadataView.getMaxOccurs()) {
-                MetadataEditor.writeMetadataEntry(division, (SimpleMetadataViewInterface) metadataView, value);
-            }
-        }
-        for (Division<?> child : division.getChildren()) {
-            addAllowedMetadataRecursive(child, keys, value);
+            ProcessHelper.saveTempProcessMetadata(tempProcess, rulesetManagement, acquisitionStage, priorityList);
         }
     }
 
@@ -849,15 +813,6 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
             PrimeFaces.current().executeScript("PF('recordIdentifierMissingDialog').show();");
         }
     }
-
-    /**
-     * Get defaultConfigurationType.
-     *
-     * @return value of defaultConfigurationType
-     */
-    public String getDefaultConfigurationType() {
-        return defaultConfigurationType;
-    }
     
     /**
      * Returns the details of the missing record identifier error.
@@ -866,5 +821,160 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
      */
     public Collection<RecordIdentifierMissingDetail> getDetailsOfRecordIdentifierMissingError() {
         return ServiceManager.getImportService().getDetailsOfRecordIdentifierMissingError();
+    }
+
+    /**
+     * Set the current import configuration.
+     *
+     * @param currentImportConfiguration current import configuration
+     */
+    public void setCurrentImportConfiguration(ImportConfiguration currentImportConfiguration) {
+        this.currentImportConfiguration = currentImportConfiguration;
+        if (Objects.nonNull(currentImportConfiguration)) {
+            if (ImportConfigurationType.OPAC_SEARCH.name().equals(currentImportConfiguration.getConfigurationType())) {
+                catalogImportDialog.setImportDepth(ImportService.getDefaultImportDepth(currentImportConfiguration));
+                catalogImportDialog.setSelectedField(ImportService.getDefaultSearchField(currentImportConfiguration));
+            }
+            else if (ImportConfigurationType.PROCESS_TEMPLATE.name().equals(currentImportConfiguration.getConfigurationType())) {
+                searchDialog.setOriginalProcess(currentImportConfiguration.getDefaultTemplateProcess());
+            }
+        }
+    }
+
+    /**
+     * Get the current ImportConfiguration.
+     *
+     * @return current ImportConfiguration
+     */
+    public ImportConfiguration getCurrentImportConfiguration() {
+        return currentImportConfiguration;
+    }
+
+    private boolean saveChildProcesses() {
+        return ((Objects.nonNull(currentImportConfiguration)
+                && MetadataFormat.EAD.name().equals(currentImportConfiguration.getMetadataFormat()))
+                || catalogImportDialog.isImportChildren());
+    }
+
+    /**
+     * Get selected ead level.
+     *
+     * @return selected ead level
+     */
+    public String getSelectedEadLevel() {
+        return selectedEadLevel;
+    }
+
+    /**
+     * Set selected ead level.
+     *
+     * @param selectedEadLevel as String
+     */
+    public void setSelectedEadLevel(String selectedEadLevel) {
+        this.selectedEadLevel = selectedEadLevel;
+    }
+
+    /**
+     * Get selected parent ead level.
+     *
+     * @return selected parent ead level
+     */
+    public String getSelectedParentEadLevel() {
+        return selectedParentEadLevel;
+    }
+
+    /**
+     * Set selected parent ead level.
+     *
+     * @param selectedParentEadLevel as String
+     */
+    public void setSelectedParentEadLevel(String selectedParentEadLevel) {
+        this.selectedParentEadLevel = selectedParentEadLevel;
+    }
+
+    /**
+     * Get ead levels.
+     *
+     * @return ead levels
+     */
+    public List<String> getEadLevels() {
+        return eadLevels;
+    }
+
+    /**
+     * Get parent ead levels.
+     *
+     * @return parent ead levels
+     */
+    public List<String> getEadParentLevels() {
+        return eadParentLevels;
+    }
+
+    /**
+     * Get xmlString.
+     *
+     * @return xmlString
+     */
+    public String getXmlString() {
+        return xmlString;
+    }
+
+    /**
+     * Set xmlString.
+     *
+     * @param xmlString as String
+     */
+    public void setXmlString(String xmlString) {
+        this.xmlString = xmlString;
+    }
+
+    /**
+     * Get filename.
+     *
+     * @return filename
+     */
+    public String getFilename() {
+        return filename;
+    }
+
+    /**
+     * Set filename.
+     *
+     * @param filename as String
+     */
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    protected boolean limitExceeded(String xmlString) throws XMLStreamException {
+        return MetadataFormat.EAD.name().equals(currentImportConfiguration.getMetadataFormat())
+                && ServiceManager.getImportService().isMaxNumberOfRecordsExceeded(xmlString, selectedEadLevel);
+    }
+
+    /**
+     * Get and return message that informs the user that the maximum number of records that can be processed in the GUI
+     * has been exceeded.
+     *
+     * @return maximum number exceeded message
+     */
+    public String getMaxNumberOfRecordsExceededMessage() {
+        return ImportService.getMaximumNumberOfRecordsExceededMessage(selectedEadLevel, numberOfEadElements);
+    }
+
+    /**
+     * Start background task importing processes from uploaded XML file and redirect either to task manager or desktop,
+     * depending on user permissions.
+     *
+     * @return String containing URL of either task manager or desktop page, depending on user permissions
+     */
+    public String importRecordsInBackground() {
+        User user = ServiceManager.getUserService().getAuthenticatedUser();
+        Client client = ServiceManager.getUserService().getSessionClientOfAuthenticatedUser();
+        TaskManager.addTask(new ImportEadProcessesThread(this, user, client));
+        if (ServiceManager.getSecurityAccessService().hasAuthorityToViewTaskManagerPage()) {
+            return "system.jsf?tabIndex=0&faces-redirect=true";
+        } else {
+            return "desktop.jsf?faces-redirect=true";
+        }
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/FileUploadDialog.java
@@ -14,21 +14,18 @@ package org.kitodo.production.forms.createprocess;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
-import org.kitodo.api.schemaconverter.DataRecord;
-import org.kitodo.api.schemaconverter.FileFormat;
 import org.kitodo.api.schemaconverter.MetadataFormat;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.exceptions.DAOException;
@@ -39,17 +36,16 @@ import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.exceptions.UnsupportedFormatException;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.TempProcess;
+import org.kitodo.production.helper.XMLUtils;
 import org.kitodo.production.services.ServiceManager;
-import org.kitodo.production.services.data.ImportService;
 import org.omnifaces.util.Ajax;
+import org.primefaces.PrimeFaces;
 import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.file.UploadedFile;
-import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 public class FileUploadDialog extends MetadataImportDialog {
 
-    private ImportConfiguration importConfiguration;
     private static final Logger logger = LogManager.getLogger(FileUploadDialog.class);
     private boolean additionalImport = false;
 
@@ -65,79 +61,39 @@ public class FileUploadDialog extends MetadataImportDialog {
      */
     public void handleFileUpload(FileUploadEvent event) {
         UploadedFile uploadedFile = event.getFile();
-        ImportService importService = ServiceManager.getImportService();
         try {
-            Document internalDocument = importService.convertDataRecordToInternal(
-                createRecordFromXMLElement(IOUtils.toString(uploadedFile.getInputStream(), Charset.defaultCharset())),
-                importConfiguration, false);
-            TempProcess tempProcess = importService.createTempProcessFromDocument(importConfiguration, internalDocument,
-                createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
-
-            LinkedList<TempProcess> processes = new LinkedList<>();
-            processes.add(tempProcess);
-
-            Collection<String> higherLevelIdentifier = this.createProcessForm.getRulesetManagement()
-                    .getFunctionalKeys(FunctionalMetadata.HIGHERLEVEL_IDENTIFIER);
-
-            if (!higherLevelIdentifier.isEmpty()) {
-                String parentID = importService.getParentID(internalDocument, higherLevelIdentifier.toArray()[0]
-                                .toString(), importConfiguration.getParentElementTrimMode());
-                importService.checkForParent(parentID, createProcessForm.getTemplate().getRuleset(),
-                    createProcessForm.getProject().getId());
-                if (Objects.isNull(importService.getParentTempProcess())) {
-                    TempProcess parentTempProcess = extractParentRecordFromFile(uploadedFile, internalDocument);
-                    if (Objects.nonNull(parentTempProcess)) {
-                        processes.add(parentTempProcess);
-                    }
-                }
-            }
-
-            if (!createProcessForm.getProcesses().isEmpty() && additionalImport) {
-                extendsMetadataTableOfMetadataTab(processes);
+            String xmlString = IOUtils.toString(uploadedFile.getInputStream(), Charset.defaultCharset());
+            createProcessForm.setXmlString(XMLUtils.removeBom(xmlString));
+            createProcessForm.setFilename(uploadedFile.getFileName());
+            if (MetadataFormat.EAD.name().equals(createProcessForm.getCurrentImportConfiguration().getMetadataFormat())
+                    && createProcessForm.limitExceeded(createProcessForm.getXmlString())) {
+                createProcessForm.calculateNumberOfEadElements();
+                Ajax.update("maxNumberOfRecordsExceededDialog");
+                PrimeFaces.current().executeScript("PF('maxNumberOfRecordsExceededDialog').show();");
             } else {
-                this.createProcessForm.setProcesses(processes);
-                TempProcess currentTempProcess = processes.getFirst();
-                attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
-                createProcessForm.fillCreateProcessForm(currentTempProcess);
-                Ajax.update(FORM_CLIENTID);
+                processXmlString();
             }
         } catch (IOException | ProcessGenerationException | URISyntaxException | ParserConfigurationException
-                | UnsupportedFormatException | SAXException | ConfigException | XPathExpressionException
-                | TransformerException | DAOException | InvalidMetadataValueException
-                | NoSuchMetadataFieldException e) {
+                 | UnsupportedFormatException | SAXException | ConfigException | XPathExpressionException
+                 | TransformerException | DAOException | InvalidMetadataValueException | NoSuchMetadataFieldException
+                 | XMLStreamException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
     }
 
-    private TempProcess extractParentRecordFromFile(UploadedFile uploadedFile, Document internalDocument)
-            throws XPathExpressionException, UnsupportedFormatException, URISyntaxException, IOException,
-            ParserConfigurationException, SAXException, ProcessGenerationException, TransformerException,
-            InvalidMetadataValueException, NoSuchMetadataFieldException {
-        Collection<String> higherLevelIdentifier = this.createProcessForm.getRulesetManagement()
-                .getFunctionalKeys(FunctionalMetadata.HIGHERLEVEL_IDENTIFIER);
-
-        if (!higherLevelIdentifier.isEmpty()) {
-            ImportService importService = ServiceManager.getImportService();
-            String parentID = importService.getParentID(internalDocument, higherLevelIdentifier.toArray()[0].toString(),
-                    importConfiguration.getParentElementTrimMode());
-            if (Objects.nonNull(parentID) && Objects.nonNull(importConfiguration.getParentMappingFile())) {
-                Document internalParentDocument = importService.convertDataRecordToInternal(
-                        createRecordFromXMLElement(IOUtils.toString(uploadedFile.getInputStream(), Charset.defaultCharset())),
-                        importConfiguration, true);
-                return importService.createTempProcessFromDocument(importConfiguration, internalParentDocument,
-                        createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
-            }
+    private void processXmlString() throws UnsupportedFormatException, XPathExpressionException,
+            ProcessGenerationException, URISyntaxException, IOException, ParserConfigurationException, SAXException,
+            InvalidMetadataValueException, TransformerException, NoSuchMetadataFieldException, DAOException {
+        LinkedList<TempProcess> processes = ServiceManager.getImportService().processUploadedFile(createProcessForm);
+        if (!createProcessForm.getProcesses().isEmpty() && additionalImport) {
+            extendsMetadataTableOfMetadataTab(processes);
+        } else {
+            createProcessForm.setProcesses(processes);
+            TempProcess currentTempProcess = processes.getFirst();
+            attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
+            createProcessForm.fillCreateProcessForm(currentTempProcess);
+            Ajax.update(FORM_CLIENTID);
         }
-        return null;
-    }
-
-    private DataRecord createRecordFromXMLElement(String xmlContent) {
-        DataRecord record = new DataRecord();
-        record.setMetadataFormat(
-            MetadataFormat.getMetadataFormat(importConfiguration.getMetadataFormat()));
-        record.setFileFormat(FileFormat.getFileFormat(importConfiguration.getReturnFormat()));
-        record.setOriginalData(xmlContent);
-        return record;
     }
 
     @Override
@@ -151,24 +107,6 @@ public class FileUploadDialog extends MetadataImportDialog {
             }
         }
         return importConfigurations;
-    }
-
-    /**
-     * Get selected importConfiguration.
-     *
-     * @return the selected importConfiguration.
-     */
-    public ImportConfiguration getImportConfiguration() {
-        return importConfiguration;
-    }
-
-    /**
-     * Set selected importConfiguration.
-     *
-     * @param importConfiguration the selected catalog.
-     */
-    public void setImportConfiguration(ImportConfiguration importConfiguration) {
-        this.importConfiguration = importConfiguration;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/MetadataImportDialog.java
@@ -54,6 +54,9 @@ public abstract class MetadataImportDialog {
      */
     MetadataImportDialog(CreateProcessForm createProcessForm) {
         this.createProcessForm = createProcessForm;
+        this.createProcessForm.numberOfEadElements = 0;
+        this.createProcessForm.setXmlString("");
+        this.createProcessForm.setFilename("");
     }
 
     void attachToExistingParentAndGenerateAtstslIfNotExist(TempProcess tempProcess)

--- a/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
@@ -272,7 +272,7 @@ public class XMLUtils {
      * @return number of EAD elements with given level
      * @throws XMLStreamException when parsing XML string fails
      */
-    public static int getNumberOfElements(String xmlString, String eadLevel) throws XMLStreamException {
+    public static int getNumberOfEADElements(String xmlString, String eadLevel) throws XMLStreamException {
         int count = 0;
         XMLInputFactory factory = XMLInputFactory.newInstance();
         XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(xmlString));

--- a/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
@@ -15,7 +15,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -23,6 +27,10 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -33,9 +41,16 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.apache.commons.io.ByteOrderMark;
+import org.kitodo.api.schemaconverter.DataRecord;
+import org.kitodo.api.schemaconverter.FileFormat;
+import org.kitodo.api.schemaconverter.MetadataFormat;
+import org.kitodo.constants.StringConstants;
+import org.kitodo.data.database.beans.ImportConfiguration;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -164,6 +179,7 @@ public class XMLUtils {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
+        xmlString = removeBom(xmlString);
         return builder.parse(new InputSource(new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8))));
     }
 
@@ -179,4 +195,97 @@ public class XMLUtils {
         XPath xpath = factory.newXPath();
         xpath.compile(xpathString);
     }
+
+    /**
+     * Remove potential BOM character because XML parser do not handle it properly.
+     * @param xmlStringWithBom String with potential BOM character
+     * @return xml String without BOM character
+     */
+    public static String removeBom(String xmlStringWithBom) {
+        if (Objects.equals(xmlStringWithBom.charAt(0), ByteOrderMark.UTF_BOM)) {
+            return xmlStringWithBom.substring(1);
+        }
+        return xmlStringWithBom;
+    }
+
+    /**
+     * Retrieve and return list of XML elements by their tag name, attribute name and attribute value from given
+     * Document.
+     *
+     * @param document XML document from which elements are retrieved
+     * @param tagName tag name of elements to retrieve
+     * @param attributeName attribute name of elements to retrieve
+     * @param attributeValue attribute value of elements to retrieve
+     * @return list of matching elements
+     */
+    public static List<Element> getElementsByTagNameAndAttributeValue(Document document, String tagName,
+                                                                      String attributeName, String attributeValue) {
+        List<Element> elements = new ArrayList<>();
+        NodeList nodes = document.getElementsByTagName(tagName);
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Element element = (Element) nodes.item(i);
+            String attributeString = element.getAttribute(attributeName);
+            if (attributeValue.equals(attributeString)) {
+                elements.add(element);
+            }
+        }
+        return elements;
+    }
+
+    /**
+     * Create and return String representation of given XML element 'Element'.
+     *
+     * @param element XML element for which String representation is created and returned
+     * @return String representation of given XML element 'Element'
+     * @throws TransformerException when creating String representation of XML element fails
+     */
+    public static String elementToString(Element element) throws TransformerException {
+        StringWriter stringWriter = new StringWriter();
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.transform(new DOMSource(element), new StreamResult(stringWriter));
+        return stringWriter.toString();
+    }
+
+    /**
+     * Create DataRecord from given String 'xmlContent' usings settings from given ImportConfiguration
+     * 'importConfigurations'.
+     *
+     * @param xmlContent String containing XML for which a DataRecord is created
+     * @param importConfiguration ImportConfiguration containing settings to be used for creating DataRecord
+     * @return DataRecord created for given String 'xmlContent'
+     */
+    public static DataRecord createRecordFromXMLElement(String xmlContent, ImportConfiguration importConfiguration) {
+        DataRecord record = new DataRecord();
+        record.setMetadataFormat(
+                MetadataFormat.getMetadataFormat(importConfiguration.getMetadataFormat()));
+        record.setFileFormat(FileFormat.getFileFormat(importConfiguration.getReturnFormat()));
+        record.setOriginalData(xmlContent);
+        return record;
+    }
+
+    /**
+     * Retrieve and return number of EAD elements with given level "eadLevel", e.g. "<c level='file'/>" from given
+     * String "xmlString".
+     *
+     * @param xmlString String containing XML to be parsed for elements
+     * @param eadLevel EAD level of elements to be counted
+     * @return number of EAD elements with given level
+     * @throws XMLStreamException when parsing XML string fails
+     */
+    public static int getNumberOfElements(String xmlString, String eadLevel) throws XMLStreamException {
+        int count = 0;
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(xmlString));
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                if (StringConstants.C_TAG_NAME.equals(reader.getLocalName())
+                        && eadLevel.equals(reader.getAttributeValue("", StringConstants.LEVEL))) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
 }

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
@@ -30,7 +30,9 @@ public class LazyHitModel extends LazyDataModel<Object> {
     private SearchResult searchResult = null;
 
     /**
-     * Empty default constructor. Sets default catalog and search field, if configured.
+     * Constructor setting this LazyHitModels 'CatalogImportDialog'.
+     *
+     * @param dialog as CatalogImportDialog
      */
     public LazyHitModel(CatalogImportDialog dialog) {
         this.catalogImportDialog = dialog;

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyHitModel.java
@@ -19,25 +19,21 @@ import java.util.stream.Collectors;
 
 import org.kitodo.api.externaldatamanagement.SearchResult;
 import org.kitodo.api.externaldatamanagement.SingleHit;
-import org.kitodo.data.database.beans.ImportConfiguration;
+import org.kitodo.production.forms.createprocess.CatalogImportDialog;
 import org.kitodo.production.services.ServiceManager;
-import org.kitodo.production.services.data.ImportService;
 import org.primefaces.model.LazyDataModel;
 import org.primefaces.model.SortOrder;
 
 public class LazyHitModel extends LazyDataModel<Object> {
 
-    private ImportConfiguration importConfiguration;
-    private String selectedField = "";
-    private String searchTerm = "";
-    private int importDepth = 2;
-
+    private final CatalogImportDialog catalogImportDialog;
     private SearchResult searchResult = null;
 
     /**
      * Empty default constructor. Sets default catalog and search field, if configured.
      */
-    public LazyHitModel() {
+    public LazyHitModel(CatalogImportDialog dialog) {
+        this.catalogImportDialog = dialog;
     }
 
     @Override
@@ -63,7 +59,8 @@ public class LazyHitModel extends LazyDataModel<Object> {
     public List<Object> load(int first, int resultSize, String sortField, SortOrder sortOrder, Map filters) {
 
         searchResult = ServiceManager.getImportService().performSearch(
-                this.selectedField, this.searchTerm, this.importConfiguration, first, resultSize);
+                catalogImportDialog.getSelectedField(), catalogImportDialog.getSearchTerm(),
+                catalogImportDialog.createProcessForm.getCurrentImportConfiguration(), first, resultSize);
 
         if (Objects.isNull(searchResult) || Objects.isNull(searchResult.getHits())) {
             return Collections.emptyList();
@@ -82,81 +79,5 @@ public class LazyHitModel extends LazyDataModel<Object> {
         } else {
             return Collections.emptyList();
         }
-    }
-
-    /**
-     * Getter for importConfiguration.
-     *
-     * @return value of importConfiguration
-     */
-    public ImportConfiguration getImportConfiguration() {
-        return importConfiguration;
-    }
-
-    /**
-     * Setter for importConfiguration. This also sets the catalogs default search field, if configured.
-     *
-     * @param importConfiguration ImportConfiguration
-     */
-    public void setImportConfiguration(ImportConfiguration importConfiguration) {
-        this.importConfiguration = importConfiguration;
-        if (Objects.nonNull(importConfiguration)) {
-            this.setSelectedField(ImportService.getDefaultSearchField(importConfiguration));
-            this.setImportDepth(ServiceManager.getImportService().getDefaultImportDepth(importConfiguration));
-        }
-    }
-
-    /**
-     * Get searchTerm.
-     *
-     * @return value of searchTerm
-     */
-    public String getSearchTerm() {
-        return this.searchTerm;
-    }
-
-    /**
-     * Set searchTerm.
-     *
-     * @param searchTerm as java.lang.String
-     */
-    public void setSearchTerm(String searchTerm) {
-        this.searchTerm = searchTerm;
-    }
-
-    /**
-     * Get selectedField.
-     *
-     * @return value of selectedField
-     */
-    public String getSelectedField() {
-        return this.selectedField;
-    }
-
-    /**
-     * Set selectedField.
-     *
-     * @param field as java.lang.String
-     */
-    public void setSelectedField(String field) {
-        this.selectedField = field;
-    }
-
-    /**
-     * Get import depth.
-     *
-     * @return import depth
-     */
-    public int getImportDepth() {
-        return importDepth;
-    }
-
-    /**
-     * Set import depth.
-     *
-     * @param depth import depth
-     */
-    public void setImportDepth(int depth) {
-        importDepth = depth;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -786,9 +786,8 @@ public class ImportService {
         List<Element> childElements = getEADElements(eadCollectionDocument, eadChildProcessLevel);
 
         if (parentElements.size() != 1) {
-            throw new ProcessGenerationException(
-                    String.format("EAD XML does not contain exactly one element of parent level '%s'!",
-                            eadParentProcessLevel));
+            throw new ProcessGenerationException(Helper.getTranslation(
+                    "importError.wrongNumberOfEadParentLevelElements", eadParentProcessLevel));
         }
 
         // create temp processes for parent (e.g. "collection") and children (e.g. "files")

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 
 import javax.faces.model.SelectItem;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -66,6 +67,7 @@ import org.kitodo.api.schemaconverter.SchemaConverterInterface;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.ConfigProject;
 import org.kitodo.config.enums.ParameterCore;
+import org.kitodo.constants.StringConstants;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.beans.MappingFile;
 import org.kitodo.data.database.beans.Process;
@@ -92,6 +94,7 @@ import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.exceptions.RecordIdentifierMissingDetail;
 import org.kitodo.exceptions.UnsupportedFormatException;
 import org.kitodo.production.dto.ProcessDTO;
+import org.kitodo.production.forms.createprocess.CreateProcessForm;
 import org.kitodo.production.forms.createprocess.ProcessBooleanMetadata;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.forms.createprocess.ProcessFieldedMetadata;
@@ -282,7 +285,7 @@ public class ImportService {
      * @param importConfiguration ImportConfiguration
      * @return default import depth of given import configuration
      */
-    public int getDefaultImportDepth(ImportConfiguration importConfiguration) {
+    public static int getDefaultImportDepth(ImportConfiguration importConfiguration) {
         int depth = importConfiguration.getDefaultImportDepth();
         if (depth < 0 || depth > 5) {
             return 2;
@@ -409,8 +412,7 @@ public class ImportService {
      */
     public TempProcess createTempProcessFromDocument(ImportConfiguration importConfiguration, Document document,
                                                      int templateID, int projectID)
-            throws ProcessGenerationException, IOException, TransformerException, InvalidMetadataValueException,
-            NoSuchMetadataFieldException {
+            throws ProcessGenerationException, IOException, TransformerException {
         Process process = null;
         // "processGenerator" needs to be initialized when function is called for the first time
         if (Objects.isNull(processGenerator)) {
@@ -443,7 +445,8 @@ public class ImportService {
             NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException, TransformerException,
             InvalidMetadataValueException, NoSuchMetadataFieldException {
 
-        Document internalDocument = importDocument(importConfiguration, recordId, allProcesses.isEmpty(), isParentInRecord);
+        DataRecord dataRecord = importExternalDataRecord(importConfiguration, recordId, allProcesses.isEmpty());
+        Document internalDocument = convertDataRecordToInternal(dataRecord, importConfiguration, isParentInRecord);
         TempProcess tempProcess = createTempProcessFromDocument(importConfiguration, internalDocument, templateID, projectID);
 
         // Workaround for classifying MultiVolumeWorks with insufficient information
@@ -460,17 +463,38 @@ public class ImportService {
         }
         allProcesses.add(tempProcess);
         if (!isParentInRecord && StringUtils.isNotBlank(parentIdMetadata)) {
-            return getParentID(internalDocument, parentIdMetadata,importConfiguration.getParentElementTrimMode());
+            return getParentID(internalDocument, parentIdMetadata, importConfiguration.getParentElementTrimMode());
         }
         return null;
     }
 
+    /**
+     * Import data record with given ID 'recordId' into project with given ID 'projectID' with template with given ID
+     * 'templateId' and using given ImportConfiguration 'importConfiguration'. Returns TempProcess containing imported
+     * data record.
+     *
+     * @param importConfiguration ImportConfiguration containing settings for import data record
+     * @param recordId catalog identifier of data record to import
+     * @param templateID ID of template to use when importing data record to TempProcess
+     * @param projectID ID of project to which imported data record is assigned
+     * @return TempProcess containing imported data record
+     * @throws UnsupportedFormatException when external data record contains data in unsupported format
+     * @throws NoRecordFoundException when no record with given ID 'recordId' could be found
+     * @throws XPathExpressionException when error message XPath in ImportConfiguration has syntax errors
+     * @throws ProcessGenerationException when creating TempProcess from imported data record fails
+     * @throws URISyntaxException when loading MappingFiles from ImportConfiguration fails
+     * @throws IOException when saving or loading imported XML file fails
+     * @throws ParserConfigurationException when parsing import XML file fails
+     * @throws SAXException when parsing import XML file fails
+     * @throws TransformerException when loading internal format document fails
+     */
     public TempProcess importTempProcess(ImportConfiguration importConfiguration, String recordId, int templateID,
                                          int projectID)
             throws UnsupportedFormatException, NoRecordFoundException, XPathExpressionException,
             ProcessGenerationException, URISyntaxException, IOException, ParserConfigurationException, SAXException,
-            InvalidMetadataValueException, TransformerException, NoSuchMetadataFieldException {
-        Document internalDocument = importDocument(importConfiguration, recordId, false, false);
+            TransformerException {
+        DataRecord dataRecord = importExternalDataRecord(importConfiguration, recordId, false);
+        Document internalDocument = convertDataRecordToInternal(dataRecord, importConfiguration, false);
         return createTempProcessFromDocument(importConfiguration, internalDocument, templateID, projectID);
     }
 
@@ -548,7 +572,7 @@ public class ImportService {
                                int importDepth, LinkedList<TempProcess> processes, String parentID, Template template,
                                String parentIdMetadata)
             throws ProcessGenerationException, IOException, XPathExpressionException, ParserConfigurationException,
-            NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException, DAOException,
+            NoRecordFoundException, UnsupportedFormatException, URISyntaxException, SAXException,
             InvalidMetadataValueException, NoSuchMetadataFieldException {
         int level = 1;
         this.parentTempProcess = null;
@@ -589,21 +613,46 @@ public class ImportService {
     /**
      * Check if there already is a parent process in Database.
      */
-    public void checkForParent(String parentID, Ruleset ruleset, int projectID)
-            throws DAOException, IOException, ProcessGenerationException {
-        if (Objects.isNull(parentID)) {
-            this.parentTempProcess = null;
-            return;
+    public void checkForParent(String parentID, Ruleset ruleset, int projectID) {
+        this.parentTempProcess = retrieveParentTempProcess(parentID, ruleset, projectID);
+    }
+
+    /**
+     * Get parentTempProcess.
+     *
+     * @return value of parentTempProcess
+     */
+    public TempProcess getParentTempProcess() {
+        return parentTempProcess;
+    }
+
+    /**
+     * Retrieve temp process containing process with given 'parentRecordId' as functional metadata 'recordIdentifier'.
+     *
+     * @param parentRecordId 'recordIdentifier' value of parent process
+     * @param ruleset Ruleset containing metadata rules
+     * @param projectID ID of project to which process belongs
+     * @return TempProcess containing parent process if it exists in database or null otherwise
+     */
+    public TempProcess retrieveParentTempProcess(String parentRecordId, Ruleset ruleset, int projectID) {
+        if (Objects.isNull(parentRecordId) || Objects.isNull(ruleset)) {
+            logger.info("Unable to get parent temp process: parentRecordId or ruleset is null!");
+            return null;
         }
-        Process parentProcess = loadParentProcess(ruleset, projectID, parentID);
-        if (Objects.nonNull(parentProcess)) {
-            logger.info("Linking last imported process to parent process with ID {} in database!", parentID);
+        Process parentProcess;
+        try {
+            parentProcess = loadParentProcess(ruleset, projectID, parentRecordId);
+            if (Objects.isNull(parentProcess)) {
+                return null;
+            }
             URI workpieceUri = ServiceManager.getProcessService().getMetadataFileUri(parentProcess);
             Workpiece parentWorkpiece = ServiceManager.getMetsService().loadWorkpiece(workpieceUri);
-            this.parentTempProcess = new TempProcess(parentProcess, parentWorkpiece);
-            return;
+            return new TempProcess(parentProcess, parentWorkpiece);
+        } catch (ProcessGenerationException | DAOException | IOException e) {
+            logger.error("Error retrieving parent process with 'recordIdentifier' {}, project ID {} and ruleset {}",
+                    parentRecordId, projectID, ruleset.getTitle());
+            return null;
         }
-        this.parentTempProcess = null;
     }
 
     private List<DataRecord> searchChildRecords(ImportConfiguration config, String parentId, int numberOfRows) {
@@ -679,11 +728,23 @@ public class ImportService {
         }
     }
 
-    private Document importDocument(ImportConfiguration importConfiguration, String identifier,
-                                    boolean extractExemplars, boolean isParentInRecord)
-            throws NoRecordFoundException, UnsupportedFormatException, URISyntaxException, IOException,
-            XPathExpressionException, ParserConfigurationException, SAXException, ProcessGenerationException {
-        // ################ IMPORT #################
+    /**
+     * Retrieve data from external data source and return DataRecord containing said external data.
+     *
+     * @param importConfiguration ImportConfiguration used for data import
+     * @param identifier ID of record to be loaded from external source
+     * @param extractExemplars boolean flag signaling whether exemplar records should be extracted from data record
+     * @return DataRecord containing data loaded from external source
+     * @throws NoRecordFoundException when loading full record by ID fails
+     * @throws IOException when extracting exemplar records fails
+     * @throws XPathExpressionException when extracting exemplar records fails
+     * @throws ParserConfigurationException when extracting exemplar records fails
+     * @throws SAXException when extracting exemplar records fails
+     */
+    public DataRecord importExternalDataRecord(ImportConfiguration importConfiguration, String identifier,
+                                                boolean extractExemplars)
+            throws NoRecordFoundException, IOException,
+            XPathExpressionException, ParserConfigurationException, SAXException {
         importModule = initializeImportModule();
         DataRecord dataRecord = importModule.getFullRecordById(
                 createDataImportFromImportConfiguration(importConfiguration),
@@ -691,7 +752,92 @@ public class ImportService {
         if (extractExemplars) {
             exemplarRecords = extractExemplarRecords(dataRecord, importConfiguration);
         }
-        return convertDataRecordToInternal(dataRecord, importConfiguration, isParentInRecord);
+        return dataRecord;
+    }
+
+    /**
+     * This method transforms a given data record that contains an EAD collection as an XML string into a list of
+     * temp processes. The first temp process in the list will contain the 'collection' itself, while all following temp
+     * processes contain the 'item' level child records of the collection.
+     *
+     * @param importedEADRecord XML string representation of
+     * @return list of temp processes
+     */
+    public LinkedList<TempProcess> parseImportedEADCollection(DataRecord importedEADRecord,
+                                                              ImportConfiguration importConfiguration, int projectId,
+                                                              int templateId, String eadChildProcessLevel,
+                                                              String eadParentProcessLevel)
+            throws IOException, ParserConfigurationException, SAXException, ProcessGenerationException,
+            TransformerException, UnsupportedFormatException, XPathExpressionException, URISyntaxException,
+            InvalidMetadataValueException, NoSuchMetadataFieldException {
+        LinkedList<TempProcess> eadCollectionProcesses = new LinkedList<>();
+
+        Document eadCollectionDocument = XMLUtils.parseXMLString((String) importedEADRecord.getOriginalData());
+
+        List<Element> parentElements = getEADElements(eadCollectionDocument, eadParentProcessLevel);
+        List<Element> childElements = getEADElements(eadCollectionDocument, eadChildProcessLevel);
+
+        if (parentElements.size() != 1) {
+            throw new ProcessGenerationException(
+                    String.format("EAD XML does not contain exactly one element of parent level '%s'!",
+                            eadParentProcessLevel));
+        }
+
+        // create temp processes for parent (e.g. "collection") and children (e.g. "files")
+        TempProcess collectionProcess = createTempProcessFromElement(parentElements.get(0), importConfiguration,
+                projectId, templateId, true);
+        eadCollectionProcesses.add(collectionProcess);
+
+        List<TempProcess> parentProcesses = Collections.singletonList(collectionProcess);
+        for (Element fileElement : childElements) {
+            TempProcess currentFileProcess = createTempProcessFromElement(fileElement, importConfiguration,
+                    projectId, templateId, false);
+            ProcessHelper.generateAtstslFields(currentFileProcess, parentProcesses, ACQUISITION_STAGE_CREATE, false);
+            eadCollectionProcesses.add(currentFileProcess);
+        }
+
+        return eadCollectionProcesses;
+    }
+
+    /**
+     * Create and return TempProcess from given XML element 'Element'.
+     *
+     * @param element XML element to be transformed into TempProcess
+     * @param importConfiguration ImportConfiguration containing settings used to transform XML element to TempProcess
+     * @param projectId ID of project for which process is created
+     * @param templateId ID of template with which process is created
+     * @param isParent boolean flag signaling whether the process to be created is a parent process and thus a separate
+     *                 parentMappingFile should be used for the XML transformation or not
+     * @return TempProcess created from given XML element
+     * @throws TransformerException when parsing external data failed
+     * @throws UnsupportedFormatException when external data could not be transformed to internal metadata format
+     * @throws XPathExpressionException when external data could not be transformed to internal metadata format
+     * @throws ProcessGenerationException when external data could not be transformed to internal metadata format
+     * @throws URISyntaxException when external data could not be transformed to internal metadata format
+     * @throws IOException when creating new process failed
+     * @throws ParserConfigurationException when external data could not be transformed to internal metadata format
+     * @throws SAXException when external data could not be transformed to internal metadata format
+     */
+    public TempProcess createTempProcessFromElement(Element element, ImportConfiguration importConfiguration,
+                                                           int projectId, int templateId, boolean isParent)
+            throws TransformerException, UnsupportedFormatException, XPathExpressionException,
+            ProcessGenerationException, URISyntaxException, IOException, ParserConfigurationException, SAXException {
+        String collectionString = XMLUtils.elementToString(element);
+        DataRecord externalCollectionRecord = XMLUtils.createRecordFromXMLElement(collectionString,
+                importConfiguration);
+        Document internalEadCollectionDocument = convertDataRecordToInternal(externalCollectionRecord,
+                importConfiguration, isParent);
+        return createTempProcessFromDocument(importConfiguration, internalEadCollectionDocument, templateId, projectId);
+    }
+
+    private List<Element> getEADElements(Document document, String level) {
+        return XMLUtils.getElementsByTagNameAndAttributeValue(document, StringConstants.C_TAG_NAME,
+                StringConstants.LEVEL, level);
+    }
+
+    public boolean isMaxNumberOfRecordsExceeded(String xmlString, String tagName) throws XMLStreamException {
+        int numberOfRecords = XMLUtils.getNumberOfElements(xmlString, tagName);
+        return numberOfRecords > ConfigCore.getIntParameterOrDefaultValue(ParameterCore.MAX_NUMBER_OF_PROCESSES_FOR_IMPORT_MASK);
     }
 
     /**
@@ -951,15 +1097,6 @@ public class ImportService {
         }
     }
 
-    /**
-     * Get parentTempProcess.
-     *
-     * @return value of parentTempProcess
-     */
-    public TempProcess getParentTempProcess() {
-        return parentTempProcess;
-    }
-
     private Process loadParentProcess(Ruleset ruleset, int projectId, String parentId)
             throws ProcessGenerationException, DAOException, IOException {
 
@@ -1184,8 +1321,10 @@ public class ImportService {
         ProcessHelper.generateAtstslFields(tempProcess, processDetails, parentTempProcesses, docType,
                 rulesetManagement, acquisitionStage, priorityList);
 
-        if (!ProcessValidator.isProcessTitleCorrect(tempProcess.getProcess().getTitle())) {
-            throw new ProcessGenerationException("Unable to create process");
+        String processTitle = tempProcess.getProcess().getTitle();
+        if (!ProcessValidator.isProcessTitleCorrect(processTitle)) {
+            throw new ProcessGenerationException(String.format("Unable to create process (invalid process title '%s')",
+                    processTitle));
         }
 
         Process process = tempProcess.getProcess();
@@ -1510,5 +1649,96 @@ public class ImportService {
     public static boolean userMayLinkToParent(int processId) throws DAOException {
         return processInAssignedProject(processId)
                 || ServiceManager.getSecurityAccessService().hasAuthorityToLinkToProcessesOfUnassignedProjects();
+    }
+
+    /**
+     * Get and return message informing user that the max number of processes that can be handled in the GUI at the same
+     * time has been exceeded and that the import will therefore be delegated to a background task.
+     *
+     * @param processLevelElement EAD level of elements that are being imported as processes
+     * @param numberOfElements number of processes that are to be imported
+     * @return max number exceeded message
+     */
+    public static String getMaximumNumberOfRecordsExceededMessage(String processLevelElement, int numberOfElements) {
+        return Helper.getTranslation("createProcessForm.limitExceeded",
+                String.valueOf(ConfigCore.getIntParameterOrDefaultValue(ParameterCore
+                        .MAX_NUMBER_OF_PROCESSES_FOR_IMPORT_MASK)),
+                String.valueOf(numberOfElements),
+                processLevelElement);
+    }
+
+    /**
+     * Create list of TempProcess from XML string stored in given CreateProcessForm 'createProcessForm'.
+     *
+     * @param createProcessForm CreateProcessForm containing XML string to convert into TempProcesses
+     * @return list of TempProcess created from XML string stored in given CreateProcessForm
+     * @throws ProcessGenerationException when converting XML string to TempProcesses fails
+     * @throws IOException when creating TempProcesses fails
+     * @throws InvalidMetadataValueException when creating EAD processes from XML string fails
+     * @throws TransformerException when creating TempProcesses fails
+     * @throws NoSuchMetadataFieldException when creating EAD processes from XML string fails
+     * @throws UnsupportedFormatException when converting XML string to TempProcesses fails
+     * @throws XPathExpressionException when creating TempProcesses fails
+     * @throws ParserConfigurationException when creating TempProcesses fails
+     * @throws URISyntaxException when creating TempProcesses fails
+     * @throws SAXException when creating TempProcesses fails
+     */
+    public LinkedList<TempProcess> processUploadedFile(CreateProcessForm createProcessForm)
+            throws ProcessGenerationException, IOException, InvalidMetadataValueException, TransformerException,
+            NoSuchMetadataFieldException, UnsupportedFormatException, XPathExpressionException,
+            ParserConfigurationException, URISyntaxException, SAXException {
+        LinkedList<TempProcess> processes = new LinkedList<>();
+        ImportConfiguration importConfiguration = createProcessForm.getCurrentImportConfiguration();
+        DataRecord externalRecord = XMLUtils.createRecordFromXMLElement(createProcessForm.getXmlString(),
+                importConfiguration);
+        if (MetadataFormat.EAD.name().equals(importConfiguration.getMetadataFormat())) {
+            LinkedList<TempProcess> eadProcesses = parseImportedEADCollection(externalRecord, importConfiguration,
+                    createProcessForm.getProject().getId(), createProcessForm.getTemplate().getId(),
+                    createProcessForm.getSelectedEadLevel(), createProcessForm.getSelectedParentEadLevel());
+            createProcessForm.setChildProcesses(new LinkedList<>(eadProcesses.subList(1, eadProcesses.size())));
+            processes = new LinkedList<>(Collections.singletonList(eadProcesses.get(0)));
+        } else {
+            Document internalDocument = convertDataRecordToInternal(externalRecord, importConfiguration, false);
+            TempProcess tempProcess = createTempProcessFromDocument(importConfiguration, internalDocument,
+                    createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
+            processes.add(tempProcess);
+            Collection<String> higherLevelIdentifier = createProcessForm.getRulesetManagement()
+                    .getFunctionalKeys(FunctionalMetadata.HIGHERLEVEL_IDENTIFIER);
+            if (!higherLevelIdentifier.isEmpty()) {
+                String parentID = getParentID(internalDocument, higherLevelIdentifier.toArray()[0]
+                        .toString(), importConfiguration.getParentElementTrimMode());
+                checkForParent(parentID, createProcessForm.getTemplate().getRuleset(),
+                        createProcessForm.getProject().getId());
+                if (Objects.isNull(getParentTempProcess())) {
+                    TempProcess parentTempProcess = extractParentRecordFromFile(internalDocument, createProcessForm);
+                    if (Objects.nonNull(parentTempProcess)) {
+                        processes.add(parentTempProcess);
+                    }
+                }
+            }
+        }
+        return processes;
+    }
+
+    private TempProcess extractParentRecordFromFile(Document internalDocument, CreateProcessForm createProcessForm)
+            throws XPathExpressionException, UnsupportedFormatException, URISyntaxException, IOException,
+            ParserConfigurationException, SAXException, ProcessGenerationException, TransformerException {
+        Collection<String> higherLevelIdentifier = createProcessForm.getRulesetManagement()
+                .getFunctionalKeys(FunctionalMetadata.HIGHERLEVEL_IDENTIFIER);
+
+        if (!higherLevelIdentifier.isEmpty()) {
+            ImportConfiguration importConfiguration = createProcessForm.getCurrentImportConfiguration();
+            ImportService importService = ServiceManager.getImportService();
+            String parentID = importService.getParentID(internalDocument, higherLevelIdentifier.toArray()[0].toString(),
+                    importConfiguration.getParentElementTrimMode());
+            if (Objects.nonNull(parentID) && Objects.nonNull(importConfiguration.getParentMappingFile())) {
+                Document internalParentDocument = importService.convertDataRecordToInternal(
+                        XMLUtils.createRecordFromXMLElement(createProcessForm.getXmlString(), importConfiguration),
+                        importConfiguration, true);
+                return importService.createTempProcessFromDocument(importConfiguration, internalParentDocument,
+                        createProcessForm.getTemplate().getId(), createProcessForm.getProject().getId());
+            }
+        }
+        return null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -852,7 +852,7 @@ public class ImportService {
      * @throws XMLStreamException when retrieving number of tags in XML content fails
      */
     public boolean isMaxNumberOfRecordsExceeded(String xmlString, String tagName) throws XMLStreamException {
-        int numberOfRecords = XMLUtils.getNumberOfElements(xmlString, tagName);
+        int numberOfRecords = XMLUtils.getNumberOfEADElements(xmlString, tagName);
         return numberOfRecords > ConfigCore.getIntParameterOrDefaultValue(ParameterCore.MAX_NUMBER_OF_PROCESSES_FOR_IMPORT_MASK);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -405,10 +405,14 @@ public class ImportService {
 
     /**
      * Creates a temporary Process from the given document with templateID und projectID.
+     * @param importConfiguration ImportConfiguration used to create TempProcess
      * @param document the given document
      * @param templateID the template to use
      * @param projectID the project to use
      * @return a temporary process
+     * @throws ProcessGenerationException when creating process for given template and project fails
+     * @throws IOException when loading workpiece of TempProcess or retrieving type of document fails
+     * @throws TransformerException when loading workpiece of TempProcess fails
      */
     public TempProcess createTempProcessFromDocument(ImportConfiguration importConfiguration, Document document,
                                                      int templateID, int projectID)
@@ -612,6 +616,10 @@ public class ImportService {
 
     /**
      * Check if there already is a parent process in Database.
+     *
+     * @param parentID ID of parent process to retrieve
+     * @param ruleset ruleset of parent process to retrieve
+     * @param projectID ID of project to which parent process must belong
      */
     public void checkForParent(String parentID, Ruleset ruleset, int projectID) {
         this.parentTempProcess = retrieveParentTempProcess(parentID, ruleset, projectID);
@@ -835,6 +843,15 @@ public class ImportService {
                 StringConstants.LEVEL, level);
     }
 
+    /**
+     * Check and return whether maximum number of tags with given tag name 'tagName' in XML with content given as
+     * 'xmlString' exceeds limit configured as maxNumberOfProcessesForImportMask in kitodo_config.properties.
+     *
+     * @param xmlString String representation of XML content to check
+     * @param tagName name of XML tag counted in XML content
+     * @return whether the number of tags exceeds the allowed limit
+     * @throws XMLStreamException when retrieving number of tags in XML content fails
+     */
     public boolean isMaxNumberOfRecordsExceeded(String xmlString, String tagName) throws XMLStreamException {
         int numberOfRecords = XMLUtils.getNumberOfElements(xmlString, tagName);
         return numberOfRecords > ConfigCore.getIntParameterOrDefaultValue(ParameterCore.MAX_NUMBER_OF_PROCESSES_FOR_IMPORT_MASK);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -316,10 +316,10 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
      * Find all parent processes for a process ordered such that the root parent comes first.
      * 
      * @param process the process whose parents are to be found
-     * @return the list of parent processes (direct parents and grand parents, and more)
+     * @return the list of parent processes (direct parents and grandparents, and more)
      */
     public List<Process> findParentProcesses(Process process) {
-        List<Process> parents = new ArrayList<Process>();
+        List<Process> parents = new ArrayList<>();
         Process current = process;
         while (Objects.nonNull(current.getParent())) {
             current = current.getParent();
@@ -958,18 +958,7 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             convertLastProcessingDates(jsonObject, processDTO);
             convertTaskProgress(jsonObject, processDTO);
 
-            List<Map<String, Object>> jsonArray = ProcessTypeField.PROPERTIES.getJsonArray(jsonObject);
-            List<PropertyDTO> properties = new ArrayList<>();
-            for (Map<String, Object> stringObjectMap : jsonArray) {
-                PropertyDTO propertyDTO = new PropertyDTO();
-                Object title = stringObjectMap.get(JSON_TITLE);
-                Object value = stringObjectMap.get(JSON_VALUE);
-                if (Objects.nonNull(title)) {
-                    propertyDTO.setTitle(title.toString());
-                    propertyDTO.setValue(Objects.nonNull(value) ? value.toString() : "");
-                    properties.add(propertyDTO);
-                }
-            }
+            List<PropertyDTO> properties = getProperties(jsonObject);
             processDTO.setProperties(properties);
 
             if (!related) {
@@ -983,6 +972,22 @@ public class ProcessService extends ProjectSearchService<Process, ProcessDTO, Pr
             }
         }
         return processDTO;
+    }
+
+    private List<PropertyDTO> getProperties(Map<String, Object> jsonObject) throws DataException {
+        List<Map<String, Object>> jsonArray = ProcessTypeField.PROPERTIES.getJsonArray(jsonObject);
+        List<PropertyDTO> properties = new ArrayList<>();
+        for (Map<String, Object> stringObjectMap : jsonArray) {
+            PropertyDTO propertyDTO = new PropertyDTO();
+            Object title = stringObjectMap.get(JSON_TITLE);
+            Object value = stringObjectMap.get(JSON_VALUE);
+            if (Objects.nonNull(title)) {
+                propertyDTO.setTitle(title.toString());
+                propertyDTO.setValue(Objects.nonNull(value) ? value.toString() : "");
+                properties.add(propertyDTO);
+            }
+        }
+        return properties;
     }
 
 

--- a/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
@@ -127,7 +127,7 @@ public class ImportEadProcessesThread extends EmptyTask {
         List<Integer> newProcessIds = new ArrayList<>();
         int newParentId = 0;
         try {
-            int numberOfElements = XMLUtils.getNumberOfElements(xmlString, eadLevel);
+            int numberOfElements = XMLUtils.getNumberOfEADElements(xmlString, eadLevel);
             XMLInputFactory inputFactory = XMLInputFactory.newInstance();
             XMLEventReader eventReader = inputFactory.createXMLEventReader(new StringReader(xmlString));
             boolean inProcessElement = false;

--- a/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
@@ -1,0 +1,348 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.thread;
+
+import static org.kitodo.constants.StringConstants.CREATE;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataEntry;
+import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
+import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
+import org.kitodo.constants.StringConstants;
+import org.kitodo.data.database.beans.Client;
+import org.kitodo.data.database.beans.ImportConfiguration;
+import org.kitodo.data.database.beans.User;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.data.exceptions.DataException;
+import org.kitodo.exceptions.CommandException;
+import org.kitodo.exceptions.InvalidMetadataValueException;
+import org.kitodo.exceptions.NoSuchMetadataFieldException;
+import org.kitodo.exceptions.ProcessGenerationException;
+import org.kitodo.exceptions.UnsupportedFormatException;
+import org.kitodo.production.forms.createprocess.CreateProcessForm;
+import org.kitodo.production.helper.ProcessHelper;
+import org.kitodo.production.helper.TempProcess;
+import org.kitodo.production.helper.XMLUtils;
+import org.kitodo.production.helper.tasks.EmptyTask;
+import org.kitodo.production.metadata.MetadataEditor;
+import org.kitodo.production.security.SecurityUserDetails;
+import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.data.ImportService;
+import org.kitodo.production.services.data.ProcessService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+
+public class ImportEadProcessesThread extends EmptyTask {
+
+    private static final Logger logger = LogManager.getLogger(ImportEadProcessesThread.class);
+    private final ImportService importService = ServiceManager.getImportService();
+    private final String xmlString;
+    private final String eadLevel;
+    private final String eadParentLevel;
+    private final int projectId;
+    private final int templateId;
+    private final ImportConfiguration importConfiguration;
+    private final RulesetManagementInterface rulesetManagementInterface;
+    private final List<Locale.LanguageRange> priorityList;
+    private final List<Namespace> namespaces;
+    private final User user;
+    private final Client client;
+    private TempProcess parentProcess = null;
+    private int count;
+
+    /**
+     * Standard constructor, creating instance of ImportEadProcessesThread with settings from given
+     * CreateProcessForm 'createProcessForm' and for given User 'user' and Client 'client'.
+     *
+     * @param createProcessForm CreateProcessForm instance encapsulating various settings required for this thread
+     * @param user User instance to which this thread is assigned
+     * @param client Client instance of current user
+     */
+    public ImportEadProcessesThread(CreateProcessForm createProcessForm, User user, Client client) {
+        super(createProcessForm.getFilename());
+        this.xmlString = createProcessForm.getXmlString();
+        this.eadLevel = createProcessForm.getSelectedEadLevel();
+        this.eadParentLevel = createProcessForm.getSelectedParentEadLevel();
+        this.projectId = createProcessForm.getProject().getId();
+        this.templateId = createProcessForm.getTemplate().getId();
+        this.importConfiguration = createProcessForm.getCurrentImportConfiguration();
+        this.rulesetManagementInterface = createProcessForm.getRulesetManagement();
+        this.priorityList = ServiceManager.getUserService().getCurrentMetadataLanguage();
+        this.namespaces = new ArrayList<>();
+        this.user = user;
+        this.client = client;
+    }
+
+    @Override
+    protected void setNameDetail(String detail) {
+        super.setNameDetail(detail);
+    }
+
+    @Override
+    public void run() {
+        setAuthenticatedUser();
+        List<Integer> newProcessIds = new ArrayList<>();
+        int newParentId = 0;
+        try {
+            int numberOfElements = XMLUtils.getNumberOfElements(xmlString, eadLevel);
+            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            XMLEventReader eventReader = inputFactory.createXMLEventReader(new StringReader(xmlString));
+            boolean inProcessElement = false;
+            boolean inParentProcessElement = false;
+            String currentTagName;
+            StringBuilder stringBuilder = new StringBuilder();
+            while (eventReader.hasNext()) {
+
+                XMLEvent event = eventReader.nextEvent();
+                switch (event.getEventType()) {
+                    case XMLEvent.START_ELEMENT:
+                        StartElement startElement = event.asStartElement();
+                        currentTagName = startElement.getName().getLocalPart();
+                        if (StringConstants.EAD.equals(currentTagName)) {
+                            Iterator<Namespace> namespaceIterator = startElement.getNamespaces();
+                            while (namespaceIterator.hasNext()) {
+                                namespaces.add(namespaceIterator.next());
+                            }
+                        }
+                        if (StringConstants.C_TAG_NAME.equals(currentTagName)) {
+                            // all metadata until first nested "<c>" element is considered when creating parent process
+                            // for EAD "collection"
+                            if (inParentProcessElement) {
+                                inParentProcessElement = false;
+                                stringBuilder.append("</c>");
+                                TempProcess tempProcess = parseXmlStringToTempProcess(stringBuilder.toString(), true);
+                                TempProcess existingParent = getParentCandidate(tempProcess);
+                                // distinguish between existing "collection" parent and newly created one
+                                if (Objects.isNull(existingParent)) {
+                                    parentProcess = processTempProcess(tempProcess);
+                                    newParentId = parentProcess.getProcess().getId();
+                                } else {
+                                    parentProcess = existingParent;
+                                }
+                                stringBuilder = new StringBuilder();
+                            }
+                            Attribute levelAttribute = startElement.getAttributeByName(QName.valueOf(StringConstants
+                                    .LEVEL));
+                            Attribute idAttribute = startElement.getAttributeByName(QName.valueOf("id"));
+                            if (Objects.nonNull(levelAttribute) && Objects.nonNull(idAttribute)) {
+                                if (eadLevel.equals(levelAttribute.getValue())) {
+                                    inProcessElement = true;
+                                    count++;
+                                    stringBuilder.append(processStartElement(event));
+                                } else {
+                                    if (eadParentLevel.equals(levelAttribute.getValue())) {
+                                        inParentProcessElement = true;
+                                        stringBuilder.append(processStartElement(event));
+                                    }
+                                }
+                            }
+                        } else {
+                            if (inParentProcessElement || inProcessElement) {
+                                String content = event.toString();
+                                if (StringUtils.isNotBlank(content)) {
+                                    stringBuilder.append(removeDefaultNamespaceUri(content));
+                                }
+                            }
+                        }
+                        break;
+                    case XMLEvent.END_ELEMENT:
+                        EndElement endElement = event.asEndElement();
+                        String endElementName = endElement.getName().getLocalPart();
+                        if (inProcessElement && StringConstants.C_TAG_NAME.equals(endElementName)) {
+                            int progress = (count * 100) / numberOfElements;
+                            setProgress(progress);
+                            inProcessElement = false;
+                            String content = event.toString();
+                            stringBuilder.append(removeDefaultNamespaceUri(content));
+                            newProcessIds.add(parseXmlStringToProcessedTempProcess(stringBuilder.toString()).getProcess().getId());
+                            stringBuilder = new StringBuilder();
+                        } else {
+                            if (inParentProcessElement || inProcessElement) {
+                                String content = event.toString();
+                                if (StringUtils.isNotBlank(content)) {
+                                    stringBuilder.append(removeDefaultNamespaceUri(content));
+                                }
+                            }
+                        }
+                        break;
+                    default:
+                        if (inParentProcessElement || inProcessElement) {
+                            String content = event.toString();
+                            if (StringUtils.isNotBlank(content)) {
+                                stringBuilder.append(removeDefaultNamespaceUri(content));
+                            }
+                        }
+                        break;
+                }
+            }
+
+        } catch (XMLStreamException | IOException | ParserConfigurationException | SAXException
+                 | UnsupportedFormatException | XPathExpressionException | ProcessGenerationException
+                 | URISyntaxException | InvalidMetadataValueException | TransformerException
+                 | NoSuchMetadataFieldException | DataException | CommandException e) {
+            logger.error(e.getMessage(), e);
+            cleanUpProcesses(newProcessIds, newParentId);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void cleanUpProcesses(List<Integer> processIds, int newParentId) {
+        logger.error("Deleting processes created until this point to resolve erroneous intermediate state.");
+        // cleanup any processes that might have been created until this point
+        for (int id : processIds) {
+            try {
+                ProcessService.deleteProcess(ServiceManager.getProcessService().getById(id));
+            } catch (DataException | DAOException | IOException ex) {
+                logger.error(ex);
+            }
+        }
+        if (newParentId > 0 && Objects.nonNull(parentProcess) && Objects.nonNull(parentProcess.getProcess())) {
+            try {
+                ProcessService.deleteProcess(parentProcess.getProcess());
+            } catch (DataException | IOException ex) {
+                logger.error(ex);
+            }
+        }
+    }
+
+    private String processStartElement(XMLEvent event) {
+        String content = event.toString();
+        for (Namespace namespace : namespaces) {
+            String prefix = namespace.getPrefix();
+            if (StringUtils.isNotBlank(prefix)) {
+                content = content.replace(">", " xmlns:" + namespace.getPrefix() + "=\""
+                        + namespace.getNamespaceURI() + "\">");
+            }
+        }
+        return removeDefaultNamespaceUri(content);
+    }
+
+    // This method is a workaround for a problem encountered during development of the EAD import where XML files
+    // defining a default names space without namespace prefix could be parsed incorrectly.
+    private String removeDefaultNamespaceUri(String xmlEventString) {
+        for (Namespace namespace : namespaces) {
+            String prefix = namespace.getPrefix();
+            if (StringUtils.isBlank(prefix)) {
+                return xmlEventString.replace("['" + namespace.getNamespaceURI() + "']::", "");
+            }
+        }
+        return xmlEventString;
+    }
+
+    private TempProcess getParentCandidate(TempProcess tempProcess) {
+        String recordId = getRecordIdentifier(tempProcess);
+        if (Objects.nonNull(recordId)) {
+            TempProcess parent = ServiceManager.getImportService().retrieveParentTempProcess(recordId,
+                    tempProcess.getProcess().getRuleset(), projectId);
+            if (Objects.nonNull(parent)) {
+                return parent;
+            }
+        }
+        return null;
+    }
+
+    private TempProcess processTempProcess(TempProcess tempProcess) throws ProcessGenerationException, IOException,
+            InvalidMetadataValueException, NoSuchMetadataFieldException, DataException, CommandException {
+        ProcessHelper.generateAtstslFields(tempProcess, Collections.emptyList(), CREATE, priorityList, false);
+        tempProcess.getProcessMetadata().preserve();
+        ImportService.processTempProcess(tempProcess, rulesetManagementInterface, CREATE, priorityList, parentProcess);
+        saveTempProcessMetadata(tempProcess);
+        if (Objects.nonNull(parentProcess)) {
+            ProcessService.setParentRelations(parentProcess.getProcess(), tempProcess.getProcess());
+            MetadataEditor.addLink(parentProcess.getProcess(), String.valueOf(count - 1), tempProcess.getProcess()
+                    .getId());
+            ServiceManager.getProcessService().save(tempProcess.getProcess(), true);
+        }
+        return tempProcess;
+    }
+
+    // used to parse parent (e.g. "collection")
+    private TempProcess parseXmlStringToTempProcess(String xmlString, boolean isParent) throws IOException,
+            ParserConfigurationException, SAXException, UnsupportedFormatException, XPathExpressionException,
+            ProcessGenerationException, URISyntaxException, TransformerException {
+        Document elementDocument = XMLUtils.parseXMLString(xmlString);
+        Element element = elementDocument.getDocumentElement();
+        return importService.createTempProcessFromElement(element, importConfiguration, projectId, templateId, isParent);
+    }
+
+    // used to parse children (e.g. "files")
+    private TempProcess parseXmlStringToProcessedTempProcess(String xmlElementString) throws IOException,
+            ParserConfigurationException, SAXException, UnsupportedFormatException, XPathExpressionException,
+            ProcessGenerationException, URISyntaxException, InvalidMetadataValueException, TransformerException,
+            NoSuchMetadataFieldException, DataException, CommandException {
+        TempProcess tempProcess = parseXmlStringToTempProcess(xmlElementString, false);
+        return processTempProcess(tempProcess);
+    }
+
+    private String getRecordIdentifier(TempProcess tempProcess) {
+        Collection<String> recordIdMetadata = rulesetManagementInterface
+                .getFunctionalKeys(FunctionalMetadata.RECORD_IDENTIFIER);
+        for (String recordId : recordIdMetadata) {
+            for (Metadata metadata : tempProcess.getWorkpiece().getLogicalStructure().getMetadata()) {
+                if (metadata instanceof MetadataEntry && recordId.equals(metadata.getKey())) {
+                    return ((MetadataEntry) metadata).getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void setAuthenticatedUser() {
+        SecurityUserDetails securityUserDetails = new SecurityUserDetails(user);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(securityUserDetails, null,
+                securityUserDetails.getAuthorities());
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityUserDetails.setSessionClient(client);
+        securityContext.setAuthentication(authentication);
+    }
+
+    private void saveTempProcessMetadata(TempProcess tempProcess) throws DataException, IOException, CommandException {
+        ServiceManager.getProcessService().save(tempProcess.getProcess(), true);
+        URI processBaseUri = ServiceManager.getFileService().createProcessLocation(tempProcess.getProcess());
+        tempProcess.getProcess().setProcessBaseUri(processBaseUri);
+        ProcessHelper.saveTempProcessMetadata(tempProcess, rulesetManagementInterface, CREATE, priorityList);
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
@@ -230,7 +230,7 @@ public class ImportEadProcessesThread extends EmptyTask {
     }
 
     private void cleanUpProcesses(List<Integer> processIds, int newParentId) {
-        logger.error("Deleting processes created until this point to resolve erroneous intermediate state.");
+        logger.info("Deleting processes created until this point to resolve erroneous intermediate state.");
         // cleanup any processes that might have been created until this point
         for (int id : processIds) {
             try {

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -789,3 +789,10 @@ security.secret.ldapManagerPassword=
 # This optional parameter can be used to limit the number of processes for which media renaming can be conducted as a
 # list function. Values different from positive integers are interpreted as "unlimited".
 #maxNumberOfProcessesForMediaRenaming=10000
+
+# The parameter 'maxNumberOfProcessesForHierarchicalImport' is used to limit the number of processes during the
+# hierarchical import that are loaded into the metadata import dialog at the same time. When this limit is exceeded,
+# e.g. more data records are imported (from a search interface or from an uploaded EAD file), a dialog is displayed
+# informing the user that the processes will be imported using a background task and the progress can be tracked via the
+# task manager.
+maxNumberOfProcessesForImportMask=5

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -796,3 +796,10 @@ security.secret.ldapManagerPassword=
 # informing the user that the processes will be imported using a background task and the progress can be tracked via the
 # task manager.
 maxNumberOfProcessesForImportMask=5
+
+# The parameter 'stopEadCollectionImportOnException' can be used to control how Kitodo should handle potential
+# exceptions occurring during the import of EAD collections. When set to 'true', the import of an upload EAD XML file
+# will be canceled and all new processes created from the uploaded file up to this point are removed. If set to 'false',
+# the import will skip the current EAD element that caused the exception and continue with the next element.
+# Defaults to 'false'.
+stopEadCollectionImportOnException=false

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -83,6 +83,7 @@ errorImporting=Fehler beim Importieren von PPN {0}: {1}
 importFailedError=Der Import von {0} ist fehlgeschlagen. Die Fehlermeldung lautet\: {1}.
 imagePaginationError=Es wurden {1} Bilder gefunden, aber {0} Bilder erwartet. Bitte \u00FCberpr\u00FCfen Sie die Paginierung.
 importError.emptyDocument=Vorgang konnte nicht aus geladenem XML-Dokument erzeugt werden.
+importError.wrongNumberOfEadParentLevelElements=EAD-XML enth\u00E4lt nicht genau ein Element vom ausgew\u00E4hltem EAD-Level "{0}"!
 invalidIdentifierCharacter=Der Wert des Identifikationsmerkmals {0} enth\u00E4lt ung\u00FCltige Zeichen.
 invalidIdentifierSame=Das Identifikationsmerkmal {0} enth\u00E4lt in {1} und {2} den gleichen Wert.
 

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -83,6 +83,7 @@ errorImporting=Error importing PPN {0}: {1}
 importFailedError=The import of {0} failed. The error message is\: {1}
 imagePaginationError={1} images found but {0} images expected. Please check the pagination.
 importError.emptyDocument=Unable to create process from imported XML document.
+importError.wrongNumberOfEadParentLevelElements=EAD XML does not contain exactly one element of parent level "{0}"!
 invalidIdentifierCharacter=The value of the identifier {0} contains invalid characters.
 invalidIdentifierSame=The identifier {0} has the same value in {1} and {2}.
 

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -663,6 +663,7 @@ importingData=Daten werden importiert...
 importChildren=Kindvorg\u00E4nge importieren
 importDepth=Importtiefe
 importDms=Export in das DMS
+importEadProcessesThread=EAD-Bestands-Import
 importProcesses=Vorg\u00E4nge importieren
 imprint=Impressum
 # used in "LegalTexts.java"
@@ -841,6 +842,8 @@ newProcess.catalogueSearch.savingSecondaryProcesses=Speichern von untergeordnete
 newProcess.childProcesses=Kindvorg\u00E4nge
 newProcess.docTypeMetadataMissing=Der Datensatz konnte nicht importiert werden. Es wurde kein Metadatum f\u00fcr die Dokumenttypklassifizierung ("use='docType'") im verwendeten Regelsatz "{0}" gefunden!
 newProcess.fileUpload.heading=Dateiupload
+newProcess.fileUpload.eadLevelParent=EAD-Level \u00DCberordnung
+newProcess.fileUpload.eadLevelChildren=EAD-Level Unterordnung
 newProcess.processHierarchy=Vorgangshierarchie
 newProcess.rulesetSelection.deactivated=Der Regelsatz wird durch die verwendete Produktionsvorlage vorgegeben und kann w\u00E4hrend der Vorgangserstellung nicht ge\u00E4ndert werden
 newProcess.titleGeneration.creationRuleNotFound=Es konnte keine Regel zur Titelgenerierung f\u00fcr Vorg\u00E4nge vom Typ \u201E{0}\u201C im Regelsatz \u201E{1}\u201C gefunden werden!
@@ -970,6 +973,7 @@ createProcessForm.titleRecordLinkTab.noInsertionPosition=Sie k\u00F6nnen den Vor
 createProcessForm.titleRecordLinkTab.searchButtonClick.empty=Suchanfrage leer
 createProcessForm.titleRecordLinkTab.searchButtonClick.error=Die Suche lief auf einen Fehler:
 createProcessForm.titleRecordLinkTab.searchButtonClick.noHits=Die Suche ist abgeschlossen, aber es wurden keine potentiellen Elternvorg\u00E4nge gefunden. Sie k\u00F6nnen nur Vorg\u00E4nge verlinken, die denselben Regelsatz nutzen.
+createProcessForm.limitExceeded=Sie k\u00F6nnen maximal {0} Datens\u00E4tze gleichzeitig \u00FCber diese Importmaske verarbeiten. Die hochgeladene Datei \u00FCberschreitet dieses Limit und enth\u00E4lt {1} Datens\u00E4tze vom Typ "{2}". Die Verarbeitung der Datei wird daher in eine Hintergrundaufgabe verschoben, deren Fortschritt Sie mit entsprechender Berechtigung \u00FCber den Taskmanager nachverfolgen k\u00F6nnen.
 quarter=Quartal
 quarters=Quartale
 ready=Fertig

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -663,6 +663,7 @@ importingData=Data are being imported
 importChildren=Import child processes
 importDepth=Import depth
 importDms=Import into DMS
+importEadProcessesThread=EAD collection import
 importProcesses=Import processes
 imprint=Imprint
 # used in "LegalTexts.java"
@@ -841,6 +842,8 @@ newProcess.catalogueSearch.savingSecondaryProcesses=Saving secondary processes
 newProcess.childProcesses=Child processes
 newProcess.docTypeMetadataMissing=Unable to import metadata. No metadata for document type classification ("use='docType'") found in ruleset "{0}"!
 newProcess.fileUpload.heading=Fileupload
+newProcess.fileUpload.eadLevelParent=EAD-Level parent process
+newProcess.fileUpload.eadLevelChildren=EAD-Level child processes
 newProcess.processHierarchy=Process hierarchy
 newProcess.rulesetSelection.deactivated=Ruleset is predetermined by given template and cannot be changed during process creation
 newProcess.titleGeneration.creationRuleNotFound=No title creation rules found for docType \u201E{0}\u201C in ruleset \u201E{1}\u201C!
@@ -970,6 +973,7 @@ createProcessForm.titleRecordLinkTab.noInsertionPosition=You cannot link the pro
 createProcessForm.titleRecordLinkTab.searchButtonClick.empty=Query is empty
 createProcessForm.titleRecordLinkTab.searchButtonClick.error=The search ran on an error:
 createProcessForm.titleRecordLinkTab.searchButtonClick.noHits=The search completed, but nothing was found. You can only find processes that have the same rule set and are potential parent processes.
+createProcessForm.limitExceeded=The maximum number of records to be processed in the import mask is {0}. The uploaded file exceeds this limit and contains {1} elements of type "{2}". Process import will be delegated to a background task.
 quarter=quarter
 quarters=quarters
 ready=Ready

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2401,6 +2401,17 @@ form#metadata div label,
     margin: 0;
 }
 
+.metadata-import-dialog-form .ead-level-selection-table {
+    width: 100%;
+}
+
+.metadata-import-dialog-form .ead-level-selection-table > tbody > tr > td.ui-panelgrid-cell {
+    vertical-align: top;
+}
+
+.ui-dialog .ui-panelgrid-cell div.ead-level-selection div {
+    margin-bottom: auto;
+}
 
 #metadataAccordion\:metadata .ui-treetable-indent,
 #metadataAccordion\:metadata .ui-treetable-toggler {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
@@ -33,10 +33,10 @@
                 <p:commandButton action="#{CreateProcessForm.fillCreateProcessForm(processAncestor)}"
                                  actionListener="#{CreateProcessForm.processMetadata.preserve()}"
                                  process="@this"
-                                 styleClass="#{CreateProcessForm.currentProcess.equals(processAncestor) ? 'selected' : ''}"
+                                 styleClass="carousel-button #{CreateProcessForm.currentProcess.equals(processAncestor) ? 'selected' : ''}"
                                  value="#{CreateProcessForm.getCatalogId(processAncestor)}"
                                  update="editForm:processFromTemplateTabView:processData
-                                         editForm:processFromTemplateTabView:processHierarchy"/>
+                                         @(.carousel-button)"/>
             </p:dataList>
 
             <p:carousel id="processChildren"
@@ -44,15 +44,15 @@
                         rendered="#{not empty CreateProcessForm.processChildren}"
                         value="#{CreateProcessForm.processChildren}"
                         var="childProcess"
-                        numVisible="3"
+                        numVisible="5"
                         responsive="true">
                 <p:commandButton action="#{CreateProcessForm.fillCreateProcessForm(childProcess)}"
                                  actionListener="#{CreateProcessForm.processMetadata.preserve()}"
                                  process="@this"
-                                 styleClass="#{CreateProcessForm.currentProcess.equals(childProcess) ? 'selected' : ''}"
+                                 styleClass="carousel-button #{CreateProcessForm.currentProcess.equals(childProcess) ? 'selected' : ''}"
                                  value="#{CreateProcessForm.getCatalogId(childProcess)}"
                                  update="editForm:processFromTemplateTabView:processData
-                                         editForm:processFromTemplateTabView:processHierarchy"/>
+                                         @(.carousel-button)"/>
             </p:carousel>
         </h:panelGroup>
     </p:panel>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/eadLevelSelection.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/eadLevelSelection.xhtml
@@ -1,0 +1,62 @@
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<ui:composition
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:p="http://primefaces.org/ui">
+
+    <ui:fragment>
+        <p:panelGrid id="eadLevelSelection"
+                     styleClass="ead-level-selection-table"
+                     columns="2">
+            <p:row style="background-color: var(--light-gray);">
+                <h:panelGroup layout="block"
+                              styleClass="ead-level-selection">
+                    <p:outputLabel for="eadLevelParentProcess"
+                                   value="#{msgs['newProcess.fileUpload.eadLevelParent']}"/>
+                    <p:selectOneRadio id="eadLevelParentProcess"
+                                      styleClass="ui-corner-all"
+                                      layout="grid"
+                                      columns="1"
+                                      value="#{CreateProcessForm.selectedParentEadLevel}">
+                        <f:selectItems value="#{CreateProcessForm.eadParentLevels}"
+                                       var="eadLevel"
+                                       itemValue="#{eadLevel}"
+                                       itemLabel="#{eadLevel.toUpperCase()}"/>
+                        <p:ajax event="change"/>
+                    </p:selectOneRadio>
+                </h:panelGroup>
+            </p:row>
+            <p:row style="background-color: var(--light-gray);">
+                <h:panelGroup layout="block"
+                              styleClass="ead-level-selection">
+                    <p:outputLabel for="eadLevelChildProcesses"
+                                   value="#{msgs['newProcess.fileUpload.eadLevelChildren']}"/>
+                    <p:selectOneRadio id="eadLevelChildProcesses"
+                                      styleClass="ui-corner-all"
+                                      layout="grid"
+                                      columns="1"
+                                      value="#{CreateProcessForm.selectedEadLevel}">
+                        <f:selectItems value="#{CreateProcessForm.eadLevels}"
+                                       var="eadLevel"
+                                       itemValue="#{eadLevel}"
+                                       itemLabel="#{eadLevel.toUpperCase()}"/>
+                        <p:ajax event="change"/>
+                    </p:selectOneRadio>
+                </h:panelGroup>
+            </p:row>
+        </p:panelGrid>
+    </ui:fragment>
+</ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/errorPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/errorPopup.xhtml
@@ -28,7 +28,7 @@
         <h:panelGroup id="messageWrapper">
             <h3>
                 <h:outputFormat value="#{err['catalogError']}">
-                    <f:param value="#{CreateProcessForm.catalogImportDialog.hitModel.importConfiguration.title}"/>
+                    <f:param value="#{CreateProcessForm.currentImportConfiguration.title}"/>
                 </h:outputFormat>
             </h3>
             <div class="select-note ui-messages-error">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/fileUpload.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/fileUpload.xhtml
@@ -19,14 +19,15 @@
         xmlns:p="http://primefaces.org/ui">
 
     <p:dialog widgetVar="fileUploadDialog"
-              id="fileUpload"
+              id="fileUploadDialog"
               width="578"
               modal="true"
-              visible="#{CreateProcessForm.defaultConfigurationType eq 'FILE_UPLOAD'}"
+              visible="#{false}"
               appendTo="@(body)"
               resizable="false">
         <h3>#{msgs['newProcess.fileUpload.heading']}</h3>
-        <h:form id="fileUploadForm">
+        <h:form id="fileUploadForm"
+                styleClass="metadata-import-dialog-form">
             <p:panelGrid layout="grid" columns="2" cellpadding="10">
                 <p:row>
                     <div>
@@ -36,7 +37,7 @@
                                          autoWidth="false"
                                          required="#{not empty param['catalogSearchForm:performCatalogSearch']}"
                                          immediate="true"
-                                         value="#{CreateProcessForm.fileUploadDialog.importConfiguration}"
+                                         value="#{CreateProcessForm.currentImportConfiguration}"
                                          converter="#{importConfigurationConverter}">
                             <f:selectItem itemValue="#{null}" itemLabel="-- #{msgs.selectCatalog} --" noSelectionOption="true"/>
                             <f:selectItems value="#{CreateProcessForm.fileUploadDialog.importConfigurations}"
@@ -48,7 +49,7 @@
                     </div>
                 </p:row>
             </p:panelGrid>
-            <p:panelGrid rendered="#{CreateProcessForm.fileUploadDialog.importConfiguration ne null}">
+            <p:panelGrid>
                 <p:row>
                     <div>
                         <p:outputLabel for="additionalImport" value="#{msgs['newProcess.catalogueSearch.additionalImport']}"/>
@@ -57,7 +58,7 @@
                         </p:selectBooleanCheckbox>
                     </div>
                     <div>
-                        <p:fileUpload rendered="#{CreateProcessForm.fileUploadDialog.importConfiguration ne null}"
+                        <p:fileUpload rendered="#{CreateProcessForm.currentImportConfiguration ne null}"
                                       listener="#{CreateProcessForm.fileUploadDialog.handleFileUpload}"
                                       allowTypes="/(\.|\/)(xml)$/"
                                       skinSimple="true"
@@ -71,10 +72,17 @@
                     </div>
                 </p:row>
             </p:panelGrid>
+            <h:panelGroup id="eadLevelSelectionWrapper">
+                <ui:fragment rendered="#{CreateProcessForm.currentImportConfiguration.configurationType eq 'FILE_UPLOAD' and
+                                         CreateProcessForm.currentImportConfiguration.metadataFormat eq 'EAD'}">
+                    <ui:include src="/WEB-INF/templates/includes/processFromTemplate/dialogs/eadLevelSelection.xhtml"/>
+                </ui:fragment>
+            </h:panelGroup>
             <h:panelGroup layout="block"
                           id="fileUploadButton">
                 <p:commandButton id="close"
                                  value="#{msgs.close}"
+                                 process="@this"
                                  styleClass="secondary right"
                                  icon="fa fa-times fa-lg"
                                  iconPos="right"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/import.xhtml
@@ -19,14 +19,15 @@
         xmlns:p="http://primefaces.org/ui">
 
     <p:dialog widgetVar="catalogSearchDialog"
-              id="catalogSearch"
+              id="catalogSearchDialog"
               width="640"
               modal="true"
               appendTo="@(body)"
-              visible="#{CreateProcessForm.defaultConfigurationType eq 'OPAC_SEARCH'}"
+              visible="#{false}"
               resizable="false">
         <h3>#{msgs['newProcess.catalogueSearch.heading']}</h3>
-        <h:form id="catalogSearchForm">
+        <h:form id="catalogSearchForm"
+                styleClass="metadata-import-dialog-form">
             <p:panelGrid layout="grid" columns="2" cellpadding="10">
                 <p:row>
                     <div>
@@ -36,7 +37,7 @@
                                          autoWidth="false"
                                          required="#{not empty param['catalogSearchForm:performCatalogSearch']}"
                                          immediate="true"
-                                         value="#{CreateProcessForm.catalogImportDialog.hitModel.importConfiguration}"
+                                         value="#{CreateProcessForm.currentImportConfiguration}"
                                          converter="#{importConfigurationConverter}">
                             <f:selectItem itemValue="#{null}" itemLabel="-- #{msgs.selectCatalog} --" noSelectionOption="true"/>
                             <f:selectItems value="#{CreateProcessForm.catalogImportDialog.importConfigurations}"
@@ -47,7 +48,8 @@
                                             catalogSearchForm:searchTerm,
                                             catalogSearchForm:importDepth,
                                             catalogSearchForm:importChildren,
-                                            catalogSearchForm:catalogSearchButton"/>
+                                            catalogSearchForm:catalogSearchButton,
+                                            catalogSearchForm:eadLevelSelectionWrapper"/>
                         </p:selectOneMenu>
                     </div>
                 </p:row>
@@ -62,9 +64,9 @@
                                        value="#{msgs.field}"/>
                         <p:selectOneMenu id="fieldSelectMenu"
                                          autoWidth="false"
-                                         disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration}"
+                                         disabled="#{empty CreateProcessForm.currentImportConfiguration}"
                                          required="#{not empty param['catalogSearchForm:performCatalogSearch']}"
-                                         value="#{CreateProcessForm.catalogImportDialog.hitModel.selectedField}">
+                                         value="#{CreateProcessForm.catalogImportDialog.selectedField}">
                             <f:selectItems value="#{CreateProcessForm.catalogImportDialog.searchFields}" var="field"/>
                             <p:ajax update="catalogSearchForm:searchTerm
                                             catalogSearchForm:catalogSearchButton"/>
@@ -75,8 +77,8 @@
                                        value="#{msgs.importDepth}"/>
                         <p:spinner id="importDepth"
                                    class="input"
-                                   disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration}"
-                                   value="#{CreateProcessForm.catalogImportDialog.hitModel.importDepth}"
+                                   disabled="#{empty CreateProcessForm.currentImportConfiguration}"
+                                   value="#{CreateProcessForm.catalogImportDialog.importDepth}"
                                    min="1"
                                    max="5"/>
                     </div>
@@ -91,8 +93,8 @@
                                        value="#{msgs.value}"/>
                         <p:inputText id="searchTerm"
                                      onkeypress="if (event.keyCode === 13) { document.getElementById('catalogSearchForm:performCatalogSearch').click(); return false; }"
-                                     disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration}"
-                                     value="#{CreateProcessForm.catalogImportDialog.hitModel.searchTerm}"
+                                     disabled="#{empty CreateProcessForm.currentImportConfiguration}"
+                                     value="#{CreateProcessForm.catalogImportDialog.searchTerm}"
                                      class="input"
                                      placeholder="#{msgs['newProcess.catalogueSearch.searchTerm']}"
                                      required="#{not empty param['catalogSearchForm:performCatalogSearch']}">
@@ -108,15 +110,21 @@
                         <p:selectBooleanCheckbox id="importChildren"
                                                  class="input switch"
                                                  title="#{CreateProcessForm.catalogImportDialog.isParentIdSearchFieldConfigured() ? msgs['importChildren'] : msgs['newProcess.catalogueSearch.parentIDParameterMissing']}"
-                                                 disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration or not CreateProcessForm.catalogImportDialog.isParentIdSearchFieldConfigured()}"
+                                                 disabled="#{empty CreateProcessForm.currentImportConfiguration or not CreateProcessForm.catalogImportDialog.isParentIdSearchFieldConfigured()}"
                                                  value="#{CreateProcessForm.catalogImportDialog.importChildren}"/>
                     </div>
                 </p:row>
             </p:panelGrid>
+            <h:panelGroup id="eadLevelSelectionWrapper">
+                <ui:fragment rendered="#{CreateProcessForm.currentImportConfiguration.configurationType eq 'OPAC_SEARCH' and
+                                         CreateProcessForm.currentImportConfiguration.metadataFormat eq 'EAD'}">
+                    <ui:include src="/WEB-INF/templates/includes/processFromTemplate/dialogs/eadLevelSelection.xhtml"/>
+                </ui:fragment>
+            </h:panelGroup>
             <h:panelGroup layout="block"
                           id="catalogSearchButton">
                 <p:commandButton id="performCatalogSearch"
-                                 disabled="#{empty CreateProcessForm.catalogImportDialog.hitModel.importConfiguration or empty CreateProcessForm.catalogImportDialog.hitModel.selectedField or empty CreateProcessForm.catalogImportDialog.hitModel.searchTerm}"
+                                 disabled="#{empty CreateProcessForm.currentImportConfiguration or empty CreateProcessForm.catalogImportDialog.selectedField or empty CreateProcessForm.catalogImportDialog.searchTerm}"
                                  action="#{CreateProcessForm.catalogImportDialog.search}"
                                  value="#{msgs.searchOPAC}"
                                  title="#{msgs.searchOPAC}"
@@ -128,6 +136,7 @@
                                  update="editForm hitlist"/>
                 <p:commandButton id="cancel"
                                  value="#{msgs.cancel}"
+                                 process="@this"
                                  styleClass="secondary right"
                                  icon="fa fa-times fa-lg"
                                  iconPos="right"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/maxNumberOfRecordsExceeded.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/maxNumberOfRecordsExceeded.xhtml
@@ -1,0 +1,51 @@
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+    <p:confirmDialog global="true"
+                     showEffect="fade"
+                     hideEffect="explode"
+                     styleClass="confirm-delete"
+                     style="padding-left: var(--default-double-size); padding-right: var(--default-double-size);"
+                     width="640px"
+                     appendTo="@(body)"
+                     message="#{CreateProcessForm.getMaxNumberOfRecordsExceededMessage()}"
+                     widgetVar="maxNumberOfRecordsExceededDialog"
+                     id="maxNumberOfRecordsExceededDialog">
+        <h:form id="maxNumberOfRecordsExceededForm">
+            <h:panelGroup styleClass="ui-confirm-dialog-message"
+                          style="display: block; margin-left: -6px; margin-top: -16px;">
+                <h:outputText value="#{msgs['doYouWantToProceed']}"/>
+            </h:panelGroup>
+            <p:commandButton
+                    id="confirmButton"
+                    value="#{msgs.yes}"
+                    styleClass="ui-confirmdialog-yes primary right"
+                    icon="fa fa-check fa-lg"
+                    iconPos="right"
+                    action="#{CreateProcessForm.importRecordsInBackground()}"
+                    onclick="PF('maxNumberOfRecordsExceededDialog').hide();"/>
+            <p:commandButton
+                    id="cancelButton"
+                    value="#{msgs.no}"
+                    styleClass="ui-confirmdialog-no secondary right"
+                    iconPos="right"
+                    onclick="PF('maxNumberOfRecordsExceededDialog').hide();"
+                    icon="fa fa-times fa-lg" />
+        </h:form>
+    </p:confirmDialog>
+</ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/searchEdit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/searchEdit.xhtml
@@ -22,7 +22,7 @@
               id="searchEditDialog"
               width="578"
               modal="true"
-              visible="#{CreateProcessForm.defaultConfigurationType eq 'PROCESS_TEMPLATE'}"
+              visible="#{false}"
               appendTo="@(body)"
               resizable="false">
         <h3>#{msgs.processTemplate}</h3>
@@ -58,6 +58,7 @@
                                  icon="fa fa-download" iconPos="right"/>
                 <p:commandButton id="close"
                                  value="#{msgs.close}"
+                                 process="@this"
                                  styleClass="secondary right"
                                  icon="fa fa-times fa-lg"
                                  iconPos="right"

--- a/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
+++ b/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
@@ -36,7 +36,6 @@
             <h:outputText value="#{msgs.createNewProcess} (#{msgs.template}: '#{CreateProcessForm.template.title}')"
                           styleClass="shortable"/>
         </h3>
-
         <p:button id="cancel"
                   value="#{msgs.cancel}"
                   onclick="setConfirmUnload(false);"
@@ -125,6 +124,7 @@
         <ui:include src="/WEB-INF/templates/includes/processFromTemplate/dialogs/progress.xhtml"/>
         <ui:include src="/WEB-INF/templates/includes/processFromTemplate/dialogs/searchEdit.xhtml"/>
         <ui:include src="/WEB-INF/templates/includes/processFromTemplate/dialogs/addMetadata.xhtml"/>
+        <ui:include src="/WEB-INF/templates/includes/processFromTemplate/dialogs/maxNumberOfRecordsExceeded.xhtml"/>
     </ui:define>
 
     <ui:define name="breadcrumbs">

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ImportServiceIT.java
@@ -18,6 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.kitodo.constants.StringConstants.COLLECTION;
+import static org.kitodo.constants.StringConstants.FILE;
 
 import com.xebialabs.restito.server.StubServer;
 
@@ -59,8 +61,10 @@ import org.kitodo.api.schemaconverter.FileFormat;
 import org.kitodo.api.schemaconverter.MetadataFormat;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
+import org.kitodo.data.database.beans.Client;
 import org.kitodo.data.database.beans.ImportConfiguration;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.beans.UrlParameter;
@@ -73,12 +77,14 @@ import org.kitodo.exceptions.NoRecordFoundException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.exceptions.UnsupportedFormatException;
+import org.kitodo.production.forms.createprocess.CreateProcessForm;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.forms.createprocess.ProcessTextMetadata;
 import org.kitodo.production.helper.ProcessHelper;
 import org.kitodo.production.helper.TempProcess;
 import org.kitodo.production.helper.XMLUtils;
 import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.thread.ImportEadProcessesThread;
 import org.kitodo.test.utils.ProcessTestUtils;
 import org.kitodo.test.utils.TestConstants;
 import org.w3c.dom.Document;
@@ -94,6 +100,7 @@ public class ImportServiceIT {
     private static final ImportService importService = ServiceManager.getImportService();
     private static StubServer server;
     private static final String TEST_FILE_PATH = "src/test/resources/sruTestRecord.xml";
+    private static final String EAD_COLLECTION_FILE = "importRecords/eadCollection.xml";
     private static final String TEST_FILE_PATH_NUMBER_OF_HITS = "src/test/resources/importRecords/sruResponseNumberOfHits.xml";
     private static final String TEST_FILE_SUCCESS_RESPONSE_PATH = "src/test/resources/customInterfaceSuccessResponse.xml";
     private static final String TEST_FILE_ERROR_RESPONSE_PATH = "src/test/resources/customInterfaceErrorResponse.xml";
@@ -296,12 +303,11 @@ public class ImportServiceIT {
      * Tests whether parent process with provided process ID exists and created parent TempProcess from it.
      *
      * @throws DAOException when test ruleset cannot be loaded from database
-     * @throws ProcessGenerationException when checking for parent process fails
      * @throws IOException when checking for parent process fails
      * @throws DataException when copying test metadata file fails
      */
     @Test
-    public void shouldCheckForParent() throws DAOException, ProcessGenerationException, IOException, DataException {
+    public void shouldCheckForParent() throws DAOException, IOException, DataException {
         int parentTestId = MockDatabase.insertTestProcess("Test parent process", PROJECT_ID, TEMPLATE_ID, RULESET_ID);
         ProcessTestUtils.copyTestMetadataFile(parentTestId, TEST_KITODO_METADATA_FILE);
         Ruleset ruleset = ServiceManager.getRulesetService().getById(RULESET_ID);
@@ -550,6 +556,55 @@ public class ImportServiceIT {
             assertTrue(process.getWorkpieces().stream().anyMatch(property -> docType.equals(property.getTitle())), "Process should contain 'DocType' property after adding it");
         } finally {
             ProcessTestUtils.removeTestProcess(processId);
+        }
+    }
+
+    /**
+     * Test EAD import.
+     *
+     * @throws Exception when something goes wrong
+     */
+    @Test
+    public void shouldImportEadCollection() throws Exception {
+        User user = ServiceManager.getUserService().getById(1);
+        Client client = ServiceManager.getClientService().getById(1);
+        Project eadProject = MockDatabase.insertProjectForEadImport(user, client);
+        Template eadTemplate = eadProject.getTemplates().get(0);
+        CreateProcessForm createProcessForm = new CreateProcessForm();
+        createProcessForm.setProject(eadProject);
+        createProcessForm.setTemplate(eadTemplate);
+        createProcessForm.setSelectedEadLevel(FILE);
+        createProcessForm.setSelectedParentEadLevel(COLLECTION);
+        createProcessForm.setCurrentImportConfiguration(eadProject.getDefaultImportConfiguration());
+        createProcessForm.updateRulesetAndDocType(eadTemplate.getRuleset());
+        File script = new File(ConfigCore.getParameter(ParameterCore.SCRIPT_CREATE_DIR_META));
+        List<Integer> allIds = ServiceManager.getProcessService().findAllIDs();
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            ExecutionPermission.setExecutePermission(script);
+        }
+        try (InputStream inputStream = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream(EAD_COLLECTION_FILE)) {
+            if (Objects.nonNull(inputStream)) {
+                String xmlString = IOUtils.toString(inputStream, Charset.defaultCharset());
+                createProcessForm.setXmlString(xmlString);
+                ImportEadProcessesThread eadProcessesThread = new ImportEadProcessesThread(createProcessForm, user, client);
+                eadProcessesThread.start();
+                assertTrue(eadProcessesThread.isAlive(), "Process should have been started");
+                eadProcessesThread.join(3000);
+                assertFalse(eadProcessesThread.isAlive(), "Process should have been stopped");
+            }
+        }
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            ExecutionPermission.setNoExecutePermission(script);
+        }
+        List<Integer> allIdsWithEad = ServiceManager.getProcessService().findAllIDs();
+        // EAD test file contains one collection and 5 files, so the system should contain 6 new processes altogether
+        assertEquals(allIds.size() + 6, allIdsWithEad.size(),
+                "Database does not contain the correct number of processes after EAD import");
+        if (allIdsWithEad.removeAll(allIds)) {
+            for (int processId : allIdsWithEad) {
+                ProcessTestUtils.removeTestProcess(processId);
+            }
         }
     }
 

--- a/Kitodo/src/test/resources/importRecords/eadCollection.xml
+++ b/Kitodo/src/test/resources/importRecords/eadCollection.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0"?>
+<ead audience="external">
+  <eadheader countryencoding="iso3166-1"
+             dateencoding="iso8601"
+             langencoding="iso639-2b"
+             repositoryencoding="iso15511"
+             scriptencoding="iso15924">
+    <filedesc>
+      <titlestmt>
+        <titleproper>Test-Archiv</titleproper>
+      </titlestmt>
+    </filedesc>
+  </eadheader>
+  <archdesc level="collection" type="Findbuch">
+    <dsc>
+      <c level="collection" id="111">
+        <did>
+          <unitid>Custom Collection</unitid>
+          <unittitle>Test-Bestand des Test-Archivs</unittitle>
+          <unitdate normal="1989-01-01/1991-12-31">1989-1991</unitdate>
+          <physdesc>
+            <genreform normal="Bilder">Foto</genreform>
+            <extent>0,3 lfm.</extent>
+          </physdesc>
+          <langmaterial>
+            <language langcode="ger" scriptcode="Latn"/>
+          </langmaterial>
+          <origination/>
+        </did>
+        <scopecontent>
+          <head>Beschreibung</head>
+          <p>Li Europan lingues es membres del sam familie. Lor separat existentie es un myth. Por scientie, musica,
+            sport etc, litot Europa usa li sam vocabular. Li lingues differe solmen in li grammatica, li pronunciation
+            e li plu commun vocabules. Omnicos directe al desirabilite de un nov lingua franca</p>
+        </scopecontent>
+        <accessrestrict>
+          <head>Zugangsbeschränkung</head>
+          <p>extern</p>
+        </accessrestrict>
+        <relatedmaterial>
+          <head>Literatur</head>
+          <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.</p>
+        </relatedmaterial>
+        <index>
+          <indexentry>
+            <persname source="GND" authfilenumber="1234567890">Martin Mustermann</persname>
+          </indexentry>
+        </index>
+        <c level="class" id="1111">
+          <did>
+            <unittitle>Personen</unittitle>
+            <abstract/>
+          </did>
+          <c level="file" id="11111">
+            <did>
+              <unitid>Custom ID 101</unitid>
+              <unittitle type="Einheitstitel">Testtitel 1</unittitle>
+              <unitdate normal="1950-01-01/1953-12-31"> 1. Januar 1950 - 31. Dezember 1953</unitdate>
+              <abstract type="Enth&#xE4;lt">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+                ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+                ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+                quis enim. Donec.</abstract>
+              <origination>Ankauf</origination>
+              <physdesc>
+                <genreform normal="Bilder">Foto</genreform>
+                <extent>1 Bild</extent>
+              </physdesc>
+              <langmaterial/>
+              <note>
+                <p/>
+              </note>
+            </did>
+            <odd>
+              <head>Technische Daten / Farbigkeit</head>
+              <p>s/w</p>
+            </odd>
+            <odd>
+              <head>Technische Daten / Fototyp</head>
+              <p>Positiv</p>
+            </odd>
+            <index>
+              <indexentry>
+                <geogname>Deutschland</geogname>
+              </indexentry>
+              <indexentry>
+                <persname role="Dargestellte Person" source="GND" authfilenumber="0000000">Müller, Hansi</persname>
+              </indexentry>
+            </index>
+          </c>
+          <c level="file" id="11112">
+            <did>
+              <unitid>Custom ID 102</unitid>
+              <unittitle type="Einheitstitel">Testtitel 2</unittitle>
+              <unitdate normal="1950-01-01/1953-12-31"> 1. Januar 1950 - 31. Dezember 1953</unitdate>
+              <abstract type="Enth&#xE4;lt">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+                ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+                ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+                quis enim. Donec.</abstract>
+              <origination>Ankauf</origination>
+              <physdesc>
+                <genreform normal="Bilder">Foto</genreform>
+                <extent>1 Bild</extent>
+              </physdesc>
+              <langmaterial/>
+              <note>
+                <p/>
+              </note>
+            </did>
+            <odd>
+              <head>Technische Daten / Farbigkeit</head>
+              <p>s/w</p>
+            </odd>
+            <odd>
+              <head>Technische Daten / Fototyp</head>
+              <p>Positiv</p>
+            </odd>
+            <index>
+              <indexentry>
+                <geogname>Deutschland</geogname>
+              </indexentry>
+              <indexentry>
+                <persname role="Dargestellte Person" source="GND" authfilenumber="0000000">Müller, Hansi</persname>
+              </indexentry>
+            </index>
+          </c>
+          <c level="file" id="11113">
+            <did>
+              <unitid>Custom ID 103</unitid>
+              <unittitle type="Einheitstitel">Testtitel 3</unittitle>
+              <unitdate normal="1950-01-01/1953-12-31"> 1. Januar 1950 - 31. Dezember 1953</unitdate>
+              <abstract type="Enth&#xE4;lt">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+                ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+                ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+                quis enim. Donec.</abstract>
+              <origination>Ankauf</origination>
+              <physdesc>
+                <genreform normal="Bilder">Foto</genreform>
+                <extent>1 Bild</extent>
+              </physdesc>
+              <langmaterial/>
+              <note>
+                <p/>
+              </note>
+            </did>
+            <odd>
+              <head>Technische Daten / Farbigkeit</head>
+              <p>s/w</p>
+            </odd>
+            <odd>
+              <head>Technische Daten / Fototyp</head>
+              <p>Positiv</p>
+            </odd>
+            <index>
+              <indexentry>
+                <geogname>Deutschland</geogname>
+              </indexentry>
+              <indexentry>
+                <persname role="Dargestellte Person" source="GND" authfilenumber="0000000">Müller, Hansi</persname>
+              </indexentry>
+            </index>
+          </c>
+          <c level="file" id="11114">
+            <did>
+              <unitid>Custom ID 104</unitid>
+              <unittitle type="Einheitstitel">Testtitel 4</unittitle>
+              <unitdate normal="1950-01-01/1953-12-31"> 1. Januar 1950 - 31. Dezember 1953</unitdate>
+              <abstract type="Enth&#xE4;lt">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+                ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+                ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+                quis enim. Donec.</abstract>
+              <origination>Ankauf</origination>
+              <physdesc>
+                <genreform normal="Bilder">Foto</genreform>
+                <extent>1 Bild</extent>
+              </physdesc>
+              <langmaterial/>
+              <note>
+                <p/>
+              </note>
+            </did>
+            <odd>
+              <head>Technische Daten / Farbigkeit</head>
+              <p>s/w</p>
+            </odd>
+            <odd>
+              <head>Technische Daten / Fototyp</head>
+              <p>Positiv</p>
+            </odd>
+            <index>
+              <indexentry>
+                <geogname>Deutschland</geogname>
+              </indexentry>
+              <indexentry>
+                <persname role="Dargestellte Person" source="GND" authfilenumber="0000000">Müller, Hansi</persname>
+              </indexentry>
+            </index>
+          </c>
+          <c level="file" id="11115">
+            <did>
+              <unitid>Custom ID 105</unitid>
+              <unittitle type="Einheitstitel">Testtitel 5</unittitle>
+              <unitdate normal="1950-01-01/1953-12-31"> 1. Januar 1950 - 31. Dezember 1953</unitdate>
+              <abstract type="Enth&#xE4;lt">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+                ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+                ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+                quis enim. Donec.</abstract>
+              <origination>Ankauf</origination>
+              <physdesc>
+                <genreform normal="Bilder">Foto</genreform>
+                <extent>1 Bild</extent>
+              </physdesc>
+              <langmaterial/>
+              <note>
+                <p/>
+              </note>
+            </did>
+            <odd>
+              <head>Technische Daten / Farbigkeit</head>
+              <p>s/w</p>
+            </odd>
+            <odd>
+              <head>Technische Daten / Fototyp</head>
+              <p>Positiv</p>
+            </odd>
+            <index>
+              <indexentry>
+                <geogname>Deutschland</geogname>
+              </indexentry>
+              <indexentry>
+                <persname role="Dargestellte Person" source="GND" authfilenumber="0000000">Müller, Hansi</persname>
+              </indexentry>
+            </index>
+          </c>
+        </c>
+      </c>
+    </dsc>
+  </archdesc>
+</ead>

--- a/Kitodo/src/test/resources/rulesets/ruleset_ead.xml
+++ b/Kitodo/src/test/resources/rulesets/ruleset_ead.xml
@@ -1,0 +1,477 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2">
+	<declaration>
+
+		<!--Divisons für Level of description (ISAD(G)) -->
+
+		<division id="bestand" processTitle="docType+'_'+name_intern" withWorkflow="false" use="createChildrenFromParent">
+			<label>Fonds</label>
+			<label lang="de">Bestand</label>
+		</division>
+
+		<division id="teilbestand" processTitle="docType+'_'+name_intern">
+			<label>Subfonds</label>
+			<label lang="de">Teilbestand</label>
+		</division>
+
+		<division id="klassifikation" processTitle="docType+'_'+id">
+			<label>Classification</label>
+			<label lang="de">Klassifikation</label>
+		</division>
+
+		<division id="series" processTitle="docType+'_'+name_intern">
+			<label>Series</label>
+			<label lang="de">Serie</label>
+		</division>
+
+		<division id="vorgang" processTitle="docType+'_'+signatur_intern">
+			<label>Item</label>
+			<label lang="de">Vorgang</label>
+		</division>
+
+		<division id="verzeichnungseinheit" processTitle="docType+'_'+id">
+			<label>file</label>
+			<label lang="de">Verzeichnungseinheit</label>
+		</division>
+
+		<!--Divisions für Strukturelemente auf dem Level von Verzeichnungseinheiten-->
+
+		<division id="article">
+            <label>Article</label>
+            <label lang="de">Artikel</label>
+        </division>
+
+		<division id="chapter">
+            <label>Kapitel</label>
+        </division>
+
+        <division id="contents">
+            <label>Table of contents</label>
+            <label lang="de">Inhaltsverzeichnis</label>
+        </division>
+
+        <division id="title_page">
+            <label>Title page</label>
+            <label lang="de">Titelblatt</label>
+        </division>
+
+        <division id="verse">
+            <label>Verse</label>
+            <label lang="de">Verse</label>
+        </division>
+
+		<!-- Keys für Level of description Bestand-->
+
+		<key id="id" use="recordIdentifier">
+			<label lang="de">ID</label>
+		</key>
+
+		<key id="name">
+		   <label lang="de">Name</label>
+		</key>
+
+		<key id="name_intern">
+		   <label lang="de">Name (intern)</label>
+		</key>
+
+		<key id="anzeigename">
+			<label lang="de">Anzeigename</label>
+		</key>
+
+		<key id="rechte">
+			<label lang="de">Rechte</label>
+		</key>
+
+		<key id="bestand_rechtebedingungen">
+			<label lang="de">Rechtebedingungen</label>
+		</key>
+
+		<key id="info_laufzeit">
+			<label lang="de">Laufzeit</label>
+		</key>
+
+		<key id="info_umfang">
+			<label lang="de">Umfang</label>
+		</key>
+
+		<key id="status_id">
+			<label lang="de">Status</label>
+		</key>
+
+		<!-- Keys für Level of description Verzeichnungseinheit-->
+
+		<key id="id" use="recordIdentifier">
+			<label lang="de">ID</label>
+		</key>
+
+		<key id="einheitstitel">
+			<label lang="de">Einheitstitel</label>
+		</key>
+
+		<key id="signatur">
+			<label lang="de">Signatur</label>
+		</key>
+
+		<key id="signatur_intern">
+			<label lang="de">Signatur (intern)</label>
+		</key>
+
+		<key id="alte_signatur">
+			<label lang="de">Alte Signatur</label>
+		</key>
+
+		<key id="enthaelt">
+			<label lang="de">Enthält</label>
+		</key>
+
+		<key id="provenienz">
+			<label lang="de">Provenienz</label>
+		</key>
+
+		<key id="umfang">
+			<label lang="de">Umfang</label>
+		</key>
+
+		<key id="ort">
+			<label lang="de">Ort</label>
+		</key>
+
+		<key id="datierung">
+			<label lang="de">Datierung-verbal</label>
+		</key>
+
+		<key id="datierung_date_bis">
+			<label lang="de">Datierung bis</label>
+		</key>
+
+		<key id="datierung_date_von">
+			<label lang="de">Datierung von</label>
+		</key>
+
+		<key id="material_technik">
+			<label lang="de">Material/Technik</label>
+		</key>
+
+		<key id="masse_format">
+			<label lang="de">Maße/Format</label>
+		</key>
+
+		<key id="objekttyp_id">
+			<label lang="de">Objekttyp</label>
+		</key>
+
+		<key id="freigabe_id">
+			<label lang="de">Freigabe</label>
+		</key>
+
+		<key id="rechte_id">
+			<label lang="de">Rechte (easyDB)</label>
+		</key>
+
+        <key id="LegalNoteAndTermsOfUse"><!-- rights information according to DINI AG KIM Lizenzen Grupppe -->
+            <label>legal note / terms of use</label>
+            <label lang="de">Rechtehinweis / Nutzungshinweis</label>
+            <option value="PDM1.0"><label>PDM 1.0</label></option>
+            <option value="FZRV1.0INC1.0"><label>Freier Zugang - Rechte vorbehalten + Urheberrechtsschutz 1.0</label></option>
+            <option value="FZRV1.0"><label>Freier Zugang - Rechte vorbehalten 1.0</label></option>
+            <option value="VW1.0"><label>Vergriffene Werke 1.0</label></option>
+            <option value="CCBYSA4.0"><label>CC BY-SA 4.0</label></option>
+            <option value="CC01.0"><label>CC0 1.0</label></option>
+            <option value="INC1.0"><label>In Copyright 1.0</label></option>
+        </key>
+
+		<key id="license">  <!-- rights information according to DFG METS Anwendungsprofil -->
+            <label>Lizenz des Digitalisats</label>
+            <option value="pdm"><label>Kennzeichnung als Public Domain</label></option>
+            <option value="cc0"><label>Lizensierung unter CC0-Lizenz</label></option>
+            <option value="cc-by"><label>Lizensierung unter CC-BY-Lizenz</label></option>
+            <option value="cc-by-sa"><label>Lizensierung unter CC-BY-SA-Lizenz</label></option>
+            <option value="cc-by-nd"><label>Lizensierung unter CC-BY-NC-Lizenz</label></option>
+            <option value="cc-by-nc-sa"><label>Lizensierung unter CC-BY-NC-SA-Lizenz</label></option>
+            <option value="cc-by-nc-nd"><label>Lizensierung unter CC-BY-NC-ND-Lizenz</label></option>
+            <option value="http://rightsstatements.org/vocab/InC/1.0/"><label>Urheberrechtsschutz</label></option>
+            <option value="http://rightsstatements.org/vocab/InC-NC/1.0/"><label>Urheberrechtsschutz - Nicht kommerzielle Nutzung gestattet</label></option>
+            <option value="reserved"><label>Sonstiger Rechtevorbehalt</label></option>
+        </key>
+
+		<!-- Keys Objektspezifische Felder Verzeichnungseinheit-->
+
+		<key id="iconclass">
+			<label lang="de">Iconclass</label>
+		</key>
+
+		<key id="signatur_des_kuenstlerers">
+			<label lang="de">Signatur des Künstlers</label>
+		</key>
+
+		<key id="projekt">
+			<label lang="de">Projekt</label>
+		</key>
+
+		<key id="fassung">
+			<label lang="de">Fassung</label>
+		</key>
+
+		<key id="besetzung">
+			<label lang="de">Besetzung</label>
+		</key>
+
+		<key id="premiere">
+			<label lang="de">Premiere-Datum</label>
+		</key>
+
+		<key id="produktion">
+			<label lang="de">Produktion</label>
+		</key>
+
+		<key id="auffuehrungsort">
+			<label lang="de">Aufführungsort</label>
+		</key>
+
+		<key id="abzug">
+			<label lang="de">Abzug</label>
+		</key>
+
+		<key id="audiocodec">
+			<label lang="de">Audiocodec</label>
+		</key>
+
+		<key id="aufloeseung">
+			<label lang="de">Auflösung</label>
+		</key>
+
+		<key id="aufnahmedatum">
+		   <label lang="de">Aufnahmedatum</label>
+		</key>
+
+		<key id="aufnahmeort">
+			<label lang="de">Aufnahmeort</label>
+		</key>
+
+		<key id="aufzeichnungsform">
+			<label lang="de">Aufzeichnungsform</label>
+		</key>
+
+		<key id="aeussere_kennzeichen">
+			<label lang="de">äußere Kennzeichen</label>
+		</key>
+
+		<key id="bandlaenge">
+			<label lang="de">Bandlänge</label>
+		</key>
+
+		<key id="entstehungstyp">
+			<label lang="de">Entstehungstyp</label>
+		</key>
+
+		<key id="farbigkeit">
+			<label lang="de">Farbigkeit</label>
+		</key>
+
+		<key id="file_type">
+			<label lang="de">File Type (Container)</label>
+		</key>
+
+		<key id="format">
+			<label lang="de">Format</label>
+		</key>
+
+		<key id="fototyp">
+			<label lang="de">Fototyp</label>
+		</key>
+
+		<key id="geschwindigkeit">
+			<label lang="de">Geschwindigkeit</label>
+		</key>
+
+		<key id="kanaltechnik">
+			<label lang="de">Kanaltechnik (Ton)</label>
+		</key>
+
+		<key id="magnetbandtyp">
+			<label lang="de">Magnetbandtyp</label>
+		</key>
+
+		<key id="massstab">
+			<label lang="de">Maßstab</label>
+		</key>
+
+		<key id="papiertyp">
+			<label lang="de">Papiertyp</label>
+		</key>
+
+		<key id="plakat_nr">
+			<label lang="de">Plakat-Nr.</label>
+		</key>
+
+		<key id="rauschunterdrueckung">
+			<label lang="de">Rauschunterdrückung</label>
+		</key>
+
+		<key id="seitenverhältnis">
+			<label lang="de">seitenverhältnis</label>
+		</key>
+
+		<key id="spieldauer">
+			<label lang="de">Spieldauer</label>
+		</key>
+
+		<key id="tonhead">
+			<label lang="de">Ton</label>
+		</key>
+
+		<key id="tonsystem">
+			<label lang="de">tonsystem</label>
+		</key>
+
+		<key id="traegermaterial">
+			<label lang="de">Trägermaterial</label>
+		</key>
+
+		<key id="tv_norm">
+			<label lang="de">TV-Norm</label>
+		</key>
+
+		<key id="video_nummer">
+			<label lang="de">Video-Nr</label>
+		</key>
+
+		<key id="inhaltliche_beschreibung">
+			<label lang="de">Inhalt (Beschreibung)</label>
+		</key>
+
+		<key id="inventarnummer">
+			<label lang="de">Inventarnummer</label>
+		</key>
+
+		<key id="verweis">
+			<label lang="de">Verweis</label>
+		</key>
+
+		<!-- Key IDs Personen Verzeichnungseinheit-->
+
+		<key id="person">
+			<label>Person</label>
+			<label lang="de">Person</label>
+			<key id="typ_id">
+				<label>Role</label>
+				<label lang="de">Rolle</label>
+			</key>
+
+			<key id="gnd_id">
+				<label>GND-ID</label>
+				<label lang="de">GND-ID</label>
+			</key>
+
+			<key id="gnd_name">
+				<label>Name</label>
+				<label lang="de">Name</label>
+			</key>
+		</key>
+
+		<!-- Higher level identifier -> contains collection ID for files! -->
+		<key id="collection_id" use="higherlevelIdentifier">
+			<label lang="de">Bestands-ID</label>
+		</key>
+
+        <key id="docType" use="docType">
+            <label>type of document</label>
+            <label lang="de">Dokumenttyp</label>
+        </key>
+
+	</declaration>
+
+	<correlation>
+		<restriction division="bestand" unspecified="forbidden">
+			<permit division="teilbestand"/>
+			<permit division="verzeichnungseinheit"/>
+			<permit key="id" minOccurs="1" maxOccurs="1"/>
+			<permit key="name" minOccurs="1" maxOccurs="1"/>
+			<permit key="name_intern" minOccurs="1" maxOccurs="1"/>
+			<permit key="anzeigename" minOccurs="1" maxOccurs="1"/>
+			<permit key="rechte" maxOccurs="1"/>
+			<permit key="rechtebedingungen" maxOccurs="1"/>
+			<permit key="info_laufzeit" maxOccurs="1"/>
+			<permit key="info_umfang" maxOccurs="1"/>
+			<permit key="status_id" minOccurs="1" maxOccurs="1"/>
+			<permit key="docType" minOccurs="1" maxOccurs="1"/>
+		</restriction>
+
+		<restriction division="teilbestand" unspecified="forbidden">
+			<permit division="verzeichnungseinheit"/>
+			<permit key="id" minOccurs="1" maxOccurs="1"/>
+			<permit key="name" minOccurs="1" maxOccurs="1"/>
+			<permit key="name_intern" minOccurs="1" maxOccurs="1"/>
+			<permit key="anzeigename" minOccurs="1" maxOccurs="1"/>
+			<permit key="rechte" maxOccurs="1"/>
+			<permit key="rechtebedingungen" maxOccurs="1"/>
+			<permit key="info_laufzeit" maxOccurs="1"/>
+			<permit key="info_umfang" maxOccurs="1"/>
+			<permit key="docType" minOccurs="1" maxOccurs="1"/>
+		</restriction>
+
+		<restriction division="klassifikation" unspecified="forbidden">
+			<permit division="verzeichnungseinheit"/>
+			<permit key="id" minOccurs="1" maxOccurs="1"/>
+			<permit key="name" minOccurs="1" maxOccurs="1"/>
+			<permit key="name_intern" minOccurs="1" maxOccurs="1"/>
+			<permit key="anzeigename" minOccurs="1" maxOccurs="1"/>
+			<permit key="rechte" maxOccurs="1"/>
+			<permit key="rechtebedingungen" maxOccurs="1"/>
+			<permit key="info_laufzeit" maxOccurs="1"/>
+			<permit key="info_umfang" maxOccurs="1"/>
+			<permit key="docType" minOccurs="1" maxOccurs="1"/>
+		</restriction>
+
+		<restriction division="verzeichnungseinheit">
+			<permit division="item"/>
+            <permit division="article"/>
+            <permit division="chapter"/>
+			<permit division="verse"/>
+            <permit division="title_page"/>
+			<permit division="contents"/>
+			<permit key="id" minOccurs="1" maxOccurs="1"/>
+			<permit key="collection_id"/>
+			<permit key="einheitstitel" minOccurs="1" maxOccurs="1"/>
+			<permit key="signatur" maxOccurs="1"/>
+			<permit key="signatur_intern" maxOccurs="1"/>
+			<permit key="alte_signatur" maxOccurs="1"/>
+			<permit key="enthaelt" maxOccurs="1"/>
+			<permit key="provenienz" maxOccurs="1"/>
+			<permit key="umfang" maxOccurs="1"/>
+			<permit key="ort" maxOccurs="1"/>
+			<permit key="datierung" maxOccurs="1"/>
+			<permit key="datierung_date_bis" maxOccurs="1"/>
+			<permit key="datierung_date_von" maxOccurs="1"/>
+			<permit key="freigabe_id" maxOccurs="1"/>
+			<permit key="rechte_id" maxOccurs="1"/>
+			<permit key="LegalNoteAndTermsOfUse" maxOccurs="1"/>
+			<permit key="license" maxOccurs="1"/>
+			<permit key="iconclass"/>
+			<permit key="signatur_des_kuenstlers" maxOccurs="1"/>
+			<permit key="projekt" maxOccurs="1"/>
+			<permit key="fassung" maxOccurs="1"/>
+			<permit key="besetzung" maxOccurs="1"/>
+			<permit key="permiere" maxOccurs="1"/>
+			<permit key="produktion" maxOccurs="1"/>
+			<permit key="auffuehrungsort" maxOccurs="1"/>
+			<permit key="inhaltliche_beschreibung" maxOccurs="1"/>
+			<permit key="inventarnummer" maxOccurs="1"/>
+			<permit key="kommentar"/>
+			<permit key="typ_id"/>
+			<permit key="gnd_id"/>
+			<permit key="ld_gnd_name"/>
+			<permit key="docType" minOccurs="1" maxOccurs="1"/>
+		</restriction>
+
+		<restriction division="title_page">
+			<permit key="name" minOccurs="1" maxOccurs="1"/>
+		</restriction>
+	</correlation>
+
+    <editing>
+        <setting key="LegalNoteAndTermsOfUse" alwaysShowing="true"/>
+        <setting key="license" alwaysShowing="true"/>
+    </editing>
+
+</ruleset>

--- a/Kitodo/src/test/resources/xslt/ead2kitodo.xsl
+++ b/Kitodo/src/test/resources/xslt/ead2kitodo.xsl
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<xsl:stylesheet version="2.0"
+                xmlns:ead="urn:isbn:1-931666-22-9"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mets="http://www.loc.gov/METS/"
+                xmlns:kitodo="http://meta.kitodo.org/v1/">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="/">
+        <mets:mdWrap>
+            <mets:xmlData>
+                <kitodo:kitodo>
+                    <!-- ### Classify document type ### -->
+                    <xsl:choose>
+                        <xsl:when test="c/@level='file'">
+                            <kitodo:metadata name="docType">
+                                <xsl:text>verzeichnungseinheit</xsl:text>
+                            </kitodo:metadata>
+                            <kitodo:metadata name="id">
+                                <xsl:value-of select="replace(c/@id, 'VE_', '')"/>
+                            </kitodo:metadata>
+                            <xsl:apply-templates select="@*|node()"/>
+                        </xsl:when>
+                        <xsl:when test="c/@level='item'">
+                            <kitodo:metadata name="docType">
+                                <xsl:text>vorgang</xsl:text>
+                            </kitodo:metadata>
+                            <kitodo:metadata name="id">
+                                <xsl:value-of select="replace(c/@id, 'VE_', '')"/>
+                            </kitodo:metadata>
+                            <xsl:apply-templates select="@*|node()"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <kitodo:metadata name="docType">
+                                <xsl:text>UNKNOWN</xsl:text>
+                            </kitodo:metadata>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </kitodo:kitodo>
+            </mets:xmlData>
+        </mets:mdWrap>
+    </xsl:template>
+
+    <!-- ### Name BK ### -->
+    <xsl:template match="c[@level='collection' and @id]/did/unittitle">
+        <kitodo:metadata name="name">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+        <!-- ### Name (intern) ### -->
+        <kitodo:metadata name="name_intern">
+            <xsl:value-of select="replace(replace(normalize-space(), ' ', '_'), '\.', '_')"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Einheitstitel VE ### -->
+    <xsl:template match="c[@level='file' and @id]/did/unittitle[@type='Einheitstitel']">
+        <kitodo:metadata name="einheitstitel">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Signatur ### -->
+    <xsl:template match="c[@level='file' and @id]/did/unitid[not(@type)]">
+        <kitodo:metadata name="signatur">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+        <!-- ### Signatur (intern) ### -->
+        <kitodo:metadata name="signatur_intern">
+            <xsl:value-of select="replace(replace(normalize-space(), ' ', '_'), '\.', '_')"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Alte Signatur ### -->
+    <xsl:template match="c[@level='file' and @id]/did/unitid[@type='Altsignatur']">
+        <kitodo:metadata name="alte_signatur">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Inventarnummer ### -->
+    <xsl:template match="//c[@level='file' and @id]/did/unitid[@type='Inventarnummer']">
+        <kitodo:metadata name="inventarnummer">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Enthält ### -->
+    <xsl:template match="//c[@level='file' and @id]/did/abstract[@type='Enth&#xE4;lt']">
+        <kitodo:metadata name="enthaelt">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Inhaltliche Beschreibung ### -->
+    <xsl:template match="//c[@level='file' and @id]/did/abstract[@type='Inhaltliche Beschreibung']">
+        <kitodo:metadata name="inhaltliche_beschreibung">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Provenienz ### -->
+    <xsl:template match="//c[@level='file' and @id]/did/origination">
+        <kitodo:metadata name="provenienz">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Umfang ### -->
+    <xsl:template match="//c[@level='file']/did/physdesc/extent">
+        <kitodo:metadata name="umfang">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Objekttyp ### -->
+    <xsl:template match="//c[@level='file']/did/physdesc/genreform[@normal]">
+        <kitodo:metadata name="objekttyp_id">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Sprache ### -->
+    <xsl:template match="//c[@level='file']/did/langmaterial/language">
+        <kitodo:metadata name="sprache">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Material/Technik ### -->
+    <xsl:template match="//c[@level='file']/did/materialspec">
+        <kitodo:metadata name="material_technik">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Freigabe-Status (VE) ### -->
+    <xsl:template match="//c[@level='file']/accessrestrict">
+        <xsl:if test="./head/text()='Zugangsbeschränkung' and ./p">
+            <kitodo:metadata name="freigabe_id">
+                <xsl:value-of select="normalize-space(./p/text())"/>
+            </kitodo:metadata>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ### Rechte (VE) & Lizenz ### -->
+    <xsl:template match="//c[@level='file']/userestrict">
+        <xsl:choose>
+            <xsl:when test="./head/text()='Lizenzen' and ./p">
+                <!-- ### Lizenz ### -->
+                <kitodo:metadata name="license">
+                    <xsl:value-of select="normalize-space(./p/text())"/>
+                </kitodo:metadata>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- ### Rechte (VE) ### -->
+                <kitodo:metadata name="rechte_id">
+                    <xsl:value-of select="normalize-space(./p/text())"/>
+                </kitodo:metadata>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- ### Maße/Format ### -->
+    <xsl:template match="//c[@level='file']/dimensions">
+        <kitodo:metadata name="masse_format">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### General rule for "odd" tags, including exceptions ### -->
+    <xsl:template match="//c[@level='file']/odd">
+        <xsl:if test="./head and ./p">
+            <xsl:variable name="metadataName" select="replace(replace(replace(replace(replace(replace(./head/text(), 'Technische Daten / ', ''), 'ä', 'ae'), 'ö', 'oe'), 'ü', 'ue'), ' ', '_'), 'ß', 'ss')"/>
+            <xsl:choose>
+                <xsl:when test="$metadataName='Projekt/Inszenierung'">
+                    <kitodo:metadata name="projekt">
+                        <xsl:value-of select="normalize-space(./p/text())"/>
+                    </kitodo:metadata>
+                </xsl:when>
+                <xsl:otherwise>
+                    <kitodo:metadata name="{concat(lower-case(substring($metadataName, 1, 1)), substring($metadataName, 2))}">
+                        <xsl:value-of select="normalize-space(./p/text())"/>
+                    </kitodo:metadata>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:if>
+    </xsl:template>
+
+
+    <!-- ### Ort ### -->
+    <xsl:template match="//c[@level='file' and @id]/index/indexentry/geogname">
+        <kitodo:metadata name="ort">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Person ### -->
+    <xsl:template match="//c[@level='file' and @id]/index/indexentry/persname[@source='GND']">
+        <kitodo:metadataGroup name="person">
+
+            <!-- Name -->
+            <kitodo:metadata name="gnd_name">
+                <xsl:value-of select="normalize-space()"/>
+            </kitodo:metadata>
+
+            <!-- Rolle -->
+            <xsl:if test="@role!=''">
+                <kitodo:metadata name="typ_id">
+                    <xsl:value-of select="normalize-space(@role)"/>
+                </kitodo:metadata>
+            </xsl:if>
+
+            <!-- GND-ID -->
+            <xsl:if test="@authfilenumber!=''">
+                <kitodo:metadata name="gnd_id">
+                    <xsl:value-of select="normalize-space(@authfilenumber)"/>
+                </kitodo:metadata>
+            </xsl:if>
+
+        </kitodo:metadataGroup>
+    </xsl:template>
+
+    <!-- ### Datierung-verbal, Datierung von, Datierung bis ### -->
+    <xsl:template match="c[@level='file']/did/unitdate[@normal]">
+        <kitodo:metadata name="datierung">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+        <kitodo:metadata name="datierung_date_von">
+            <xsl:value-of select="substring-before(normalize-space(@normal), '/')"/>
+        </kitodo:metadata>
+        <kitodo:metadata name="datierung_date_bis">
+            <xsl:value-of select="substring-after(normalize-space(@normal), '')"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- pass-through rule -->
+    <xsl:template match="@*|node()">
+        <xsl:apply-templates select="@*|node()"/>
+    </xsl:template>
+</xsl:stylesheet>

--- a/Kitodo/src/test/resources/xslt/eadParent2kitodo.xsl
+++ b/Kitodo/src/test/resources/xslt/eadParent2kitodo.xsl
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+
+<xsl:stylesheet version="2.0"
+                xmlns="urn:isbn:1-931666-22-9"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mets="http://www.loc.gov/METS/"
+                xmlns:kitodo="http://meta.kitodo.org/v1/">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="/">
+        <mets:mdWrap>
+            <mets:xmlData>
+                <kitodo:kitodo>
+                    <!-- ### Classify document type ### -->
+                    <xsl:choose>
+                        <xsl:when test="c/@level='collection'">
+                            <kitodo:metadata name="docType">
+                                <xsl:text>bestand</xsl:text>
+                            </kitodo:metadata>
+                            <kitodo:metadata name="id">
+                                <xsl:value-of select="replace(c/@id, 'BK_', '')"/>
+                            </kitodo:metadata>
+                            <xsl:apply-templates select="@*|./child::*[not(self::c[@level='file'])]"/>
+                        </xsl:when>
+                        <xsl:when test="c/@level='class'">
+                            <kitodo:metadata name="docType">
+                                <xsl:text>klassifikation</xsl:text>
+                            </kitodo:metadata>
+                            <kitodo:metadata name="id">
+                                <xsl:value-of select="replace(c/@id, 'BK_', '')"/>
+                            </kitodo:metadata>
+                            <xsl:apply-templates select="@*|./child::*[not(self::c[@level='file'])]"/>
+                        </xsl:when>
+                        <xsl:when test="c/@level='series'">
+                            <kitodo:metadata name="docType">
+                                <xsl:text>series</xsl:text>
+                            </kitodo:metadata>
+                            <kitodo:metadata name="id">
+                                <xsl:value-of select="replace(c/@id, 'BK_', '')"/>
+                            </kitodo:metadata>
+                            <xsl:apply-templates select="@*|./child::*[not(self::c[@level='file'])]"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <kitodo:metadata name="docType">
+                                <xsl:text>UNKNOWN</xsl:text>
+                            </kitodo:metadata>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </kitodo:kitodo>
+            </mets:xmlData>
+        </mets:mdWrap>
+    </xsl:template>
+
+    <!-- ### Name ### -->
+    <xsl:template match="c[@level='collection' and @id]/did/unittitle">
+        <kitodo:metadata name="name">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+        <!-- ### Name (intern) ### -->
+        <kitodo:metadata name="name_intern">
+            <xsl:value-of select="replace(replace(normalize-space(), ' ', '_'), '\.', '_')"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Laufzeit (Bestand) ### -->
+    <xsl:template match="//c[@level='collection' and @id]/did/unitdate">
+        <kitodo:metadata name="info_laufzeit">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- ### Rechtebedingungen (Bestand) ### -->
+    <xsl:template match="//c[@level='collection']/userestrict">
+        <xsl:if test="./head/text()='Nutzungsbedingungen' and ./p">
+            <kitodo:metadata name="bestand_rechtebedingungen">
+                <xsl:value-of select="normalize-space(./p/text())"/>
+            </kitodo:metadata>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ### Status (Bestand) ### -->
+    <xsl:template match="//c[@level='collection']/accessrestrict">
+        <xsl:if test="./head/text()='Zugangsbeschränkung' and ./p">
+            <kitodo:metadata name="status_id">
+                <xsl:value-of select="normalize-space(./p/text())"/>
+            </kitodo:metadata>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- ### Umfang (Bestand) ### -->
+    <xsl:template match="//c[@level='collection']/did/physdesc/extent">
+        <kitodo:metadata name="info_umfang">
+            <xsl:value-of select="normalize-space()"/>
+        </kitodo:metadata>
+    </xsl:template>
+
+    <!-- pass-through rule -->
+    <xsl:template match="@*|node()">
+        <xsl:apply-templates select="@*|node()"/>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This pull request adds the option to import EAD collections from uploaded XML files. The import creates one (parent) process for the collection and one (child) for _each_ "file" contained in the XML file, thus allowing complete collections ("Bestände) into individual processes from a single file upload.

To be able to use this EAD import, first a ruleset and an Import configuration of type "File Upload" has to be configured with metadata format `EAD`:
<img width="1502" alt="Bildschirmfoto 2024-11-08 um 00 34 29" src="https://github.com/user-attachments/assets/42e07a56-5147-497d-a071-f4b30efc691b">

Accordingly, the mapping file used in the import configuration has to map EAD to the Kitodo internal metadata format:
<img width="1492" alt="Bildschirmfoto 2024-11-08 um 00 39 34" src="https://github.com/user-attachments/assets/ccaccaf6-ff7d-42b2-9def-c89e351d8f3c">

A separate mapping file can be configured to map the collection level of the imported EAD XML file, in the field "Mapping file for parent record":
<img width="1490" alt="Bildschirmfoto 2024-11-08 um 00 41 17" src="https://github.com/user-attachments/assets/8449ba7d-5d46-4605-a1de-5434a71f8cd2">

This pull request adds example mapping files for the parent and child processes (`eadParent2kitodo.xsl` and `ead2kitodo.xsl`) as well as a corresponding ruleset (`ruleset_ead.xml`) that can be used for this purpose and that of cause can also extended when required.

The user can then use this import configuration to upload an EAD XML file containing the EAD collection. The upload dialog also allows to select the EAD level of the element that is to be transformed into the parent process from `COLLECTION`, `CLASS` and `SERIES` and the EAD level of items that are transformed into child processes from `FILE` and `ITEM`:
<img width="569" alt="Bildschirmfoto 2024-11-08 um 00 30 33" src="https://github.com/user-attachments/assets/508d78bb-02c4-45eb-8693-50d2a2d15c71">

Additionally, a limit for the maximum number or child processes that can be processed interactively in the import mask can now be configured in `kitodo_config.properties` using the parameter `maxNumberOfProcessesForImportMask`. (this value defaults to 5). If the number of child elements in the uploaded file exceeds this limit, the user is offered with a choice to relocate the import of all processes to a background task:
<img width="698" alt="Bildschirmfoto 2024-11-08 um 00 51 50" src="https://github.com/user-attachments/assets/efbd6f5e-5fff-4de1-bd30-183a34b17923">

If the user has the corresponding permission, the progress of this background import can then be monitored on the "Task manager" page of Kitodo:
<img width="1497" alt="Bildschirmfoto 2024-11-08 um 00 53 15" src="https://github.com/user-attachments/assets/eded309d-98f4-4b3c-b91d-886d76dffe4f">


Fixes #5984 