### PR TITLE
Add `kitodo_config.properties` parameter to customize LTP validation report

### DIFF
--- a/Kitodo-LongTermPreservationValidation/src/test/resources/kitodo_config.properties
+++ b/Kitodo-LongTermPreservationValidation/src/test/resources/kitodo_config.properties
@@ -9,12 +9,5 @@
 # GPL3-License.txt file that was distributed with this source code.
 #
 
-LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
-LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
-LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR
-LongTermPreservationValidation.mapping.TRUE.FALSE=WARNING
-LongTermPreservationValidation.mapping.TRUE.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.TRUE.UNDETERMINED=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
-LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING
+LongTermPreservationValidation.maxReportedFilesPerFolder=5
+LongTermPreservationValidation.maxReportedFolders=3

--- a/Kitodo-Query-URL-Import/src/test/resources/kitodo_config.properties
+++ b/Kitodo-Query-URL-Import/src/test/resources/kitodo_config.properties
@@ -48,16 +48,6 @@ metsEditor.lockingTime=2
 
 #copyData.onExport=/@GoobiIdentifier \= $process.id;
 
-LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
-LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
-LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR
-LongTermPreservationValidation.mapping.TRUE.FALSE=WARNING
-LongTermPreservationValidation.mapping.TRUE.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.TRUE.UNDETERMINED=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
-LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING
-
 file.maxWaitMilliseconds=3000
 
 processPropertyColumns=

--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -669,7 +669,20 @@ public enum ParameterCore implements ParameterInterface {
      * not. If set to true, a checkbox will be displayed in the "Create new process" form allowing the user to
      * deactivate validation during process creation. Default value is 'false', thus validation is enforced by default.
      */
-    OPTIONAL_VALIDATION_ON_PROCESS_CREATION(new Parameter<>("metadataValidationOptionalDuringProcessCreation", false));
+    OPTIONAL_VALIDATION_ON_PROCESS_CREATION(new Parameter<>("metadataValidationOptionalDuringProcessCreation", false)),
+
+    /**
+     * Optional parameter that determines how many files with warning or errors
+     * are listed for each folder in the LTP validation report.
+     */
+    LTP_VALIDATION_MAX_REPORTED_FILES_PER_FOLDER(
+            new Parameter<>("LongTermPreservationValidation.maxReportedFilesPerFolder", 5)),
+
+    /**
+     * Optional parameter that determines how many folders with warning or
+     * errors are listed in the LTP validation report.
+     */
+    LTP_VALIDATION_MAX_REPORTED_FOLDERS(new Parameter<>("LongTermPreservationValidation.maxReportedFolders", 3));
 
     private final Parameter<?> parameter;
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationReportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationReportDialog.java
@@ -24,6 +24,8 @@ import javax.inject.Named;
 
 import org.kitodo.api.validation.longtermpreservation.LtpValidationResult;
 import org.kitodo.api.validation.longtermpreservation.LtpValidationResultState;
+import org.kitodo.config.ConfigCore;
+import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Folder;
 import org.kitodo.data.database.beans.LtpValidationCondition;
 import org.kitodo.data.database.beans.Task;
@@ -49,7 +51,8 @@ public class LtpValidationReportDialog implements Serializable {
      * the user and all files in all folders have validation errors.
      * </p>
      */
-    private static final int MAX_NUMBER_OF_REPORTED_FOLDERS = 3;
+    private static final int MAX_NUMBER_OF_REPORTED_FOLDERS = ConfigCore
+            .getIntParameter(ParameterCore.LTP_VALIDATION_MAX_REPORTED_FOLDERS);
 
     /**
      * The maximum number of files (that contain validation errors) that are
@@ -61,7 +64,8 @@ public class LtpValidationReportDialog implements Serializable {
      * the user and all files in all folders have validation errors.
      * </p>
      */
-    private static final int MAX_NUMBER_OF_REPORTED_FILES_PER_FOLDER = 5;
+    private static final int MAX_NUMBER_OF_REPORTED_FILES_PER_FOLDER = ConfigCore
+            .getIntParameter(ParameterCore.LTP_VALIDATION_MAX_REPORTED_FILES_PER_FOLDER);
 
     /**
      * Contains all validation results for all folders and files.

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -694,25 +694,11 @@ activeMQ.kitodoScript.allow=createFolders&export&searchForMedia
 #ImageManagement.sshHosts=user@rhost1.kitodo.org,user@rhost2.kitodo.org
 
 # -----------------------------------
-# LongTermPreservationValidatiuon
+# LongTermPreservationValidation
 # -----------------------------------
 
-# Maps the output parameter of the JHove process to the interface parameters of
-# Kitodo. JHove distinguishes between well-formedness (the first value) and
-# validity (the second value) of an image. Depending on the output state, the
-# process either runs through (SUCCESS), must be continued manually (WARNING)
-# or is locked (ERROR). With manual processing, the continuation is always
-# locked. The mapping can be changed as required.
-
-LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
-LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
-LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR
-LongTermPreservationValidation.mapping.TRUE.FALSE=WARNING
-LongTermPreservationValidation.mapping.TRUE.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.TRUE.UNDETERMINED=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
-LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING
+LongTermPreservationValidation.maxReportedFilesPerFolder=5
+LongTermPreservationValidation.maxReportedFolders=3
 
 # Controls whether metadata validation should fail on warnings ("true") or just on errors ("false")
 validationFailOnWarning=true

--- a/Kitodo/src/test/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/kitodo_config.properties
@@ -50,15 +50,12 @@ metsEditor.lockingTime=2
 
 activeMQ.kitodoScript.allow=test&test2
 
-LongTermPreservationValidation.mapping.FALSE.FALSE=ERROR
-LongTermPreservationValidation.mapping.FALSE.TRUE=ERROR
-LongTermPreservationValidation.mapping.FALSE.UNDETERMINED=ERROR
-LongTermPreservationValidation.mapping.TRUE.FALSE=WARNING
-LongTermPreservationValidation.mapping.TRUE.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.TRUE.UNDETERMINED=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.FALSE=ERROR
-LongTermPreservationValidation.mapping.UNDETERMINED.TRUE=SUCCESS
-LongTermPreservationValidation.mapping.UNDETERMINED.UNDETERMINED=WARNING
+# -----------------------------------
+# LongTermPreservationValidation
+# -----------------------------------
+
+LongTermPreservationValidation.maxReportedFilesPerFolder=5
+LongTermPreservationValidation.maxReportedFolders=3
 
 file.maxWaitMilliseconds=3000
 


### PR DESCRIPTION
Improves upon #6505 

Allows to configure how may files per folder and folders with errors or warnings are listed in the LTP validation report from the `kitodo_config.properties` file.

By default, 5 files per folder with warnings or errors, and 3 folders with warnings or errors are shown.

Also cleans up some old configuration options  that are not used any longer.