### PR TITLE
Preserve metadata in collapsed metadata group panels during process creation

### DIFF
--- a/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
+++ b/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
@@ -335,8 +335,10 @@ public class MetadataValidation implements MetadataValidationInterface {
             String location, Map<String, String> translations, LinkedList<Map<MetadataEntry, Boolean>> surroundingMetadata) {
         boolean error = false;
         Collection<String> messages = new HashSet<>();
-        surroundingMetadata.addLast(containedMetadata.parallelStream().filter(MetadataEntry.class::isInstance)
-                .map(MetadataEntry.class::cast).collect(Collectors.toMap(Function.identity(), all -> Boolean.FALSE)));
+        surroundingMetadata.addLast(containedMetadata.parallelStream()
+                .filter(MetadataEntry.class::isInstance)
+                .map(MetadataEntry.class::cast)
+                .collect(Collectors.toMap(Function.identity(), each -> Boolean.FALSE, (value1, value2) -> value1)));
         List<MetadataViewWithValuesInterface> metadataViewsWithValues = containingMetadataView
                 .getSortedVisibleMetadata(containedMetadata, Collections.emptyList());
         for (MetadataViewWithValuesInterface metadataViewWithValues : metadataViewsWithValues) {

--- a/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
+++ b/Kitodo-Validation/src/main/java/org/kitodo/validation/metadata/MetadataValidation.java
@@ -338,7 +338,7 @@ public class MetadataValidation implements MetadataValidationInterface {
         surroundingMetadata.addLast(containedMetadata.parallelStream()
                 .filter(MetadataEntry.class::isInstance)
                 .map(MetadataEntry.class::cast)
-                .collect(Collectors.toMap(Function.identity(), each -> Boolean.FALSE, (value1, value2) -> value1)));
+                .collect(Collectors.toMap(Function.identity(), each -> Boolean.FALSE, (firstValue, secondValue) -> firstValue)));
         List<MetadataViewWithValuesInterface> metadataViewsWithValues = containingMetadataView
                 .getSortedVisibleMetadata(containedMetadata, Collections.emptyList());
         for (MetadataViewWithValuesInterface metadataViewWithValues : metadataViewsWithValues) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -207,12 +207,13 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                         createProcessForm.fillCreateProcessForm(tempProcess);
                     }
                     createProcessForm.setProcesses(processes);
-                    TempProcess currentTempProcess = null;
-                    for (int i = processes.size() -1; i >= 0; i--) {
-                        currentTempProcess = processes.get(i);
+                    for (int i = processes.size() - 1; i >= 0; i--) {
+                        TempProcess currentTempProcess = processes.get(i);
+                        if (i == 0) {
+                            attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
+                        }
                         createProcessForm.fillCreateProcessForm(currentTempProcess);
                     }
-                    attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
                     showMessageAndRecord(importConfiguration, processes);
                 }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -203,9 +203,15 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
                 if (!createProcessForm.getProcesses().isEmpty() && additionalImport) {
                     extendsMetadataTableOfMetadataTab(processes);
                 } else {
+                    for (TempProcess tempProcess : createProcessForm.getChildProcesses()) {
+                        createProcessForm.fillCreateProcessForm(tempProcess);
+                    }
                     createProcessForm.setProcesses(processes);
-                    TempProcess currentTempProcess = processes.getFirst();
-                    createProcessForm.fillCreateProcessForm(currentTempProcess);
+                    TempProcess currentTempProcess = null;
+                    for (int i = processes.size() -1; i >= 0; i--) {
+                        currentTempProcess = processes.get(i);
+                        createProcessForm.fillCreateProcessForm(currentTempProcess);
+                    }
                     attachToExistingParentAndGenerateAtstslIfNotExist(currentTempProcess);
                     showMessageAndRecord(importConfiguration, processes);
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -11,6 +11,7 @@
 
 package org.kitodo.production.forms.createprocess;
 
+import static org.kitodo.api.validation.State.ERROR;
 import static org.kitodo.constants.StringConstants.CREATE;
 
 import java.io.IOException;
@@ -19,6 +20,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -43,6 +45,7 @@ import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.api.schemaconverter.MetadataFormat;
+import org.kitodo.api.validation.ValidationResult;
 import org.kitodo.constants.StringConstants;
 import org.kitodo.data.database.beans.Client;
 import org.kitodo.data.database.beans.ImportConfiguration;
@@ -114,6 +117,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
     private String xmlString;
     private String filename;
     protected int numberOfEadElements;
+    private HashMap<String, ValidationResult> validationResultHashMap = new HashMap<>();
 
     public CreateProcessForm() {
         priorityList = ServiceManager.getUserService().getCurrentMetadataLanguage();
@@ -367,6 +371,8 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
             Helper.setErrorMessage("rulesetNotFound", new Object[] {rulesetFile }, logger, e);
         } catch (IOException | ProcessGenerationException e) {
             logger.error(e.getLocalizedMessage(), e);
+        } catch (DAOException e) {
+            Helper.setErrorMessage("Error validating process metadata", e);
         }
         return this.stayOnCurrentPage;
     }
@@ -390,7 +396,8 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                 + "&faces-redirect=true";
     }
 
-    private boolean canCreateProcess() throws IOException {
+    private boolean canCreateProcess() throws IOException, DAOException {
+        validationResultHashMap = new HashMap<>();
         if (Objects.nonNull(titleRecordLinkTab.getTitleRecordProcess())) {
             if ((Objects.isNull(titleRecordLinkTab.getSelectedInsertionPosition())
                     || titleRecordLinkTab.getSelectedInsertionPosition().isEmpty())) {
@@ -403,8 +410,60 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                     processDataTab.getDocType(), forbiddenParentType));
                 return false;
             }
+        } else {
+            // validate process and potential ancestors
+            for (TempProcess tempProcess : processes) {
+                ValidationResult result = ServiceManager.getMetadataValidationService().validate(
+                        tempProcess.getWorkpiece(), rulesetManagement, false);
+                if (ERROR.equals(result.getState())) {
+                    validationResultHashMap.put(getCatalogId(tempProcess), result);
+                }
+            }
+            // validate potential process children
+            for (TempProcess tempProcess : childProcesses) {
+                ValidationResult result = ServiceManager.getMetadataValidationService().validate(
+                        tempProcess.getWorkpiece(), rulesetManagement, false);
+                if (ERROR.equals(result.getState())) {
+                    validationResultHashMap.put(getCatalogId(tempProcess), result);
+                }
+            }
+            if (!validationResultHashMap.isEmpty()) {
+                Helper.setErrorMessage("dataEditor.validation.state.error");
+                for (Map.Entry<String, ValidationResult> resultEntry : validationResultHashMap.entrySet()) {
+                    if (processes.size() > 1 || childProcesses.size() > 1) {
+                        Helper.setErrorMessage(Helper.getTranslation("process") + ": " +  resultEntry.getKey());
+                    }
+                    for (String message : resultEntry.getValue().getResultMessages()) {
+                        Helper.setErrorMessage(" - " + message);
+                    }
+                }
+                PrimeFaces.current().ajax().update("editForm:processFromTemplateTabView:processHierarchyContent");
+                return false;
+            }
         }
         return true;
+    }
+
+    /**
+     * Get CSS style classes for UI button representing given TempProcess "process"
+     * in import masks "Process hierarchy" panel as whitespace separated string of class names.
+     * Always contains class name 'carousel-button'.
+     * Also contains class name
+     * - 'selected' if given process is currently selected in the import mask
+     * - 'validation-error' if ruleset based metadata validation failed for given process
+     * @param process TempProcess for which CSS style classes are returned
+     * @return String containing style classes, separated by whitespaces, for given process
+     */
+    public String getProcessButtonStyleClass(TempProcess process) {
+        String styleClass = "carousel-button";
+        if (currentProcess.equals(process)) {
+            styleClass = styleClass + " selected";
+        }
+        String catalogId = getCatalogId(process);
+        if (!validationResultHashMap.isEmpty() && validationResultHashMap.containsKey(catalogId)) {
+            styleClass = styleClass + " validation-error";
+        }
+        return styleClass;
     }
 
     private String parentTypeIfForbidden() throws IOException {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -384,7 +384,7 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
      */
     public String createNewProcessAndContinue() {
         String destination = createNewProcess();
-        if (!destination.equals(processListPath)) {
+        if (!processListPath.equals(destination)) {
             return destination;
         }
         Process parentProcess = titleRecordLinkTab.getTitleRecordProcess();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -410,36 +410,35 @@ public class CreateProcessForm extends BaseForm implements MetadataTreeTableInte
                     processDataTab.getDocType(), forbiddenParentType));
                 return false;
             }
-        } else {
-            // validate process and potential ancestors
-            for (TempProcess tempProcess : processes) {
-                ValidationResult result = ServiceManager.getMetadataValidationService().validate(
-                        tempProcess.getWorkpiece(), rulesetManagement, false);
-                if (ERROR.equals(result.getState())) {
-                    validationResultHashMap.put(getCatalogId(tempProcess), result);
+        }
+        // validate process and potential ancestors
+        for (TempProcess tempProcess : processes) {
+            ValidationResult result = ServiceManager.getMetadataValidationService().validate(
+                    tempProcess.getWorkpiece(), rulesetManagement, false);
+            if (ERROR.equals(result.getState())) {
+                validationResultHashMap.put(getCatalogId(tempProcess), result);
+            }
+        }
+        // validate potential process children
+        for (TempProcess tempProcess : childProcesses) {
+            ValidationResult result = ServiceManager.getMetadataValidationService().validate(
+                    tempProcess.getWorkpiece(), rulesetManagement, false);
+            if (ERROR.equals(result.getState())) {
+                validationResultHashMap.put(getCatalogId(tempProcess), result);
+            }
+        }
+        if (!validationResultHashMap.isEmpty()) {
+            Helper.setErrorMessage("dataEditor.validation.state.error");
+            for (Map.Entry<String, ValidationResult> resultEntry : validationResultHashMap.entrySet()) {
+                if (processes.size() > 1 || childProcesses.size() > 1) {
+                    Helper.setErrorMessage(Helper.getTranslation("process") + ": " +  resultEntry.getKey());
+                }
+                for (String message : resultEntry.getValue().getResultMessages()) {
+                    Helper.setErrorMessage(" - " + message);
                 }
             }
-            // validate potential process children
-            for (TempProcess tempProcess : childProcesses) {
-                ValidationResult result = ServiceManager.getMetadataValidationService().validate(
-                        tempProcess.getWorkpiece(), rulesetManagement, false);
-                if (ERROR.equals(result.getState())) {
-                    validationResultHashMap.put(getCatalogId(tempProcess), result);
-                }
-            }
-            if (!validationResultHashMap.isEmpty()) {
-                Helper.setErrorMessage("dataEditor.validation.state.error");
-                for (Map.Entry<String, ValidationResult> resultEntry : validationResultHashMap.entrySet()) {
-                    if (processes.size() > 1 || childProcesses.size() > 1) {
-                        Helper.setErrorMessage(Helper.getTranslation("process") + ": " +  resultEntry.getKey());
-                    }
-                    for (String message : resultEntry.getValue().getResultMessages()) {
-                        Helper.setErrorMessage(" - " + message);
-                    }
-                }
-                PrimeFaces.current().ajax().update("editForm:processFromTemplateTabView:processHierarchyContent");
-                return false;
-            }
+            PrimeFaces.current().ajax().update("editForm:processFromTemplateTabView:processHierarchyContent");
+            return false;
         }
         return true;
     }

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -1686,6 +1686,14 @@ Import form
     background: var(--blue);
 }
 
+#editForm\:processFromTemplateTabView\:processHierarchyContent .ui-widget-content .ui-button.validation-error {
+    background: var(--orange);
+}
+
+#editForm\:processFromTemplateTabView\:processHierarchyContent .ui-widget-content .selected.validation-error {
+    background: var(--focused-orange);
+}
+
 #editForm\:processFromTemplateTabView\:processChildren {
     margin: auto;
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -43,8 +43,6 @@
                  styleClass="no-header"
                  widgetVar="metadataTable"
                  id="metadataTable">
-        <p:ajax event="collapse"
-                onstart="return #{request.requestURI.contains('metadataEditor')};"/>
         <p:column>
             <span class="input-wrapper">
                 <!-- field label
@@ -67,7 +65,6 @@
                                  label="#{item.label}"
                                  value="#{item.value}"
                                  disabled="#{not item.editable or readOnly}"
-                                 required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                  styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
                                  onkeydown="metadataEditor.metadataTree.handleKeyDown(event, this)">
                         <p:ajax event="change"
@@ -83,7 +80,6 @@
                                      value="#{item.value}"
                                      rows="2"
                                      disabled="#{not item.editable or readOnly}"
-                                     required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                      styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
                         <p:ajax event="change"
                                 oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
@@ -97,7 +93,6 @@
                                label="#{item.label}"
                                value="#{item.value}"
                                disabled="#{not item.editable or readOnly}"
-                               required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
                         <p:ajax event="change"
                                 oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
@@ -112,7 +107,6 @@
                                 pattern="yyyy-MM-dd"
                                 styleClass="input-with-button #{not item.editable or readOnly ? 'read-only disabled' : ''}"
                                 showOn="button"
-                                required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                 disabled="#{not item.editable or readOnly}">
                         <p:ajax event="dateSelect"
                                 oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>
@@ -127,7 +121,6 @@
                                       readonly="#{not item.editable}"
                                       styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
                                       disabled="#{not item.editable or readOnly}"
-                                      required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                       showCheckbox="true"
                                       filter="#{item.filterable}"
                                       filterMatchMode="contains">
@@ -146,7 +139,6 @@
                                      readonly="#{not item.editable}"
                                      autoWidth="false"
                                      disabled="#{not item.editable or readOnly}"
-                                     required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                      styleClass="#{readOnly ? 'read-only' : ''}"
                                      filter="#{item.filterable}"
                                      filterMatchMode="contains">
@@ -166,7 +158,6 @@
                                       label="#{item.label}"
                                       value="#{item.selectedItem}"
                                       readonly="#{not item.editable}"
-                                      required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                       disabled="#{not item.editable or readOnly}"
                                       styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}"
                                       layout="grid"
@@ -182,7 +173,6 @@
                     <p:selectBooleanCheckbox id="toggleSwitch"
                                              label="#{item.label}"
                                              disabled="#{not item.editable or readOnly}"
-                                             required="#{item.required and (not empty param['editForm:save'] or not empty param['editForm:saveContinue'])}"
                                              value="#{item.active}">
                         <p:ajax event="change"
                                 oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -43,6 +43,7 @@
                  styleClass="no-header"
                  widgetVar="metadataTable"
                  id="metadataTable">
+        <p:ajax event="collapse"/>
         <p:column>
             <span class="input-wrapper">
                 <!-- field label

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dataEdit.xhtml
@@ -33,7 +33,7 @@
                 <p:commandButton action="#{CreateProcessForm.fillCreateProcessForm(processAncestor)}"
                                  actionListener="#{CreateProcessForm.processMetadata.preserve()}"
                                  process="@this"
-                                 styleClass="carousel-button #{CreateProcessForm.currentProcess.equals(processAncestor) ? 'selected' : ''}"
+                                 styleClass="#{CreateProcessForm.getProcessButtonStyleClass(processAncestor)}"
                                  value="#{CreateProcessForm.getCatalogId(processAncestor)}"
                                  update="editForm:processFromTemplateTabView:processData
                                          @(.carousel-button)"/>
@@ -49,7 +49,7 @@
                 <p:commandButton action="#{CreateProcessForm.fillCreateProcessForm(childProcess)}"
                                  actionListener="#{CreateProcessForm.processMetadata.preserve()}"
                                  process="@this"
-                                 styleClass="carousel-button #{CreateProcessForm.currentProcess.equals(childProcess) ? 'selected' : ''}"
+                                 styleClass="#{CreateProcessForm.getProcessButtonStyleClass(childProcess)}"
                                  value="#{CreateProcessForm.getCatalogId(childProcess)}"
                                  update="editForm:processFromTemplateTabView:processData
                                          @(.carousel-button)"/>

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -2360,4 +2360,41 @@ public class MockDatabase {
                     .then(Action.ok(), Action.contentType("text/xml"), Action.stringContent(serverResponse));
         }
     }
+
+    /**
+     * Add simple template with one task that can be used to create processes.
+     *
+     * @throws DAOException when loading role or template fails
+     * @throws DataException when saving template task fails
+     */
+    public static void insertTestTemplateForCreatingProcesses() throws DAOException, DataException {
+        Project project = ServiceManager.getProjectService().getById(1);
+        Client client = ServiceManager.getClientService().getById(1);
+
+        Ruleset bookRuleset = new Ruleset();
+        bookRuleset.setTitle("Book");
+        bookRuleset.setFile("simple-book.xml");
+        bookRuleset.setOrderMetadataByRuleset(false);
+        bookRuleset.setClient(client);
+        ServiceManager.getRulesetService().save(bookRuleset);
+        int bookRulesetId = bookRuleset.getId();
+
+        Template bookTemplate = new Template();
+        bookTemplate.setTitle("Book template");
+        bookTemplate.setClient(project.getClient());
+        bookTemplate.setDocket(ServiceManager.getDocketService().getById(2));
+        bookTemplate.setRuleset(ServiceManager.getRulesetService().getById(bookRulesetId));
+        bookTemplate.getProjects().add(project);
+        ServiceManager.getTemplateService().save(bookTemplate, true);
+        int bookTemplateId = bookTemplate.getId();
+
+        Role role = ServiceManager.getRoleService().getById(1);
+        Task templateTask = new Task();
+        templateTask.setTitle("Template task");
+        templateTask.setProcessingStatus(TaskStatus.OPEN);
+        templateTask.setTemplate(ServiceManager.getTemplateService().getById(bookTemplateId));
+        templateTask.getRoles().add(role);
+        role.getTasks().add(templateTask);
+        ServiceManager.getTaskService().save(templateTask);
+    }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ImportingST.java
@@ -62,6 +62,7 @@ public class ImportingST extends BaseTestSelenium {
         MockDatabase.insertMappingFiles();
         MockDatabase.insertImportConfigurations();
         MockDatabase.addDefaultChildProcessImportConfigurationToFirstProject();
+        MockDatabase.insertTestTemplateForCreatingProcesses();
         server = new StubServer(MockDatabase.PORT).run();
         setupServer();
     }
@@ -151,6 +152,29 @@ public class ImportingST extends BaseTestSelenium {
         List<String> importConfigurationNames = importPage.getImportConfigurationsTitles();
         assertEquals(TestConstants.GBV, importConfigurationNames.get(1), "Wrong title of first import configuration");
         assertEquals(TestConstants.K10PLUS, importConfigurationNames.get(2), "Wrong title of second import configuration");
+    }
+
+    /**
+     * Checks whether checkboxes in group in the metadata table of the "create new process" form are preserved on
+     * collapsing the group UI element or not.
+     *
+     * @throws Exception when opening the "create new process" form fails
+     */
+    @Test
+    public void checkCollapsedCheckboxMetadataIsPreserved() throws Exception {
+        projectsPage.createNewProcess("Book template");
+        importPage.cancelCatalogSearch();
+        importPage.insertTestTitle();
+        importPage.selectCheckBox(0);
+        importPage.toggleTreeTable();
+        importPage.clickSaveButton();
+        await("Waiting to be redirected to processes page after saving process with selected mandatory checkbox "
+                + "in collapsed metadata group")
+                .pollDelay(500, TimeUnit.MILLISECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .until(() -> processesPage.isAt());
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -107,6 +107,9 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
     @FindBy(id = "catalogSearchForm:cancel")
     private WebElement cancelCatalogSearchButton;
 
+    @FindBy(id = "editForm:processFromTemplateTabView:metadataTable_data")
+    private WebElement metadataTable;
+
     public ProcessFromTemplatePage() {
         super("pages/processFromTemplate.jsf");
     }
@@ -370,5 +373,42 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
     public void cancel() throws IllegalAccessException, InstantiationException {
         clickButtonAndWaitForRedirect(cancelButton, Pages.getProjectsPage().getUrl());
         Pages.getProcessesPage();
+    }
+
+    /**
+     * Select checkbox in metadata table with given index.
+     *
+     * @param index index of checkbox to click
+     */
+    public void selectCheckBox(int index) {
+        metadataTable.findElements(By.className("ui-chkbox-icon")).get(index).click();
+    }
+
+    /**
+     * Click first tree table toggler in metadata table.
+     */
+    public void toggleTreeTable() {
+        metadataTable.findElement(By.className("ui-treetable-toggler")).click();
+    }
+
+    /**
+     * Click 'cancel' button on catalog search popup to close dialog.
+     */
+    public void cancelCatalogSearch() {
+        clickElement(cancelCatalogSearchButton);
+    }
+
+    /**
+     * Click 'save' button in 'new process form'.
+     */
+    public void clickSaveButton() {
+        clickElement(saveButton);
+    }
+
+    /**
+     * Insert String into 'process title' input field.
+     */
+    public void insertTestTitle() {
+        processTitleInput.sendKeys("Testvorgang");
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProjectsPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProjectsPage.java
@@ -295,10 +295,26 @@ public class ProjectsPage extends Page<ProjectsPage> {
         return getTableDataByColumn(rulesetsTable, 0);
     }
 
+    /**
+     * Open "create new process" page with template "First template".
+     *
+     * @throws Exception if "create new process" page could not be opened
+     */
     public void createNewProcess() throws Exception {
+        createNewProcess("First template");
+    }
+
+    /**
+     * Open "create new process" page with template with given title "templateTitle".
+     *
+     * @param templateTitle title of template to use
+     *
+     * @throws Exception if "create new process" page could not be opened
+     */
+    public void createNewProcess(String templateTitle) throws Exception {
         switchToTabByIndex(TabIndex.TEMPLATES.getIndex());
 
-        int index = triggerRowToggle(templatesTable, "First template");
+        int index = triggerRowToggle(templatesTable, templateTitle);
         WebElement createProcess = Browser.getDriver()
                 .findElement(By.id(TEMPLATE_TABLE + ":" + index + ":createProcessForm:projects:0:createProcess"));
         clickButtonAndWaitForRedirect(createProcess, Pages.getProcessFromTemplatePage().getUrl());

--- a/Kitodo/src/test/resources/rulesets/simple-book.xml
+++ b/Kitodo/src/test/resources/rulesets/simple-book.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ *
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ *
+-->
+<!-- An example how the perhaps simplest variant of a rule set might look like.
+     It has only the declaration section. With this rule set, only books
+     can be described. For each book author, year, title, publisher and place
+     of publication can be recorded.
+-->
+<ruleset xmlns="http://names.kitodo.org/ruleset/v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://names.kitodo.org/ruleset/v2 ruleset.xsd">
+    <declaration>
+        <division id="book">
+            <label>Book</label>
+            <label lang="de">Buch</label>
+            <label lang="fr">Livre</label>
+        </division>
+        <key id="document_type" use="docType">
+            <label>Document type</label>
+        </key>
+        <key id="publicationYear">
+            <label>Publication year</label>
+            <codomain type="integer"/>
+        </key>
+        <key id="language">
+            <label>Language</label>
+            <!--<codomain namespace="http://id.loc.gov/vocabulary/iso639-2/"/>-->
+            <option value="de"><label>Deutsch</label></option>
+            <option value="fr"><label>Französisch</label></option>
+        </key>
+        <key id="titleDocMain" use="structureTreeTitle">
+            <label>Main title</label>
+        </key>
+        <key id="publisherName">
+            <label>Publisher</label>
+        </key>
+        <key id="placeOfPublication">
+            <label>Place of publication</label>
+        </key>
+        <key id="person">
+            <label lang="de">Person (Gruppe)</label>
+            <label lang="en">Person (Group)</label>
+            <key id="RoleCode">
+                <label>Relationship designation (code)</label>
+                <label lang="de">Beziehungskennzeichnung (Code)</label>
+                <option value="pht"><label>Fotograf</label></option>
+                <option value="edt"><label>Herausgeber</label></option>
+                <option value="aut"><label>Verfasser</label></option>
+            </key>
+        </key>
+    </declaration>
+    <correlation>
+        <restriction division="book">
+            <permit key="person" minOccurs="1"/>
+        </restriction>
+        <restriction key="person">
+            <permit key="RoleCode" minOccurs="1"/>
+        </restriction>
+    </correlation>
+    <editing>
+        <setting key="language" filterable="true"/>
+    </editing>
+</ruleset>


### PR DESCRIPTION
This pull request fixes #5932 by replacing the client side validation of HTML form fields with server side ruleset based validation, which is also used in the metadata editor, albeit in a stricter mode. 