### PR TITLE
Fix NPE when importing newspaper course with metadata

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
@@ -48,6 +50,7 @@ import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.DoctypeMissingException;
 import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
+import org.kitodo.production.forms.createprocess.ProcessSimpleMetadata;
 import org.kitodo.production.forms.createprocess.ProcessTextMetadata;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.XMLUtils;
@@ -616,12 +619,17 @@ public class CalendarForm implements Serializable {
                 return;
             }
             Document xml = XMLUtils.load(uploadedFile.getInputStream());
-            course = new Course(xml);
+            List<ProcessDetail> processDetails = CalendarService
+                    .getAddableMetadataTable(ServiceManager.getProcessService().getById(parentId));
+            Map<String, ProcessSimpleMetadata> processDetailsByMetadataID = processDetails.stream()
+                    .filter(ProcessSimpleMetadata.class::isInstance).map(ProcessSimpleMetadata.class::cast)
+                    .collect(Collectors.toMap(ProcessDetail::getMetadataID, Function.identity()));
+            course = new Course(xml, processDetailsByMetadataID);
             Helper.removeManagedBean("GranularityForm");
             navigate(course.get(0));
         } catch (SAXException e) {
             Helper.setErrorMessage(UPLOAD_ERROR, "errorSAXException", logger, e);
-        } catch (IOException e) {
+        } catch (IOException | DataException | DAOException e) {
             Helper.setErrorMessage(UPLOAD_ERROR, e.getLocalizedMessage(), logger, e);
         } catch (IllegalArgumentException e) {
             Helper.setErrorMessage("calendar.upload.overlappingDateRanges", logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
@@ -48,6 +48,7 @@ import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.DoctypeMissingException;
+import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.ProcessGenerationException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.forms.createprocess.ProcessSimpleMetadata;
@@ -637,6 +638,8 @@ public class CalendarForm implements Serializable {
             Helper.setErrorMessage(UPLOAD_ERROR, "calendar.upload.missingMandatoryElement", logger, e);
         } catch (NullPointerException e) {
             Helper.setErrorMessage("calendar.upload.missingMandatoryValue", logger, e);
+        } catch (InvalidMetadataValueException e) {
+            Helper.setErrorMessage("calendar.upload.invalidMetadata", logger, e);
         } finally {
             uploadedFile = null;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
@@ -57,7 +57,7 @@ public class ProcessBooleanMetadata extends ProcessSimpleMetadata implements Ser
     }
 
     @Override
-    ProcessBooleanMetadata getClone() {
+    public ProcessBooleanMetadata getClone() {
         return new ProcessBooleanMetadata(this);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessBooleanMetadata.java
@@ -122,4 +122,9 @@ public class ProcessBooleanMetadata extends ProcessSimpleMetadata implements Ser
     public void setActive(boolean active) {
         this.active = active;
     }
+
+    @Override
+    public void setValue(String value) {
+        setActive(StringUtils.isNotBlank(value));
+    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessDateMetadata.java
@@ -41,7 +41,7 @@ public class ProcessDateMetadata extends ProcessTextMetadata {
     }
 
     @Override
-    ProcessTextMetadata getClone() {
+    public ProcessTextMetadata getClone() {
         return new ProcessDateMetadata(this);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import javax.faces.model.SelectItem;
@@ -225,5 +226,13 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     @Override
     public String getMetadataID() {
         return settings.getId();
+    }
+
+    @Override
+    public void setValue(String value) throws InvalidMetadataValueException {
+        if (!items.parallelStream().anyMatch(selectItem -> Objects.equals(value, selectItem.getValue()))) {
+            throw new InvalidMetadataValueException(super.label, value);
+        }
+        setSelectedItem(value);
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import javax.faces.model.SelectItem;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSelectMetadata.java
@@ -87,7 +87,7 @@ public class ProcessSelectMetadata extends ProcessSimpleMetadata implements Seri
     }
 
     @Override
-    ProcessSelectMetadata getClone() {
+    public ProcessSelectMetadata getClone() {
         return new ProcessSelectMetadata(this);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -23,7 +23,7 @@ import org.kitodo.api.dataformat.Division;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.PhysicalDivision;
 
-abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializable {
+public abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializable {
 
     static final List<Class<? extends Division<?>>> PARENT_CLASSES = Arrays.asList(LogicalDivision.class,
         PhysicalDivision.class);
@@ -50,7 +50,7 @@ abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializab
      *
      * @return an independently mutable copy
      */
-    abstract ProcessSimpleMetadata getClone();
+    public abstract ProcessSimpleMetadata getClone();
 
     /**
      * Returns a simpler string representation of the Metadata.

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessSimpleMetadata.java
@@ -22,6 +22,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterfac
 import org.kitodo.api.dataformat.Division;
 import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.PhysicalDivision;
+import org.kitodo.exceptions.InvalidMetadataValueException;
 
 public abstract class ProcessSimpleMetadata extends ProcessDetail implements Serializable {
 
@@ -92,4 +93,16 @@ public abstract class ProcessSimpleMetadata extends ProcessDetail implements Ser
     public int getMinOccurs() {
         return settings.getMinOccurs();
     }
+    
+
+    /**
+     * Sets the contents of the input field of this process metadata.
+     *
+     * @param value
+     *            value to be set
+     * @throws InvalidMetadataValueException if an invalid value was given for a
+     *                                       select-type metadata
+     * 
+     */
+    public abstract void setValue(String value) throws InvalidMetadataValueException;
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -122,12 +122,6 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
         return getValue();
     }
 
-    /**
-     * Sets the contents of the text input field of this process metadata.
-     *
-     * @param value
-     *            value to be set
-     */
     public void setValue(String value) {
         this.value = addLeadingZeros(value);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -48,7 +48,7 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
     }
 
     @Override
-    ProcessTextMetadata getClone() {
+    public ProcessTextMetadata getClone() {
         return new ProcessTextMetadata(this);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessTextMetadata.java
@@ -122,6 +122,7 @@ public class ProcessTextMetadata extends ProcessSimpleMetadata implements Serial
         return getValue();
     }
 
+    @Override
     public void setValue(String value) {
         this.value = addLeadingZeros(value);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.MetadataException;
 import org.kitodo.production.forms.createprocess.ProcessSimpleMetadata;
 import org.kitodo.production.helper.XMLUtils;
@@ -283,6 +284,8 @@ public class Course extends ArrayList<Block> {
      *            XML document data structure
      * @param possibleProcessDetails
      *            possible process details from the process creation form
+     * @throws InvalidMetadataValueException
+     *             if an invalid value was given for a select-type metadata
      * @throws NoSuchElementException
      *             if ELEMENT_COURSE or ELEMENT_PROCESSES cannot be found
      * @throws IllegalArgumentException
@@ -290,7 +293,7 @@ public class Course extends ArrayList<Block> {
      * @throws NullPointerException
      *             if a mandatory element is absent
      */
-    public Course(Document xml, Map<String, ProcessSimpleMetadata> possibleProcessDetails) {
+    public Course(Document xml, Map<String, ProcessSimpleMetadata> possibleProcessDetails) throws InvalidMetadataValueException {
         super();
         processesAreVolatile = false;
         Element rootNode = XMLUtils.getFirstChildWithTagName(xml, ELEMENT_COURSE);
@@ -367,7 +370,7 @@ public class Course extends ArrayList<Block> {
     }
 
     private void processRecoveredMetadata(List<RecoveredMetadata> recoveredMetadata,
-            Map<String, ProcessSimpleMetadata> possibleProcessDetails) {
+            Map<String, ProcessSimpleMetadata> possibleProcessDetails) throws InvalidMetadataValueException {
         Map<Pair<Block, String>, CountableMetadata> last = new HashMap<>();
         for (RecoveredMetadata metaDatum : recoveredMetadata) {
             Block foundBlock = null;

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Course.java
@@ -34,6 +34,8 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.kitodo.exceptions.MetadataException;
+import org.kitodo.production.forms.createprocess.ProcessSimpleMetadata;
 import org.kitodo.production.helper.XMLUtils;
 import org.kitodo.production.model.bibliography.course.metadata.CountableMetadata;
 import org.kitodo.production.model.bibliography.course.metadata.RecoveredMetadata;
@@ -279,6 +281,8 @@ public class Course extends ArrayList<Block> {
      *
      * @param xml
      *            XML document data structure
+     * @param possibleProcessDetails
+     *            possible process details from the process creation form
      * @throws NoSuchElementException
      *             if ELEMENT_COURSE or ELEMENT_PROCESSES cannot be found
      * @throws IllegalArgumentException
@@ -286,7 +290,7 @@ public class Course extends ArrayList<Block> {
      * @throws NullPointerException
      *             if a mandatory element is absent
      */
-    public Course(Document xml) {
+    public Course(Document xml, Map<String, ProcessSimpleMetadata> possibleProcessDetails) {
         super();
         processesAreVolatile = false;
         Element rootNode = XMLUtils.getFirstChildWithTagName(xml, ELEMENT_COURSE);
@@ -308,7 +312,7 @@ public class Course extends ArrayList<Block> {
             }
             initialCapacity = processProcessNode(initialCapacity, lastIssueForDate, recoveredMetadata, processNode);
         }
-        processRecoveredMetadata(recoveredMetadata);
+        processRecoveredMetadata(recoveredMetadata, possibleProcessDetails);
         recalculateRegularityOfIssues();
         processesAreVolatile = true;
     }
@@ -362,7 +366,8 @@ public class Course extends ArrayList<Block> {
         }
     }
 
-    private void processRecoveredMetadata(List<RecoveredMetadata> recoveredMetadata) {
+    private void processRecoveredMetadata(List<RecoveredMetadata> recoveredMetadata,
+            Map<String, ProcessSimpleMetadata> possibleProcessDetails) {
         Map<Pair<Block, String>, CountableMetadata> last = new HashMap<>();
         for (RecoveredMetadata metaDatum : recoveredMetadata) {
             Block foundBlock = null;
@@ -382,6 +387,12 @@ public class Course extends ArrayList<Block> {
             }
             CountableMetadata metadata = new CountableMetadata(foundBlock, Pair.of(metaDatum.getDate(), foundIssue));
             metadata.setMetadataType(metaDatum.getMetadataType());
+            ProcessSimpleMetadata processSimpleMetadata = possibleProcessDetails.get(metaDatum.getMetadataType());
+            if (Objects.isNull(processSimpleMetadata)) {
+                throw new MetadataException("Cannot add metadata key " + metaDatum.getMetadataType(),
+                        new NoSuchElementException(metaDatum.getMetadataType()));
+            }
+            metadata.setMetadataDetail(processSimpleMetadata.getClone());
             metadata.setStartValue(metaDatum.getValue());
             metadata.setStepSize(metaDatum.getStepSize());
             if (Objects.nonNull(foundBlock)) {

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadata.java
@@ -29,7 +29,7 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
-import org.kitodo.production.forms.createprocess.ProcessTextMetadata;
+import org.kitodo.production.forms.createprocess.ProcessSimpleMetadata;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.pagination.Paginator;
 import org.kitodo.production.model.bibliography.course.Block;
@@ -302,8 +302,8 @@ public class CountableMetadata {
      * @param startValue
      *            the start value to set
      */
-    public void setStartValue(String startValue) {
-        ((ProcessTextMetadata) metadataDetail).setValue(startValue);
+    public void setStartValue(String startValue) throws InvalidMetadataValueException {
+        ((ProcessSimpleMetadata) metadataDetail).setValue(startValue);
         this.startValue = startValue;
     }
 

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -22,6 +22,7 @@ batchPropertyEmpty=Die Eigenschaft {0} im Vorgang {1} ist ein Pflichtfeld, enth\
 # C
 calendar.upload.error=Fehler beim Laden der Datei\:
 calendar.upload.isEmpty=Es wurde keine Datei \u00FCbertragen.
+calendar.upload.invalidMetadata=Der Wert "{1}" ist für den Metadateneintrag "{0}" unzul\u00E4ssig.
 calendar.upload.missingMandatoryElement=Ein erforderliches XML-Element konnte nicht gefunden werden.
 calendar.upload.missingMandatoryValue=Ein erforderlicher Wert konnte nicht gefunden werden.
 calendar.upload.overlappingDateRanges=Der Erscheinungsverlauf konnte nicht importiert werden, da sich Datumsbereiche von Bl\u00F6cken \u00FCberlappen\:

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -22,7 +22,7 @@ batchPropertyEmpty=Die Eigenschaft {0} im Vorgang {1} ist ein Pflichtfeld, enth\
 # C
 calendar.upload.error=Fehler beim Laden der Datei\:
 calendar.upload.isEmpty=Es wurde keine Datei \u00FCbertragen.
-calendar.upload.invalidMetadata=Der Wert "{1}" ist für den Metadateneintrag "{0}" unzul\u00E4ssig.
+calendar.upload.invalidMetadata=Der Wert "{1}" ist f\u00FCr den Metadateneintrag "{0}" unzul\u00E4ssig.
 calendar.upload.missingMandatoryElement=Ein erforderliches XML-Element konnte nicht gefunden werden.
 calendar.upload.missingMandatoryValue=Ein erforderlicher Wert konnte nicht gefunden werden.
 calendar.upload.overlappingDateRanges=Der Erscheinungsverlauf konnte nicht importiert werden, da sich Datumsbereiche von Bl\u00F6cken \u00FCberlappen\:
@@ -100,7 +100,7 @@ kitodoScript.importProcesses.indir.isNull=Parameter ''indir'' fehlt!
 kitodoScript.importProcesses.indir.isNoDirectory=''indir'' ist kein existierendes Verzeichnis!
 kitodoScript.importProcesses.indir.cannotExecute=Der Inhalt des Importverzeichnisses kann nicht abgerufen werden (fehlende Berechtigung \u201Cexecute\u201D)
 kitodoScript.importProcesses.missingChildren=Vorgang {0} enth\u004E Verweise auf fehlendene Kindvorg\u004Enge {1}
-kitodoScript.importProcesses.noProcessTitleRule=Regelsatz gibt keine Bildungsvorschrift für den ''processTitle'' für Division {0} an!
+kitodoScript.importProcesses.noProcessTitleRule=Regelsatz gibt keine Bildungsvorschrift f\u00FCr den ''processTitle'' f\u00FCr Division {0} an!
 kitodoScript.importProcesses.project.isNull=Parameter ''project'' fehlt!
 kitodoScript.importProcesses.project.isNoProjectID=''project'' ist keine g\u00FCltige Projekt-ID
 kitodoScript.importProcesses.project.noProjectWithID=Ein solches Projekt existiert nicht!
@@ -218,4 +218,3 @@ workflowExceptionParallelGatewayNoTask=Auf die Parallel-Verzweigung folgen keine
 
 # X
 xsltFileNotFound=XSLT-Datei existiert nicht\: {0}
-

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -22,6 +22,7 @@ batchPropertyEmpty=The property {0} in process {1} is a mandatory field but cont
 # C
 calendar.upload.error=Error while loading the file\:
 calendar.upload.isEmpty=No file was transferred.
+calendar.upload.invalidMetadata=The value "{1}" is not allowed for the metadata entry "{0}".
 calendar.upload.missingMandatoryElement=A mandatory XML element could not be found.
 calendar.upload.missingMandatoryValue=A mandatory value could not be found.
 calendar.upload.overlappingDateRanges=Due to overlapping date ranges of blocks, the course of appearance could not be imported\:

--- a/Kitodo/src/main/resources/messages/errors_es.properties
+++ b/Kitodo/src/main/resources/messages/errors_es.properties
@@ -22,6 +22,7 @@ batchPropertyEmpty=La propiedad {0} en la operación {1} es un campo obligatorio
 # C
 calendar.upload.error=Error al cargar el archivo\:
 calendar.upload.isEmpty=No se ha transferido ningún archivo.
+calendar.upload.invalidMetadata=El valor "{1}" no est\u00E1 permitido para la entrada de metadatos "{0}".
 calendar.upload.missingMandatoryElement=No se pudo encontrar un elemento XML requerido.
 calendar.upload.missingMandatoryValue=No se ha podido encontrar un valor requerido.
 calendar.upload.overlappingDateRanges=No se ha podido importar el historial de publicaciones porque los intervalos de fechas de los bloques se solapaban\:

--- a/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Collections;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -28,10 +29,10 @@ import org.xml.sax.SAXException;
 public class CourseTest {
 
     @Test
-    public void testCloneMethod() throws IOException, ParserConfigurationException, SAXException {
+    public void testCloneMethod() throws Exception {
         String xmlString = new String(Files.readAllBytes(new File("src/test/resources/newspaper-course.xml").toPath()));
         Document xmlDocument = XMLUtils.parseXMLString(xmlString);
-        Course course = new Course(xmlDocument, null);
+        Course course = new Course(xmlDocument, Collections.emptyMap());
 
         // assert / check some data from the xml file
         assertEquals(23L, course.getIndividualIssues().size());

--- a/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/CourseTest.java
@@ -31,7 +31,7 @@ public class CourseTest {
     public void testCloneMethod() throws IOException, ParserConfigurationException, SAXException {
         String xmlString = new String(Files.readAllBytes(new File("src/test/resources/newspaper-course.xml").toPath()));
         Document xmlDocument = XMLUtils.parseXMLString(xmlString);
-        Course course = new Course(xmlDocument);
+        Course course = new Course(xmlDocument, null);
 
         // assert / check some data from the xml file
         assertEquals(23L, course.getIndividualIssues().size());

--- a/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadataIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadataIT.java
@@ -35,6 +35,7 @@ import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.model.bibliography.course.Block;
 import org.kitodo.production.model.bibliography.course.Course;
@@ -121,7 +122,7 @@ public class CountableMetadataIT {
     }
 
     @Test
-    public void shouldGetValue() throws DAOException, DataException {
+    public void shouldGetValue() throws DAOException, DataException, InvalidMetadataValueException {
         List<ProcessDetail> metadataTypes = getMetadataTypes();
         countableMetadata.setMetadataDetail(metadataTypes.get(0));
         countableMetadata.setStartValue(METADATA_START_VALUE);
@@ -131,7 +132,7 @@ public class CountableMetadataIT {
     }
 
     @Test
-    public void shouldMatch() throws DAOException, DataException {
+    public void shouldMatch() throws DAOException, DataException, InvalidMetadataValueException {
         List<ProcessDetail> metadataTypes = getMetadataTypes();
         ProcessDetail firstMetadataType = metadataTypes.get(0);
         countableMetadata.setMetadataDetail(firstMetadataType);

--- a/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadataIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/model/bibliography/course/metadata/CountableMetadataIT.java
@@ -35,7 +35,6 @@ import org.kitodo.SecurityTestUtils;
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.model.bibliography.course.Block;
 import org.kitodo.production.model.bibliography.course.Course;
@@ -122,7 +121,7 @@ public class CountableMetadataIT {
     }
 
     @Test
-    public void shouldGetValue() throws DAOException, DataException, InvalidMetadataValueException {
+    public void shouldGetValue() throws Exception {
         List<ProcessDetail> metadataTypes = getMetadataTypes();
         countableMetadata.setMetadataDetail(metadataTypes.get(0));
         countableMetadata.setStartValue(METADATA_START_VALUE);
@@ -132,7 +131,7 @@ public class CountableMetadataIT {
     }
 
     @Test
-    public void shouldMatch() throws DAOException, DataException, InvalidMetadataValueException {
+    public void shouldMatch() throws Exception {
         List<ProcessDetail> metadataTypes = getMetadataTypes();
         ProcessDetail firstMetadataType = metadataTypes.get(0);
         countableMetadata.setMetadataDetail(firstMetadataType);

--- a/Kitodo/src/test/java/org/kitodo/production/services/calendar/CalendarServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/calendar/CalendarServiceIT.java
@@ -29,6 +29,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
+import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.model.bibliography.course.Block;
 import org.kitodo.production.model.bibliography.course.Course;
@@ -104,7 +105,7 @@ public class CalendarServiceIT {
     }
 
     @Test
-    public void shouldGetMetadataSummary() throws DAOException, DataException, IOException {
+    public void shouldGetMetadataSummary() throws DAOException, DataException, IOException, InvalidMetadataValueException {
         Process process = ServiceManager.getProcessService().getById(newspaperTestProcessId);
         List<ProcessDetail> addableMetadata = CalendarService.getAddableMetadataTable(process);
         Course course = new Course();

--- a/Kitodo/src/test/java/org/kitodo/production/services/calendar/CalendarServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/calendar/CalendarServiceIT.java
@@ -29,7 +29,6 @@ import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.exceptions.DataException;
-import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.model.bibliography.course.Block;
 import org.kitodo.production.model.bibliography.course.Course;
@@ -105,7 +104,7 @@ public class CalendarServiceIT {
     }
 
     @Test
-    public void shouldGetMetadataSummary() throws DAOException, DataException, IOException, InvalidMetadataValueException {
+    public void shouldGetMetadataSummary() throws Exception {
         Process process = ServiceManager.getProcessService().getById(newspaperTestProcessId);
         List<ProcessDetail> addableMetadata = CalendarService.getAddableMetadataTable(process);
         Course course = new Course();


### PR DESCRIPTION
Restores functionality for uploading newspaper courses containing metadata.

Fixes #6069