### PR TITLE
Add LTP validation condition operation to check for non empty value

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/validation/longtermpreservation/LtpValidationConditionOperation.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/validation/longtermpreservation/LtpValidationConditionOperation.java
@@ -52,5 +52,10 @@ public enum LtpValidationConditionOperation {
      * The extracted value matches the provided regular expression without
      * considering letter casing.
      */
-    MATCHES
+    MATCHES,
+
+    /**
+     * There is a non-empty value present. The exact value does not matter.
+     */
+    NON_EMPTY
 }

--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/conditions/LtpValidationConditionEvaluator.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/conditions/LtpValidationConditionEvaluator.java
@@ -288,6 +288,28 @@ public class LtpValidationConditionEvaluator {
     }
 
     /**
+     * Evaluate a validation condition that checks whether the value is at least
+     * not empty.
+     * 
+     * @param value
+     *            the value extracted from the image
+     * @param condition
+     *            the condition
+     * @return the condition result
+     */
+    private static LtpValidationConditionResult evaluateNonEmptyCondition(String value,
+            LtpValidationConditionInterface condition) {
+        if (Objects.nonNull(condition.getValues()) && condition.getValues().size() > 0) {
+            return getConditionIncorrectNumberOfValuesResult(value);
+        }
+
+        if (value.trim().isEmpty()) {
+            return getConditionFalseResult(value);
+        }
+        return new LtpValidationConditionResult(true, null, value);
+    }
+
+    /**
      * Evaluates a single validation condition against the property values
      * extracted from an image.
      * 
@@ -323,6 +345,8 @@ public class LtpValidationConditionEvaluator {
             return evaluateSmallerThanCondition(value, condition);
         } else if (condition.getOperation().equals(LtpValidationConditionOperation.IN_BETWEEN)) {
             return evaluateInBetweenThanCondition(value, condition);
+        } else if (condition.getOperation().equals(LtpValidationConditionOperation.NON_EMPTY)) {
+            return evaluateNonEmptyCondition(value, condition);
         }
 
         // unknown operation

--- a/Kitodo-LongTermPreservationValidation/src/test/java/org/kitodo/longtermpreservationvalidation/LongTermPreservationValidationIT.java
+++ b/Kitodo-LongTermPreservationValidation/src/test/java/org/kitodo/longtermpreservationvalidation/LongTermPreservationValidationIT.java
@@ -313,6 +313,32 @@ public class LongTermPreservationValidationIT {
                 .equals(LtpValidationConditionError.PATTERN_INVALID_SYNTAX));
     }
 
+    /**
+     * Check that a validation condition for non-empty values is valid.
+     */
+    @Test
+    public void testValidNonEmptyConditionOperation() {
+        LongTermPreservationValidationInterface validator = new LongTermPreservationValidation();
+
+        LtpValidationCondition wrongValuesCondition = new LtpValidationCondition("imageWidth",
+                LtpValidationConditionOperation.NON_EMPTY, Arrays.asList("60"),
+                LtpValidationConditionSeverity.ERROR);
+
+        LtpValidationCondition validCondition = new LtpValidationCondition("imageWidth",
+                LtpValidationConditionOperation.NON_EMPTY, Collections.emptyList(),
+                LtpValidationConditionSeverity.ERROR);
+
+        assert (validator
+                .validate(TIF_URI, FileType.TIFF,
+                    Arrays.asList(new LtpValidationCondition[] { wrongValuesCondition }))
+                .getState().equals(LtpValidationResultState.ERROR));
+
+        assert (validator
+                .validate(TIF_URI, FileType.TIFF,
+                    Arrays.asList(new LtpValidationCondition[] { validCondition }))
+                .getState().equals(LtpValidationResultState.VALID));
+    }
+
     private LtpValidationResultState simpleValidateFile(URI file, FileType fileType) {
         LongTermPreservationValidationInterface validator = new LongTermPreservationValidation();
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/validation/LtpValidationHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/validation/LtpValidationHelper.java
@@ -122,6 +122,8 @@ public class LtpValidationHelper {
             return Helper.getTranslation("ltpValidation.condition.operation.smallerThan");
         } else if (operation.equals(LtpValidationConditionOperation.IN_BETWEEN)) {
             return Helper.getTranslation("ltpValidation.condition.operation.inBetween");
+        } else if (operation.equals(LtpValidationConditionOperation.NON_EMPTY)) {
+            return Helper.getTranslation("ltpValidation.condition.operation.nonEmpty");
         }
         // should never happen
         return "unknown operation";

--- a/Kitodo/src/main/resources/messages/messages_de.properties
+++ b/Kitodo/src/main/resources/messages/messages_de.properties
@@ -734,6 +734,7 @@ ltpValidation.condition.operation.equal=ist exakt
 ltpValidation.condition.operation.oneOf=eines von
 ltpValidation.condition.operation.matches=passt zu
 ltpValidation.condition.operation.noneOf=keines von
+ltpValidation.condition.operation.nonEmpty=nicht leer
 ltpValidation.condition.operation.largerThan=größer als
 ltpValidation.condition.operation.smallerThan=kleiner als
 ltpValidation.condition.operation.inBetween=im Intervall von

--- a/Kitodo/src/main/resources/messages/messages_en.properties
+++ b/Kitodo/src/main/resources/messages/messages_en.properties
@@ -734,6 +734,7 @@ ltpValidation.condition.operation.equal=is exactly
 ltpValidation.condition.operation.oneOf=one of
 ltpValidation.condition.operation.matches=matches
 ltpValidation.condition.operation.noneOf=none of
+ltpValidation.condition.operation.nonEmpty=not empty
 ltpValidation.condition.operation.largerThan=larger than
 ltpValidation.condition.operation.smallerThan=smaller than
 ltpValidation.condition.operation.inBetween=in between of

--- a/Kitodo/src/main/resources/messages/messages_es.properties
+++ b/Kitodo/src/main/resources/messages/messages_es.properties
@@ -741,6 +741,7 @@ ltpValidation.condition.operation.equal=es exactamente
 ltpValidation.condition.operation.oneOf=uno de
 ltpValidation.condition.operation.matches=coincide con
 ltpValidation.condition.operation.noneOf=ninguno de
+ltpValidation.condition.operation.nonEmpty=no vacía
 ltpValidation.condition.operation.largerThan=más grande que
 ltpValidation.condition.operation.smallerThan=más pequeña que
 ltpValidation.condition.operation.inBetween=en el medio de


### PR DESCRIPTION
Improves upon #6505.

At the moment, only `equals`, `one of` or `none of` operations are available. This does not allow to check whether there is at least some property defined, independent of the exact value.

In theory, it would be possible to use the `none of` operation with an unlikely value. Anyway, a specific operation to verify a non-empty value is more user friendly.