### PR TITLE
Fix "path must include project and resource name" in Eclipse

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -145,6 +145,9 @@
               that means first entry will be added as last resource and may override other resources -->
             <resource>
                 <!-- ATTENTION! we need the config-local declaration at first cause it shall be placed as last resource in the classpath -->
+                <!-- See also:
+                       • https://github.com/apache/maven/pull/840
+                       • https://github.com/apache/maven/pull/1061          -->
                 <directory>${maven.multiModuleProjectDirectory}/config-local</directory>
             </resource>
             <resource>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -145,7 +145,7 @@
               that means first entry will be added as last resource and may override other resources -->
             <resource>
                 <!-- ATTENTION! we need the config-local declaration at first cause it shall be placed as last resource in the classpath -->
-                <directory>../config-local</directory>
+                <directory>${maven.multiModuleProjectDirectory}/config-local</directory>
             </resource>
             <resource>
                 <directory>src/main/java</directory>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -315,6 +315,9 @@
             </resource>
             <resource>
                 <!-- ATTENTION! we need the config-local declaration at first cause it shall be placed as last resource in the classpath -->
+                <!-- See also:
+                       • https://github.com/apache/maven/pull/840
+                       • https://github.com/apache/maven/pull/1061          -->
                 <directory>${maven.multiModuleProjectDirectory}/config-local</directory>
             </resource>
             <resource>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -315,7 +315,7 @@
             </resource>
             <resource>
                 <!-- ATTENTION! we need the config-local declaration at first cause it shall be placed as last resource in the classpath -->
-                <directory>../config-local</directory>
+                <directory>${maven.multiModuleProjectDirectory}/config-local</directory>
             </resource>
             <resource>
                 <directory>src/main/resources</directory>


### PR DESCRIPTION
Eclipse is unwilling to resolve the  directory '../config-local' because it is located outside the module's sub-folder. Using the Maven variable instead fixes it.