### PR TITLE
[3.8] Update ActiveMQ to latest supported 5.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
-                <version>5.18.6</version>
+                <version>5.19.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Switch to the current supported ActiveMQ 5.x version according to https://activemq.apache.org/components/classic/download/