### PR TITLE
Speed up process list by faster check for empty directory

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
@@ -13,8 +13,11 @@ package org.kitodo.production.model;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -302,6 +305,23 @@ public class Subfolder {
         URI uri = getUri(canonical);
         return new File(uri.getPath()).isFile() ? Optional.of(uri) : Optional.empty();
     }
+
+    /**
+     * Checks if the folder determined by determineDirectoryAndFileNamePattern() is empty.
+     * Retrieve the directory URI and lists its contents.
+     * It stops checking as soon as the first file is found.
+     *
+     * @return true if the folder is empty, false if it contains at least one file
+     */
+    public boolean isFolderEmpty() {
+        URI dir = determineDirectoryAndFileNamePattern().getLeft();
+        try (Stream<Path> entries = Files.list(Paths.get(dir))) {
+            return entries.findFirst().isEmpty(); // Stop after first file is found
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
 
     /**
      * Returns a map of canonical file name parts to URIs with all files

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1453,11 +1453,8 @@ public class FileService {
      * @return whether given URI points to empty directory or not
      */
     public static boolean hasImages(Process process, Folder generatorSource) {
-        if (Objects.nonNull(generatorSource)) {
-            Subfolder sourceFolder = new Subfolder(process, generatorSource);
-            return !sourceFolder.listContents().isEmpty();
-        }
-        return false;
+        Subfolder sourceFolder = new Subfolder(process, generatorSource);
+        return !sourceFolder.isFolderEmpty();
     }
 
     /**


### PR DESCRIPTION
Whily trying to use a S3 storage for the Kitodo files i noticed that the process list became very slow. S3 storage is slower than NFS or local storage of course, but we can sigificantly speed up the process lf we refactor file existence checks.

The problem is that for every process in the process list a check is triggered wether the document can be exported.

https://github.com/kitodo/kitodo-production/blob/84b049749e7c8d8f3f773e18d560f768b2d37cf4/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java#L2830-2847

This calls a function which checks if the process has images, which checks wether the directory with the original images is empty

https://github.com/kitodo/kitodo-production/blob/84b049749e7c8d8f3f773e18d560f768b2d37cf4/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java#L1451-1461

This in turn calls a complex function which does way more than returning the contents of the dir to check if the dir is empty.

https://github.com/kitodo/kitodo-production/blob/84b049749e7c8d8f3f773e18d560f768b2d37cf4/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java#L346-357

I replaced this with an optimized file existence check, which speeds up performance significantly. (On S3 from 15 seconds to one second.


