### PR TITLE
Fix minor layout bug on import configuration edit page

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/formatRow.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/importConfigurationEdit/rows/formatRow.xhtml
@@ -101,6 +101,7 @@
                            value="#{msgs['tooltip.importConfig.metadataFormatHelp']}"/>
             </div>
             <h:panelGroup layout="block"
+                          id="metadataRecordTitleXPathWrapper"
                           rendered="#{importConfigurationEditView.importConfiguration.interfaceType eq 'SRU'}">
                 <p:outputLabel for="metadataRecordTitleXPath"
                                value="#{msgs['importConfig.field.metadataRecordTitleXPath']} *"/>


### PR DESCRIPTION
Fixes a minor layout issue where a margin was missing between two input fields in the "ImportConfiguration" edit mask.

Missing margin:
<img width="1458" alt="Bildschirmfoto 2025-03-03 um 15 54 44" src="https://github.com/user-attachments/assets/ec44a966-13b7-43b5-ba25-f8da8d7f5184" />


Fixed by this PR:
<img width="1461" alt="Bildschirmfoto 2025-03-03 um 15 54 11" src="https://github.com/user-attachments/assets/a5af42b1-4570-4f26-b7cc-d1e2dd995693" />
