### PR TITLE
Fix metadata dialog in calendar

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/calendar/CalendarService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/calendar/CalendarService.java
@@ -48,6 +48,7 @@ import org.kitodo.production.model.bibliography.course.metadata.CountableMetadat
 import org.kitodo.production.model.bibliography.course.metadata.MetadataEditMode;
 import org.kitodo.production.security.SecurityUserDetails;
 import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.data.ProcessService;
 
 public class CalendarService {
 
@@ -92,7 +93,7 @@ public class CalendarService {
         List<Locale.LanguageRange> priorityList = Locale.LanguageRange.parse(authenticatedUser.getMetadataLanguage());
 
         // get the basic rule set type of the newspaper
-        String newspaperType = ServiceManager.getProcessService().getBaseType(completeEdition.getId());
+        String newspaperType = ProcessService.getBaseType(completeEdition);
 
         // descend to the issue
         StructuralElementViewInterface newspaperView = ruleset.getStructuralElementView(newspaperType, CREATE, priorityList);


### PR DESCRIPTION
When adding metadata  in the calendar an exception occurs, because the used `getBaseType(int)` method only returns the value from the Process object, which is never assigned a value.
The `getBaseType(Process)` method loads the value from the file system.