### PR TITLE
Remove unnecessary string conversion

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
+++ b/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
@@ -148,7 +148,7 @@ public class KitodoServiceLoader<T> {
                 try (JarFile jarFile = new JarFile(f.toString())) {
                     if (hasFrontendFiles(jarFile)) {
                         Enumeration<JarEntry> entries = jarFile.entries();
-                        URL[] urls = {new URL("jar:file:" + f.toString() + "!/") };
+                        URL[] urls = {new URL("jar:file:" + f + "!/") };
                         try (URLClassLoader cl = URLClassLoader.newInstance(urls)) {
                             while (entries.hasMoreElements()) {
                                 JarEntry je = entries.nextElement();

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -262,7 +262,7 @@ public class DivXmlElementAccess extends LogicalDivision {
         Optional<MdSecType> optionalDmdSec = createMdSec(super.getMetadata(), MdSec.DMD_SEC);
         if (optionalDmdSec.isPresent()) {
             MdSecType dmdSec = optionalDmdSec.get();
-            String name = metsReferrerId + ':' + MdSec.DMD_SEC.toString();
+            String name = metsReferrerId + ':' + MdSec.DMD_SEC;
             dmdSec.setID(KitodoUUID.nameUUIDFromBytes(name.getBytes(StandardCharsets.UTF_8)));
             mets.getDmdSec().add(dmdSec);
             div.getDMDID().add(dmdSec);

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/TypeInterface.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/elasticsearch/index/type/enums/TypeInterface.java
@@ -39,8 +39,8 @@ interface TypeInterface {
         try {
             return (Boolean) jsonObject.get(this.toString());
         } catch (ClassCastException | NullPointerException e) {
-            throw new DataException("Not possible to retrieve boolean value for key " + this.toString()
-                    + ". Exception: " + e.getMessage());
+            throw new DataException("Not possible to retrieve boolean value for key " + this + ". Exception: "
+                    + e.getMessage());
         }
     }
 
@@ -55,8 +55,8 @@ interface TypeInterface {
         try {
             return (Integer) jsonObject.get(this.toString());
         } catch (ClassCastException | NullPointerException e) {
-            throw new DataException("Not possible to retrieve int value for key " + this.toString()
-                    + ". Exception: " + e.getMessage());
+            throw new DataException("Not possible to retrieve int value for key " + this + ". Exception: "
+                    + e.getMessage());
         }
     }
 
@@ -71,8 +71,8 @@ interface TypeInterface {
         try {
             return (double) jsonObject.get(this.toString());
         } catch (ClassCastException | NullPointerException e) {
-            throw new DataException("Not possible to retrieve double value for key " + this.toString()
-                    + ". Exception: " + e.getMessage());
+            throw new DataException("Not possible to retrieve double value for key " + this + ". Exception: "
+                    + e.getMessage());
         }
     }
 
@@ -87,8 +87,8 @@ interface TypeInterface {
         try {
             return (String) jsonObject.get(this.toString());
         } catch (ClassCastException | NullPointerException e) {
-            throw new DataException("Not possible to retrieve String value for key " + this.toString()
-                    + ". Exception: " + e.getMessage());
+            throw new DataException("Not possible to retrieve String value for key " + this + ". Exception: "
+                    + e.getMessage());
         }
     }
 
@@ -104,8 +104,8 @@ interface TypeInterface {
         try {
             return (List<Map<String, Object>>) jsonObject.get(this.toString());
         } catch (ClassCastException | NullPointerException e) {
-            throw new DataException("Not possible to retrieve JsonArray value for key " + this.toString()
-                    + ". Exception: " + e.getMessage());
+            throw new DataException("Not possible to retrieve JsonArray value for key " + this + ". Exception: "
+                    + e.getMessage());
         }
     }
 
@@ -121,8 +121,8 @@ interface TypeInterface {
             try {
                 return ((List) object.get(this.toString())).size();
             } catch (ClassCastException | NullPointerException e) {
-                throw new DataException("Not possible to retrieve size of array for key " + this.toString()
-                        + ". Exception: " + e.getMessage());
+                throw new DataException("Not possible to retrieve size of array for key " + this + ". Exception: "
+                        + e.getMessage());
             }
         }
         return 0;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/LanguageForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/LanguageForm.java
@@ -120,7 +120,7 @@ public class LanguageForm implements Serializable {
                 translation.put("displayLanguageTranslated",
                     supportedLocale.getDisplayLanguage(currentDisplayLanguage));
                 translation.put("selected", supportedLocale.equals(currentDisplayLanguage));
-                translation.put("flag", "javax.faces.resource/images/" + supportedLocale.toString() + ".svg.jsf");
+                translation.put("flag", "javax.faces.resource/images/" + supportedLocale + ".svg.jsf");
                 supportedLocales.add(translation);
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/CustomListColumnInitializer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/CustomListColumnInitializer.java
@@ -60,8 +60,8 @@ public class CustomListColumnInitializer {
             logger.error("Unable to update custom list columns in database!");
         } catch (NoSuchElementException e) {
             logger.info("Configuration key '"
-                    + ParameterCore.PROCESS_PROPERTIES.toString()
-                    + "' or '" + ParameterCore.TASK_CUSTOM_COLUMNS.toString()
+                    + ParameterCore.PROCESS_PROPERTIES
+                    + "' or '" + ParameterCore.TASK_CUSTOM_COLUMNS
                     + "' not found in configuration => unable to load corresponding custom columns!");
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -322,7 +322,7 @@ public class VariableReplacer {
             logger.warn("Cannot replace \"(projectid)\": process has no project assigned");
             return variableFinder.group(1);
         }
-        return variableFinder.group(1) + String.valueOf(process.getProject().getId());
+        return variableFinder.group(1) + process.getProject().getId();
     }
 
     private String determineReplacementForStepid(Matcher variableFinder) {
@@ -330,7 +330,7 @@ public class VariableReplacer {
             logger.warn("Cannot replace \"(stepid)\": no task given");
             return variableFinder.group(1);
         }
-        return variableFinder.group(1) + String.valueOf(task.getId());
+        return variableFinder.group(1) + task.getId();
     }
 
     private String determineReplacementForStepname(Matcher variableFinder) {

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Block.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Block.java
@@ -633,11 +633,11 @@ public class Block {
     public String toString() {
         StringBuilder result = new StringBuilder();
         if (Objects.nonNull(firstAppearance)) {
-            result.append(firstAppearance.toString());
+            result.append(firstAppearance);
         }
         result.append(" - ");
         if (Objects.nonNull(lastAppearance)) {
-            result.append(lastAppearance.toString());
+            result.append(lastAppearance);
         }
         result.append(" [");
         boolean first = true;

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
@@ -532,7 +532,7 @@ public class Issue {
         result.append(daysOfWeek.contains(DayOfWeek.SUNDAY.getValue()) ? 'S' : '-');
         result.append(") +");
         if (additions.size() <= 5) {
-            result.append(additions.toString());
+            result.append(additions);
         } else {
             result.append("[…(");
             result.append(additions.size());
@@ -540,7 +540,7 @@ public class Issue {
         }
         result.append(" -");
         if (exclusions.size() <= 5) {
-            result.append(exclusions.toString());
+            result.append(exclusions);
         } else {
             result.append("[…(");
             result.append(exclusions.size());


### PR DESCRIPTION
Cleanup some code by removing unnecessary explicit String conversions in methods were objects are converted to strings automatically.