### PR TITLE
Use JQuery animate for row focus

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_table.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_table.js
@@ -62,20 +62,26 @@ class FocusMetadataRow {
      */
     focus() {
         this.#removeHighlights();
+        setTimeout(() => {
+            // find last metadata row matching currently selected metadata type
+            let row = $(
+                "div[id$='metadataTable'] " + // metadata table selector
+                "tr[data-prk='" + this.#lastSelectedRowKey + "'] " + // remembered metadata group
+                "label[data-metadataid='" + this.#getSelectedMetadataType() + "']" // selected metadata type
+            ).last().closest("tr");
 
-        // find last metadata row matching currently selected metadata type
-        let row = $(
-            "div[id$='metadataTable'] " + // metadata table selector
-            "tr[data-prk='" + this.#lastSelectedRowKey + "'] " + // remembered metadata group
-            "label[data-metadataid='" + this.#getSelectedMetadataType() + "']" // selected metadata type
-        ).last().closest("tr");
-        
-        // if found, focus row
-        if (row.length === 1) {
-            row.addClass("focusedRow");
-            row.get(0).scrollIntoView();
-            row.find("input:enabled:visible,textarea:enabled:visible").first().focus();
-        }
+            // if found, focus row
+            if (row.length === 1 && row.is(":visible")) {
+                row.addClass("focusedRow");
+                let tableContainer = $("div[id$='metadataTable']");
+                let rowPosition = row.offset().top - tableContainer.offset().top + tableContainer.scrollTop();
+                tableContainer.animate({ scrollTop: rowPosition }, 300);
+                let input = row.find("input:enabled:visible,textarea:enabled:visible").first();
+                if (input.length) {
+                    input.focus();
+                }
+            }
+        }, 150)
     }
 
 }

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_table.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_table.js
@@ -75,13 +75,13 @@ class FocusMetadataRow {
                 row.addClass("focusedRow");
                 let tableContainer = $("div[id$='metadataTable']");
                 let rowPosition = row.offset().top - tableContainer.offset().top + tableContainer.scrollTop();
-                tableContainer.animate({ scrollTop: rowPosition }, 300);
+                tableContainer.animate({ scrollTop: rowPosition }, 0);
                 let input = row.find("input:enabled:visible,textarea:enabled:visible").first();
                 if (input.length) {
                     input.focus();
                 }
             }
-        }, 150)
+        }, 150);
     }
 
 }


### PR DESCRIPTION
fixes https://github.com/kitodo/kitodo-production/issues/6438

I am not sure why this issue exists in Chrome, but since we are already using JQuery, we can replace the functionality with JQuery.animate(), which works across browsers in my tests. I am also adding a timeout, to account for UI rendering delays and some checks.