### PR TITLE
Speed up process template page

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
@@ -260,6 +260,22 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
     }
 
     /**
+     * Executes an HQL query that returns scalar projections (e.g., specific fields or aggregate results)
+     * instead of full entity objects.
+     *
+     * @param hql the HQL query string
+     * @param parameters query parameters
+     * @return list of scalar projection results
+     */
+    public List<Object[]> getProjectionByQuery(String hql, Map<String, Object> parameters) {
+        try (Session session = HibernateUtil.getSession()) {
+            Query<Object[]> query = session.createQuery(hql, Object[].class);
+            addParameters(query, parameters);
+            return query.getResultList();
+        }
+    }
+
+    /**
      * Removes the object from the database with with specified class type and
      * {@code id}.
      *

--- a/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
@@ -15,12 +15,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.SessionScoped;
+import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 
 import org.apache.commons.lang3.StringUtils;
@@ -46,7 +49,7 @@ import org.kitodo.production.services.workflow.WorkflowControllerService;
 import org.kitodo.production.workflow.model.Converter;
 
 @Named("TemplateForm")
-@SessionScoped
+@ViewScoped
 public class TemplateForm extends TemplateBaseForm {
 
     private static final Logger logger = LogManager.getLogger(TemplateForm.class);
@@ -60,6 +63,7 @@ public class TemplateForm extends TemplateBaseForm {
     private List<String> templateFilters;
     private List<String> selectedTemplateFilters;
     private static final String DEACTIVATED_TEMPLATES_FILTER = "deactivatedTemplates";
+    private Map<Integer,Boolean> templateUsageMap;
 
     /**
      * Constructor.
@@ -457,12 +461,11 @@ public class TemplateForm extends TemplateBaseForm {
      * @return whether template is used by any processes or not
      */
     public boolean isTemplateUsed(int templateId) {
-        try {
-            return !ServiceManager.getProcessService().findByTemplate(templateId).isEmpty();
-        } catch (DataException e) {
-            Helper.setErrorMessage(e);
-            return false;
+        if (Objects.isNull(templateUsageMap)) {
+            templateUsageMap = ServiceManager.getTemplateService().getTemplateUsageMap();
         }
+        Boolean isUsed = templateUsageMap.get(templateId);
+        return Boolean.TRUE.equals(isUsed);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/TemplateForm.java
@@ -15,14 +15,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.SessionScoped;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TemplateService.java
@@ -86,6 +86,27 @@ public class TemplateService extends ClientSearchService<Template, TemplateDTO, 
         return localReference;
     }
 
+    /**
+     * Retrieves a map indicating the usage status of templates.
+     * The method executes an HQL query to determine whether each template is used
+     * (i.e., has associated processes).
+     *
+     * @return a map where the key is the template ID and the value is a boolean
+     *         indicating whether the template is used
+     */
+    public Map<Integer, Boolean> getTemplateUsageMap() {
+        String hql = "SELECT t.id AS templateId, "
+                + " CASE WHEN EXISTS (SELECT 1 FROM Process p WHERE p.template.id = t.id) "
+                + " THEN true ELSE false END AS isUsed "
+                + " FROM Template t";
+        List<Object[]> results = getProjectionByQuery(hql);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        row -> (Integer) row[0], // templateId
+                        row -> (Boolean) row[1]  // isUsed
+                ));
+    }
+
     @Override
     public Long countDatabaseRows() throws DAOException {
         return countDatabaseRows("SELECT COUNT(*) FROM Template");

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchDatabaseService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/base/SearchDatabaseService.java
@@ -198,6 +198,17 @@ public abstract class SearchDatabaseService<T extends BaseBean, S extends BaseDA
     }
 
     /**
+     * Executes an HQL query that returns scalar projections (e.g., specific fields or aggregate results)
+     * instead of full entity objects.
+     *
+     * @param hql the HQL query string
+     * @return list of scalar projection results
+     */
+    protected List<Object[]> getProjectionByQuery(String hql) {
+        return dao.getProjectionByQuery(hql, null);
+    }
+
+    /**
      * Evict given bean object.
      *
      * @param baseBean

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/TemplateServiceIT.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -101,5 +102,18 @@ public class TemplateServiceIT {
         templateDTO = templateService.findById(3);
         condition = templateService.hasCompleteTasks(templateDTO.getTasks());
         assertFalse(condition, "Process DTO has complete tasks!");
+    }
+
+    @Test
+    public void shouldCorrectlyDetermineTemplateUsage() throws Exception {
+        Map<Integer, Boolean> templateUsageMap = templateService.getTemplateUsageMap();
+        Map<Integer, Boolean> expectedMap = Map.of(
+                1, true,
+                2, false,
+                3, false,
+                4, false
+        );
+        // Assert that the generated map matches the expected map
+        assertEquals(expectedMap, templateUsageMap, "The template usage map does not match expected results.");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/5336

Using a custom HQL-query should speed up the retrieval of the process templates significantly. We only have to compute the template usage once and reuse it in the view.