### PR TITLE
[3.8] Made allowed characters of symbolic link name configurable

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -175,6 +175,10 @@ public enum ParameterCore implements ParameterInterface {
      */
     PROCESS_PROPERTY_SYMLINK_NAME(new Parameter<>("processProperty_symLinkName", "")),
 
+    /**
+     * Define the allowed characters used in symbolic link name generation.
+     */
+    ALLOWED_CHARACTERS_FOR_SYMLINK(new Parameter<>("allowedCharactersForSymLink", "[^A-Za-z0-9]")),
     /*
      * Runnotes
      */

--- a/Kitodo/src/main/java/org/kitodo/production/helper/WebDav.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/WebDav.java
@@ -224,10 +224,11 @@ public class WebDav implements Serializable {
                 }
             }
         }
+        String allowedCharacters = ConfigCore.getParameterOrDefaultValue(ParameterCore.ALLOWED_CHARACTERS_FOR_SYMLINK);
         if (propertyValue.isEmpty()) {
-            return Helper.getNormalizedTitle(process.getTitle()).replaceAll("[^A-Za-z0-9]", "_") + "__[" + process.getId() + "]";
+            return Helper.getNormalizedTitle(process.getTitle()).replaceAll(allowedCharacters, "_") + "__[" + process.getId() + "]";
         } else {
-            return Helper.getNormalizedTitle(propertyValue.replaceAll("[^A-Za-z0-9]", "_") + "_" + process.getId());
+            return Helper.getNormalizedTitle(propertyValue.replaceAll(allowedCharacters, "_") + "_" + process.getId());
         }
     }
 

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -184,6 +184,9 @@ script_deleteSymLink=/usr/local/kitodo/scripts/script_deleteSymLink(.sh|.bat)
 # If none is specified or if the property cannot be found the process title will be used by default.
 # processProperty_symLinkName=NameOfProcessProperty
 
+# Allowed characters for symbolic link name. By default, it is set to [^A-Za-z0-9]
+#allowedCharactersForSymLink=[^A-Za-z0-9]
+
 
 # -----------------------------------
 # Runnotes


### PR DESCRIPTION
Backport of #6537 to the `3.8` branch.