### PR TITLE
Update Github Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: update chrome to latest stable


### PR DESCRIPTION
Github workflows should now use Ubuntu 22.04.

https://github.com/actions/runner-images/issues/11101