### PR TITLE
Add test to check encoding of message properties

### DIFF
--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -13,15 +13,15 @@ error=Fehler...
 errors=Fehler
 
 # A
-errorAdding=Fehler beim Hinzuf\u00FCgen von ''{0}''
+errorAdding=Fehler beim Hinzufügen von ''{0}''
 authorityAssignedError=Berechtigung kann nicht gel\u00F6scht werden, da dieser noch Rollen zugewiesen sind.
 
 # B
-batchPropertyEmpty=Die Eigenschaft {0} im Vorgang {1} ist ein Pflichtfeld, enth\u00E4lt aber keinen Wert.
+batchPropertyEmpty=Die Eigenschaft {0} im Vorgang {1} ist ein Pflichtfeld, enthält aber keinen Wert.
 
 # C
 calendar.upload.error=Fehler beim Laden der Datei\:
-calendar.upload.isEmpty=Es wurde keine Datei \u00FCbertragen.
+calendar.upload.isEmpty=Es wurde keine Datei übertragen.
 calendar.upload.missingMandatoryElement=Ein erforderliches XML-Element konnte nicht gefunden werden.
 calendar.upload.missingMandatoryValue=Ein erforderlicher Wert konnte nicht gefunden werden.
 calendar.upload.overlappingDateRanges=Der Erscheinungsverlauf konnte nicht importiert werden, da sich Datumsbereiche von Bl\u00F6cken \u00FCberlappen\:
@@ -98,7 +98,7 @@ kitodoScript.importProcesses.indir.isNull=Parameter ''indir'' fehlt!
 kitodoScript.importProcesses.indir.isNoDirectory=''indir'' ist kein existierendes Verzeichnis!
 kitodoScript.importProcesses.indir.cannotExecute=Der Inhalt des Importverzeichnisses kann nicht abgerufen werden (fehlende Berechtigung \u201Cexecute\u201D)
 kitodoScript.importProcesses.missingChildren=Vorgang {0} enth\u004E Verweise auf fehlendene Kindvorg\u004Enge {1}
-kitodoScript.importProcesses.noProcessTitleRule=Regelsatz gibt keine Bildungsvorschrift f�r den ''processTitle'' f�r Division {0} an!
+kitodoScript.importProcesses.noProcessTitleRule=Regelsatz gibt keine Bildungsvorschrift für den ''processTitle'' für Division {0} an!
 kitodoScript.importProcesses.project.isNull=Parameter ''project'' fehlt!
 kitodoScript.importProcesses.project.isNoProjectID=''project'' ist keine g\u00FCltige Projekt-ID
 kitodoScript.importProcesses.project.noProjectWithID=Ein solches Projekt existiert nicht!

--- a/Kitodo/src/main/resources/messages/errors_es.properties
+++ b/Kitodo/src/main/resources/messages/errors_es.properties
@@ -105,7 +105,7 @@ kitodoScript.importProcesses.project.noProjectWithID=¡El proyecto con ese ID no
 kitodoScript.importProcesses.template.isNull=¡Falta la variable ''template''!
 kitodoScript.importProcesses.template.isNoTemplateID=¡''template'' no es un entero!
 kitodoScript.importProcesses.template.noTemplateWithID=No existe la plantilla con este ID
-kitodoScript.noStructureOfTypeFound=No se encontró ningún elemento estructurado de tipo "{0}" 
+kitodoScript.noStructureOfTypeFound=No se encontró ningún elemento estructurado de tipo "{0}"
 
 # L
 errorLoadingDocTypes=Error de configuración del conjunto de reglas: No se ha encontrado ningún DocType ('division')

--- a/Kitodo/src/main/resources/messages/password_de.properties
+++ b/Kitodo/src/main/resources/messages/password_de.properties
@@ -9,7 +9,7 @@
 # GPL3-License.txt file that was distributed with this source code.
 #
 
-HISTORY_VIOLATION=Passwort entspricht einem von %1$s der vorherigen Passw\u00F6rter.
+HISTORY_VIOLATION=Passwort entspricht einem von %1$s der vorherigen Passwörter.
 ILLEGAL_WORD=Passwort enth\u00E4lt das W\u00F6rterbuchwort '%1$s'.
 ILLEGAL_WORD_REVERSED=Passwort enth\u00E4lt das umgekehrte W\u00F6rterbuchwort '%1$s'.
 ILLEGAL_MATCH=Passwort stimmt mit dem ung\u00FCltigen Muster \u00FCberein '%1$s'.
@@ -17,7 +17,7 @@ ALLOWED_MATCH=Passwort muss dem Muster '%1$s' entsprechen.
 ILLEGAL_CHAR=Passwort enth\u00E4lt das unzul\u00E4ssige Zeichen '%1$s'.
 ALLOWED_CHAR=Passwort enth\u00E4lt das unzul\u00E4ssige Zeichen '%1$s'.
 ILLEGAL_SEQUENCE=Passwort enth\u00E4lt die ung\u00FCltige Sequenz '%1$s'.
-ILLEGAL_USERNAME=Passwort enth\u00E4lt die Benutzer-ID '%1$s'.
+ILLEGAL_USERNAME=Passwort enthält die Benutzer-ID '%1$s'.
 ILLEGAL_USERNAME_REVERSED=Passwort enth\u00E4lt die umgekehrte Benutzer-ID '%1$s'.
 ILLEGAL_WHITESPACE=Passwort darf keine Leerzeichen enthalten.
 INSUFFICIENT_UPPERCASE=Passwort muss mindestens %1$s Gro\u00DFbuchstaben enthalten.

--- a/Kitodo/src/main/resources/messages/password_es.properties
+++ b/Kitodo/src/main/resources/messages/password_es.properties
@@ -9,23 +9,23 @@
 # GPL3-License.txt file that was distributed with this source code.
 #
 
-HISTORY_VIOLATION=La contraseÒa corresponde a uno de los %1$s de las contraseÒas anteriores.
-ILLEGAL_WORD=La contraseÒa contiene la palabra del diccionario '%1$s'.
-ILLEGAL_WORD_REVERSED=La contraseÒa contiene la palabra invertida del diccionario '%1$s'.
-ILLEGAL_MATCH=La contraseÒa coincide con el modelo no v·lido '%1$s'.
-ALLOWED_MATCH=La contraseÒa debe coincidir con el modelo '%1$s'.
-ILLEGAL_CHAR=La contraseÒa contiene el car·cter inv·lida '%1$s'.
-ALLOWED_CHAR=La contraseÒa contiene el car·cter permitido '%1$s'.
-ILLEGAL_SEQUENCE=La contraseÒa contiene la secuencia inv·lida '%1$s'.
-ILLEGAL_USERNAME=La contraseÒa contiene la identificaciÛn del usuario '%1$s'.
-ILLEGAL_USERNAME_REVERSED=La contraseÒa contiene la identificaciÛn invertida del usuario '%1$s'.
-ILLEGAL_WHITESPACE=La contraseÒa no debe contener espacios.
-INSUFFICIENT_UPPERCASE=La contraseÒa debe contener al menos %1$s letras may˙sculas.
-INSUFFICIENT_LOWERCASE=La contraseÒa debe contener al menos %1$s letras min˙sculas.
-INSUFFICIENT_ALPHABETICAL=La contraseÒa debe contener al menos %1$s caracteres alfabÈticos.
-INSUFFICIENT_DIGIT=La contraseÒa debe contener al menos %1$s dÌgitos.
-INSUFFICIENT_SPECIAL=La contraseÒa debe contener al menos %1$s caracteres especiales.
-INSUFFICIENT_CHARACTERISTICS=La contraseÒa coincide con %1$s de %3$s reglas de caracteres, pero %2$s son obligatorios.
-SOURCE_VIOLATION=La contraseÒa no debe ser la misma que su contraseÒa %1$s.
-TOO_LONG=La contraseÒa no debe tener m·s de %2$s caracteres.
-TOO_SHORT=La contraseÒa debe tener al menos %1$s caracteres.
+HISTORY_VIOLATION=La contrase√±a corresponde a uno de los %1$s de las contrase√±as anteriores.
+ILLEGAL_WORD=La contrase√±a contiene la palabra del diccionario '%1$s'.
+ILLEGAL_WORD_REVERSED=La contrase√±a contiene la palabra invertida del diccionario '%1$s'.
+ILLEGAL_MATCH=La contrase√±a coincide con el modelo no v√°lido '%1$s'.
+ALLOWED_MATCH=La contrase√±a debe coincidir con el modelo '%1$s'.
+ILLEGAL_CHAR=La contrase√±a contiene el car√°cter inv√°lida '%1$s'.
+ALLOWED_CHAR=La contrase√±a contiene el car√°cter permitido '%1$s'.
+ILLEGAL_SEQUENCE=La contrase√±a contiene la secuencia inv√°lida '%1$s'.
+ILLEGAL_USERNAME=La contrase√±a contiene la identificaci√≥n del usuario '%1$s'.
+ILLEGAL_USERNAME_REVERSED=La contrase√±a contiene la identificaci√≥n invertida del usuario '%1$s'.
+ILLEGAL_WHITESPACE=La contrase√±a no debe contener espacios.
+INSUFFICIENT_UPPERCASE=La contrase√±a debe contener al menos %1$s letras may√∫sculas.
+INSUFFICIENT_LOWERCASE=La contrase√±a debe contener al menos %1$s letras min√∫sculas.
+INSUFFICIENT_ALPHABETICAL=La contrase√±a debe contener al menos %1$s caracteres alfab√©ticos.
+INSUFFICIENT_DIGIT=La contrase√±a debe contener al menos %1$s d√≠gitos.
+INSUFFICIENT_SPECIAL=La contrase√±a debe contener al menos %1$s caracteres especiales.
+INSUFFICIENT_CHARACTERISTICS=La contrase√±a coincide con %1$s de %3$s reglas de caracteres, pero %2$s son obligatorios.
+SOURCE_VIOLATION=La contrase√±a no debe ser la misma que su contrase√±a %1$s.
+TOO_LONG=La contrase√±a no debe tener m√°s de %2$s caracteres.
+TOO_SHORT=La contrase√±a debe tener al menos %1$s caracteres.

--- a/Kitodo/src/test/java/org/kitodo/PropertyEncodingTest.java
+++ b/Kitodo/src/test/java/org/kitodo/PropertyEncodingTest.java
@@ -1,0 +1,185 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class PropertyEncodingTest {
+
+    private Properties messages;
+    private static final Charset CORRECT_ENCODING = StandardCharsets.UTF_8;
+    private static final Charset WRONG_ENCODING = StandardCharsets.ISO_8859_1;
+    private static final String MESSAGES_DIR = "src/main/resources/messages/";
+    private static final HashMap<String, String> GERMAN_TEST_MESSAGES = new HashMap<>();
+    private static final HashMap<String, String> GERMAN_ERROR_MESSAGES = new HashMap<>();
+    private static final HashMap<String, String> GERMAN_PASSWORD_MESSAGES = new HashMap<>();
+    private static final HashMap<String, String> SPANISH_TEST_MESSAGES = new HashMap<>();
+    private static final HashMap<String, String> SPANISH_ERROR_MESSAGES = new HashMap<>();
+    private static final HashMap<String, String> SPANISH_PASSWORD_MESSAGES = new HashMap<>();
+    private static final String GERMAN_MESSAGE_PROPERTIES = MESSAGES_DIR + "messages_de.properties";
+    private static final String SPANISH_MESSAGE_PROPERTIES = MESSAGES_DIR + "messages_es.properties";
+    private static final String GERMAN_ERROR_PROPERTIES = MESSAGES_DIR + "errors_de.properties";
+    private static final String SPANISH_ERROR_PROPERTIES = MESSAGES_DIR + "errors_es.properties";
+    private static final String GERMAN_PASSWORD_PROPERTIES = MESSAGES_DIR + "password_de.properties";
+    private static final String SPANISH_PASSWORD_PROPERTIES = MESSAGES_DIR + "password_es.properties";
+
+    @BeforeAll
+    public static void prepare() {
+        // prepare German test messages
+        GERMAN_TEST_MESSAGES.put("viewPageInNewWindow", "Seite in neuem Browser-Fenster öffnen");
+        GERMAN_TEST_MESSAGES.put("importConfig.searchFields.idPrefix", "ID-Präfix");
+        GERMAN_TEST_MESSAGES.put("addMappingFile", "Abbildungsdatei hinzufügen");
+
+        // prepare German error test messages
+        GERMAN_ERROR_MESSAGES.put("errorAdding", "Fehler beim Hinzufügen von ''{0}''");
+        GERMAN_ERROR_MESSAGES.put("batchPropertyEmpty", "Die Eigenschaft {0} im Vorgang {1} ist ein Pflichtfeld, enthält aber keinen Wert.");
+        GERMAN_ERROR_MESSAGES.put("calendar.upload.isEmpty", "Es wurde keine Datei übertragen.");
+
+        // prepare German password test messages
+        GERMAN_PASSWORD_MESSAGES.put("HISTORY_VIOLATION", "Passwort entspricht einem von %1$s der vorherigen Passwörter.");
+        GERMAN_PASSWORD_MESSAGES.put("ILLEGAL_USERNAME", "Passwort enthält die Benutzer-ID '%1$s'.");
+
+        // prepare Spanish test messages
+        SPANISH_TEST_MESSAGES.put("confirm", "Esta acción puede llevar algún tiempo. ¿Estás seguro de que deseas continuar?");
+        SPANISH_TEST_MESSAGES.put("passwordChanged", "La contraseña se ha cambiado con éxito.");
+        SPANISH_TEST_MESSAGES.put("projectNotAssignedToCurrentUser", "¡El proyecto \"{0}\" no está asignado al usuario actual!");
+
+        // prepare Spanish error test messages
+        SPANISH_ERROR_MESSAGES.put("errorAdding", "Error al añadir ''{0}''");
+        SPANISH_ERROR_MESSAGES.put("projectTitleAlreadyInUse", "El título del proyecto ya está en uso.");
+        SPANISH_ERROR_MESSAGES.put("workflowExceptionParallelGatewayNoTask", "¡Ninguna tarea sigue la ramificación paralela!");
+
+        // prepare Spanish password test messages
+        SPANISH_PASSWORD_MESSAGES.put("HISTORY_VIOLATION", "La contraseña corresponde a uno de los %1$s de las contraseñas anteriores.");
+        SPANISH_PASSWORD_MESSAGES.put("ILLEGAL_WORD", "La contraseña contiene la palabra del diccionario '%1$s'.");
+    }
+
+    @Test
+    public void checkCharacterEncodingOfGermanMessagesFile() throws Exception {
+        // ensure messages are decoded as expected using UTF-8 encoding
+        messages = readPropertiesWithEncoding(GERMAN_MESSAGE_PROPERTIES, CORRECT_ENCODING);
+        for (Map.Entry<String, String> testMessage : GERMAN_TEST_MESSAGES.entrySet()) {
+            assertEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+
+        // ensure messages are _not_ decoded as expected using ISO_8859_1 encoding
+        messages = readPropertiesWithEncoding(GERMAN_MESSAGE_PROPERTIES, WRONG_ENCODING);
+        for (Map.Entry<String, String> testMessage : GERMAN_TEST_MESSAGES.entrySet()) {
+            assertNotEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+    }
+
+    @Test
+    public void checkCharacterEncodingsOfGermanErrorMessageFile() throws Exception {
+        // ensure messages are decoded as expected using UTF-8 encoding
+        messages = readPropertiesWithEncoding(GERMAN_ERROR_PROPERTIES, CORRECT_ENCODING);
+        for (Map.Entry<String, String> testMessage : GERMAN_ERROR_MESSAGES.entrySet()) {
+            assertEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+
+        // ensure messages are _not_ decoded as expected using ISO_8859_1 encoding
+        messages = readPropertiesWithEncoding(GERMAN_ERROR_PROPERTIES, WRONG_ENCODING);
+        for (Map.Entry<String, String> testMessage : GERMAN_ERROR_MESSAGES.entrySet()) {
+            assertNotEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+    }
+
+    @Test
+    public void checkCharacterEncodingOfGermanPasswordMessageFile() throws Exception {
+        // ensure messages are decoded as expected using UTF-8 encoding
+        messages = readPropertiesWithEncoding(GERMAN_PASSWORD_PROPERTIES, CORRECT_ENCODING);
+        for (Map.Entry<String, String> testMessage : GERMAN_PASSWORD_MESSAGES.entrySet()) {
+            assertEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+
+        // ensure messages are _not_ decoded as expected using ISO_8895_1 encoding
+        messages = readPropertiesWithEncoding(GERMAN_PASSWORD_PROPERTIES, WRONG_ENCODING);
+        for (Map.Entry<String, String> testMessage : GERMAN_PASSWORD_MESSAGES.entrySet()) {
+            assertNotEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+    }
+
+    @Test
+    public void checkCharacterEncodingsOfSpanishMessagesFile() throws Exception {
+        // ensure messages are decoded as expected using UTF-8 encoding
+        messages = readPropertiesWithEncoding(SPANISH_MESSAGE_PROPERTIES, CORRECT_ENCODING);
+        for (Map.Entry<String, String> testMessage : SPANISH_TEST_MESSAGES.entrySet()) {
+            assertEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+
+        // ensure messages are _not_ decoded as expected using ISO_8859_1 encoding
+        messages = readPropertiesWithEncoding(SPANISH_MESSAGE_PROPERTIES, WRONG_ENCODING);
+        for (Map.Entry<String, String> testMessage : SPANISH_TEST_MESSAGES.entrySet()) {
+            assertNotEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+    }
+
+    @Test
+    public void checkCharacterEncodingsOfSpanishErrorMessagesFile() throws Exception {
+        // ensure messages are decoded as expected using UTF-8 encoding
+        messages = readPropertiesWithEncoding(SPANISH_ERROR_PROPERTIES, CORRECT_ENCODING);
+        for (Map.Entry<String, String> testMessage : SPANISH_ERROR_MESSAGES.entrySet()) {
+            assertEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+
+        // ensure messages are _not_ decoded as expected using ISO_8859_1 encoding
+        messages = readPropertiesWithEncoding(SPANISH_ERROR_PROPERTIES, WRONG_ENCODING);
+        for (Map.Entry<String, String> testMessage : SPANISH_ERROR_MESSAGES.entrySet()) {
+            assertNotEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+    }
+
+    @Test
+    public void checkCharacterEncodingOfSpanishPasswordMessageFile() throws Exception {
+        // ensure messages are decoded as expected using UTF-8 encoding
+        messages = readPropertiesWithEncoding(SPANISH_PASSWORD_PROPERTIES, CORRECT_ENCODING);
+        for (Map.Entry<String, String> testMessage : SPANISH_PASSWORD_MESSAGES.entrySet()) {
+            assertEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+
+        // ensure messages are _not_ decoded as expected using ISO_8859_1 encoding
+        messages = readPropertiesWithEncoding(SPANISH_PASSWORD_PROPERTIES, WRONG_ENCODING);
+        for (Map.Entry<String, String> testMessage : SPANISH_PASSWORD_MESSAGES.entrySet()) {
+            assertNotEquals(testMessage.getValue(), messages.getProperty(testMessage.getKey()));
+        }
+    }
+
+    private Properties readPropertiesWithEncoding(String pathString, Charset encoding)
+            throws IOException {
+        Path path = Paths.get(pathString);
+        assertTrue(Files.exists(path));
+        Properties properties = new Properties();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(path.toFile()),
+                encoding))) {
+            properties.load(reader);
+            return properties;
+        }
+    }
+}


### PR DESCRIPTION
Resolves #6331 

This PR adds a test that loads the German and Spanish message property files used in Kitodo.Production and checks if they their contents are encoded with `UTF-8`. This is done by loading specific messages known to contain unicode special characters and decode them with `UTF-8`. The results are then compared with strings containing those special characters. The tests fail if the decoded message does not match the expected strings.

This PR also sets the encoding of `Kitodo/src/main/resources/messages/password_es.properties` and `Kitodo/src/main/resources/messages/errors_de.properties` to `UTF-8` and therefore fixes #6324 

**Note**: this PR does _not_ yet replace all the codepoints like `\u00FC` with the actual special characters like `ü` in the message files. That should be done in a follow-up pull request.