### PR TITLE
Prevent potential NullPointerExceptions

### DIFF
--- a/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
+++ b/Kitodo-Query-URL-Import/src/main/java/org/kitodo/queryurlimport/QueryURLImport.java
@@ -285,7 +285,7 @@ public class QueryURLImport implements ExternalDataImportInterface {
                 }
                 try (InputStream inputStream = httpEntity.getContent()) {
                     String content = IOUtils.toString(inputStream, Charset.defaultCharset());
-                    if (Objects.nonNull(interfaceType.getNumberOfRecordsString())
+                    if (Objects.nonNull(interfaceType) && Objects.nonNull(interfaceType.getNumberOfRecordsString())
                             && XmlResponseHandler.extractNumberOfRecords(content, interfaceType) < 1) {
                         throw new NoRecordFoundException("No record with ID \"" + identifier + "\" found!");
                     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -469,7 +469,8 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                     processDataTab.setAllDocTypes(docTypes);
                     titleRecordLinkTab.setChosenParentProcess(String.valueOf(parentId));
                     titleRecordLinkTab.chooseParentProcess();
-                    if (Objects.nonNull(project.getDefaultChildProcessImportConfiguration())) {
+                    if (Objects.nonNull(project) && Objects.nonNull(project
+                            .getDefaultChildProcessImportConfiguration())) {
                         setCurrentImportConfiguration(project.getDefaultChildProcessImportConfiguration());
                     }
                     if (setChildCount(titleRecordLinkTab.getTitleRecordProcess(), rulesetManagement, workpiece)) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -221,7 +221,9 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
             }
         }
         List<MetadataViewWithValuesInterface> tableData = metadataView.getSortedVisibleMetadata(entered, additionallySelectedFields);
-        treeNode.getChildren().clear();
+        if (Objects.nonNull(treeNode) && Objects.nonNull(treeNode.getChildren())) {
+            treeNode.getChildren().clear();
+        }
         hiddenMetadata = Collections.emptyList();
         for (MetadataViewWithValuesInterface rowData : tableData) {
             Optional<MetadataViewInterface> optionalMetadataView = rowData.getMetadata();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -538,12 +538,14 @@ public class StructurePanel implements Serializable {
 
     private void restoreSelection(String rowKey, TreeNode parentNode) {
         for (TreeNode childNode : parentNode.getChildren()) {
-            if (Objects.nonNull(childNode) && rowKey.equals(childNode.getRowKey())) {
-                childNode.setSelected(true);
-                break;
-            } else {
-                childNode.setSelected(false);
-                restoreSelection(rowKey, childNode);
+            if (Objects.nonNull(childNode)) {
+                if (rowKey.equals(childNode.getRowKey())) {
+                    childNode.setSelected(true);
+                    break;
+                } else {
+                    childNode.setSelected(false);
+                    restoreSelection(rowKey, childNode);
+                }
             }
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/TaskActionProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/TaskActionProcessor.java
@@ -200,8 +200,11 @@ public class TaskActionProcessor extends ActiveMQProcessor {
     }
 
     private static boolean isEqualCorrectionTask(Integer correctionTaskId, Task correctionTask) {
-        return (Objects.isNull(correctionTaskId) && Objects.isNull(correctionTask)) || (Objects.nonNull(
-                correctionTaskId) && correctionTaskId.equals(correctionTask.getId()));
+        return (Objects.isNull(correctionTaskId)
+                    && Objects.isNull(correctionTask))
+                || (Objects.nonNull(correctionTaskId)
+                    && Objects.nonNull(correctionTask)
+                    && correctionTaskId.equals(correctionTask.getId()));
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
@@ -384,8 +384,10 @@ public class Course extends ArrayList<Block> {
             metadata.setMetadataType(metaDatum.getMetadataType());
             metadata.setStartValue(metaDatum.getValue());
             metadata.setStepSize(metaDatum.getStepSize());
-            foundBlock.addMetadata(metadata);
-            last.put(Pair.of(foundBlock, metaDatum.getMetadataType()), metadata);
+            if (Objects.nonNull(foundBlock)) {
+                foundBlock.addMetadata(metadata);
+                last.put(Pair.of(foundBlock, metaDatum.getMetadataType()), metadata);
+            }
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadata.java
@@ -259,7 +259,8 @@ public class CountableMetadata {
                         && (Objects.isNull(delete) || new IssueComparator(block).compare(issue, delete) < 0)
                         || Boolean.TRUE.equals(create) && Pair.of(this.create.getLeft(), this.create.getMiddle()).equals(issue)
                         || Boolean.FALSE.equals(create)
-                        && (Objects.isNull(issue) && Objects.isNull(this.delete) || issue.equals(this.delete)));
+                        && (Objects.isNull(issue) && Objects.isNull(this.delete)
+                            || (Objects.nonNull(issue) && issue.equals(this.delete))));
             }
         }
         return false;
@@ -342,7 +343,7 @@ public class CountableMetadata {
                 Helper.setErrorMessage("Unable to load metadata types: " + e.getMessage());
             }
         }
-        if (Objects.nonNull(metadataDetail)) {
+        if (Objects.nonNull(metadataDetail) && Objects.nonNull(allMetadataTypes)) {
             for (int i = 0; i < allMetadataTypes.size(); i++) {
                 if (allMetadataTypes.get(i).getMetadataID().equals(metadataDetail.getMetadataID())) {
                     allMetadataTypes.set(i, metadataDetail);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchService.java
@@ -631,7 +631,7 @@ public abstract class SearchService<T extends BaseIndexedBean, S extends BaseDTO
      * @return query
      */
     protected QueryBuilder createSetQuery(String key, Set<?> values, boolean contains) {
-        if (contains && !values.isEmpty()) {
+        if (contains && Objects.nonNull(values) && !values.isEmpty()) {
             return termsQuery(key, values);
         } else if (!contains && Objects.nonNull(values)) {
             BoolQueryBuilder boolQuery = new BoolQueryBuilder();


### PR DESCRIPTION
Prevent some potential `NullPointerException`s reported by CodeQL by adding corresponding null checks.