### PR TITLE
Fix NPE in ExportMetsIT

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/production/forms/IndexingFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/IndexingFormIT.java
@@ -55,6 +55,7 @@ public class IndexingFormIT {
     @AfterAll
     public static void tearDown() throws Exception {
         MockDatabase.stopNode();
+        MockDatabase.cleanDatabase();
     }
 
     @Test


### PR DESCRIPTION
Recently, automated tests on GitHub failed with:

```
2025-04-23T16:24:47.1831377Z [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.17 s <<< FAILURE! - in org.kitodo.production.exporter.download.ExportMetsIT
2025-04-23T16:24:47.1833882Z [ERROR] exportMetsTest  Time elapsed: 0.007 s  <<< ERROR!
2025-04-23T16:24:47.1834804Z java.lang.NullPointerException
2025-04-23T16:24:47.1835748Z 	at org.kitodo.production.exporter.download.ExportMetsIT.exportMetsTest(ExportMetsIT.java:107)
```

Weirdly, I couldn't reproduce  the problem on my machine. After multiple hours of debugging, it turns out the problem was caused by the test that runs before `ExportMetsIT`. In `IndexingFormIT`, the database was not cleaned up, which caused weird problems in `ExportMetsIT`.