### PR TITLE
Update Kitodo.Production to version 3.9.0.RC1

### DIFF
--- a/Kitodo-API/pom.xml
+++ b/Kitodo-API/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - API</name>

--- a/Kitodo-Command/pom.xml
+++ b/Kitodo-Command/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Command</name>

--- a/Kitodo-DataEditor/pom.xml
+++ b/Kitodo-DataEditor/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Data Editor</name>

--- a/Kitodo-DataFormat/pom.xml
+++ b/Kitodo-DataFormat/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Data Format</name>

--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Data Management</name>

--- a/Kitodo-Docket/pom.xml
+++ b/Kitodo-Docket/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Docket</name>

--- a/Kitodo-FileManagement/pom.xml
+++ b/Kitodo-FileManagement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - File Management</name>

--- a/Kitodo-ImageManagement/pom.xml
+++ b/Kitodo-ImageManagement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Image Management</name>

--- a/Kitodo-LongTermPreservationValidation/pom.xml
+++ b/Kitodo-LongTermPreservationValidation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Long Term Preservation Validation</name>

--- a/Kitodo-PersistentIdentifier/pom.xml
+++ b/Kitodo-PersistentIdentifier/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Persistent Identifier</name>

--- a/Kitodo-Query-URL-Import/pom.xml
+++ b/Kitodo-Query-URL-Import/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Query URL Import</name>

--- a/Kitodo-Validation/pom.xml
+++ b/Kitodo-Validation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Validation</name>

--- a/Kitodo-XML-SchemaConverter/pom.xml
+++ b/Kitodo-XML-SchemaConverter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kitodo-production</artifactId>
         <groupId>org.kitodo</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - XML SchemaConverter</name>

--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.kitodo</groupId>
         <artifactId>kitodo-production</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0-RC1</version>
     </parent>
 
     <name>Kitodo - Core</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.kitodo</groupId>
     <artifactId>kitodo-production</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>3.9.0-RC1</version>
     <packaging>pom</packaging>
 
     <organization>
@@ -30,7 +30,7 @@
     <url>https://github.com/kitodo/kitodo-production</url>
 
     <properties>
-        <kitodo.version>3.9.0-SNAPSHOT</kitodo.version>
+        <kitodo.version>3.9.0-RC1</kitodo.version>
         <checkstyle.config.location>config/checkstyle.xml</checkstyle.config.location>
         <main.basedir>${project.basedir}</main.basedir>
         <phase.prop>none</phase.prop>


### PR DESCRIPTION
This pull request updates the version of Kitodo.Production to 3.9.0.RC1 ("Release Candidate 1"). A new branch `3.9.x` will be created from this version which will eventually result in 3.9.0 proper (and probably patch releases 3.9.1, 3.9.2 etc. afterwards). 

This makes the way free for feature development for the next [major version 4.0.0](https://github.com/kitodo/kitodo-production/milestone/24) to be introduced into the `main` branch. All future bug fixes for features introduced in 3.9.0 - e.g. fixes for bugs related to HibernateSearch, the new long term preservation functionalitites and metadata import from CSV data - will have to be provided for both branches, `3.9.x` and `main`.
