### PR TITLE
[3.8] Use title.keyword for sorting projects

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
@@ -41,7 +41,7 @@ import org.primefaces.model.SortOrder;
 @ViewScoped
 public class DesktopForm extends BaseForm {
     private static final Logger logger = LogManager.getLogger(DesktopForm.class);
-    private static final String SORT_TITLE = "title";
+    private static final String SORT_TITLE = "title.keyword";
     private static final String SORT_ID = "id";
     private List<TaskDTO> taskList = new ArrayList<>();
     private List<ProcessDTO> processList = new ArrayList<>();


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/6345
Fixes https://github.com/kitodo/kitodo-production/issues/6378

This harmonizes the sorting of the project page and the projects on the desktop widget. It is a 3.8 only PR as 3.9 should use the database for project lists.