### PR TITLE
Provide default hibernate.properties file

### DIFF
--- a/Kitodo/src/main/resources/hibernate.properties
+++ b/Kitodo/src/main/resources/hibernate.properties
@@ -1,0 +1,30 @@
+#
+# (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+#
+# This file is part of the Kitodo project.
+#
+# It is licensed under GNU General Public License version 3 or later.
+#
+# For the full copyright and license information, please read the
+# GPL3-License.txt file that was distributed with this source code.
+
+# The Hibernate Search integration into Hibernate ORM will start automatically,
+# at the same time as Hibernate ORM, as soon as it is present in the classpath.
+# If for some reason you need to prevent Hibernate Search from starting, set
+# the boolean property hibernate.search.enabled to false.
+#
+# Kidodo.Production works when this value is set to True.
+
+hibernate.search.enabled=true
+
+
+# the hostname and ports of the Elasticsearch servers to connect to
+
+hibernate.search.backend.hosts=localhost:9205
+
+
+# You may change the protocol used to communicate with the hosts using this
+# configuration property. The default for this property is http. This property
+# may be set to either http or https
+
+hibernate.search.backend.protocol=http

--- a/Kitodo/src/main/resources/hibernate.properties
+++ b/Kitodo/src/main/resources/hibernate.properties
@@ -20,7 +20,7 @@ hibernate.search.enabled=true
 
 # the hostname and ports of the Elasticsearch servers to connect to
 
-hibernate.search.backend.hosts=localhost:9205
+hibernate.search.backend.hosts=localhost:9200
 
 
 # You may change the protocol used to communicate with the hosts using this


### PR DESCRIPTION
Fixes #6552 

Even Kitodo.Production is working without this file as this all default values the file is needed for some other in future implemented changes.