### PR TITLE
[3.8] Sort newspaper years by 'ORDERLABEL'

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/NewspaperProcessesGenerator.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale.LanguageRange;
@@ -748,7 +749,10 @@ public class NewspaperProcessesGenerator extends ProcessGenerator {
         link.setLoctype("Kitodo.Production");
         link.setUri(processService.getProcessURI(getGeneratedProcess()));
         newYearChild.setLink(link);
+        newYearChild.setOrderlabel(yearMark);
         overallWorkpiece.getLogicalStructure().getChildren().add(newYearChild);
+        overallWorkpiece.getLogicalStructure().getChildren().sort(Comparator.comparing(LogicalDivision::getOrderlabel,
+                Comparator.nullsLast(Comparator.naturalOrder())));
 
         LogicalDivision logicalStructure = new LogicalDivision();
         logicalStructure.setType(yearType);


### PR DESCRIPTION
Backport of #6421 for Kitodo.Production 3.8 (note that the same caveats apply!)