### PR TITLE
Replace 'Arrays.asList' for single element lists

### DIFF
--- a/Kitodo-Docket/src/main/java/org/kitodo/docket/ExportXmlLog.java
+++ b/Kitodo-Docket/src/main/java/org/kitodo/docket/ExportXmlLog.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -89,7 +88,7 @@ public class ExportXmlLog implements Consumer<OutputStream> {
      *            docket data
      */
     ExportXmlLog(DocketData docketData) {
-        this.docketData = Arrays.asList(docketData);
+        this.docketData = Collections.singletonList(docketData);
     }
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyInnerPhysicalDocStructHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyInnerPhysicalDocStructHelper.java
@@ -92,12 +92,12 @@ public class LegacyInnerPhysicalDocStructHelper implements LegacyDocStructHelper
     public List<LegacyMetadataHelper> getAllMetadataByType(LegacyMetadataTypeHelper metadataType) {
         if (metadataType == LegacyMetadataTypeHelper.SPECIAL_TYPE_ORDER) {
             return Objects.nonNull(physicalDivision)
-                    ? Arrays.asList(
-                        new LegacyMetadataHelper(this, metadataType, Integer.toString(physicalDivision.getOrder())))
+                    ? List.of(
+                            new LegacyMetadataHelper(this, metadataType, Integer.toString(physicalDivision.getOrder())))
                     : Collections.emptyList();
         } else if (metadataType == LegacyMetadataTypeHelper.SPECIAL_TYPE_ORDERLABEL) {
             return Objects.nonNull(physicalDivision) && Objects.nonNull(physicalDivision.getOrderlabel())
-                    ? Arrays.asList(new LegacyMetadataHelper(this, metadataType, physicalDivision.getOrderlabel()))
+                    ? List.of(new LegacyMetadataHelper(this, metadataType, physicalDivision.getOrderlabel()))
                     : Collections.emptyList();
         } else {
             throw new UnsupportedOperationException("Not yet implemented");

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
@@ -100,7 +100,7 @@ public class LegacyPrefsHelper {
                 StructuralElementViewInterface divisionView = ruleset.getStructuralElementView("", EDIT,
                     priorityList);
                 List<MetadataViewWithValuesInterface> entryViews = divisionView
-                        .getSortedVisibleMetadata(Collections.emptyList(), Arrays.asList(identifier));
+                        .getSortedVisibleMetadata(Collections.emptyList(), List.of(identifier));
                 MetadataViewInterface resultKeyView = entryViews.parallelStream()
                         .map(MetadataViewWithValuesInterface::getMetadata).filter(Optional::isPresent).map(Optional::get)
                         .filter(keyView -> keyView.getId().equals(identifier)).findFirst()

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -216,7 +216,7 @@ public class KitodoScriptService {
         switch (this.parameters.get("action")) {
             case "generateImages":
                 String folders = parameters.get("folders");
-                List<String> foldersList = Arrays.asList("all");
+                List<String> foldersList = List.of("all");
                 if (Objects.nonNull(folders)) {
                     foldersList = Arrays.asList(folders.split(","));
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -511,7 +511,7 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
                 logger.info("Calling KitodoScript interpreter: {}", script);
 
                 KitodoScriptService kitodoScriptService = ServiceManager.getKitodoScriptService();
-                kitodoScriptService.execute(Arrays.asList(task.getProcess()), script);
+                kitodoScriptService.execute(Collections.singletonList(task.getProcess()), script);
                 executedSuccessful = true;
             } else {
                 logger.info("Calling the shell: {}", script);


### PR DESCRIPTION
This pull request resolves some performance related code issues by replacing calls to `Arrays.asList()` with only one argument by either `Collections.singletonList()` or `List.of()`, depending on whether the resulting list should be immutable or not. 