### PR TITLE
Remove startup of MockDatabase in unit test ProcessDataTabTest

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/production/forms/createprocess/ProcessDataTabTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/createprocess/ProcessDataTabTest.java
@@ -15,10 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kitodo.MockDatabase;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Ruleset;
 import org.kitodo.production.helper.TempProcess;
@@ -27,17 +24,6 @@ import org.kitodo.test.utils.ProcessTestUtils;
 import org.primefaces.model.DefaultTreeNode;
 
 public class ProcessDataTabTest {
-
-    @BeforeAll
-    public static void setUp() throws Exception {
-        MockDatabase.startNode();
-    }
-
-    @AfterAll
-    public static void tearDown() throws Exception {
-        MockDatabase.stopNode();
-        MockDatabase.cleanDatabase();
-    }
 
     /**
      * Test the generation of atstsl fields.


### PR DESCRIPTION
I saw that the ProcessDataTabTest boots up a Database and an Index although there is no database or index driven integration test. This slows down `mvn install` (with tests) and could be avoided to speed up the build.