### PR TITLE
Fix pagination of single page is not saved

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
@@ -355,6 +355,7 @@ public class PaginationPanel {
         } catch (NumberFormatException e) {
             Helper.setErrorMessage("paginationFormatError", new Object[] { paginationStartValue });
         }
+        dataEditor.getMetadataPanel().update();
         dataEditor.refreshStructurePanel();
         preparePaginationSelectionItems();
         preparePaginationSelectionSelectedItems();


### PR DESCRIPTION
Fixes #6514 

The problem was that the metadata panel was not updated after the pagination, such that the outdated `orderLabel` from the metadata panel was overwriting the pagination value.