### PR TITLE
Fix translation of metadata keys in mass import form

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.data.database.beans.ImportConfiguration;
+import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.exceptions.ConfigException;
@@ -53,6 +54,7 @@ public class MassImportForm extends BaseForm {
     private int projectId;
     private int templateId;
     private String templateTitle;
+    private Ruleset ruleset;
     private ImportConfiguration importConfiguration;
     private UploadedFile file;
     private String csvSeparator = ";";
@@ -80,6 +82,7 @@ public class MassImportForm extends BaseForm {
         try {
             Template template = ServiceManager.getTemplateService().getById(templateId);
             templateTitle = template.getTitle();
+            ruleset = template.getRuleset();
             RulesetManagementInterface ruleset = ServiceManager.getRulesetService().openRuleset(template.getRuleset());
             addMetadataDialog.setRulesetManagement(ruleset);
             checkRecordIdentifierConfigured(ruleset);
@@ -220,7 +223,13 @@ public class MassImportForm extends BaseForm {
      */
     public String getColumnHeader(Integer columnIndex) {
         if (columnIndex < metadataKeys.size()) {
-            return Helper.getTranslation(metadataKeys.get(columnIndex));
+            String metadataKey = metadataKeys.get(columnIndex);
+            try {
+                return ServiceManager.getImportService().getMetadataTranslation(ruleset, metadataKey);
+            } catch (IOException e) {
+                Helper.setErrorMessage(e);
+                return metadataKey;
+            }
         }
         return "";
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
@@ -83,9 +83,9 @@ public class MassImportForm extends BaseForm {
             Template template = ServiceManager.getTemplateService().getById(templateId);
             templateTitle = template.getTitle();
             ruleset = template.getRuleset();
-            RulesetManagementInterface ruleset = ServiceManager.getRulesetService().openRuleset(template.getRuleset());
-            addMetadataDialog.setRulesetManagement(ruleset);
-            checkRecordIdentifierConfigured(ruleset);
+            RulesetManagementInterface rulesetInterface = ServiceManager.getRulesetService().openRuleset(template.getRuleset());
+            addMetadataDialog.setRulesetManagement(rulesetInterface);
+            checkRecordIdentifierConfigured(rulesetInterface);
         } catch (DAOException | IOException e) {
             Helper.setErrorMessage(e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -1737,6 +1737,23 @@ public class ImportService {
         return processes;
     }
 
+    /**
+     * Retrieve and return label of metadata with given key 'metadataKey'.
+     *
+     * @param ruleset Ruleset from which metadata label is retrieved
+     * @param metadataKey key of metadata for which label ir retrieved
+     * @return label of metadata
+     * @throws IOException if ruleset file could not be read
+     */
+    public String getMetadataTranslation(Ruleset ruleset, String metadataKey) throws IOException {
+        RulesetManagementInterface managementInterface = ServiceManager.getRulesetService().openRuleset(ruleset);
+        User user = ServiceManager.getUserService().getCurrentUser();
+        String metadataLanguage = user.getMetadataLanguage();
+        List<Locale.LanguageRange> languages = Locale.LanguageRange.parse(metadataLanguage.isEmpty()
+                ? Locale.ENGLISH.getCountry() : metadataLanguage);
+        return managementInterface.getTranslationForKey(metadataKey, languages).orElse(metadataKey);
+    }
+
     private TempProcess extractParentRecordFromFile(Document internalDocument, CreateProcessForm createProcessForm)
             throws XPathExpressionException, UnsupportedFormatException, URISyntaxException, IOException,
             ParserConfigurationException, SAXException, ProcessGenerationException, TransformerException {


### PR DESCRIPTION
Fixes #6192 as well as the problem previously thought to be resolved by #6186 (but that PR incorrectly used the `Helper` class and the `messages` files trying to translate metadata keys, instead of retrieving the corresponding labels from the ruleset, which is what this pull request now does!)