### PR TITLE
Enable linking pages via gallery while media is hidden in structure tree

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -432,7 +432,7 @@ public class GalleryPanel {
     }
 
     private void addStripesRecursive(LogicalDivision structure) {
-        List<Integer> treeNodeIdList = new ArrayList<Integer>();
+        List<Integer> treeNodeIdList = new ArrayList<>();
         Integer idx = 0;
         Process process = dataEditor.getProcess();
         if (Objects.nonNull(process) && Objects.nonNull(process.getParent())) {
@@ -458,7 +458,7 @@ public class GalleryPanel {
                 // add child
                 if (Objects.isNull(child.getLink())) {
                     List<Integer> childTreeNodeIdList = new ArrayList<>(treeNodeIdList);
-                    if (!dataEditor.getStructurePanel().logicalStructureTreeContainsMedia()) {
+                    if (dataEditor.getStructurePanel().isSeparateMedia()) {
                         childTreeNodeIdList.add(siblingWithoutViewsIdx);
                     } else {
                         childTreeNodeIdList.add(siblingWithViewsIdx);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -482,11 +482,7 @@ public class StructurePanel implements Serializable {
             this.preserveLogical();
             this.preservePhysical();
         } else {
-            if (isHideMediaInLogicalTree()) {
-                this.preserveLogical();
-            } else {
-                this.preserveLogicalAndPhysical();
-            }
+            this.preserveLogicalAndPhysical();
         }
     }
 
@@ -1270,10 +1266,10 @@ public class StructurePanel implements Serializable {
      */
     private void preserveAfterDragDrop(boolean logicalMoved, boolean pageMoved, boolean physicalMoved) {
         if (logicalMoved || pageMoved) {
-            if (logicalStructureTreeContainsMedia()) {
-                preserveLogicalAndPhysical();
-            } else {
+            if (this.isSeparateMedia()) {
                 preserveLogical();
+            } else {
+                preserveLogicalAndPhysical();
             }
             this.dataEditor.getGalleryPanel().updateStripes();
             this.dataEditor.getPaginationPanel().show();
@@ -2040,15 +2036,6 @@ public class StructurePanel implements Serializable {
             throw new IllegalArgumentException("node label option must be either type, title or type+title");
         }
         this.nodeLabelOption = nodeLabelOption;
-    }
-
-    /**
-     * Returns true if the logical structure tree is a combined tree of structure nodes and view nodes (media).
-     *
-     * @return true if logical structure tree contains media
-     */
-    public boolean logicalStructureTreeContainsMedia() {
-        return !this.isSeparateMedia() && !this.isHideMediaInLogicalTree();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1825,6 +1825,8 @@ public class StructurePanel implements Serializable {
     /**
      * Check if the given TreeNode's PhysicalDivision is assigned to several LogicalDivisions.
      *
+     * @param treeNode TreeNode to be checked for assignment to multiple LogicalDivisions
+     *
      * @return {@code true} when the PhysicalDivision is assigned to more than one logical element
      */
     private boolean isAssignedSeveralTimes(TreeNode treeNode) {
@@ -1933,6 +1935,8 @@ public class StructurePanel implements Serializable {
      * Check if the given TreeNode's PhysicalDivision can be assigned to the next logical element in addition to the
      * current assignment.
      *
+     * @param treeNode TreeNode representing View to be checked
+     *
      * @return {@code true} if the PhysicalDivision can be assigned to the next LogicalDivision
      */
     private boolean isAssignableSeveralTimes(TreeNode treeNode) {
@@ -1973,6 +1977,8 @@ public class StructurePanel implements Serializable {
 
     /**
      * Assign given TreeNode's PhysicalDivision to the next LogicalDivision.
+     *
+     * @param treeNode TreeNode representing View to be assigned to next LogicalDivision
      */
     private void assign(TreeNode treeNode) {
         TreeNode nextLogical = findNextLogicalNodeForViewAssignment(treeNode);
@@ -1992,6 +1998,7 @@ public class StructurePanel implements Serializable {
 
     /**
      * Unassign the selected Node's PhysicalDivision from the LogicalDivision parent at the selected position.
+     * If media is hidden in the structure tree the selected node is retrieved from the selected logical structure first.
      * This does not remove it from other LogicalDivisions.
      */
     public void unassign() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -2017,6 +2017,8 @@ public class StructurePanel implements Serializable {
     /**
      * Unassign the givens TreeNode's PhysicalDivision from the LogicalDivision parent at the selected position.
      * This does not remove it from other LogicalDivisions.
+     *
+     * @param treeNode TreeNode representing View to be unassigned from the LogicalDivision parent at the selected position
      */
     private void unassign(TreeNode treeNode) {
         if (isAssignedSeveralTimes()) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1814,12 +1814,7 @@ public class StructurePanel implements Serializable {
      * @return {@code true} when the PhysicalDivision is assigned to more than one logical element
      */
     public boolean isAssignedSeveralTimes() {
-        TreeNode selected = getSelectedLogicalNodeIfSingle();
-        if (isHideMediaInLogicalTree()) {
-            return isAssignedSeveralTimes(getSelectedView(selected));
-        } else {
-            return isAssignedSeveralTimes(selected);
-        }
+        return isAssignedSeveralTimes(getSelectedLogicalNodeIfSingle());
     }
 
     /**
@@ -1924,11 +1919,7 @@ public class StructurePanel implements Serializable {
         if (Objects.isNull(selectedLogicalNode)) {
             return false;
         }
-        if (isHideMediaInLogicalTree()) {
-            return isAssignableSeveralTimes(getSelectedView(selectedLogicalNode));
-        } else {
-            return isAssignableSeveralTimes(selectedLogicalNode);
-        }
+        return isAssignableSeveralTimes(selectedLogicalNode);
     }
 
     /**
@@ -1968,11 +1959,7 @@ public class StructurePanel implements Serializable {
             logger.error("assign called without selection or too many selected, should not happen");
             return;
         }
-        if (isHideMediaInLogicalTree()) {
-            assign(getSelectedView(selectedLogicalNode));
-        } else {
-            assign(selectedLogicalNode);
-        }
+        assign(selectedLogicalNode);
     }
 
     /**
@@ -2007,11 +1994,7 @@ public class StructurePanel implements Serializable {
             logger.error("unassign called without selection or too many selected, should not happen");
             return;
         }
-        if (isHideMediaInLogicalTree()) {
-            unassign(getSelectedView(selectedLogicalNode));
-        } else {
-            unassign(selectedLogicalNode);
-        }
+        unassign(selectedLogicalNode);
     }
 
     /**
@@ -2147,47 +2130,5 @@ public class StructurePanel implements Serializable {
             toggleAll(childNode, expanded);
         }
         treeNode.setExpanded(expanded);
-    }
-
-    private TreeNode getSelectedView(TreeNode node) {
-        if (node.getData() instanceof StructureTreeNode) {
-            StructureTreeNode structureTreeNode = (StructureTreeNode) node.getData();
-            if (structureTreeNode.getDataObject() instanceof LogicalDivision) {
-                LogicalDivision logicalDivision = (LogicalDivision) structureTreeNode.getDataObject();
-                TreeNode selectedNode = getSelectedViewOfLogicalDivision(logicalDivision, node);
-                if (Objects.nonNull(selectedNode)) {
-                    return selectedNode;
-                }
-            }
-        }
-        return null;
-    }
-
-    private TreeNode getSelectedViewOfLogicalDivision(LogicalDivision logicalDivision, TreeNode node) {
-        for (View view : logicalDivision.getViews()) {
-            GalleryMediaContent content = dataEditor.getGalleryPanel().getGalleryMediaContent(view);
-            if (Objects.nonNull(content) && dataEditor.isSelected(content.getView().getPhysicalDivision(), logicalDivision)) {
-                TreeNode matchingTreeNode = getChildTreeNodeWithMatchingView(node, content.getView());
-                if (Objects.nonNull(matchingTreeNode)) {
-                    return matchingTreeNode;
-                }
-            }
-        }
-        return null;
-    }
-
-    private TreeNode getChildTreeNodeWithMatchingView(TreeNode parentNode, View targetView) {
-        for (TreeNode childNode : parentNode.getChildren()) {
-            if (childNode.getData() instanceof StructureTreeNode) {
-                StructureTreeNode childStructureTreeNode = (StructureTreeNode) childNode.getData();
-                if (childStructureTreeNode.getDataObject() instanceof View) {
-                    View childView = (View) childStructureTreeNode.getDataObject();
-                    if (childView.equals(targetView)) {
-                        return childNode;
-                    }
-                }
-            }
-        }
-        return null;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -729,7 +729,7 @@ public class StructurePanel implements Serializable {
         }
 
         Set<View> viewsShowingOnAChild = new HashSet<>();
-        if (!this.logicalStructureTreeContainsMedia()) {
+        if (this.isSeparateMedia()) {
             for (LogicalDivision child : structure.getChildren()) {
                 viewsShowingOnAChild.addAll(buildStructureTreeRecursively(child, parent, processTypeMap, viewCache));
             }
@@ -1815,8 +1815,21 @@ public class StructurePanel implements Serializable {
      */
     public boolean isAssignedSeveralTimes() {
         TreeNode selected = getSelectedLogicalNodeIfSingle();
-        if (Objects.nonNull(selected) && selected.getData() instanceof StructureTreeNode) {
-            StructureTreeNode structureTreeNode = (StructureTreeNode) selected.getData();
+        if (isHideMediaInLogicalTree()) {
+            return isAssignedSeveralTimes(getSelectedView(selected));
+        } else {
+            return isAssignedSeveralTimes(selected);
+        }
+    }
+
+    /**
+     * Check if the given TreeNode's PhysicalDivision is assigned to several LogicalDivisions.
+     *
+     * @return {@code true} when the PhysicalDivision is assigned to more than one logical element
+     */
+    private boolean isAssignedSeveralTimes(TreeNode treeNode) {
+        if (Objects.nonNull(treeNode) && treeNode.getData() instanceof  StructureTreeNode) {
+            StructureTreeNode structureTreeNode = (StructureTreeNode) treeNode.getData();
             if (structureTreeNode.getDataObject() instanceof View) {
                 View view = (View) structureTreeNode.getDataObject();
                 return view.getPhysicalDivision().getLogicalDivisions().size() > 1;
@@ -1829,7 +1842,7 @@ public class StructurePanel implements Serializable {
      * Find the next logical structure node that can be used to create a new link to the currently selected node. 
      * The node needs to be the last node amongst its siblings.
      * 
-     * @param node the tree node of the currently selected physical devision node
+     * @param node the tree node of the currently selected physical division node
      * @return the next logical tree node 
      */
     private TreeNode findNextLogicalNodeForViewAssignment(TreeNode node) {
@@ -1899,9 +1912,9 @@ public class StructurePanel implements Serializable {
     }
 
     /**
-     * Check if the selected Node's PhysicalDivision can be assigned to the next logical element in addition to the 
+     * Check if the selected Node's PhysicalDivision can be assigned to the next logical element in addition to the
      * current assignment.
-     * 
+     *
      * @return {@code true} if the PhysicalDivision can be assigned to the next LogicalDivision
      */
     public boolean isAssignableSeveralTimes() {
@@ -1909,13 +1922,27 @@ public class StructurePanel implements Serializable {
         if (Objects.isNull(selectedLogicalNode)) {
             return false;
         }
-        TreeNode nextLogical = findNextLogicalNodeForViewAssignment(selectedLogicalNode);
+        if (isHideMediaInLogicalTree()) {
+            return isAssignableSeveralTimes(getSelectedView(selectedLogicalNode));
+        } else {
+            return isAssignableSeveralTimes(selectedLogicalNode);
+        }
+    }
+
+    /**
+     * Check if the given TreeNode's PhysicalDivision can be assigned to the next logical element in addition to the
+     * current assignment.
+     *
+     * @return {@code true} if the PhysicalDivision can be assigned to the next LogicalDivision
+     */
+    private boolean isAssignableSeveralTimes(TreeNode treeNode) {
+        TreeNode nextLogical = findNextLogicalNodeForViewAssignment(treeNode);
         if (Objects.nonNull(nextLogical)) {
-            // check whether first child is already view of current node (too avoid adding views multiple times)
+            // check whether first child is already view of current node (to avoid adding views multiple times)
             if (!nextLogical.getChildren().isEmpty()) {
                 TreeNode childNode = nextLogical.getChildren().get(0);
                 View childNodeView = getTreeNodeView(childNode);
-                View selectedView = getTreeNodeView(selectedLogicalNode);
+                View selectedView = getTreeNodeView(treeNode);
                 if (Objects.nonNull(childNodeView) && Objects.nonNull(selectedView)) {
                     if (childNodeView.equals(selectedView)) {
                         // first child is already a view for the currently selected node
@@ -1937,9 +1964,20 @@ public class StructurePanel implements Serializable {
             logger.error("assign called without selection or too many selected, should not happen");
             return;
         }
-        TreeNode nextLogical = findNextLogicalNodeForViewAssignment(selectedLogicalNode);
+        if (isHideMediaInLogicalTree()) {
+            assign(getSelectedView(selectedLogicalNode));
+        } else {
+            assign(selectedLogicalNode);
+        }
+    }
+
+    /**
+     * Assign given TreeNode's PhysicalDivision to the next LogicalDivision.
+     */
+    private void assign(TreeNode treeNode) {
+        TreeNode nextLogical = findNextLogicalNodeForViewAssignment(treeNode);
         if (Objects.nonNull(nextLogical)) {
-            View view = (View) ((StructureTreeNode) selectedLogicalNode.getData()).getDataObject();
+            View view = (View) ((StructureTreeNode) treeNode.getData()).getDataObject();
             View viewToAssign = new View();
             viewToAssign.setPhysicalDivision(view.getPhysicalDivision());
             StructureTreeNode structureTreeNodeSibling = (StructureTreeNode) nextLogical.getData();
@@ -1962,11 +2000,23 @@ public class StructurePanel implements Serializable {
             logger.error("unassign called without selection or too many selected, should not happen");
             return;
         }
+        if (isHideMediaInLogicalTree()) {
+            unassign(getSelectedView(selectedLogicalNode));
+        } else {
+            unassign(selectedLogicalNode);
+        }
+    }
+
+    /**
+     * Unassign the givens TreeNode's PhysicalDivision from the LogicalDivision parent at the selected position.
+     * This does not remove it from other LogicalDivisions.
+     */
+    private void unassign(TreeNode treeNode) {
         if (isAssignedSeveralTimes()) {
-            StructureTreeNode structureTreeNode = (StructureTreeNode) selectedLogicalNode.getData();
+            StructureTreeNode structureTreeNode = (StructureTreeNode) treeNode.getData();
             View view = (View) structureTreeNode.getDataObject();
-            if (selectedLogicalNode.getParent().getData() instanceof StructureTreeNode) {
-                StructureTreeNode structureTreeNodeParent = (StructureTreeNode) selectedLogicalNode.getParent().getData();
+            if (treeNode.getParent().getData() instanceof StructureTreeNode) {
+                StructureTreeNode structureTreeNodeParent = (StructureTreeNode) treeNode.getParent().getData();
                 if (structureTreeNodeParent.getDataObject() instanceof LogicalDivision) {
                     LogicalDivision logicalDivision =
                             (LogicalDivision) structureTreeNodeParent.getDataObject();
@@ -2088,5 +2138,47 @@ public class StructurePanel implements Serializable {
             toggleAll(childNode, expanded);
         }
         treeNode.setExpanded(expanded);
+    }
+
+    private TreeNode getSelectedView(TreeNode node) {
+        if (node.getData() instanceof StructureTreeNode) {
+            StructureTreeNode structureTreeNode = (StructureTreeNode) node.getData();
+            if (structureTreeNode.getDataObject() instanceof LogicalDivision) {
+                LogicalDivision logicalDivision = (LogicalDivision) structureTreeNode.getDataObject();
+                TreeNode selectedNode = getSelectedViewOfLogicalDivision(logicalDivision, node);
+                if (Objects.nonNull(selectedNode)) {
+                    return selectedNode;
+                }
+            }
+        }
+        return null;
+    }
+
+    private TreeNode getSelectedViewOfLogicalDivision(LogicalDivision logicalDivision, TreeNode node) {
+        for (View view : logicalDivision.getViews()) {
+            GalleryMediaContent content = dataEditor.getGalleryPanel().getGalleryMediaContent(view);
+            if (Objects.nonNull(content) && dataEditor.isSelected(content.getView().getPhysicalDivision(), logicalDivision)) {
+                TreeNode matchingTreeNode = getChildTreeNodeWithMatchingView(node, content.getView());
+                if (Objects.nonNull(matchingTreeNode)) {
+                    return matchingTreeNode;
+                }
+            }
+        }
+        return null;
+    }
+
+    private TreeNode getChildTreeNodeWithMatchingView(TreeNode parentNode, View targetView) {
+        for (TreeNode childNode : parentNode.getChildren()) {
+            if (childNode.getData() instanceof StructureTreeNode) {
+                StructureTreeNode childStructureTreeNode = (StructureTreeNode) childNode.getData();
+                if (childStructureTreeNode.getDataObject() instanceof View) {
+                    View childView = (View) childStructureTreeNode.getDataObject();
+                    if (childView.equals(targetView)) {
+                        return childNode;
+                    }
+                }
+            }
+        }
+        return null;
     }
 }

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2788,6 +2788,10 @@ Column content
     margin-right: 3px;
 }
 
+#structureTreeForm .hidden-tree-node {
+    display: none;
+}
+
 #structureTreeForm .ui-treenode .pageRange {
     margin-left: 0.3em;
 }

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -2788,6 +2788,7 @@ Column content
     margin-right: 3px;
 }
 
+#structureTreeForm .hidden-tree-node + .ui-tree-droppoint,
 #structureTreeForm .hidden-tree-node {
     display: none;
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/logicalStructureMenu.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/logicalStructureMenu.xhtml
@@ -36,7 +36,7 @@
                     itemLabel="#{msgs.showOnlyStructureElements}">
                         <p:ajax event="change"
                             listener="#{DataEditorForm.structurePanel.onHideMediaInLogicalTreeChange}"
-                            update="@this logicalTree @(.pageList) imagePreviewForm:thumbnailStripe"/>
+                            update="@this logicalTree @(.pageList) imagePreviewForm:thumbnailStripe imagePreviewForm:mediaContextMenu"/>
                     </p:selectBooleanCheckbox>
                 </li>
                 <li>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -138,7 +138,7 @@
                               styleClass="pageRange"/>
             </p:treeNode>
             <p:treeNode type="#{StructurePanel.VIEW_NODE_TYPE}"
-                        rendered="#{not DataEditorForm.structurePanel.hideMediaInLogicalTree}"
+                        styleClass="#{DataEditorForm.structurePanel.hideMediaInLogicalTree ? 'hidden-tree-node' : ''}"
                         icon="ui-icon-document">
                 <h:outputText value="#{empty logicalNode.label ? msgs['dataEditor.withoutType'] : logicalNode.label}"
                               title="#{logicalNode.undefined ? msgs['dataEditor.undefinedStructure'] : ''}"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -138,6 +138,7 @@
                               styleClass="pageRange"/>
             </p:treeNode>
             <p:treeNode type="#{StructurePanel.VIEW_NODE_TYPE}"
+                        rendered="#{not DataEditorForm.structurePanel.hideMediaInLogicalTree}"
                         icon="ui-icon-document">
                 <h:outputText value="#{empty logicalNode.label ? msgs['dataEditor.withoutType'] : logicalNode.label}"
                               title="#{logicalNode.undefined ? msgs['dataEditor.undefinedStructure'] : ''}"/>


### PR DESCRIPTION
Fixes #6098 

To fix the linked issue, some logic had to be adapted. The node relationships in the structure tree are used to determine whether a page can be linked to the next structure. Since the structure tree was rebuild _skipping_ the leaves representing pages or other media entirely when toggling the "hide media" switch, though, those relations could not be evalutated correctly for linking when the "show structures only" option was selected. 

I now changed this behavior so that nodes/leaves representing media in the structure tree are never omitted, but only _hidden_ when the option mentioned above is activated.

@thomaslow do you remember why you chose to actually exclude those page nodes from the structure tree instead of just not rendering them when you implemented this feature? I analysed the code but couldn't find a reason why the pages would have to be discarded entirely from the tree when the "show structures only" option was selected, but perhaps you remember some special constellations I missed.