### PR TITLE
Prevent NPE in calendar when selecting same granularity twice

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
@@ -223,10 +223,12 @@ public class CalendarForm implements Serializable {
      * @param granularity as org.kitodo.production.model.bibliography.course.Granularity
      */
     public void setGranularity(Granularity granularity) {
-        this.granularity = granularity;
-        course.splitInto(granularity);
-        if (Objects.nonNull(PrimeFaces.current()) && Objects.nonNull(FacesContext.getCurrentInstance())) {
-            PrimeFaces.current().ajax().update("createProcessesConfirmDialog");
+        if (Objects.nonNull(granularity)) {
+            this.granularity = granularity;
+            course.splitInto(granularity);
+            if (Objects.nonNull(PrimeFaces.current()) && Objects.nonNull(FacesContext.getCurrentInstance())) {
+                PrimeFaces.current().ajax().update("createProcessesConfirmDialog");
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #6437 

As @oliver-stoehr suspected, clicking the same `<p:selectOneButton>` twice actually _deselects_ the corresponding button/option - as can be seen in [this PrimeFaces showcase](https://www.primefaces.org/showcase/ui/input/oneButton.xhtml) - which results in _no_ option being selected.

Since we do not support selecting _no_ granularity at all in the calendar tool at the moment, simply ignoring the "deselection" events in the correponding bean action should be enough to effectively prevent the reported NPE.