### PR TITLE
Update version support in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,9 @@ The following versions of Kitodo.Production are currently being supported with o
 
 | Version | Active Development       |      Security Fixes      |
 |-----| :----------------------: |:------------------------:|
-| 3.8 | :heavy_check_mark:       |    :heavy_check_mark:    |
-| 3.7 | :heavy_multiplication_x: |    :heavy_check_mark:    |
+| 3.9 | :heavy_check_mark:       |    :heavy_check_mark:    |
+| 3.8 | :heavy_multiplication_x: |    :heavy_check_mark:    |
+| 3.7 | :heavy_multiplication_x: | :heavy_multiplication_x: |
 | 3.6 | :heavy_multiplication_x: | :heavy_multiplication_x: |
 | 3.5 | :heavy_multiplication_x: | :heavy_multiplication_x: |
 | 3.4 | :heavy_multiplication_x: | :heavy_multiplication_x: |


### PR DESCRIPTION
Update `SECURITY.md` to reflect changes in supported versions with the release of [Kitodo.Production 3.8.0](https://github.com/kitodo/kitodo-production/releases/tag/kitodo-production-3.8.0)