### PR TITLE
[3.8] Create backup before manipulate metadata

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/EditDataScript.java
@@ -107,10 +107,13 @@ public abstract class EditDataScript {
      * @param process the process to save
      */
     public void saveChanges(Workpiece workpiece, Process process) {
-        try (OutputStream out = ServiceManager.getFileService()
-                .write(ServiceManager.getFileService().getMetadataFilePath(process))) {
-            ServiceManager.getMetsService().save(workpiece, out);
-            ServiceManager.getProcessService().saveToIndex(process, false);
+        try {
+            ServiceManager.getFileService().createBackupFile(process);
+            try (OutputStream out = ServiceManager.getFileService()
+                    .write(ServiceManager.getProcessService().getMetadataFileUri(process))) {
+                ServiceManager.getMetsService().save(workpiece, out);
+                ServiceManager.getProcessService().saveToIndex(process, false);
+            }
         } catch (IOException | CustomResponseException | DataException e) {
             logger.error(e.getMessage());
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -262,8 +262,6 @@ public class KitodoScriptService {
                 LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                         .readMetadataFile(process);
                 deleteDataScript.process(metadataFile, process, script);
-                ServiceManager.getMetsService().saveWorkpiece(metadataFile.getWorkpiece(),
-                        ServiceManager.getProcessService().getMetadataFileUri(process));
                 Helper.setMessage("deleteDataOk", currentProcessTitle);
             } catch (IOException | KitodoScriptExecutionException e) {
                 Helper.setErrorMessage("deleteDataError", currentProcessTitle + ": " + e.getMessage(), logger, e);
@@ -311,8 +309,6 @@ public class KitodoScriptService {
                 LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                         .readMetadataFile(process);
                 overwriteDataScript.process(metadataFile, process, script);
-                ServiceManager.getMetsService().saveWorkpiece(metadataFile.getWorkpiece(),
-                        ServiceManager.getProcessService().getMetadataFileUri(process));
                 Helper.setMessage("overwriteDataOk", currentProcessTitle);
             } catch (IOException | KitodoScriptExecutionException e) {
                 Helper.setErrorMessage("overwriteDataError", currentProcessTitle + ": " + e.getMessage(), logger, e);
@@ -382,8 +378,6 @@ public class KitodoScriptService {
                 LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                         .readMetadataFile(process);
                 addDataScript.process(metadataFile, process, script);
-                ServiceManager.getMetsService().saveWorkpiece(metadataFile.getWorkpiece(),
-                        ServiceManager.getProcessService().getMetadataFileUri(process));
                 Helper.setMessage("addDataOk", currentProcessTitle);
             } catch (IOException | KitodoScriptExecutionException e) {
                 Helper.setErrorMessage("addDataError", currentProcessTitle + ": " + e.getMessage(), logger, e);

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -13,6 +13,7 @@ package org.kitodo.production.services.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -26,8 +27,8 @@ import java.util.Map;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kitodo.ExecutionPermission;
 import org.kitodo.MockDatabase;
@@ -232,11 +233,19 @@ public class KitodoScriptServiceIT {
     public void shouldAddDataWithValue() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "LegalNoteAndTermsOfUse";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "PDM1.0");
 
         final List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should not contain metadata beforehand");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:addData " + "key:" + metadataKey + " value:PDM1.0";
         List<Process> processes = new ArrayList<>();
@@ -247,6 +256,10 @@ public class KitodoScriptServiceIT {
         final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
                 .findByMetadata(metadataSearchMap);
         assertEquals(1, processByMetadataAfter.size(), "does not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
@@ -254,11 +267,18 @@ public class KitodoScriptServiceIT {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "LegalNoteAndTermsOfUse";
 
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                 .readMetadataFile(process);
         Workpiece workpiece = metadataFile.getWorkpiece();
         Collection<Metadata> metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(1, metadataOfChapter.size(), "should not contain metadata beforehand");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:addData " + "key:" + metadataKey + " value:PDM1.0" + " type:Chapter";
         List<Process> processes = new ArrayList<>();
@@ -271,6 +291,10 @@ public class KitodoScriptServiceIT {
         workpiece = metadataFile.getWorkpiece();
         metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(2, metadataOfChapter.size(), "metadata should have been added");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
@@ -278,11 +302,18 @@ public class KitodoScriptServiceIT {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMain";
 
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                 .readMetadataFile(process);
         Workpiece workpiece = metadataFile.getWorkpiece();
         Collection<Metadata> metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(1, metadataOfChapter.size(), "should contain metadata beforehand");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:deleteData " + "key:" + metadataKey + " type:Chapter";
         List<Process> processes = new ArrayList<>();
@@ -295,6 +326,10 @@ public class KitodoScriptServiceIT {
         workpiece = metadataFile.getWorkpiece();
         metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(0, metadataOfChapter.size(), "metadata should have been deleted");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
@@ -302,11 +337,18 @@ public class KitodoScriptServiceIT {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMain";
 
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                 .readMetadataFile(process);
         Workpiece workpiece = metadataFile.getWorkpiece();
         Collection<Metadata> metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(1, metadataOfChapter.size(), "should contain metadata beforehand");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:deleteData " + "key:" + metadataKey + " value:test" + " type:Chapter";
         List<Process> processes = new ArrayList<>();
@@ -319,6 +361,10 @@ public class KitodoScriptServiceIT {
         workpiece = metadataFile.getWorkpiece();
         metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(1, metadataOfChapter.size(), "metadata should not have been deleted");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
@@ -326,11 +372,18 @@ public class KitodoScriptServiceIT {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
 
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         LegacyMetsModsDigitalDocumentHelper metadataFile = ServiceManager.getProcessService()
                 .readMetadataFile(process);
         Workpiece workpiece = metadataFile.getWorkpiece();
         Collection<Metadata> metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(1, metadataOfChapter.size(), "should contain metadata beforehand");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:deleteData " + "key:" + metadataKey + " type:Chapter";
         List<Process> processes = new ArrayList<>();
@@ -343,6 +396,10 @@ public class KitodoScriptServiceIT {
         workpiece = metadataFile.getWorkpiece();
         metadataOfChapter = workpiece.getLogicalStructure().getChildren().get(0).getMetadata();
         assertEquals(1, metadataOfChapter.size(), "metadata should not have been deleted");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
@@ -372,11 +429,19 @@ public class KitodoScriptServiceIT {
     public void shouldAddDataWithWhitespace() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "LegalNoteAndTermsOfUse";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "legal note");
 
         final List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap, true);
         assertEquals(0, processByMetadata.size(), "should not contain metadata beforehand");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:addData " + "key:" + metadataKey + " \"value:legal note\"";
         List<Process> processes = new ArrayList<>();
@@ -387,11 +452,21 @@ public class KitodoScriptServiceIT {
         final List<ProcessDTO> processByMetadataAfter = ServiceManager.getProcessService()
                 .findByMetadata(metadataSearchMap, true);
         assertEquals(1, processByMetadataAfter.size(), "does not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldAddDataWithMultipleScripts() throws Exception {
+        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "LegalNoteAndTermsOfUse";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "legal note");
 
@@ -406,7 +481,6 @@ public class KitodoScriptServiceIT {
 
         String script = "action:addData " + "key:" + metadataKey + " value:legal note;" + "key:" + metadataKey + " value:secondNote";
         List<Process> processes = new ArrayList<>();
-        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         processes.add(process);
         KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();
         kitodoScript.execute(processes, script);
@@ -415,17 +489,29 @@ public class KitodoScriptServiceIT {
         assertEquals(1, processByMetadataAfter.size(), "does not contain metadata");
         processByMetadataAfter = ServiceManager.getProcessService().findByMetadata(secondMetadataSearchMap);
         assertEquals(1, processByMetadataAfter.size(), "does not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldCopyDataWithSource() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "LegalNoteAndTermsOfUse";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "Proc");
 
         List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(0, processByMetadata.size(), "does not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:addData " + "key:" + metadataKey + " source:TSL_ATS";
         List<Process> processes = new ArrayList<>();
@@ -436,17 +522,29 @@ public class KitodoScriptServiceIT {
         Thread.sleep(2000);
         processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(1, processByMetadata.size(), "does not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldAddDataWithVariable() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "LegalNoteAndTermsOfUse";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, String.valueOf(kitodoScriptTestProcessId));
 
         List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(0, processByMetadata.size(), "does not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:addData " + "key:" + metadataKey + " variable:(processid)";
         List<Process> processes = new ArrayList<>();
@@ -457,17 +555,29 @@ public class KitodoScriptServiceIT {
         Thread.sleep(2000);
         processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(1, processByMetadata.size(), "does not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldDeleteData() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
         List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(1, processByMetadata.size(), "should contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:deleteData " + "key:" + metadataKey;
         List<Process> processes = new ArrayList<>();
@@ -478,12 +588,21 @@ public class KitodoScriptServiceIT {
         Thread.sleep(2000);
         processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldDeleteDataWithValue() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
@@ -499,11 +618,20 @@ public class KitodoScriptServiceIT {
         Thread.sleep(2000);
         processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
     @Test
     public void shouldDeleteAllDataWithSameKey() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TSL_ATS";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "Proc");
 
@@ -519,17 +647,29 @@ public class KitodoScriptServiceIT {
         Thread.sleep(2000);
         processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldDeleteDataWithSource() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
         List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(1, processByMetadata.size(), "should contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:deleteData " + "key:" + metadataKey + " source:TitleDocMainShort";
         List<Process> processes = new ArrayList<>();
@@ -540,17 +680,29 @@ public class KitodoScriptServiceIT {
         Thread.sleep(2000);
         processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should not contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldNotDeleteDataWithValue() throws Exception {
         Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> metadataSearchMap = new HashMap<>();
         metadataSearchMap.put(metadataKey, "SecondMetaShort");
 
         List<ProcessDTO> processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(1, processByMetadata.size(), "should contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
 
         String script = "action:deleteData" + " key:" + metadataKey + " value:SecondMetaLong";
         List<Process> processes = new ArrayList<>();
@@ -561,11 +713,21 @@ public class KitodoScriptServiceIT {
         Thread.sleep(2000);
         processByMetadata = ServiceManager.getProcessService().findByMetadata(metadataSearchMap);
         assertEquals(1, processByMetadata.size(), "should still contain metadata");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldOverwriteDataWithValue() throws Exception {
+        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> oldMetadataSearchMap = new HashMap<>();
         oldMetadataSearchMap.put(metadataKey, "SecondMetaShort");
 
@@ -578,7 +740,9 @@ public class KitodoScriptServiceIT {
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should contain new metadata value");
 
-        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
+
         String script = "action:overwriteData " + "key:" + metadataKey + " value:Overwritten";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
@@ -591,11 +755,21 @@ public class KitodoScriptServiceIT {
 
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
         assertEquals(1, processByMetadata.size(), "should contain new metadata value");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldOverwriteDataWithSource() throws Exception {
+        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> oldMetadataSearchMap = new HashMap<>();
         oldMetadataSearchMap.put(metadataKey, "SecondMetaShort");
 
@@ -608,7 +782,9 @@ public class KitodoScriptServiceIT {
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should contain new metadata value");
 
-        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
+
         String script = "action:overwriteData " + "key:" + metadataKey + " source:TitleDocMain";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
@@ -621,11 +797,21 @@ public class KitodoScriptServiceIT {
 
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
         assertEquals(1, processByMetadata.size(), "should contain new metadata value");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 
     @Test
     public void shouldOverwriteDataWithVariable() throws Exception {
+        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
         String metadataKey = "TitleDocMainShort";
+
+        File processDir = new File(ConfigCore.getKitodoDataDirectory(), process.getId().toString());
+        File mainMetsFile = new File(processDir, "meta.xml");
+        File backupMetsFile = new File(processDir, "meta.xml.1");
+
         HashMap<String, String> oldMetadataSearchMap = new HashMap<>();
         oldMetadataSearchMap.put(metadataKey, "SecondMetaShort");
 
@@ -638,7 +824,9 @@ public class KitodoScriptServiceIT {
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
         assertEquals(0, processByMetadata.size(), "should contain new metadata value");
 
-        Process process = ServiceManager.getProcessService().getById(kitodoScriptTestProcessId);
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertFalse(backupMetsFile.exists(), "Backup file meta.xml.1 should not exist");
+
         String script = "action:overwriteData " + "key:" + metadataKey + " variable:(processid)";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
@@ -651,5 +839,9 @@ public class KitodoScriptServiceIT {
 
         processByMetadata = ServiceManager.getProcessService().findByMetadata(newMetadataSearchMap);
         assertEquals(1, processByMetadata.size(), "should contain new metadata value");
+
+        assertTrue(mainMetsFile.exists(), "File meta.xml should exist");
+        assertTrue(backupMetsFile.exists(), "Backup file meta.xml.1 should exist");
+        assertNotEquals(mainMetsFile.length(), backupMetsFile.length(), "meta.xml and meta.xml.1 should not have same size");
     }
 }


### PR DESCRIPTION
Fix #5726 for the 3.8.x branch. Will be ported to the main branch too.