### PR TITLE
Fix physical divisions cannot be deleted in physical structure tree

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -262,7 +262,9 @@ public class StructurePanel implements Serializable {
                         return;
                     }
 
-                    dataEditor.getUnsavedDeletedMedia().add(physicalDivision);
+                    if (!physicalDivision.getMediaFiles().isEmpty()) {
+                        dataEditor.getUnsavedDeletedMedia().add(physicalDivision);
+                    }
                 }
             }
         }
@@ -272,12 +274,12 @@ public class StructurePanel implements Serializable {
      * Delete all currently selected physical divisons.
      */
     public void deleteSelectedPhysicalDivisions() {
-        if (Objects.isNull(selectedLogicalNodes)) {
+        if (Objects.isNull(selectedPhysicalNodes)) {
             // there is nothing to do
             return;
         }
-        for (TreeNode selectedLogicalNode : selectedLogicalNodes) {
-            deleteSelectedPhysicalDivision(selectedLogicalNode);
+        for (TreeNode selectedPhysicalNode : selectedPhysicalNodes) {
+            deleteSelectedPhysicalDivision(selectedPhysicalNode);
         }
 
         int i = 1;


### PR DESCRIPTION
When adding physical divisions to the physical structure tree (in separate structure tree mode), they currently cannot be removed via right-click and selecting "Remove Element".

This pull request fixes this problem.

https://github.com/user-attachments/assets/329a80b4-0d4b-4a19-93cc-116ebc806b06

