### PR TITLE
Fix mass process deletion from list

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProcessForm.java
@@ -597,6 +597,10 @@ public class ProcessForm extends TemplateBaseForm {
     public void executeKitodoScriptSelection() {
         Stopwatch stopwatch = new Stopwatch(this, "executeKitodoScriptSelection");
         executeKitodoScriptForProcesses(getSelectedProcesses(), this.kitodoScriptSelection);
+        // Clear selection if deleteProcess was executed
+        if (kitodoScriptSelection != null && kitodoScriptSelection.startsWith("action:deleteProcess")) {
+            this.selectedProcesses.clear();
+        }
         stopwatch.stop();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -359,8 +359,12 @@ public class KitodoScriptService {
                 }
             } else {
                 try {
-                    ServiceManager.getProcessService().deleteProcess(process);
-                    Helper.setMessage("Process " + title + " deleted.");
+                    if (!process.hasChildren()) {
+                        ProcessService.deleteProcess(process);
+                        Helper.setMessage("Process " + title + " deleted.");
+                    } else {
+                        Helper.setMessage("Process " + title + " skipped.");
+                    }
                 } catch (DAOException | IOException e) {
                     Helper.setErrorMessage("errorDeleting",
                         new Object[] {Helper.getTranslation("process") + " " + title }, logger, e);


### PR DESCRIPTION
Fixes  https://github.com/kitodo/kitodo-production/issues/5342

As described in the linked issue: Using the Kitodo delete Script action can lead to the problem that parent processes are deleted which have existing child processes. We should skip the delete action for those.

When the deletion is done we should unset the delete processes as otherwise those processes are still selected and will be included in all the next actions.

