### PR TITLE
Expand textareas on page load

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataTreeTable.xhtml
@@ -85,6 +85,15 @@
                                      rows="2"
                                      disabled="#{not item.editable or readOnly}"
                                      styleClass="#{not item.editable or readOnly ? 'read-only disabled' : ''}">
+                         <h:outputScript>
+                            document.addEventListener("DOMContentLoaded", function() {
+                                setTimeout(function() {
+                                document.querySelectorAll("textarea").forEach(function(textarea) {
+                                    textarea.style.height = "auto"; // Reset height first
+                                    textarea.style.height = textarea.scrollHeight + "px"; // Set to content height
+                                });}, 100);
+                            });
+                        </h:outputScript>
                         <p:ajax event="keyup"
                                 delay="300"
                                 oncomplete="preserveMetadata(); #{item.leading ? (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadataWithTable();' : 'updateProcessMetadata();') : (request.requestURI.contains('metadataEditor') ? 'updateTitleMetadata();' : '')}"/>


### PR DESCRIPTION
This PR tries to make a quality of life improvement for disabled textareas. Those textareas might contain text which spans over multiple lines. If the textarea has editing disabled, the box cannot be expanded and the editor does not see the full content. I am using Javascript to expand the textareas to the necessary size.

With this change the editor always sees the full content.

![image](https://github.com/user-attachments/assets/7d6faf8e-e3f2-4ad3-9d18-cd47098c30fd)
