### PR TITLE
Prevent LDAP autocomplete

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
@@ -51,7 +51,7 @@
                              value="#{UserForm.userObject.location}"/>
             </div>
             <!--
-            Use invisible pseudo fields to brevent browser autofill from targeting actual login
+            Use invisible pseudo fields to prevent browser autofill from targeting actual login
             and password fields. Browsers often ignore autocomplete="off", even when passed through with
             pt:autocomplete="off" (using xmlns:pt="http://xmlns.jcp.org/jsf/passthrough" namespace declaration).-->
             <h:panelGroup layout="block" style="position:absolute; left:-9999px; top:-9999px;">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
@@ -50,6 +50,10 @@
                              placeholder="#{msgs.location}"
                              value="#{UserForm.userObject.location}"/>
             </div>
+            <!--
+            Use invisible pseudo fields to brevent browser autofill from targeting actual login
+            and password fields. Browsers often ignore autocomplete="off", even when passed through with
+            pt:autocomplete="off" (using xmlns:pt="http://xmlns.jcp.org/jsf/passthrough" namespace declaration).-->
             <h:panelGroup layout="block" style="position:absolute; left:-9999px; top:-9999px;">
                 <h:inputText value="" readonly="true">
                     <f:passThroughAttribute name="autocomplete" value="username"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
@@ -51,7 +51,7 @@
                              value="#{UserForm.userObject.location}"/>
             </div>
             <!--
-            Use invisible pseudo fields to prevent browser autofill from targeting actual login
+            Use invisible pseudo fields to prevent browser autofill from targeting the ldap login
             and password fields. Browsers often ignore autocomplete="off", even when passed through with
             pt:autocomplete="off" (using xmlns:pt="http://xmlns.jcp.org/jsf/passthrough" namespace declaration).-->
             <h:panelGroup layout="block" style="position:absolute; left:-9999px; top:-9999px;">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/userEdit/details.xhtml
@@ -50,6 +50,14 @@
                              placeholder="#{msgs.location}"
                              value="#{UserForm.userObject.location}"/>
             </div>
+            <h:panelGroup layout="block" style="position:absolute; left:-9999px; top:-9999px;">
+                <h:inputText value="" readonly="true">
+                    <f:passThroughAttribute name="autocomplete" value="username"/>
+                </h:inputText>
+                <h:inputSecret value="" readonly="true">
+                    <f:passThroughAttribute name="autocomplete" value="new-password"/>
+                </h:inputSecret>
+            </h:panelGroup>
             <div>
                 <p:outputLabel for="ldapLogin" value="#{msgs.ldaplogin}"/>
                 <p:inputText id="ldapLogin" class="input" disabled="#{isViewMode || isConfigMode}"


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/6531

One might call it a dirty hack, but injecting two (by using extreme absolute values) invisible boxes was the only reliable way for me to prevent the behaviours of browsers like chrome to autofill the ldap login and the password field.

Using `pt:autocomplete="off"` for injecting autocomplete=off directly in the browser does not work. (using xmlns:pt="http://xmlns.jcp.org/jsf/passthrough" namespace declaration)

