### PR TITLE
Fix linking physical and logical division 

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -257,9 +257,13 @@ public class DivXmlElementAccess extends LogicalDivision {
         }
         div.setORDERLABEL(super.getOrderlabel());
         div.setTYPE(super.getType());
-        smLinkData.addAll(super.getViews().stream().map(View::getPhysicalDivision)
-            .sorted(Comparator.comparing(PhysicalDivision::getOrder)).map(physicalDivisionIDs::get)
-            .map(physicalDivisionId -> Pair.of(metsReferrerId, physicalDivisionId)).collect(Collectors.toList()));
+        if (!super.getViews().isEmpty()) {
+            smLinkData.addAll(super.getViews().stream().map(View::getPhysicalDivision)
+                    .sorted(Comparator.comparing(PhysicalDivision::getOrder)).map(physicalDivisionIDs::get)
+                    .filter(Objects::nonNull)
+                    .map(physicalDivisionId -> Pair.of(metsReferrerId, physicalDivisionId))
+                    .collect(Collectors.toList()));
+        }
 
         Optional<MdSecType> optionalDmdSec = createMdSec(super.getMetadata(), MdSec.DMD_SEC);
         if (optionalDmdSec.isPresent()) {

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/FileXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/FileXmlElementAccess.java
@@ -117,6 +117,7 @@ public class FileXmlElementAccess {
             this.physicalDivision.setOrder(physicalDivision.getOrder());
             this.physicalDivision.setOrderlabel(physicalDivision.getOrderlabel());
             this.physicalDivision.setType(physicalDivision.getType());
+
             if (physicalDivision.hasMediaPartial()) {
                 this.physicalDivision.setMediaPartial(physicalDivision.getMediaPartial());
             }
@@ -133,20 +134,15 @@ public class FileXmlElementAccess {
      * @param mediaFilesToIDFiles
      *            map containing the corresponding XML file element for each
      *            physical division, necessary for linking
-     * @param physicalDivisionIDs
-     *            map with the assigned identifier for each physical division to form
-     *            the link pairs of the struct link section
      * @param mets
      *            the METS structure in which the metadata is added
      * @return a new {@code <div>} element for this physical division
      */
-    DivType toDiv(Map<URI, FileType> mediaFilesToIDFiles,
-            Map<PhysicalDivision, String> physicalDivisionIDs, MetsType mets) {
+    DivType toDiv(Map<URI, FileType> mediaFilesToIDFiles, MetsType mets) {
 
         DivType div = new DivType();
         String divId = physicalDivision.getDivId();
         div.setID(divId);
-        physicalDivisionIDs.put(physicalDivision, divId);
         if (physicalDivision.getOrder() > 0) {
             div.setORDER(BigInteger.valueOf(physicalDivision.getOrder()));
         }

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -410,7 +410,8 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
 
     private DivType generatePhysicalStructMapRecursive(PhysicalDivision physicalDivision, Map<URI, FileType> mediaFilesToIDFiles,
             Map<PhysicalDivision, String> physicalDivisionIDs, MetsType mets) {
-        DivType div = new FileXmlElementAccess(physicalDivision).toDiv(mediaFilesToIDFiles, physicalDivisionIDs, mets);
+        DivType div = new FileXmlElementAccess(physicalDivision).toDiv(mediaFilesToIDFiles, mets);
+        physicalDivisionIDs.put(physicalDivision, div.getID());
         for (PhysicalDivision child : physicalDivision.getChildren()) {
             div.getDiv().add(generatePhysicalStructMapRecursive(child, mediaFilesToIDFiles, physicalDivisionIDs, mets));
         }


### PR DESCRIPTION
- Check if the logical structure has no views and add null filter
- Add the original physical division to the mapping of physical division to divID to prevent faulty comparison

Fixes #6445