### PR TITLE
Lookup BaseType in the correct way

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -164,9 +164,7 @@ public class TitleRecordLinkTab {
 
         if (selectableInsertionPositions.isEmpty()) {
             selectedInsertionPosition = null;
-            Helper.setErrorMessage(
-                    Helper.getTranslation("createProcessForm.titleRecordLinkTab.noInsertionPosition")
-            );
+            Helper.setErrorMessage("createProcessForm.titleRecordLinkTab.noInsertionPosition");
         } else {
             selectedInsertionPosition = (String) ((LinkedList<SelectItem>) selectableInsertionPositions).getLast()
                     .getValue();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/TitleRecordLinkTab.java
@@ -164,7 +164,9 @@ public class TitleRecordLinkTab {
 
         if (selectableInsertionPositions.isEmpty()) {
             selectedInsertionPosition = null;
-            Helper.setErrorMessage("createProcessForm.titleRecordLinkTab.noInsertionPosition");
+            Helper.setErrorMessage(
+                    Helper.getTranslation("createProcessForm.titleRecordLinkTab.noInsertionPosition")
+            );
         } else {
             selectedInsertionPosition = (String) ((LinkedList<SelectItem>) selectableInsertionPositions).getLast()
                     .getValue();


### PR DESCRIPTION
Creating a process as a child from the parent using the plus icon in the process list is broken right now. (3.9 and Master)

<img width="127" height="39" alt="image" src="https://github.com/user-attachments/assets/bfca4ad1-68f1-4720-bfc4-d24c56005cf7" />

<img width="1779" height="304" alt="image" src="https://github.com/user-attachments/assets/5702102c-792a-4472-8bd5-f7a4850a9a27" />

(on a side note: this error message is not translated)

The problem is, that the Parent process' base type is `null` at that point and has to be looked up using `ProcessService.getBaseType()`.

https://github.com/BartChris/kitodo-production/blob/cd7909046e50b3f1383a5b33caee8e57dca7c2a6/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java#L531-L533

The base type of the process is currently not saved in the database. I am somewhat confused what `String baseType = parentProcess.getBaseType();` should do here. The entity description confuses me as well:

https://github.com/kitodo/kitodo-production/blob/db2ed2c8223faef07c5a6e750dc0f7572ec61c1e/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java#L694-L701.

I guess `media form of the business object` here means the  base type (e.g. `periodical) of the root logical element? @matthias-ronge 





