### PR TITLE
[3.8] Fix missing link to child process in asynchronous export

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -62,7 +62,7 @@ public class ExportDms extends ExportMets {
     private final ProcessService processService = ServiceManager.getProcessService();
 
     private boolean exportWithImages = true;
-
+    private boolean optimisticExportFlagSet = false;
     private Task workFlowTask;
 
     public ExportDms() {
@@ -108,6 +108,7 @@ public class ExportDms extends ExportMets {
         if (wasNotAlreadyExported) {
             process.setExported(true);
             processService.save(process);
+            this.optimisticExportFlagSet = true;
         }
 
         boolean exportSuccessful = startExport(process, (URI) null);
@@ -132,7 +133,7 @@ public class ExportDms extends ExportMets {
     @Override
     public boolean startExport(Process process, URI unused) {
         if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.ASYNCHRONOUS_AUTOMATIC_EXPORT)) {
-            TaskManager.addTask(new ExportDmsTask(this, process));
+            TaskManager.addTask(new ExportDmsTask(this, process, this.optimisticExportFlagSet));
             Helper.setMessage(TaskSitter.isAutoRunningThreads() ? "DMSExportByThread" : "DMSExportThreadCreated",
                 process.getTitle());
             return false;
@@ -343,6 +344,15 @@ public class ExportDms extends ExportMets {
      */
     public Task getWorkflowTask() {
         return workFlowTask;
+    }
+
+    /**
+     * Returns whether the optimistic export flag is set.
+     *
+     * @return true if the optimistic export flag is set; false otherwise
+     */
+    public boolean isOptimisticExportFlagSet() {
+        return optimisticExportFlagSet;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -114,7 +114,7 @@ public class ExportDms extends ExportMets {
         if (Objects.nonNull(process.getParent())) {
             startExport(process.getParent());
         }
-        if (wasNotAlreadyExported) {
+        if (wasNotAlreadyExported && !ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.ASYNCHRONOUS_AUTOMATIC_EXPORT)) {
             process.setExported(exportSuccessful);
             processService.save(process);
         }

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -133,7 +133,7 @@ public class ExportDms extends ExportMets {
     @Override
     public boolean startExport(Process process, URI unused) {
         if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.ASYNCHRONOUS_AUTOMATIC_EXPORT)) {
-            TaskManager.addTask(new ExportDmsTask(this, process, this.optimisticExportFlagSet));
+            TaskManager.addTask(new ExportDmsTask(this, process));
             Helper.setMessage(TaskSitter.isAutoRunningThreads() ? "DMSExportByThread" : "DMSExportThreadCreated",
                 process.getTitle());
             return false;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
@@ -36,6 +36,7 @@ public class ExportDmsTask extends EmptyTask {
 
     private final ExportDms exportDms;
     private final Process process;
+    private boolean optimisticExportFlagSet;
 
     /**
      * ExportDmsTask constructor. Creates a ExportDmsTask.
@@ -45,10 +46,11 @@ public class ExportDmsTask extends EmptyTask {
      * @param process
      *            the process to export
      */
-    public ExportDmsTask(ExportDms exportDms, Process process) {
+    public ExportDmsTask(ExportDms exportDms, Process process, boolean optimisticExportFlagSet) {
         super(process.getTitle());
         this.exportDms = exportDms;
         this.process = process;
+        this.optimisticExportFlagSet = optimisticExportFlagSet;
     }
 
     /**
@@ -89,8 +91,10 @@ public class ExportDmsTask extends EmptyTask {
             exportSuccessful = false;
         }
         try {
-            process.setExported(exportSuccessful);
-            ServiceManager.getProcessService().save(process);
+            if (exportDms.isOptimisticExportFlagSet()) {
+                process.setExported(exportSuccessful);
+                ServiceManager.getProcessService().save(process);
+            }
         } catch (DataException e) {
             logger.error(e.getMessage(), e);
         }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
@@ -45,6 +45,9 @@ public class ExportDmsTask extends EmptyTask {
      *            exportDMS configuration
      * @param process
      *            the process to export
+     * @param optimisticExportFlagSet
+     *            if the process export flag is set optimistically
+     *            before the export completes
      */
     public ExportDmsTask(ExportDms exportDms, Process process, boolean optimisticExportFlagSet) {
         super(process.getTitle());

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java
@@ -36,7 +36,6 @@ public class ExportDmsTask extends EmptyTask {
 
     private final ExportDms exportDms;
     private final Process process;
-    private boolean optimisticExportFlagSet;
 
     /**
      * ExportDmsTask constructor. Creates a ExportDmsTask.
@@ -45,15 +44,11 @@ public class ExportDmsTask extends EmptyTask {
      *            exportDMS configuration
      * @param process
      *            the process to export
-     * @param optimisticExportFlagSet
-     *            if the process export flag is set optimistically
-     *            before the export completes
      */
-    public ExportDmsTask(ExportDms exportDms, Process process, boolean optimisticExportFlagSet) {
+    public ExportDmsTask(ExportDms exportDms, Process process) {
         super(process.getTitle());
         this.exportDms = exportDms;
         this.process = process;
-        this.optimisticExportFlagSet = optimisticExportFlagSet;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/6624

As elaborated in the linked issue, in my tests the child process is not linked reliable in the exported parent process, when using the async DMS export (Manual and automatic) the first time. It is only linked, when it is exported a second time. (Checked on my dev system as well as on the server, both running with local db)

The problem appears to be, that the code does the following things (in async mode):

a) mark the to-be-exported process as exported in the database, so that it is included in the export of the parent process
b) export the child process in a different thread
c) export the parent process(es) in another thread

While those two (or more) exports are running in the background (in the case of an asynchronous) export 

d) the code continues and sets the state of the process to the result of the export operation. 

https://github.com/kitodo/kitodo-production/blob/fa8e2256ebefc05ea10c1a88411b96f1961eebe1/Kitodo/src/main/java/org/kitodo/export/ExportDms.java#L117-L120

This works in the synchronous case, but in the asynchronous case the export state is always immediately set to false (to be set to the right state later).

Only when the background thread is finished it is set to true.

Under specific timing conditions - it probably plays a role how long the export takes or how fast database writes are (local db vs remote db e.g.) - the database set the process to `not exported` and this value is read while generating the parent export. In consequence no link is written to the METS file.

I therefor in the PR's code call the logic from line 117-120 only in the synchronous case. The state of the exported processes should be recorded in the thread the export is happening.

There i added another condition

 https://github.com/kitodo/kitodo-production/blob/c2eec2c00040cb064d7c19c6a06646963978b246/Kitodo/src/main/java/org/kitodo/production/helper/tasks/ExportDmsTask.java#L94-L97

to ensure that the database export status of a process is only changed if this process has never been exported before. 

Edit: Will check and forward port to main, if this fix is accepted.