### PR TITLE
Fix MARC XPATHs

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormat.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormat.java
@@ -47,7 +47,7 @@ public enum MetadataFormat {
             case "MODS":
                 return ".//*[local-name()='recordInfo']/*[local-name()='recordIdentifier']/text()";
             case "MARC":
-                return ".//*[local-name()='datafield'][@tag='245']/*[local-name()='subfield'][@code='a']/text()";
+                return ".//*[local-name()='controlfield'][@tag='001']/text()";
             case "PICA":
                 return ".//*[local-name()='datafield'][@tag='003@']/*[local-name()='subfield'][@code='0']/text()";
             default:
@@ -66,7 +66,7 @@ public enum MetadataFormat {
             case "MODS":
                 return ".//*[local-name()='titleInfo']/*[local-name()='title']/text()";
             case "MARC":
-                return ".//*[local-name()='controlfield'][@tag='001']/text()";
+                return ".//*[local-name()='datafield'][@tag='245']/*[local-name()='subfield'][@code='a']/text()";
             case "PICA":
                 return ".//*[local-name()='datafield'][@tag='021A']/*[local-name()='subfield'][@code='a']/text()";
             default:

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ImportConfigurationEditView.java
@@ -62,7 +62,7 @@ public class ImportConfigurationEditView extends BaseForm {
     static {
         DEFAULT_ID_XPATHS = List.of(
                 ".//*[local-name()='recordInfo']/*[local-name()='recordIdentifier']/text()",
-                ".//*[local-name()='datafield'][@tag='245']/*[local-name()='subfield'][@code='a']/text()",
+                ".//*[local-name()='controlfield'][@tag='001']/text()",
                 ".//*[local-name()='datafield'][@tag='003@']/*[local-name()='subfield'][@code='0']/text()"
         );
     }
@@ -70,7 +70,7 @@ public class ImportConfigurationEditView extends BaseForm {
     static {
         DEFAULT_TITLE_XPATHS = List.of(
                 ".//*[local-name()='titleInfo']/*[local-name()='title']/text()",
-                ".//*[local-name()='controlfield'][@tag='001']/text()",
+                ".//*[local-name()='datafield'][@tag='245']/*[local-name()='subfield'][@code='a']/text()",
                 ".//*[local-name()='datafield'][@tag='021A']/*[local-name()='subfield'][@code='a']/text()"
         );
     }


### PR DESCRIPTION
The default MARC XPath expressions provided by Kitodo for use in the Import Configuration are incorrect. The XPath intended for the ID is mistakenly used to retrieve the MARC title field, and vice versa. This PR corrects the XPath mappings.