### PR TITLE
Fix script output

### DIFF
--- a/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
+++ b/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
@@ -45,19 +45,17 @@ public class Command implements CommandInterface {
             process = new ProcessBuilder(callSequence).start();
             try (InputStream inputStream = process.getInputStream();
                     InputStream errorInputStream = process.getErrorStream()) {
+                int errCode = process.waitFor();
                 List<String> outputMessage = inputStreamArrayToList(inputStream);
                 List<String> errorMessage = inputStreamArrayToList(errorInputStream);
-                int errCode = process.waitFor();
-
-                outputMessage.addAll(errorMessage);
-
-                commandResult = new CommandResult(command, errCode == 0, outputMessage);
-                if (commandResult.isSuccessful()) {
+                if (Integer.valueOf(errCode).equals(0)) {
+                    commandResult = new CommandResult(command, true, outputMessage);
                     logger.info("Execution of Command {} was successful!: {}",
-                        commandResult.getCommand(), commandResult.getMessages());
+                            commandResult.getCommand(), commandResult.getMessages());
                 } else {
+                    commandResult = new CommandResult(command, false, errorMessage);
                     logger.error("Execution of Command {} failed!: {}",
-                        commandResult.getCommand(), commandResult.getMessages());
+                            commandResult.getCommand(), commandResult.getMessages());
                 }
             }
         } catch (InterruptedException e) {

--- a/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
+++ b/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,15 +49,17 @@ public class Command implements CommandInterface {
                     InputStream errorInputStream = process.getErrorStream()) {
                 List<String> outputMessage = inputStreamArrayToList(inputStream);
                 List<String> errorMessage = inputStreamArrayToList(errorInputStream);
+                List<String> combinedMessages = Stream.concat(outputMessage.stream(), errorMessage.stream())
+                        .collect(Collectors.toList());
                 int errCode = process.waitFor();
                 if (Integer.valueOf(errCode).equals(0)) {
                     commandResult = new CommandResult(command, true, outputMessage);
                     logger.info("Execution of Command {} was successful!: {}",
-                            commandResult.getCommand(), commandResult.getMessages());
+                            commandResult.getCommand(), combinedMessages);
                 } else {
                     commandResult = new CommandResult(command, false, errorMessage);
                     logger.error("Execution of Command {} failed!: {}",
-                            commandResult.getCommand(), commandResult.getMessages());
+                            commandResult.getCommand(), combinedMessages);
                 }
             }
         } catch (InterruptedException e) {

--- a/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
+++ b/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
@@ -45,9 +45,9 @@ public class Command implements CommandInterface {
             process = new ProcessBuilder(callSequence).start();
             try (InputStream inputStream = process.getInputStream();
                     InputStream errorInputStream = process.getErrorStream()) {
-                int errCode = process.waitFor();
                 List<String> outputMessage = inputStreamArrayToList(inputStream);
                 List<String> errorMessage = inputStreamArrayToList(errorInputStream);
+                int errCode = process.waitFor();
                 if (Integer.valueOf(errCode).equals(0)) {
                     commandResult = new CommandResult(command, true, outputMessage);
                     logger.info("Execution of Command {} was successful!: {}",

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -20,18 +20,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.kitodo.api.command.CommandInterface;
 import org.kitodo.api.command.CommandResult;
 import org.kitodo.production.helper.Helper;
-import org.kitodo.production.services.data.TaskService;
 import org.kitodo.serviceloader.KitodoServiceLoader;
 
 public class CommandService {
     private final CommandInterface commandModule;
     private final ArrayList<CommandResult> finishedCommandResults = new ArrayList<>();
-    private static final Logger logger = LogManager.getLogger(CommandService.class);
 
     /**
      * Initialize Command Service.

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -31,7 +31,7 @@ import org.kitodo.serviceloader.KitodoServiceLoader;
 public class CommandService {
     private final CommandInterface commandModule;
     private final ArrayList<CommandResult> finishedCommandResults = new ArrayList<>();
-    private static final Logger logger = LogManager.getLogger(TaskService.class);
+    private static final Logger logger = LogManager.getLogger(CommandService.class);
 
     /**
      * Initialize Command Service.

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -53,8 +53,9 @@ public class CommandService {
         }
         CommandResult commandResult = commandModule.runCommand(script);
         List<String> commandResultMessages = commandResult.getMessages();
-        if (!commandResultMessages.isEmpty() && commandResultMessages.get(0).contains("IOException")) {
-            throw new IOException(commandResultMessages.get(1));
+        if (!commandResult.isSuccessful() && !commandResultMessages.isEmpty()) {
+            String fullErrorMessage = String.join(" | ", commandResultMessages);
+            throw new IOException(fullErrorMessage);
         }
         return commandResult;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -51,7 +51,13 @@ public class CommandService {
         if (Objects.isNull(script)) {
             return null;
         }
-        return commandModule.runCommand(script);
+        CommandResult commandResult = commandModule.runCommand(script);
+        List<String> commandResultMessages = commandResult.getMessages();
+        if (!commandResult.isSuccessful() && !commandResultMessages.isEmpty()) {
+            String fullErrorMessage = String.join(" | ", commandResultMessages);
+            throw new IOException(fullErrorMessage);
+        }
+        return commandResult;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -20,13 +20,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kitodo.api.command.CommandInterface;
 import org.kitodo.api.command.CommandResult;
+import org.kitodo.production.helper.Helper;
+import org.kitodo.production.services.data.TaskService;
 import org.kitodo.serviceloader.KitodoServiceLoader;
 
 public class CommandService {
     private final CommandInterface commandModule;
     private final ArrayList<CommandResult> finishedCommandResults = new ArrayList<>();
+    private static final Logger logger = LogManager.getLogger(TaskService.class);
 
     /**
      * Initialize Command Service.
@@ -54,6 +59,9 @@ public class CommandService {
         CommandResult commandResult = commandModule.runCommand(script);
         List<String> commandResultMessages = commandResult.getMessages();
         if (!commandResult.isSuccessful() && !commandResultMessages.isEmpty()) {
+            for (String message : commandResultMessages) {
+                Helper.setErrorMessage(message);
+            }
             String fullErrorMessage = String.join(" | ", commandResultMessages);
             throw new IOException(fullErrorMessage);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -51,13 +51,7 @@ public class CommandService {
         if (Objects.isNull(script)) {
             return null;
         }
-        CommandResult commandResult = commandModule.runCommand(script);
-        List<String> commandResultMessages = commandResult.getMessages();
-        if (!commandResult.isSuccessful() && !commandResultMessages.isEmpty()) {
-            String fullErrorMessage = String.join(" | ", commandResultMessages);
-            throw new IOException(fullErrorMessage);
-        }
-        return commandResult;
+        return commandModule.runCommand(script);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -518,11 +518,9 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
                 CommandService commandService = ServiceManager.getCommandService();
                 CommandResult commandResult = commandService.runCommand(script);
                 executedSuccessful = commandResult.isSuccessful();
-                for (String message : commandResult.getMessages()) {
-                    if (executedSuccessful) {
+                if (executedSuccessful && !commandResult.getMessages().isEmpty()) {
+                    for (String message : commandResult.getMessages()) {
                         Helper.setMessage(message);
-                    } else {
-                        Helper.setErrorMessage(message, logger);
                     }
                 }
             }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -515,10 +515,12 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
                 executedSuccessful = true;
             } else {
                 logger.info("Calling the shell: {}", script);
-
                 CommandService commandService = ServiceManager.getCommandService();
                 CommandResult commandResult = commandService.runCommand(script);
                 executedSuccessful = commandResult.isSuccessful();
+                if (executedSuccessful && !commandResult.getMessages().isEmpty()) {
+                    Helper.setMessage(String.join(" | ", commandResult.getMessages()));
+                }
             }
             finishOrReturnAutomaticTask(task, automatic, executedSuccessful);
         } catch (IOException | DAOException | InvalidImagesException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -518,9 +518,11 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
                 CommandService commandService = ServiceManager.getCommandService();
                 CommandResult commandResult = commandService.runCommand(script);
                 executedSuccessful = commandResult.isSuccessful();
-                if (executedSuccessful && !commandResult.getMessages().isEmpty()) {
-                    for (String message : commandResult.getMessages()) {
+                for (String message : commandResult.getMessages()) {
+                    if (executedSuccessful) {
                         Helper.setMessage(message);
+                    } else {
+                        Helper.setErrorMessage(message, logger);
                     }
                 }
             }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -519,7 +519,9 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
                 CommandResult commandResult = commandService.runCommand(script);
                 executedSuccessful = commandResult.isSuccessful();
                 if (executedSuccessful && !commandResult.getMessages().isEmpty()) {
-                    Helper.setMessage(String.join(" | ", commandResult.getMessages()));
+                    for (String message : commandResult.getMessages()) {
+                        Helper.setMessage(message);
+                    }
                 }
             }
             finishOrReturnAutomaticTask(task, automatic, executedSuccessful);

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -669,9 +669,13 @@ public class WorkflowControllerService {
                 process, null);
 
         script = replacer.replace(script);
-
-        CommandResult commandResult = ServiceManager.getCommandService().runCommand(script);
-        return commandResult.isSuccessful();
+        try {
+            CommandResult commandResult = ServiceManager.getCommandService().runCommand(script);
+            return commandResult.isSuccessful();
+        } catch (IOException e) {
+            Helper.setErrorMessage("runCommandError", logger, e);
+            return false;
+        }
     }
 
     private boolean runXPathCondition(Process process, String xpath) throws IOException {


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/6449

This Pull Request tries to apply a minimal fix for the specific problem in https://github.com/kitodo/kitodo-production/issues/6449, by printing the sucess messages line by line to the task screen on script success. 
The user sees only the success or the error messages. Error messages are joined with " | ". The application log tracks all  messages combined without specific order. 
The printed messages should not take up too much space since the notification area is limited in size and scrollable.

![image](https://github.com/user-attachments/assets/6d2d02b8-6175-48c5-8804-ec56f9a987c0)

All further ideas as discssed in https://github.com/kitodo/kitodo-production/discussions/6461 are not considered here.


