### PR TITLE
Harden query parsing: prevent numeric titles and non-numeric IDs from breaking search

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -416,7 +416,7 @@ public class FilterService extends BaseBeanService<Filter, FilterDAO> {
 
         if (indexed && Objects.nonNull(filterField.getSearchField())) {
             return new IndexQueryPart(filterField, value, operand);
-        } else if (Objects.equals(filterField, FilterField.PROCESS_ID)) {
+        } else if (Objects.equals(filterField, FilterField.PROCESS_ID) && value.matches(".*\\d.*"))  {
             return new DatabaseIdQueryPart(filterField, value, operand);
         } else {
             return new DatabaseQueryPart(filterField, value, operand);


### PR DESCRIPTION
fixes https://github.com/kitodo/kitodo-production/issues/6670
fixes https://github.com/kitodo/kitodo-production/issues/6630

Both bugs are a consequence of applying SQL queries which rely on a specific type (ID or string) and which break if wrong types are passed in.

Regarding https://github.com/kitodo/kitodo-production/issues/6670

As outlined in: https://github.com/kitodo/kitodo-production/issues/6670#issuecomment-3270725657

process titles are always strings and should be searched with string values (this is set formally set here: https://github.com/kitodo/kitodo-production/blob/713df084ae086625e2773a9a40a9f5bbcbd1ae41/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java#L28). Even if the user searches for a number the query should not be Integer based. 

Regarding https://github.com/kitodo/kitodo-production/issues/6630

Queries on the `processID` field have at least to contain one number. It can even be strings like `12SEPERATOR13`, which are parsed as "12 13" and result in a query for multiple IDs. But there has to be at least one number. 

I tried to the exceptions without a big refactoring and as small targeted fix.