### PR TITLE
Update only necessary dialog in calendar

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/calendarBlocks.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/calendarEdit/calendarBlocks.xhtml
@@ -106,7 +106,7 @@
                                     <p:ajax event="keyup"
                                             delay="300"
                                             listener="#{block.checkIssuesWithSameHeading()}"
-                                            update="editForm:calendarTabView:calendarDetailsLayout"/>
+                                            update="calendarDayDialog"/>
                                 </p:inputText>
                                 <span class="issue-badge"
                                       style="background-color: #{CalendarForm.getIssueColor(rowIndex)};


### PR DESCRIPTION
Updating the broader `calendarDetailsDialog` is not necessary as the value from the inputText is only displayed in the `calendarDayDialog`. 
This fixes an issue, where the broader update also updated the inputText itself, which could lead to missing characters when the update and typing happened at the same time.