### PR TITLE
Do not flush after closing the exported PDF Document

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1171,7 +1171,6 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
 
                 document.close();
                 wb.close();
-                out.flush();
                 facesContext.responseComplete();
             }
         }


### PR DESCRIPTION
Calling flush after the PDF document has been created and the stream being closed sometimes leads to an exception (only in the log) and should not be done.

https://api.itextpdf.com/iText5/java/latest/com/itextpdf/text/Document.html

states: "After closing the document, every listener (as well as its OutputStream) is closed too."

ERROR] 2025-08-06 14:48:31.593 [http-nio-8080-exec-3] ProcessListBaseView - errorCreating
java.io.IOException: Stream is already closed.
	at org.omnifaces.io.ResettableBufferedOutputStream.checkClosed(ResettableBufferedOutputStream.java:177) ~[omnifaces-3.13.4.jar:3.13.4]
	at org.omnifaces.io.ResettableBufferedOutputStream.flush(ResettableBufferedOutputStream.java:145) ~[omnifaces-3.13.4.jar:3.13.4]
	at org.omnifaces.io.DefaultServletOutputStream.flush(DefaultServletOutputStream.java:67) ~[omnifaces-3.13.4.jar:3.13.4]
	at org.kitodo.production.services.data.ProcessService.generateResultAsPdf(ProcessService.java:1174) ~[classes/:3.9.0-SNAPSHOT]
	at org.kitodo.production.forms.ProcessListBaseView.generateResultAsPdf(ProcessListBaseView.java:402) ~[classes/:3.9.0-SNAPSHOT]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.apache.el.parser.AstValue.invoke(AstValue.java:252) ~[jasper-el.jar:9.0.67]
	at org.apache.el.MethodExpressionImpl.invoke(MethodExpressionImpl.java:266) ~[jasper-el.jar:9.0.67]
	at org.jboss.weld.util.el.ForwardingMethodExpression.invoke(ForwardingMethodExpression.java:40) ~[weld-servlet-2.4.8.Final.jar:2.4.8.Final]
	at org.jboss.weld.el.WeldMethodExpression.invoke(WeldMethodExpression.java:50) ~[weld-servlet-2.4.8.Final.jar:2.4.8.Final]
	at org.jboss.weld.util.el.ForwardingMethodExpression.invoke(ForwardingMethodExpression.java:40) ~[weld-servlet-2.4.8.Final.jar:2.4.8.Final]
	at org.jboss.weld.el.WeldMethodExpression.invoke(WeldMethodExpression.java:50) ~[weld-servlet-2.4.8.Final.jar:2.4.8.Final]
	at org.apache.myfaces.view.facelets.el.ContextAwareTagMethodExpression.invoke(ContextAwareTagMethodExpression.java:96) ~[myfaces-impl-2.3.10.jar:2.3.10]
	at org.apache.myfaces.application.ActionListenerImpl.processAction(ActionListenerImpl.java:74) ~[myfaces-impl-2.3.10.jar:2.3.10]
	at org.springframework.faces.webflow.FlowActionListener.processAction(FlowActionListener.java:71) ~[spring-faces-2.5.1.RELEASE.jar:2.5.1.RELEASE]
	at org.springframework.faces.model.SelectionTrackingActionListener.processAction(SelectionTrackingActionListener.java:64) ~[spring-faces-2.5.1.RELEASE.jar:2.5.1.RELEASE]
	at javax.faces.component.UICommand.broadcast(UICommand.java:120) ~[myfaces-api-2.3.10.jar:2.3.10]
	at javax.faces.component.UIViewRoot._broadcastAll(UIViewRoot.java:1255) ~[myfaces-api-2.3.10.jar:2.3.10]
	at javax.faces.component.UIViewRoot.broadcastEvents(UIViewRoot.java:420) ~[myfaces-api-2.3.10.jar:2.3.10]
	at javax.faces.component.UIViewRoot._process(UIViewRoot.java:1741) ~[myfaces-api-2.3.10.jar:2.3.10]
	at javax.faces.component.UIViewRoot.processApplication(UIViewRoot.java:935) ~[myfaces-api-2.3.10.jar:2.3.10]
	at org.apache.myfaces.lifecycle.InvokeApplicationExecutor.execute(InvokeApplicationExecutor.java:42) ~[myfaces-impl-2.3.10.jar:2.3.10]
	at org.apache.myfaces.lifecycle.LifecycleImpl.executePhase(LifecycleImpl.java:195) ~[myfaces-impl-2.3.10.jar:2.3.10]
	at org.apache.myfaces.lifecycle.LifecycleImpl.execute(LifecycleImpl.java:142) ~[myfaces-impl-2.3.10.jar:2.3.10]