### PR TITLE
[3.8] Adapt error handling in script logging

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/command/CommandResult.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/command/CommandResult.java
@@ -13,32 +13,37 @@ package org.kitodo.api.command;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 
 public class CommandResult {
 
     /** The command as a String. */
     private String command;
 
+    private final int exitCode;
+
     /** If the command execution was successful. */
     private boolean successful;
 
-    /** The resultMessages. */
-    private List<String> messages;
+    private final List<String> stdOutMessages;
+
+    private final List<String> stdErrMessages;
 
     /**
      * Constructor.
-     * 
+     *
      * @param command
      *            The command.
-     * @param successful
-     *            If command was successful.
-     * @param messages
-     *            The resultMessages
      */
-    public CommandResult(String command, boolean successful, List<String> messages) {
+    public CommandResult(String command, int exitCode,
+                         List<String> stdOutMessages, List<String> stdErrMessages) {
         this.command = command;
-        this.successful = successful;
-        this.messages = messages;
+        this.exitCode = exitCode;
+        this.successful = (exitCode == 0);
+        this.stdOutMessages = stdOutMessages;
+        this.stdErrMessages = stdErrMessages;
     }
 
     /**
@@ -50,6 +55,16 @@ public class CommandResult {
         return command;
     }
 
+
+    /**
+     * Gets the exit code.
+     *
+     * @return The exit code.
+     */
+    public int getExitCode() {
+        return exitCode;
+    }
+
     /**
      * Gets if command was successful.
      * 
@@ -59,14 +74,23 @@ public class CommandResult {
         return successful;
     }
 
+    public List<String> getStdOutMessages() {
+        return stdOutMessages;
+    }
+
+    public List<String> getStdErrMessages() {
+        return stdErrMessages;
+    }
+
     /**
-     * Gets the messages.
-     * 
-     * @return The messages.
+     * Fallback für bestehenden Code:
+     * kombiniert stdout und stderr.
      */
     public List<String> getMessages() {
-        return messages;
+        return Stream.concat(stdOutMessages.stream(), stdErrMessages.stream())
+                .collect(Collectors.toList());
     }
+
 
     /**
      * Indicates whether a CommandResults is "equal to" this one.
@@ -84,15 +108,17 @@ public class CommandResult {
         if (object instanceof CommandResult) {
             CommandResult that = (CommandResult) object;
 
-            return this.successful == that.successful
-                    && this.command.equals(that.command)
-                    && this.messages.equals(that.messages);
+            return this.exitCode == that.exitCode
+                    && this.successful == that.successful
+                    && Objects.equals(this.command, that.command)
+                    && Objects.equals(this.stdOutMessages, that.stdOutMessages)
+                    && Objects.equals(this.stdErrMessages, that.stdErrMessages);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(successful, command, messages);
+        return Objects.hash(command, exitCode, successful, stdOutMessages, stdErrMessages);
     }
 }

--- a/Kitodo-API/src/main/java/org/kitodo/api/command/CommandResult.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/command/CommandResult.java
@@ -74,17 +74,29 @@ public class CommandResult {
         return successful;
     }
 
+    /**
+     * Returns the list of messages written to standard output (stdout).
+     *
+     * @return list of stdout messages
+     */
     public List<String> getStdOutMessages() {
         return stdOutMessages;
     }
 
+    /**
+    * Returns the list of messages written to standard error (stderr).
+    *
+    * @return list of stderr messages
+    */
     public List<String> getStdErrMessages() {
         return stdErrMessages;
     }
 
     /**
-     * Fallback für bestehenden Code:
-     * kombiniert stdout und stderr.
+     * Fallback for existing code:
+     * returns a combined list of standard output and error messages.
+     *
+     * @return list containing both stdout and stderr messages
      */
     public List<String> getMessages() {
         return Stream.concat(stdOutMessages.stream(), stdErrMessages.stream())

--- a/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
+++ b/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
@@ -17,8 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -49,32 +47,31 @@ public class Command implements CommandInterface {
                     InputStream errorInputStream = process.getErrorStream()) {
                 List<String> outputMessage = inputStreamArrayToList(inputStream);
                 List<String> errorMessage = inputStreamArrayToList(errorInputStream);
-                List<String> combinedMessages = Stream.concat(outputMessage.stream(), errorMessage.stream())
-                        .collect(Collectors.toList());
                 int errCode = process.waitFor();
-                if (Integer.valueOf(errCode).equals(0)) {
-                    commandResult = new CommandResult(command, true, outputMessage);
-                    logger.info("Execution of Command {} was successful!: {}",
-                            commandResult.getCommand(), combinedMessages);
+                commandResult = new CommandResult(command, errCode, outputMessage, errorMessage);
+                for (String line : outputMessage) {
+                    logger.info("[STDOUT] {}", line);
+                }
+                for (String line : errorMessage) {
+                    logger.error("[STDERR] {}", line);
+                }
+                if (commandResult.isSuccessful()) {
+                    logger.info("Execution of Command {} was successful", commandResult.getCommand());
                 } else {
-                    commandResult = new CommandResult(command, false, errorMessage);
-                    logger.error("Execution of Command {} failed!: {}",
-                            commandResult.getCommand(), combinedMessages);
+                    logger.error("Execution of Command {} failed with exit code {}",
+                            commandResult.getCommand(), commandResult.getExitCode());
                 }
             }
         } catch (InterruptedException e) {
-            commandResult = new CommandResult(command, false, Collections.singletonList(e.getMessage()));
-            logger.error("Execution of Command Thread was interrupted!");
             Thread.currentThread().interrupt();
-            return commandResult;
+            commandResult = new CommandResult(command, -1, Collections.emptyList(),
+                    Collections.singletonList("Interrupted: " + e.getMessage()));
+            logger.error("Execution of Command {} was interrupted!", command);
         } catch (IOException e) {
-            List<String> errorMessages = new ArrayList<>();
-            errorMessages.add(e.getCause().toString());
-            errorMessages.add(e.getMessage());
-            commandResult = new CommandResult(command, false, errorMessages);
-            logger.error("Execution of Command {} failed!: {}", commandResult.getCommand(),
-                commandResult.getMessages());
-            return commandResult;
+            commandResult = new CommandResult(command, -1, Collections.emptyList(),
+                    Collections.singletonList("IOException: " + e.getMessage()));
+            logger.error("Execution of Command {} failed to start: {}", command, e.getMessage());
+
         }
         return commandResult;
     }

--- a/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
+++ b/Kitodo-Command/src/main/java/org/kitodo/command/Command.java
@@ -71,7 +71,6 @@ public class Command implements CommandInterface {
             commandResult = new CommandResult(command, -1, Collections.emptyList(),
                     Collections.singletonList("IOException: " + e.getMessage()));
             logger.error("Execution of Command {} failed to start: {}", command, e.getMessage());
-
         }
         return commandResult;
     }

--- a/Kitodo-Command/src/test/java/org/kitodo/command/CommandTest.java
+++ b/Kitodo-Command/src/test/java/org/kitodo/command/CommandTest.java
@@ -79,7 +79,7 @@ public class CommandTest {
 
         expectedMessages.add("Hello World");
 
-        CommandResult expectedCommandResult = new CommandResult(commandString, true, expectedMessages);
+        CommandResult expectedCommandResult = new CommandResult(commandString, 0, expectedMessages, new ArrayList<>());
 
         assertEquals(expectedCommandResult.isSuccessful(),
                 commandResult.isSuccessful(),
@@ -99,7 +99,7 @@ public class CommandTest {
         String commandString = "src/test/resources/notExistingScript" + scriptExtension;
         CommandResult commandResult = command.runCommand(commandString);
 
-        CommandResult expectedCommandResult = new CommandResult(commandString, false, null);
+        CommandResult expectedCommandResult = new CommandResult(commandString, -1, new ArrayList<>(), commandResult.getStdErrMessages());
 
         assertEquals(expectedCommandResult.isSuccessful(),
                 commandResult.isSuccessful(),
@@ -113,7 +113,7 @@ public class CommandTest {
         String commandString = "src/test/resources/not_working_script" + scriptExtension;
         CommandResult commandResult = command.runCommand(commandString);
 
-        CommandResult expectedCommandResult = new CommandResult(commandString, false, null);
+        CommandResult expectedCommandResult = new CommandResult(commandString, commandResult.getExitCode(), new ArrayList<>(), commandResult.getStdErrMessages());
 
         assertEquals(expectedCommandResult.isSuccessful(),
                 commandResult.isSuccessful(),
@@ -136,7 +136,7 @@ public class CommandTest {
 
         expectedMessages.add("testParameter");
 
-        CommandResult expectedCommandResult = new CommandResult(commandString, true, expectedMessages);
+        CommandResult expectedCommandResult = new CommandResult(commandString, 0,  expectedMessages, new ArrayList<>());
 
         assertEquals(expectedCommandResult.isSuccessful(),
                 commandResult.isSuccessful(),

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -52,14 +52,19 @@ public class CommandService {
         if (Objects.isNull(script)) {
             return null;
         }
+
         CommandResult commandResult = commandModule.runCommand(script);
-        List<String> commandResultMessages = commandResult.getMessages();
-        if (!commandResult.isSuccessful() && !commandResultMessages.isEmpty()) {
-            for (String message : commandResultMessages) {
+
+        if (Objects.isNull(commandResult)) {
+            throw new IOException("Command execution failed: no result returned");
+        }
+        for (String message : commandResult.getStdOutMessages()) {
+            Helper.setMessage(message);
+        }
+        if (commandResult.getExitCode() != 0) {
+            for (String message : commandResult.getStdErrMessages()) {
                 Helper.setErrorMessage(message);
             }
-            String fullErrorMessage = String.join(" | ", commandResultMessages);
-            throw new IOException(fullErrorMessage);
         }
         return commandResult;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -519,11 +519,6 @@ public class TaskService extends ProjectSearchService<Task, TaskDTO, TaskDAO> {
                 CommandService commandService = ServiceManager.getCommandService();
                 CommandResult commandResult = commandService.runCommand(script);
                 executedSuccessful = commandResult.isSuccessful();
-                if (executedSuccessful && !commandResult.getMessages().isEmpty()) {
-                    for (String message : commandResult.getMessages()) {
-                        Helper.setMessage(message);
-                    }
-                }
             }
             finishOrReturnAutomaticTask(task, automatic, executedSuccessful);
         } catch (IOException | DAOException | InvalidImagesException e) {

--- a/Kitodo/src/test/resources/scripts/exit0_with_stderr.sh
+++ b/Kitodo/src/test/resources/scripts/exit0_with_stderr.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "Test StdOut output"
+echo "Test StdErr output" 1>&2
+exit 0

--- a/Kitodo/src/test/resources/scripts/exit1_with_stderr.sh
+++ b/Kitodo/src/test/resources/scripts/exit1_with_stderr.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "Test StdOut output"
+echo "Test StdErr output" 1>&2
+exit 1


### PR DESCRIPTION
Spec from: https://github.com/kitodo/kitodo-production/issues/6665

> Command module is only logging the output from standard output channel as INFO message. Output from the standard error output channel should be logged on ERROR level.

> Command Service class should output the standard output channel as normal message (Helper.setMessage) and maybe depending on exit state or nor the output from standard error channel as error message (Helper.setErrorMessage) but without in both cases to log this messages again as this is already done by the Command Module.
