### PR TITLE
Move growls down to keep dashboard and user menu accessible

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/pattern-library.css
@@ -1619,6 +1619,10 @@ Popup dialogs
     padding: 5px 10px;
 }
 
+.ui-growl {
+    top: 55px;
+}
+
 .ui-growl-item {
     background: var(--green);
     text-shadow: 0 0 0 transparent;


### PR DESCRIPTION
This PR moves the growls a few pixels down. This keeps both menu icons in the top right corner accessible when notifications are displayed. 

![Bildschirmfoto 2025-01-16 um 14 04 29](https://github.com/user-attachments/assets/0929a13d-a76c-4698-ba0d-7553c8f69bef)
Default growl position

![Bildschirmfoto 2025-01-16 um 14 02 02](https://github.com/user-attachments/assets/4fb0d638-62bb-40f2-83aa-3872c8f9baa0)
Improved growl position