### PR TITLE
Do not update results while editing filter

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/filter.js
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please read the
  * GPL3-License.txt file that was distributed with this source code.
  */
-/* globals removeFilter, updateSuggestions, submitFilters, filterKeydownEvents */
+/* globals removeFilter, removeFilterForEdit, updateSuggestions, submitFilters, filterKeydownEvents */
 
 /* Define identifiers used to select elements */
 const FILTER_INPUT_FORM = "#filterInputForm";
@@ -192,7 +192,7 @@ $(document).ready(function () {
             let filter = target.siblings(".plainFilter").length ? target.siblings(".plainFilter").first().text()
                 : target.find(".plainFilter").first().text();
             $(FILTER_INPUT).val(filter);
-            removeFilter([{name: "plainFilter", value: filter}]);
+            removeFilterForEdit([{name: "plainFilter", value: filter}]);
             $(FILTER_INPUT).focus();
         }
     });

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/filterMenu.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/filterMenu.xhtml
@@ -22,6 +22,10 @@
                      update="processesTabView:processesForm:processesTable
                              parsedFiltersForm:parsedFilters
                              processCount"/>
+    <p:remoteCommand name="removeFilterForEdit"
+                     action="#{ProcessForm.filterMenu.removeFilter}"
+                     oncomplete="setFilterInputPadding()"
+                     update="parsedFiltersForm:parsedFilters"/>
     <p:remoteCommand name="updateSuggestions"
                      action="#{ProcessForm.filterMenu.updateSuggestions}"
                      update="filterOptionsForm:suggestions"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/filterMenu.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/filterMenu.xhtml
@@ -21,6 +21,10 @@
                      action="#{CurrentTaskForm.filterMenu.removeFilter}"
                      oncomplete="setFilterInputPadding()"
                      update="tasksTabView:tasksForm:taskTable parsedFiltersForm:parsedFilters"/>
+    <p:remoteCommand name="removeFilterForEdit"
+                     action="#{CurrentTaskForm.filterMenu.removeFilter}"
+                     oncomplete="setFilterInputPadding()"
+                     update="parsedFiltersForm:parsedFilters"/>
     <p:remoteCommand name="updateSuggestions"
                      action="#{CurrentTaskForm.filterMenu.updateSuggestions}"
                      update="filterOptionsForm:suggestions"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/filterMenu.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/filterMenu.xhtml
@@ -20,6 +20,10 @@
                      action="#{UserForm.filterMenu.removeFilter}"
                      oncomplete="setFilterInputPadding()"
                      update="usersTabView:usersTable parsedFiltersForm:parsedFilters"/>
+    <p:remoteCommand name="removeFilterForEdit"
+                     action="#{UserForm.filterMenu.removeFilter}"
+                     oncomplete="setFilterInputPadding()"
+                     update="parsedFiltersForm:parsedFilters"/>
     <p:remoteCommand name="updateSuggestions"
                      action="#{UserForm.filterMenu.updateSuggestions}"
                      update="filterOptionsForm:suggestions"/>


### PR DESCRIPTION
With this change the result list is no longer updated while the user clicks on a filter to edit it. The result list is updated when the user hits enter or leaves the input field.

Resolves #6348.