### PR TITLE
Fix error with empty workflow svg and error when saving empty workflow

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowForm.java
@@ -83,12 +83,15 @@ public class WorkflowForm extends BaseForm {
     private Integer roleId;
     private boolean migration;
     private static final String MIGRATION_FORM_PATH = MessageFormat.format(REDIRECT_PATH,"system");
+    private ExternalContext externalContext;
 
     /**
      * Constructor.
      */
     public WorkflowForm() {
         super.setLazyDTOModel(new LazyDTOModel(ServiceManager.getWorkflowService()));
+        this.externalContext = FacesContext.getCurrentInstance() != null
+                ? FacesContext.getCurrentInstance().getExternalContext() : null;
     }
 
     /**
@@ -116,6 +119,10 @@ public class WorkflowForm extends BaseForm {
      */
     public void setWorkflowStatus(WorkflowStatus workflowStatus) {
         this.workflowStatus = workflowStatus;
+    }
+
+    public void setExternalContext(ExternalContext externalContext) {
+        this.externalContext = externalContext; // Allow test injection
     }
 
     /**
@@ -420,10 +427,9 @@ public class WorkflowForm extends BaseForm {
                 this.svgDiagram = IOUtils.toString(svgInputStream, StandardCharsets.UTF_8);
             }
             // Store duplicated workflow in Flash scope
-            ExternalContext externalContext = FacesContext.getCurrentInstance().getExternalContext();
-            externalContext.getFlash().put("duplicatedWorkflow", this.workflow);
-            externalContext.getFlash().put("xmlDiagram", this.xmlDiagram);
-            externalContext.getFlash().put("svgDiagram", this.svgDiagram);
+            storeInFlashScope("duplicatedWorkflow", this.workflow);
+            storeInFlashScope("xmlDiagram", this.xmlDiagram);
+            storeInFlashScope("svgDiagram", this.svgDiagram);
 
             return workflowEditPath + "&id=0";
 
@@ -489,6 +495,12 @@ public class WorkflowForm extends BaseForm {
         } catch (DAOException e) {
             Helper.setErrorMessage(ERROR_LOADING_ONE, new Object[] {ObjectType.WORKFLOW.getTranslationSingular(), id },
                 logger, e);
+        }
+    }
+
+    private void storeInFlashScope(String key, Object value) {
+        if (externalContext != null) {
+            externalContext.getFlash().put(key, value);
         }
     }
 

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -47,6 +47,7 @@ docTypeNotFound=docType ''{0}'' wurde nicht im selektierten Regelsatz gefunden
 duplicatedTitles=Es wurden dublette Ausgabe-Bezeichnungen gefunden. Dies erzeugt gegebenenfalls dublette Vorgangstitel!
 duplicateWorkflowTitle=Ein Workflow mit dem Titel "{0}" existiert bereits.
 emptySourceFolder=Der Quellordner zur Bildgenerierung ist leer
+emptyWorkflow=Der Workflow ist leer und kann nicht gespeichert werden
 errorDataIncomplete=Unvollst\u00E4ndige Daten\:
 errorDatabaseReading=Fehler beim Datenbanklesen von ''{0}'' with ID {1}.
 errorDeleting=Fehler beim L\u00F6schen von ''{0}''

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -48,6 +48,7 @@ docTypeNotFound=docType ''{0}'' could not be found in selected ruleset
 duplicatedTitles=Duplicate issue designations were found. This may produce duplicate process titles!
 duplicateWorkflowTitle=Workflow with title "{0}" already exists.
 emptySourceFolder=The source folder is empty
+emptyWorkflow=The workflow is empty and cannot be saved
 errorDataIncomplete=Incomplete data\:
 errorDatabaseReading=Error on reading database for ''{0}'' with ID {1}.
 errorDeleting=Error deleting ''{0}''

--- a/Kitodo/src/main/resources/messages/errors_es.properties
+++ b/Kitodo/src/main/resources/messages/errors_es.properties
@@ -46,6 +46,7 @@ docketTitleDuplicated=Ya existe una hoja de ruta con el mismo título.
 docTypeNotFound=docType ''{0}'' o se encontró en el conjunto de reglas seleccionado
 duplicatedTitles=Se han encontrado títulos de salida duplicados. ¡Esto puede crear títulos de proceso duplicados!
 duplicateWorkflowTitle=El flujo de trabajo con el título "{0}" ya existe.
+emptyWorkflow=El flujo de trabajo est� vac�o y no se puede guardar
 emptySourceFolder=La carpeta de origen para la generación de imágenes está vacía
 errorDataIncomplete=Datos incompletos\:
 errorDatabaseReading=Error al leer ''{0}'' con ID {1} de la base de datos.

--- a/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
@@ -11,18 +11,19 @@
 
 package org.kitodo.production.forms;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kitodo.MockDatabase;
+import org.kitodo.config.ConfigCore;
 import org.kitodo.data.database.beans.DataEditorSetting;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.Template;
@@ -35,12 +36,25 @@ import org.kitodo.exceptions.WorkflowException;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.DataEditorSettingService;
 import org.kitodo.production.services.data.TaskService;
+import org.mockito.ArgumentCaptor;
+
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+import javax.faces.context.Flash;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WorkflowFormIT {
 
     private WorkflowForm currentWorkflowForm = new WorkflowForm();
     private static final TaskService taskService = ServiceManager.getTaskService();
     private static final DataEditorSettingService dataEditorSettingService = ServiceManager.getDataEditorSettingService();
+    private ExternalContext mockExternalContext;
+    private Flash mockFlash;
 
     /**
      * Setup Database and start elasticsearch.
@@ -120,6 +134,45 @@ public class WorkflowFormIT {
         assertEquals(0.5f, dataEditorSettingForTaskOfSecondTemplate.get(0).getStructureWidth(), 0);
         assertEquals(0.6f, dataEditorSettingForTaskOfSecondTemplate.get(0).getMetadataWidth(), 0);
         assertEquals(0.6f, dataEditorSettingForTaskOfSecondTemplate.get(0).getGalleryWidth(), 0);
+    }
+
+    @Test
+    public void shouldDuplicateWorkflowAndStoreInFlash() throws Exception {
+        // Mock ExternalContext and Flash
+        mockExternalContext = mock(ExternalContext.class);
+        mockFlash = mock(Flash.class);
+        currentWorkflowForm.setExternalContext(mockExternalContext);
+
+        when(mockExternalContext.getFlash()).thenReturn(mockFlash); // Ensure Flash scope is returned
+
+        // Call the duplicate method
+        String resultUrl = currentWorkflowForm.duplicate(1);
+
+        // Ensure redirection to the edit page
+        assertTrue(resultUrl.contains("&id=0"));
+
+        // Capture arguments that were passed to Flash
+        ArgumentCaptor<Workflow> workflowCaptor = ArgumentCaptor.forClass(Workflow.class);
+        ArgumentCaptor<String> xmlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> svgCaptor = ArgumentCaptor.forClass(String.class);
+
+        // Verify and capture actual method calls
+        verify(mockFlash, times(1)).put(eq("duplicatedWorkflow"), workflowCaptor.capture());
+        verify(mockFlash, times(1)).put(eq("xmlDiagram"), xmlCaptor.capture());
+        verify(mockFlash, times(1)).put(eq("svgDiagram"), svgCaptor.capture());
+
+        // Assert the captured workflow is not null and has expected values
+        Workflow duplicatedWorkflow = workflowCaptor.getValue();
+        String xmlWorkflow = xmlCaptor.getValue();
+        assertNotNull(duplicatedWorkflow, "Duplicated workflow should not be null");
+        assertEquals("gateway-test1", duplicatedWorkflow.getTitle().replaceFirst("_[^_]*$", ""),
+                "Expected duplicated workflow title");
+
+        String diagramPath = ConfigCore.getKitodoDiagramDirectory() + "gateway-test1" + ".bpmn20.xml";
+        String data = FileUtils.readFileToString(new File(diagramPath), StandardCharsets.UTF_8);
+        assertEquals(data, xmlWorkflow, "Expected duplicated workflow title");
+        assertNotNull(xmlCaptor.getValue(), "XML Diagram should be stored");
+        assertNotNull(svgCaptor.getValue(), "SVG Diagram should be stored");
     }
 
     private Task createAndSaveTemplateTask(TaskStatus taskStatus, int ordering, Template template) throws DataException {


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/6290
Adresses https://github.com/kitodo/kitodo-production/pull/6355#issuecomment-2627106319

Additional changes
- Switch to ViewScoped to prevent having old workflows in the session which migh overwrite another workflow
- Deletion of old workflow files when the title of a workflow get changed