### PR TITLE
Show progress bar on task manager page

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1216,6 +1216,9 @@ tr.ui-expanded-row-content:hover .ui-datatable tbody {
     color: var(--carbon-blue) !important;
 }
 
+.ui-progressbar-determinate .ui-progressbar-label {
+    line-height: initial;
+}
 
 .ui-picklist-caption {
     border-bottom: 1px solid var(--carbon-blue) !important;

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/taskmanager.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/system/taskmanager.xhtml
@@ -24,8 +24,9 @@
             <p:column headerText="#{msgs.title}">
                 <h:outputText value="#{item.name}"/>
             </p:column>
-            <p:column headerText="#{msgs.progress}">
-                <h:outputText value="#{item.progress}%"/>
+            <p:column headerText="#{msgs.progress}" width="200">
+                <p:progressBar value="#{item.progress}"
+                               labelTemplate="{value}%"/>
             </p:column>
             <p:column headerText="#{msgs.status}">
                 <h:outputText value="#{item.stateDescription}"/>


### PR DESCRIPTION
The progress of tasks in the task manager is currently only displayed as a number:

<img width="1291" alt="Bildschirmfoto 2024-11-19 um 12 48 34" src="https://github.com/user-attachments/assets/e1e3f24a-dce1-4e7e-9d86-ee0d586f90cd">

This PR adds a graphical progress bar to the display: 

<img width="1296" alt="Bildschirmfoto 2024-11-19 um 12 48 52" src="https://github.com/user-attachments/assets/3960e088-f75d-488f-8e43-4c9dc0904b8b">
