### PR TITLE
[3.8] Prevent NPE in calendar when selecting same granularity twice

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CalendarForm.java
@@ -226,10 +226,12 @@ public class CalendarForm implements Serializable {
      * @param granularity as org.kitodo.production.model.bibliography.course.Granularity
      */
     public void setGranularity(Granularity granularity) {
-        this.granularity = granularity;
-        course.splitInto(granularity);
-        if (Objects.nonNull(PrimeFaces.current()) && Objects.nonNull(FacesContext.getCurrentInstance())) {
-            PrimeFaces.current().ajax().update("createProcessesConfirmDialog");
+        if (Objects.nonNull(granularity)) {
+            this.granularity = granularity;
+            course.splitInto(granularity);
+            if (Objects.nonNull(PrimeFaces.current()) && Objects.nonNull(FacesContext.getCurrentInstance())) {
+                PrimeFaces.current().ajax().update("createProcessesConfirmDialog");
+            }
         }
     }
 


### PR DESCRIPTION
Backport of #6523 for Kitodo 3.8