### PR TITLE
Fix link page to next division selenium test

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/gallery.xhtml
@@ -206,7 +206,7 @@
                                 DataEditorForm.structurePanel.selectedLogicalNode.type eq StructurePanel.VIEW_NODE_TYPE and 
                                 mediaProvider.hasPreviewVariant(DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key))}"
                             icon="fa fa-external-link fa-sm"
-                            styleClass="plain"
+                            styleClass="plain viewPageInNewWindow"
                             outcome="externalView" 
                             target="_blank">
                     <f:param name="processId" value="#{DataEditorForm.process.id}"/>
@@ -216,7 +216,7 @@
                 </p:menuitem>
                 <p:menuitem value="#{msgs.assignToNextElement}"
                             icon="fa fa-link fa-sm"
-                            styleClass="plain"
+                            styleClass="plain assignToNextElement"
                             disabled="#{readOnly}"
                             rendered="#{DataEditorForm.structurePanel.assignableSeveralTimes and
                             DataEditorForm.selectedMedia.size() eq 1}"
@@ -230,7 +230,7 @@
                                 imagePreviewForm:mediaContextMenu"/>
                 <p:menuitem value="#{msgs.unassign}"
                             icon="fa fa-chain-broken fa-sm"
-                            styleClass="plain"
+                            styleClass="plain unassign"
                             disabled="#{readOnly}"
                             rendered="#{DataEditorForm.structurePanel.assignedSeveralTimes and DataEditorForm.selectedMedia.size() == 1}"
                             action="#{DataEditorForm.structurePanel.unassign}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -177,7 +177,7 @@
                                 DataEditorForm.structurePanel.selectedLogicalNode.type eq StructurePanel.VIEW_NODE_TYPE and
                                 mediaProvider.hasPreviewVariant(DataEditorForm.galleryPanel.getGalleryMediaContent(DataEditorForm.galleryPanel.lastSelection.key))}"
                         icon="fa fa-external-link fa-sm"
-                        styleClass="plain"
+                        styleClass="plain viewPageInNewWindow"
                         outcome="externalView" 
                         target="_blank">
                 <f:param name="processId" value="#{DataEditorForm.process.id}"/>
@@ -196,7 +196,7 @@
                         update="dialogEditDocStrucTypeDialog"/>
             <p:menuitem value="#{msgs.assignToNextElement}"
                         icon="fa fa-link fa-sm"
-                        styleClass="plain"
+                        styleClass="plain assignToNextElement"
                         disabled="#{readOnly}"
                         rendered="#{DataEditorForm.structurePanel.assignableSeveralTimes and not DataEditorForm.structurePanel.selectedLogicalNode.data.linked}"
                         action="#{DataEditorForm.structurePanel.assign}"
@@ -209,7 +209,7 @@
                                 imagePreviewForm:mediaContextMenu"/>
             <p:menuitem value="#{msgs.unassign}"
                         icon="fa fa-chain-broken fa-sm"
-                        styleClass="plain"
+                        styleClass="plain unassign"
                         disabled="#{readOnly}"
                         rendered="#{DataEditorForm.structurePanel.assignedSeveralTimes and not DataEditorForm.structurePanel.selectedLogicalNode.data.linked}"
                         action="#{DataEditorForm.structurePanel.unassign}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/physicalStructure.xhtml
@@ -102,7 +102,7 @@
                         update="dialogAddPhysicalDivisionForm"/>
             <p:menuitem value="#{msgs.assignToNextElement}"
                         icon="fa fa-link fa-sm"
-                        styleClass="plain"
+                        styleClass="plain assignToNextElement"
                         disabled="#{readOnly}"
                         rendered="#{DataEditorForm.structurePanel.assignableSeveralTimes and not
                             DataEditorForm.structurePanel.assignedSeveralTimes and DataEditorForm.selectedMedia.size() eq 1}"
@@ -116,7 +116,7 @@
                                 imagePreviewForm:mediaContextMenu"/>
             <p:menuitem value="#{msgs.unassign}"
                         icon="fa fa-chain-broken fa-sm"
-                        styleClass="plain"
+                        styleClass="plain unassign"
                         disabled="#{readOnly}"
                         rendered="#{DataEditorForm.structurePanel.assignedSeveralTimes and DataEditorForm.selectedMedia.size() == 1}"
                         action="#{DataEditorForm.structurePanel.unassign}"

--- a/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
@@ -433,7 +433,7 @@ public class MetadataST extends BaseTestSelenium {
         metaDataEditor.openContextMenuForStructureTreeNode("0_0_0_0");
 
         // click on 2nd menu entry "assign to next element"
-        metaDataEditor.clickStructureTreeContextMenuEntry(2);
+        metaDataEditor.clickStructureTreeContextMenuEntry("assignToNextElement");
 
         // verify page "2" is now marked as "linked"
         assertTrue(metaDataEditor.isStructureTreeNodeAssignedSeveralTimes("0_0_0_0"));
@@ -448,7 +448,7 @@ public class MetadataST extends BaseTestSelenium {
         metaDataEditor.openContextMenuForStructureTreeNode("0_1_0_0");
 
         // click on 2nd menu entry "remove assignment"
-        metaDataEditor.clickStructureTreeContextMenuEntry(2);
+        metaDataEditor.clickStructureTreeContextMenuEntry("unassign");
 
         // check page "2" is not marked as "linked" any more
         assertFalse(metaDataEditor.isStructureTreeNodeAssignedSeveralTimes("0_0_0_0"));
@@ -475,20 +475,11 @@ public class MetadataST extends BaseTestSelenium {
         await().ignoreExceptions().pollDelay(100, TimeUnit.MILLISECONDS).atMost(5, TimeUnit.SECONDS)
             .until(() -> Browser.getDriver().findElement(By.id("logicalTree")).isDisplayed());
 
-        // right click on first tree node representing image 2
-        WebElement firstTreeNode = Browser.getDriver().findElement(
-            By.cssSelector("#logicalTree\\:0_0 .ui-treenode-content")
-        );
-        new Actions(Browser.getDriver()).contextClick(firstTreeNode).build().perform();
-
-        // wait until menu is visible
-        await().ignoreExceptions().pollDelay(100, TimeUnit.MILLISECONDS).atMost(5, TimeUnit.SECONDS)
-            .until(() -> Browser.getDriver().findElement(By.id("contextMenuLogicalTree")).isDisplayed());
+        // open context menu for linked page "2"
+        Pages.getMetadataEditorPage().openContextMenuForStructureTreeNode("0_0");
 
         // click second menu entry to open new tab
-        Browser.getDriver().findElement(By.cssSelector(
-            "#contextMenuLogicalTree .ui-menuitem:nth-child(2) .ui-menuitem-link"
-        )).click();
+        Browser.getDriver().findElement(By.cssSelector("#contextMenuLogicalTree .viewPageInNewWindow")).click();
 
         // find handle of new tab window
         String newWindowHandle = Browser.getDriver().getWindowHandles().stream()

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/MetadataEditorPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/MetadataEditorPage.java
@@ -251,13 +251,11 @@ public class MetadataEditorPage extends Page<MetadataEditorPage> {
     /**
      * Click on a menu entry in the structure tree context menu.
      * 
-     * @param menuEntry the menu entry index (starting with 1)
+     * @param menuItemClassName the class name of the menu entry
      */
-    public void clickStructureTreeContextMenuEntry(int menuEntry) {
+    public void clickStructureTreeContextMenuEntry(String menuItemClassName) {
         // click on menu entry
-        contextMenuLogicalTree.findElement(By.cssSelector(
-            ".ui-menuitem:nth-child(" + menuEntry +  ") .ui-menuitem-link"
-        )).click();
+        contextMenuLogicalTree.findElement(By.className(menuItemClassName)).click();
         // wait for context menu to disappear
         await().ignoreExceptions().pollDelay(100, TimeUnit.MILLISECONDS).atMost(5, TimeUnit.SECONDS)
                 .until(() -> !contextMenuLogicalTree.isDisplayed());


### PR DESCRIPTION
This pull request fixes the broken selenium test in master, which was introduced by changing the order of context menu items for the logical structure tree in the metadata editor. Instead, menu items are now identified by class name (because the same context menu exists for the structure tree and gallery).