### PR TITLE
Change CSS width of search and filter boxes

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -172,11 +172,13 @@ body.first-visit #portal-header {
 #portal-search {
     margin-left: var(--default-double-size);
     margin-right: var(--default-full-size);
+    width:45%
 }
 
 #portal-search form {
     background: var(--focused-blue);
     border-radius: var(--default-border-radius);
+    width: 100%;
     display: table;
     white-space: nowrap;
 }
@@ -852,7 +854,7 @@ label.ui-outputlabel[for] {
 
 #filterMenuWrapper {
     min-width: 430px;
-    width: 35%;
+    width: 50%;
 }
 
 #filterMenuWrapper > .ui-inputgroup {


### PR DESCRIPTION
This PR increases the width of the search and filter boxes to improve visibility of long inputs:

Before:

![image](https://github.com/user-attachments/assets/5ed61fe9-f7d4-4990-aabd-180d03a76238)


After:

![image](https://github.com/user-attachments/assets/b0efc4fd-d8a2-486f-9a60-7c4b6d2f474f)
