### PR TITLE
Fix multiple filters and adapt side wide search

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
@@ -310,14 +310,6 @@ public class FilterMenu {
      * @return value of filterInEditMode
      */
     public String getFilterInEditMode() {
-        Map<String, String> parameters = FacesContext.getCurrentInstance().getExternalContext()
-                .getRequestParameterMap();
-        String input = parameters.get("input");
-        if (StringUtils.isNotBlank(input) && StringUtils.isBlank(filterInEditMode)) {
-            filterInEditMode = input;
-            parsedFilters.clear();
-            submitFilters();
-        }
         return filterInEditMode;
     }
 

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -27,6 +27,12 @@
         <o:viewAction action="#{ProcessForm.changeFilter('project:' += projecttitle)}"
                       if="#{not empty projecttitle}"
                       update="parsedFiltersForm:parsedFilters"/>
+
+        <!--@elvariable id="input" type="java.lang.String"-->
+        <f:viewParam name="input"/>
+        <o:viewAction action="#{ProcessForm.changeFilter('process:'.concat(input))}"
+                      if="#{not empty input}"
+                      update="parsedFiltersForm:parsedFilters"/>
     </f:metadata>
 
     <ui:define name="contentHeader">


### PR DESCRIPTION
This PR tries to fix a bug in current Main Branch. Right now it is not possible to first filter for a project, and then, additionally filter for an open task. The filters always get reset and only the last filter is used. I therefor adapted the logic. This required additional changes to keep the side wide search on the top left working.

Screenshots illustrating the bug:

1. Search for project

![image](https://github.com/user-attachments/assets/e51a8465-d97b-4bf5-be72-05d0a8099ab2)

2. Search additionally for a task

![image](https://github.com/user-attachments/assets/1ce2ebb2-a56a-4835-a1c9-79ee48c5532b)

3. Project filter is completely removed:

![image](https://github.com/user-attachments/assets/b2eb5da1-f07b-4a18-8851-2ee51b1b06ce)


