### PR TITLE
Skip subfolders of ruleset directory when listing ruleset xml files

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/RulesetForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/RulesetForm.java
@@ -198,7 +198,7 @@ public class RulesetForm extends BaseForm {
      * @return list of ruleset filenames
      */
     public List<Path> getRulesetFilenames() {
-        try (Stream<Path> rulesetPaths = Files.walk(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_RULESETS)))) {
+        try (Stream<Path> rulesetPaths = Files.walk(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_RULESETS)), 1)) {
             return rulesetPaths.filter(f -> f.toString().endsWith(".xml")).map(Path::getFileName).sorted()
                     .collect(Collectors.toList());
         } catch (IOException e) {


### PR DESCRIPTION
Fixes #6666 

(_note_: this pull request fixes the linked issue by skipping subfolders of the ruleset directory. I still prefer the solution to be able to organize xml files in separate subfolders eventually, but since that requires a lot more changes to the code I am content with this simple fix for the time being, so that at least the bug does not occur anymore; the feature with the subfolders can later still be implemented, when someone finds the resources to do so)