### PR TITLE
[3.8] Display error messages about empty or duplicate project titles

### DIFF
--- a/Kitodo/src/main/webapp/pages/projectEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/projectEdit.xhtml
@@ -64,7 +64,7 @@
                          iconPos="right"
                          onclick="setConfirmUnload(false);PF('notifications').renderMessage({'summary':'#{msgs.projectSaving}','detail':'#{msgs.youWillBeRedirected}','severity':'info'});"
                          disabled="#{ProjectForm.saveDisabled}"
-                         update="notifications"/>
+                         update="notifications editForm:error-messages"/>
     </ui:define>
 
     <ui:define name="messages">


### PR DESCRIPTION
Backport of #6342 for Kitodo.Production 3.8