### PR TITLE
Changes to search

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -979,18 +979,6 @@ public class Process extends BaseTemplateBean {
     }
 
     /**
-     * When indexing, outputs the index keywords for searching by project name.
-     * 
-     * @return the index keywords for searching by project name
-     */
-    @Transient
-    @FullTextField(name = "searchProject")
-    @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
-    public String getKeywordsForSearchingByProjectName() {
-        return initializeKeywords().getSearchProject();
-    }
-
-    /**
      * When indexing, outputs the index keywords for searching for assignment to
      * batches.
      * 

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -991,19 +991,6 @@ public class Process extends BaseTemplateBean {
         return initializeKeywords().getSearchBatch();
     }
 
-    /**
-     * When indexing, outputs the index keywords for searching for task
-     * information.
-     * 
-     * @return the index keywords for searching for task information
-     */
-    @Transient
-    @FullTextField(name = "searchTask")
-    @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
-    public String getKeywordsForSearchingForTaskInformation() {
-        return initializeKeywords().getSearchTask();
-    }
-
     private ProcessKeywords initializeKeywords() {
         if (this.processKeywords == null) {
             ProcessKeywords indexingKeyworder = new ProcessKeywords(this);

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
@@ -430,16 +430,6 @@ class ProcessKeywords {
     }
 
     /**
-     * Returns the search keywords for the project name search. These are the
-     * words from the project name in normalized form.
-     * 
-     * @return search keywords for the project
-     */
-    public String getSearchProject() {
-        return String.join(" ", projectKeywords);
-    }
-
-    /**
      * Returns the search keywords for searching for operations assigned to a
      * batch. The same splitting criteria apply as for the title.
      * 

--- a/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
@@ -21,7 +21,7 @@ public enum FilterString {
     TASKDONETITLE("stepdonetitle:", "abgeschlossenerschritttitel:"),
     TASKDONEUSER("stepdoneuser:", "abgeschlossenerschrittbenutzer:"),
     PROJECT("project:", "projekt:"),
-    PROJECT_EXACT("projectexact:", "projektexakt:"),
+    PROJECT_LOOSE("project_loose:", "projekt_trunkiert:"),
     ID("id:", "id:"),
     PARENTPROCESSID("parentprocessid:", "elternprozessid:"),
     PROCESS("process:", "prozess:"),

--- a/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
@@ -41,7 +41,7 @@ public class FilterMenu {
             FilterString.TASKOPEN,
             FilterString.TASKDONE,
             FilterString.PROJECT,
-            FilterString.PROJECT_EXACT,
+            FilterString.PROJECT_LOOSE,
             FilterString.ID,
             FilterString.PARENTPROCESSID,
             FilterString.PROCESS,
@@ -53,7 +53,7 @@ public class FilterMenu {
             FilterString.TASKINWORK,
             FilterString.TASKOPEN,
             FilterString.PROJECT,
-            FilterString.PROJECT_EXACT,
+            FilterString.PROJECT_LOOSE,
             FilterString.ID,
             FilterString.PROCESS,
             FilterString.BATCH,
@@ -220,7 +220,7 @@ public class FilterMenu {
                 suggestions.addAll(createStringSuggestionsMatchingInput(input, filterService.initStepTitles(), FilterPart.VALUE));
                 break;
             case PROJECT:
-            case PROJECT_EXACT:
+            case PROJECT_LOOSE:
                 suggestions.addAll(createStringSuggestionsMatchingInput(input, filterService.initProjects(), FilterPart.VALUE));
                 break;
             case PROPERTY:
@@ -257,7 +257,7 @@ public class FilterMenu {
                 suggestions.addAll(createStringSuggestionsMatchingInput(input, filterService.initStepTitles(), FilterPart.VALUE));
                 break;
             case PROJECT:
-            case PROJECT_EXACT:
+            case PROJECT_LOOSE:
                 suggestions.addAll(createStringSuggestionsMatchingInput(input, filterService.initProjects(), FilterPart.VALUE));
                 break;
             case PROPERTY:

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DatabaseQueryPart.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DatabaseQueryPart.java
@@ -60,8 +60,9 @@ public class DatabaseQueryPart implements UserSpecifiedFilter {
         }
         if (asteriskAllowed) {
             return value.replace("*", "%");
-        } else
+        } else {
             return value;
+        }
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DatabaseQueryPart.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DatabaseQueryPart.java
@@ -37,7 +37,31 @@ public class DatabaseQueryPart implements UserSpecifiedFilter {
     DatabaseQueryPart(FilterField filterField, String value, boolean operand) {
         this.filterField = filterField;
         this.operand = operand;
-        this.value = value;
+        this.value = likeValue(filterField.getLikeSearch(), value);
+    }
+
+    /**
+     * Returns a value like the search value, depending on the like search mode
+     * specified for the search field.
+     * 
+     * @param likeSearch
+     *            like search setting
+     * @param value
+     *            user entered search value
+     * @return search value for like search
+     */
+    private static final String likeValue(LikeSearch likeSearch, String value) {
+        boolean asteriskAllowed = Objects.equals(likeSearch, LikeSearch.ALLOWED);
+        if (!asteriskAllowed) {
+            value = value.replace("*", "");
+        }
+        if (Objects.equals(likeSearch, LikeSearch.ALWAYS_RIGHT)) {
+            return value.concat("%");
+        }
+        if (asteriskAllowed) {
+            return value.replace("*", "%");
+        } else
+            return value;
     }
 
     /**
@@ -71,7 +95,8 @@ public class DatabaseQueryPart implements UserSpecifiedFilter {
             return SQL_FALSE;
         }
         query = query.contains("~") ? query.replace("~", varName) : varName + '.' + query;
-        query = query.contains("#") ? query.replace("#", parameterName) : query + " = :" + parameterName;
+        query = query.contains("#") ? query.replace("#", parameterName)
+                : query + (value.contains("%") ? " LIKE :" : " = :") + parameterName;
         return operand ? query : "NOT (" + query + ')';
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
@@ -30,34 +30,34 @@ enum FilterField {
             null, null, null),
     BATCH("process.batches AS batch WITH batch.title", "process.batches AS batch WITH batch.title",
             LikeSearch.NO, "batches AS batch WITH batch.id", "process.batches AS batch WITH batch.id", null, null, null),
-    TASK("tasks AS task WITH task.title", "title", LikeSearch.NO, "tasks AS task WITH task.id", "id", null, "searchTask", null),
+    TASK("tasks AS task WITH task.title", "title", LikeSearch.NO, "tasks AS task WITH task.id", "id", null, null, null),
     TASK_AUTOMATIC("tasks AS task WITH task.typeAutomatic = :queryObject AND task.title",
             "~.typeAutomatic = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.typeAutomatic = :queryObject AND task.id", "typeAutomatic = :queryObject AND id",
-            Boolean.TRUE, "searchTask", "automatic"),
+            Boolean.TRUE, null, null),
     TASK_UNREADY("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.LOCKED, "searchTask", "locked"),
+            "processingStatus = :queryObject AND id", TaskStatus.LOCKED, null, null),
     TASK_READY("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.OPEN, "searchTask", "open"),
+            "processingStatus = :queryObject AND id", TaskStatus.OPEN, null, null),
     TASK_ONGOING("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.INWORK, "searchTask", "inwork"),
+            "processingStatus = :queryObject AND id", TaskStatus.INWORK, null, null),
     TASK_FINISHED("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.DONE, "searchTask", "closed"),
+            "processingStatus = :queryObject AND id", TaskStatus.DONE, null, null),
     TASK_FINISHED_USER(
             "tasks AS task WITH task.processingStatus = :queryObject AND (task.processingUser.name = # OR task.processingUser.surname = # "
                     .concat("OR task.processingUser.login = # OR task.processingUser.ldapLogin = #)"),
             "~.processingStatus = :queryObject AND (~.processingUser.name = # OR ~.processingUser.surname = # "
                     .concat("OR ~.processingUser.login = # OR ~.processingUser.ldapLogin = #)"), LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.processingUser.id",
-            "processingStatus = :queryObject AND processingUser.id", TaskStatus.DONE, "searchTask", "closeduser");
+            "processingStatus = :queryObject AND processingUser.id", TaskStatus.DONE, null, null);
 
     /**
      * Here the string search field names (user input) are mapped to the

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LikeSearch.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LikeSearch.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+package org.kitodo.production.services.data;
+
+/**
+ * Specifies whether like search is enabled, or always enabled, on the database
+ * field.
+ */
+enum LikeSearch {
+    /**
+     * Like search is possible, but must be activated with the search operator
+     * {@code *}. A {@code *} in the search query is not filtered and is
+     * converted to a {@code %} at the end.
+     */
+    ALLOWED,
+
+    /**
+     * A like right search is always carried out. A {@code *} in the search
+     * query is filtered out, and a {@code %} is always appended at the end.
+     */
+    ALWAYS_RIGHT,
+
+    /**
+     * Like search is not allowed. A {@code *} in the search query is filtered
+     * out.
+     */
+    NO
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LikeSearch.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LikeSearch.java
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please read the
  * GPL3-License.txt file that was distributed with this source code.
  */
+
 package org.kitodo.production.services.data;
 
 /**


### PR DESCRIPTION
**Changes to the project search**

The project search is now only performed in the database. The search index field `searchProject` has been deleted. Searching with the "project:" search field is now also possible using the SQL `LIKE` operator. If a "*" is entered as the symbol, a left-truncated search is also possible, for example, "project:*eitungen." The "project_loose:" field always searches with a right-truncated search.

**Changes to task search**

The task search is now performed only on the database. The search index field `searchTask` has been deleted.