### PR TITLE
Update plexus-archiver and poi dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <myfaces.version>2.3.10</myfaces.version>
         <mysql.version>8.2.0</mysql.version>
         <pdfbox.version>3.0.3</pdfbox.version>
-        <poi.version>5.2.5</poi.version>
+        <poi.version>5.3.0</poi.version>
         <primefaces.extensions.version>8.0.5</primefaces.extensions.version>
         <saxon.version>9.9.1-8</saxon.version>
         <log4j.version>2.19.0</log4j.version>
@@ -441,7 +441,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-archiver</artifactId>
-                <version>4.8.0</version>
+                <version>4.10.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
While working on https://github.com/kitodo/kitodo-production/pull/6174 i encountered the problem that the current versions of plexus-archiver and apache-poi require different versions of Apache commons-compress. (https://commons.apache.org/proper/commons-compress/) 
Via plexus-archiver a older version (1.23.0) of commons-compress is installed as transitive dependency which seems to be incompatible with the installed version of apache poi. In addition to that there are  vulnerabilities for this version of commons-compress (https://mvnrepository.com/artifact/org.apache.commons/commons-compress)

To adress both the incompatbility as well as the security issues, this PR updates apache-poi and plexus-archiver to their latest version. I have not yet discovered any issues by doing so. PDF and Excel file generation are still working.

