### PR TITLE
Render panelGroup only if user has the right authority

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/userList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/userList.xhtml
@@ -137,13 +137,13 @@
                 </h:link>
 
                 <h:panelGroup styleClass="action"
+                              rendered="#{SecurityAccessController.hasAuthorityToUnassignTasks()}"
                               title="#{empty UserForm.getTasksInProgress(item) ? msgs.userWithoutTasks : msgs.unassignTasks}">
                     <p:commandLink id="unassignTasks"
                                    action="#{UserForm.resetTasksToOpen(item)}"
                                    styleClass="#{empty UserForm.getTasksInProgress(item) ? 'ui-state-disabled' : ''}"
                                    disabled="#{empty UserForm.getTasksInProgress(item)}"
-                                   update="@this"
-                                   rendered="#{SecurityAccessController.hasAuthorityToUnassignTasks()}">
+                                   update="@this">
                         <h:outputText><i class="fa fa-user-times"/></h:outputText>
                         <p:confirm message=" #{msgs.confirmUnassignTasks}" header="#{msgs.confirmRelease}"/>
                     </p:commandLink>


### PR DESCRIPTION
Render the `h:panelGroup` for unassign tasks of users only if the current user has the authority  to do this. This condition is already existing on the `p:commandLink` but the check if a user has assigned tasks or not will be executed independent of the authority is available or not. 

With this change the user overview will be displayed a lot faster if the current user did not have this authority.

This change can be back ported to `3.8.x` if wanted.