### PR TITLE
Remove leftovers from previous search index implementation

### DIFF
--- a/Kitodo-DataManagement/src/test/java/org/kitodo/MockIndex.java
+++ b/Kitodo-DataManagement/src/test/java/org/kitodo/MockIndex.java
@@ -8,14 +8,15 @@
  * For the full copyright and license information, please read the
  * GPL3-License.txt file that was distributed with this source code.
  */
+
 package org.kitodo;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+
 import org.apache.commons.io.FileUtils;
-import org.kitodo.config.ConfigMain;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.node.Node;
@@ -29,7 +30,7 @@ public class MockIndex {
 
     public static void startNode() throws Exception {
         final String nodeName = "index";
-        final String port = ConfigMain.getParameter("elasticsearch.port", "9205");
+        final String port = "9205"; // defined in test resources file hibernate.cfg.xml
         Environment environment = prepareEnvironment(port, nodeName, Paths.get("target", "classes"));
         removeOldDataDirectories("target/" + nodeName);
         node = new ExtendedNode(environment, Collections.singleton(Netty4Plugin.class));

--- a/Kitodo-DataManagement/src/test/resources/kitodo_config.properties
+++ b/Kitodo-DataManagement/src/test/resources/kitodo_config.properties
@@ -8,7 +8,3 @@
 # For the full copyright and license information, please read the
 # GPL3-License.txt file that was distributed with this source code.
 #
-
-elasticsearch.port=9205
-elasticsearch.index=testindex
-elasticsearch.useAuthentication=false

--- a/Kitodo-Query-URL-Import/src/test/resources/kitodo_config.properties
+++ b/Kitodo-Query-URL-Import/src/test/resources/kitodo_config.properties
@@ -41,9 +41,6 @@ metadataLanguage.list=Deutsch-de&English-en
 # -----------------------------------
 numberOfMetaBackups=2
 directory.modules=modules/
-elasticsearch.port=9205
-elasticsearch.index=testindex
-elasticsearch.useAuthentication=false
 directory.config=src/test/resources/
 directory.users=src/test/resources/users/
 

--- a/Kitodo/src/main/java/org/kitodo/config/ConfigCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/ConfigCore.java
@@ -12,8 +12,6 @@
 package org.kitodo.config;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.time.Duration;
 import java.time.temporal.TemporalUnit;
 import java.util.NoSuchElementException;
@@ -23,7 +21,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.beans.Parameter;
 import org.kitodo.config.enums.ParameterCore;
-import org.kitodo.config.enums.ParameterInterface;
 import org.kitodo.exceptions.ConfigParameterException;
 
 public class ConfigCore extends KitodoConfig {
@@ -176,26 +173,5 @@ public class ConfigCore extends KitodoConfig {
      */
     public static String getKitodoDiagramDirectory() {
         return getParameter(ParameterCore.DIR_DIAGRAMS);
-    }
-
-    /**
-     * Returns the URL of the search server.
-     * 
-     * @return the URL
-     * @throws MalformedURLException
-     *             if an unknown protocol, or the port is a negative number
-     *             other than -1
-     */
-    public static URL getSearchServerUrl() throws MalformedURLException {
-        String host = getParameter("elasticsearch.host", "localhost");
-        int port = getIntParameter(new ParameterInterface() {
-            @Override
-            public String getName() {
-                return "elasticsearch.port";
-            }
-        }, 9200);
-        String protocol = getParameter("elasticsearch.protocol", "http");
-        String path = getParameter("elasticsearch.path", "/");
-        return new URL(protocol, host, port, path);
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -638,15 +638,6 @@ public enum ParameterCore implements ParameterInterface {
             TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS))),
 
     /*
-     * Elasticsearch properties
-     */
-    ELASTICSEARCH_INDEXLIMIT(new Parameter<>("elasticsearch.indexLimit", 5000)),
-    ELASTICSEARCH_BATCH(new Parameter<>("elasticsearch.batch", 500)),
-    ELASTICSEARCH_ATTEMPTS(new Parameter<>("elasticsearch.attempts", 10)),
-    ELASTICSEARCH_TIME_BETWEEN_ATTEMPTS(new Parameter<>("elasticsearch.timeBetweenAttempts", 2000)),
-    ELASTICSEARCH_THREADS(new Parameter<>("elasticsearch.threads", 4)),
-
-    /*
      * Security properties
      */
 

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -649,52 +649,6 @@ activeMQ.kitodoScript.allow=createFolders&export&searchForMedia
 #activeMQ.createNewProcesses.queue=KitodoProduction.CreateNewProcesses.Queue
 
 
-# -----------------------------------
-# Elasticsearch properties
-# -----------------------------------
-
-elasticsearch.host=localhost
-elasticsearch.port=9200
-elasticsearch.protocol=http
-# path information must start and end with a slash, f.e. "/elastic_search/"
-elasticsearch.path=/
-elasticsearch.index=kitodo
-elasticsearch.useAuthentication=true
-elasticsearch.user=kitodo
-elasticsearch.password=kitodo
-
-# The maximum number of ElasticSearch documents that are retrieved from the 
-# index using a single request to the index. This value is restricted by the 
-# ElasticSearch setting 'max_result_window' (usually around 10.000). 
-# It affects the process that tries to match already indexed objects with their
-# corresponding database objects in order to find any indexed objects that 
-# have recently been deleted in the database (and thus, should also be deleted
-# in the index). The implementation of this feature is incomplete, though.
-elasticsearch.indexLimit=5000
-
-# The number of database objects that are queried and indexed in one batch 
-# while indexing all database objects. A larger batch size might improve 
-# performance but requires more RAM, default=250.
-elasticsearch.batch=250
-
-# The number of times a batch indexing job is repeated if there is some kind of 
-# error until the indexing is given up for good. For example, if ElasticSearch 
-# is temporarily not available, the indexing will be tried x-times, default 10.
-elasticsearch.attempts=10
-
-# The waiting time between individual indexing attempts in case of any error 
-# in milliseconds, default 2000ms. This means (with attempts set to 10) the 
-# indexing is given up after a total of 20 seconds of continuous errors.
-elasticsearch.timeBetweenAttempts=2000
-
-# The number of parallel worker threads that are used to index all database 
-# objects. Depending on your hardware, this should be roughly equivalent to 
-# the number of cpu cores. Keep in mind that with each thread there is an 
-# additional memory overhead, which could cause problems in case there is not
-# enough RAM available.
-elasticsearch.threads=4
-
-
 # =============================================================================
 #      CONFIGURATION OF PLUG-INS
 # =============================================================================

--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -54,7 +54,6 @@ import org.kitodo.api.externaldatamanagement.ImportConfigurationType;
 import org.kitodo.api.externaldatamanagement.SearchInterfaceType;
 import org.kitodo.api.schemaconverter.FileFormat;
 import org.kitodo.api.schemaconverter.MetadataFormat;
-import org.kitodo.config.ConfigMain;
 import org.kitodo.data.database.beans.Authority;
 import org.kitodo.data.database.beans.Batch;
 import org.kitodo.data.database.beans.Client;
@@ -142,7 +141,7 @@ public class MockDatabase {
 
     public static void startNode() throws Exception {
         final String nodeName = "index";
-        final String port = ConfigMain.getParameter("elasticsearch.port", "9205");
+        final String port = "9205"; // defined in test resources file hibernate.cfg.xml
         Environment environment = prepareEnvironment(port, nodeName, Paths.get("target", "classes"));
         removeOldDataDirectories("target/" + nodeName);
         node = new ExtendedNode(environment, Collections.singleton(Netty4Plugin.class));

--- a/Kitodo/src/test/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/kitodo_config.properties
@@ -41,11 +41,6 @@ metadataLanguage.list=Deutsch-de&English-en
 # -----------------------------------
 numberOfMetaBackups=2
 directory.modules=modules/
-elasticsearch.port=9205
-# path information must start and end with a slash, f.e. "/elastic_search/"
-elasticsearch.path=/
-elasticsearch.index=testindex
-elasticsearch.useAuthentication=false
 directory.config=src/test/resources/
 directory.users=src/test/resources/users/
 

--- a/Kitodo/src/test/resources/log4j2.xml
+++ b/Kitodo/src/test/resources/log4j2.xml
@@ -28,12 +28,6 @@
             <AppenderRef ref="STDOUT"/>
         </Logger>
 
-        <!-- KitodoRestClient log level set to info to reduce log output on automatic execution -->
-        <!-- in case of errors with elastic search set it to debug or trace -->
-        <Logger name="org.kitodo.data.elasticsearch.KitodoRestClient" level="info" additivity="false">
-            <AppenderRef ref="STDOUT"/>
-        </Logger>
-
         <Logger name="org.opensearch.node" level="info" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </Logger>

--- a/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
@@ -474,12 +474,5 @@ useWebApi=true
 # You can provide a queue from which messages are read to finalise steps
 #activeMQ.finaliseStep.queue=KitodoProduction.FinaliseStep.Queue
 
-# Elasticsearch properties
-elasticsearch.host=localhost
-elasticsearch.protocol=http
-elasticsearch.index=testindex
-elasticsearch.port=9205
-# path information must start and end with a slash, f.e. "/elastic_search/"
-elasticsearch.path=/
 # deactivate mandatory metadata validation during process creation for selenium test
 metadataValidationOptionalDuringProcessCreation=true

--- a/Kitodo/src/test/resources/selenium/resources/log4j2.xml
+++ b/Kitodo/src/test/resources/selenium/resources/log4j2.xml
@@ -27,11 +27,6 @@
         <Logger name="org.kitodo" level="debug" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </Logger>
-        <!-- KitodoRestClient log level set to info to reduce log output on automatic execution -->
-        <!-- in case of errors with elastic search set it to debug or trace -->
-        <Logger name="org.kitodo.data.elasticsearch.KitodoRestClient" level="info" additivity="false">
-            <AppenderRef ref="STDOUT"/>
-        </Logger>
         <Root level="error">
             <AppenderRef ref="STDOUT"/>
         </Root>


### PR DESCRIPTION
Fixes #6551 

- old "elasticsearch" options which are not used anymore got removed
- log configuration entries from not existing classes got removed
- used ports inside tests are now hard coded but this should be fine as they did not change in a regular way