### PR TITLE
[3.8] Add missing default namespace to EAD processing via SAX parser

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
@@ -265,6 +265,8 @@ public class ImportEadProcessesThread extends EmptyTask {
             if (StringUtils.isNotBlank(prefix)) {
                 content = content.replace(">", " xmlns:" + namespace.getPrefix() + "=\""
                         + namespace.getNamespaceURI() + "\">");
+            } else {
+                content = content.replace(">", " xmlns=\"" + namespace.getNamespaceURI() + "\">");
             }
         }
         return removeDefaultNamespaceUri(content);

--- a/Kitodo/src/test/resources/importRecords/eadCollection.xml
+++ b/Kitodo/src/test/resources/importRecords/eadCollection.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ead audience="external">
+<ead audience="external"
+     xmlns="urn:isbn:1-931666-22-9">
   <eadheader countryencoding="iso3166-1"
              dateencoding="iso8601"
              langencoding="iso639-2b"

--- a/Kitodo/src/test/resources/xslt/ead2kitodo.xsl
+++ b/Kitodo/src/test/resources/xslt/ead2kitodo.xsl
@@ -13,7 +13,8 @@
 -->
 
 <xsl:stylesheet version="2.0"
-                xmlns:ead="urn:isbn:1-931666-22-9"
+                xmlns="urn:isbn:1-931666-22-9"
+                xpath-default-namespace="urn:isbn:1-931666-22-9"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:mets="http://www.loc.gov/METS/"
                 xmlns:kitodo="http://meta.kitodo.org/v1/">

--- a/Kitodo/src/test/resources/xslt/eadParent2kitodo.xsl
+++ b/Kitodo/src/test/resources/xslt/eadParent2kitodo.xsl
@@ -14,6 +14,7 @@
 
 <xsl:stylesheet version="2.0"
                 xmlns="urn:isbn:1-931666-22-9"
+                xpath-default-namespace="urn:isbn:1-931666-22-9"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:mets="http://www.loc.gov/METS/"
                 xmlns:kitodo="http://meta.kitodo.org/v1/">


### PR DESCRIPTION
This pull request fixes a bug where XML default namespaces in imported EAD collection files where not processed correctly when individually parsing XML fragments during the SAX parser based metadata mass import. 