### PR TITLE
Optional validation on process creation

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -667,7 +667,14 @@ public enum ParameterCore implements ParameterInterface {
      * Optional parameter controlling whether the import of all elements from an uploaded EAD XML file should be
      * canceled when an exception occurs or not. Defaults to 'false'.
      */
-    STOP_EAD_COLLECTION_IMPORT_ON_EXCEPTION(new Parameter<>("stopEadCollectionImportOnException", false));
+    STOP_EAD_COLLECTION_IMPORT_ON_EXCEPTION(new Parameter<>("stopEadCollectionImportOnException", false)),
+
+    /*
+     * Optional parameter controlling whether ruleset based metadata validation during process creation is optional or
+     * not. If set to true, a checkbox will be displayed in the "Create new process" form allowing the user to
+     * deactivate validation during process creation. Default value is 'false', thus validation is enforced by default.
+     */
+    OPTIONAL_VALIDATION_ON_PROCESS_CREATION(new Parameter<>("metadataValidationOptionalDuringProcessCreation", false));
 
     private final Parameter<?> parameter;
 

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -803,3 +803,9 @@ maxNumberOfProcessesForImportMask=5
 # the import will skip the current EAD element that caused the exception and continue with the next element.
 # Defaults to 'false'.
 stopEadCollectionImportOnException=false
+
+# The parameter 'metadataValidationOptionalDuringProcessCreation' controls whether ruleset based metadata validation is
+# optional when creating new processes via the 'Create new process' form or not. If set to true, a checkbox
+# is displayed in the aforementioned form allowing the user to deactivate ruleset based metadata validation.
+# The default value is 'false'.
+metadataValidationOptionalDuringProcessCreation=false

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -1224,6 +1224,7 @@ userNotFound=Benutzer kann nicht ermittelt werden
 userSaving=Benutzer wird gespeichert...
 validatingData=Daten werden validiert...
 validate=Validieren
+validateOnSave=Beim Speichern validieren
 validator={0}-Bilder validieren
 value=Wert
 video=Video

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -1224,6 +1224,7 @@ userNotFound=User not found
 userSaving=Saving user...
 validatingData=Validating data...
 validate=Validate
+validateOnSave=Validate on saving
 validator=Validate {0} images
 value=Value
 video=Video

--- a/Kitodo/src/main/resources/messages/messages_es.properties
+++ b/Kitodo/src/main/resources/messages/messages_es.properties
@@ -1224,6 +1224,8 @@ userNotFound=No se puede determinar el usuario
 userSaving=El usuario se guarda...
 validatingData=Los datos se validan...
 validate=Validar
+# translated with Google; please verify
+validateOnSave=Validar al guardar
 validator=Validar {0}-imágenes
 value=Valor
 video=Video

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -3171,6 +3171,16 @@ button.settings-loaded-task::after {
     padding-right: 26px;
 }
 
+#editForm\:validateWrapper {
+    margin: 12px var(--default-full-size) -31px auto;
+    z-index: 1;
+}
+
+#editForm\:validateWrapper .ui-outputlabel {
+    display: inline-block;
+    margin-left: var(--default-half-size);
+}
+
 #metadataAccordion\:metadata\:metadataTable_data .ui-selectoneradio {
     display: inline-table;
 }

--- a/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
+++ b/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
@@ -101,6 +101,15 @@
     </ui:define>
 
     <ui:define name="pageTabView">
+        <h:panelGroup layout="block"
+                      id="validateWrapper"
+                      rendered="#{CreateProcessForm.validationOptional}">
+            <p:selectBooleanCheckbox id="validate"
+                                     value="#{CreateProcessForm.validate}"/>
+            <p:outputLabel title="#{msgs.validateOnSave}"
+                           for="validate"
+                           value="#{msgs.validate}"/>
+        </h:panelGroup>
         <p:tabView id="processFromTemplateTabView"
                    widgetVar="processFromTemplateTabView"
                    activeIndex="#{CreateProcessForm.editActiveTabIndex}">

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -409,8 +409,9 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
 
     /**
      * Insert String into 'process title' input field.
+     * @param testTitle title as String
      */
-    public void insertTestTitle() {
-        processTitleInput.sendKeys("Testvorgang");
+    public void insertTestTitle(String testTitle) {
+        processTitleInput.sendKeys(testTitle);
     }
 }

--- a/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
@@ -481,3 +481,5 @@ elasticsearch.index=testindex
 elasticsearch.port=9205
 # path information must start and end with a slash, f.e. "/elastic_search/"
 elasticsearch.path=/
+# deactivate mandatory metadata validation during process creation for selenium test
+metadataValidationOptionalDuringProcessCreation=true


### PR DESCRIPTION
This pull request adds the _optional_ parameter `metadataValidationOptionalDuringProcessCreation` to the `kitodo_config.properties` file proposed in https://github.com/kitodo/kitodo-production/pull/6471#issuecomment-2774876764 to make metadata validation during process creation skippable.

If `metadataValidationOptionalDuringProcessCreation` is set to `true`, a small checkbox is displayed in the "Create process form" with which the user can control metadata validation during process creation and thus whether creating a process with invalid or incomplete metadata should be possible or not:

<img width="330" alt="Bildschirmfoto 2025-04-03 um 23 09 06" src="https://github.com/user-attachments/assets/5e4fe58d-0e99-4543-af79-47cfae149f5c" />

Setting `metadataValidationOptionalDuringProcessCreation` to `false` or not adding the parameter to `kitodo_config.properties` at all results in the checkbox not being shown and thus ensures the current behaviour, where metadata validation is always mandatory. Therefore, using this new option/checkbox is completely optional, e.g. the new checkbox is only offered when actively adjusting `kitodo_config.properties` and adding the new parameter mentioned above.

