### PR TITLE
Reduce number of SQL queries during Excel export

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessExportDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessExportDTO.java
@@ -1,0 +1,115 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class ProcessExportDTO implements Serializable {
+
+    private final Integer id;
+    private final String title;
+    private final Date creationDate;
+    private final Integer sortHelperImages;
+    private final Integer sortHelperDocstructs;
+    private final Integer sortHelperMetadata;
+    private final String projectTitle;
+    private final String status;
+
+    /**
+     * Constructor.
+     */
+    public ProcessExportDTO(Integer id, String title, Date creationDate,
+                            Integer sortHelperImages, Integer sortHelperDocstructs,
+                            Integer sortHelperMetadata, String projectTitle, String status) {
+        this.id = id;
+        this.title = title;
+        this.creationDate = creationDate;
+        this.sortHelperImages = sortHelperImages;
+        this.sortHelperDocstructs = sortHelperDocstructs;
+        this.sortHelperMetadata = sortHelperMetadata;
+        this.projectTitle = projectTitle;
+        this.status = status;
+    }
+
+    /**
+     * Returns the process identifier.
+     *
+     * @return process ID
+     */
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * Returns the process title.
+     *
+     * @return title of the process
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Returns the creation date of the process.
+     *
+     * @return creation date
+     */
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    /**
+     * Returns the number of images.
+     *
+     * @return image count
+     */
+    public Integer getSortHelperImages() {
+        return sortHelperImages;
+    }
+
+    /**
+     * Returns the number of docstructs.
+     *
+     * @return docstruct count
+     */
+    public Integer getSortHelperDocstructs() {
+        return sortHelperDocstructs;
+    }
+
+    /**
+     * Returns the number of metadata entries.
+     *
+     * @return metadata count
+     */
+    public Integer getSortHelperMetadata() {
+        return sortHelperMetadata;
+    }
+
+    /**
+     * Returns the title of the project.
+     *
+     * @return project title
+     */
+    public String getProjectTitle() {
+        return projectTitle;
+    }
+
+    /**
+     * Returns the process status.
+     *
+     * @return current status
+     */
+    public String getStatus() {
+        return status;
+    }
+}

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessExportDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessExportDTO.java
@@ -14,6 +14,9 @@ package org.kitodo.production.dto;
 import java.io.Serializable;
 import java.util.Date;
 
+/**
+ * Data Transfer Object for process export.
+ */
 public class ProcessExportDTO implements Serializable {
 
     private final Integer id;
@@ -47,7 +50,7 @@ public class ProcessExportDTO implements Serializable {
      * @return process ID
      */
     public Integer getId() {
-        return id;
+        return id != null ? id : 0;
     }
 
     /**
@@ -56,7 +59,7 @@ public class ProcessExportDTO implements Serializable {
      * @return title of the process
      */
     public String getTitle() {
-        return title;
+        return title != null ? title : "";
     }
 
     /**
@@ -74,7 +77,7 @@ public class ProcessExportDTO implements Serializable {
      * @return image count
      */
     public Integer getSortHelperImages() {
-        return sortHelperImages;
+        return sortHelperImages != null ? sortHelperImages : 0;
     }
 
     /**
@@ -83,7 +86,7 @@ public class ProcessExportDTO implements Serializable {
      * @return docstruct count
      */
     public Integer getSortHelperDocstructs() {
-        return sortHelperDocstructs;
+        return sortHelperDocstructs != null ? sortHelperDocstructs : 0;
     }
 
     /**
@@ -92,7 +95,7 @@ public class ProcessExportDTO implements Serializable {
      * @return metadata count
      */
     public Integer getSortHelperMetadata() {
-        return sortHelperMetadata;
+        return sortHelperMetadata != null ? sortHelperMetadata : 0;
     }
 
     /**
@@ -101,7 +104,7 @@ public class ProcessExportDTO implements Serializable {
      * @return project title
      */
     public String getProjectTitle() {
-        return projectTitle;
+        return projectTitle != null ? projectTitle : "";
     }
 
     /**
@@ -110,6 +113,7 @@ public class ProcessExportDTO implements Serializable {
      * @return current status
      */
     public String getStatus() {
-        return status;
+        return status != null ? status : "";
     }
 }
+

--- a/Kitodo/src/main/java/org/kitodo/production/dto/ProcessExportDTO.java
+++ b/Kitodo/src/main/java/org/kitodo/production/dto/ProcessExportDTO.java
@@ -13,6 +13,7 @@ package org.kitodo.production.dto;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * Data Transfer Object for process export.
@@ -50,7 +51,7 @@ public class ProcessExportDTO implements Serializable {
      * @return process ID
      */
     public Integer getId() {
-        return id != null ? id : 0;
+        return Objects.nonNull(id) ? id : 0;
     }
 
     /**
@@ -59,7 +60,7 @@ public class ProcessExportDTO implements Serializable {
      * @return title of the process
      */
     public String getTitle() {
-        return title != null ? title : "";
+        return Objects.nonNull(title) ? title : "";
     }
 
     /**
@@ -77,7 +78,7 @@ public class ProcessExportDTO implements Serializable {
      * @return image count
      */
     public Integer getSortHelperImages() {
-        return sortHelperImages != null ? sortHelperImages : 0;
+        return Objects.nonNull(sortHelperImages) ? sortHelperImages : 0;
     }
 
     /**
@@ -86,7 +87,7 @@ public class ProcessExportDTO implements Serializable {
      * @return docstruct count
      */
     public Integer getSortHelperDocstructs() {
-        return sortHelperDocstructs != null ? sortHelperDocstructs : 0;
+        return Objects.nonNull(sortHelperDocstructs) ? sortHelperDocstructs : 0;
     }
 
     /**
@@ -95,7 +96,7 @@ public class ProcessExportDTO implements Serializable {
      * @return metadata count
      */
     public Integer getSortHelperMetadata() {
-        return sortHelperMetadata != null ? sortHelperMetadata : 0;
+        return Objects.nonNull(sortHelperMetadata) ? sortHelperMetadata : 0;
     }
 
     /**
@@ -104,7 +105,7 @@ public class ProcessExportDTO implements Serializable {
      * @return project title
      */
     public String getProjectTitle() {
-        return projectTitle != null ? projectTitle : "";
+        return Objects.nonNull(projectTitle) ? projectTitle : "";
     }
 
     /**
@@ -113,7 +114,7 @@ public class ProcessExportDTO implements Serializable {
      * @return current status
      */
     public String getStatus() {
-        return status != null ? status : "";
+        return Objects.nonNull(status) ? status : "";
     }
 }
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -13,6 +13,7 @@ package org.kitodo.production.helper;
 
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -105,8 +106,7 @@ public class SearchResultGeneration {
         row.createCell(0).setCellValue(data.getTitle());
         row.createCell(1).setCellValue(data.getId());
         row.createCell(2).setCellValue(
-                data.getCreationDate() != null ? dateFormatter.format(data.getCreationDate()) : ""
-        );
+                Objects.nonNull(data.getCreationDate()) ? dateFormatter.format(data.getCreationDate()) : "");
         row.createCell(3).setCellValue(data.getSortHelperImages());
         row.createCell(4).setCellValue(data.getSortHelperDocstructs());
         row.createCell(5).setCellValue(data.getSortHelperMetadata());

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -102,13 +102,15 @@ public class SearchResultGeneration {
 
     private void prepareRow(int rowCounter, Sheet sheet, ProcessExportDTO data) {
         Row row = sheet.createRow(rowCounter);
-        row.createCell(0).setCellValue(data.getTitle() != null ? data.getTitle() : "");
-        row.createCell(1).setCellValue(data.getId() != null ? data.getId() : 0);
-        row.createCell(2).setCellValue(data.getCreationDate() != null ? dateFormatter.format(data.getCreationDate()) : "");
-        row.createCell(3).setCellValue(data.getSortHelperImages() != null ? data.getSortHelperImages() : 0);
-        row.createCell(4).setCellValue(data.getSortHelperDocstructs() != null ? data.getSortHelperDocstructs() : 0);
-        row.createCell(5).setCellValue(data.getSortHelperMetadata() != null ? data.getSortHelperMetadata() : 0);
-        row.createCell(6).setCellValue(data.getProjectTitle() != null ? data.getProjectTitle() : "");
-        row.createCell(7).setCellValue(data.getStatus() != null ? data.getStatus() : "");
+        row.createCell(0).setCellValue(data.getTitle());
+        row.createCell(1).setCellValue(data.getId());
+        row.createCell(2).setCellValue(
+                data.getCreationDate() != null ? dateFormatter.format(data.getCreationDate()) : ""
+        );
+        row.createCell(3).setCellValue(data.getSortHelperImages());
+        row.createCell(4).setCellValue(data.getSortHelperDocstructs());
+        row.createCell(5).setCellValue(data.getSortHelperMetadata());
+        row.createCell(6).setCellValue(data.getProjectTitle());
+        row.createCell(7).setCellValue(data.getStatus());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/SearchResultGeneration.java
@@ -54,7 +54,7 @@ public class SearchResultGeneration {
     }
 
     private List<ProcessExportDTO> getResultsWithFilter() {
-        return ServiceManager.getProcessService().getForExcel(
+        return ServiceManager.getProcessService().getProcessesForExport(
                 filter,
                 this.showClosedProcesses,
                 this.showInactiveProjects,

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
@@ -93,6 +93,14 @@ public class BeanQuery {
     }
 
     /**
+     * Add an explicit inner join to the query.
+     * Example: query.addInnerJoin("p.project proj");
+     */
+    public void addInnerJoin(String join) {
+        innerJoins.add(varName + "." + join);
+    }
+
+    /**
      * Requires that the hits must correspond to any of the specified values in
      * the specified class field.
      * 
@@ -396,6 +404,21 @@ public class BeanQuery {
         innerFormQuery(query);
         if (sorted) {
             query.append(" ORDER BY ").append(sorting.getKey()).append(' ').append(sorting.getValue());
+        }
+        return query.toString();
+    }
+
+    /**
+     * Forms and returns a query without a SELECT clause.
+     *
+     * @return the query starting with FROM
+     */
+    public String formQueryWithoutSelect() {
+        StringBuilder query = new StringBuilder(512);
+        innerFormQuery(query);
+        if (Objects.nonNull(sorting)) {
+            query.append(" ORDER BY ").append(sorting.getKey())
+                    .append(' ').append(sorting.getValue());
         }
         return query.toString();
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -2383,17 +2383,20 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
     }
 
     /**
-     * Wrapper for ProcessDAO.getForExcel().
+     * Retrieves a list of processes prepared for export, applying the given filters.
+     * Instead of returning full entities, it projects the data into {@link ProcessExportDTO}
+     * objects suitable for use in reports or export (e.g., Excel, CSV).
      *
-     * @param showClosedProcesses whether to include closed processes
-     * @param showInactiveProjects whether to include inactive projects
-     * @return list of raw projection rows (Object[])
+     * @param filter               optional user-defined filter string
+     * @param includeClosed         whether to include closed processes
+     * @param includeInactiveProjects whether to include inactive projects
+     * @param sessionClientId       client ID to restrict the query
+     * @return list of processes as export-ready DTOs
      */
-
-    public List<ProcessExportDTO> getForExcel(
+    public List<ProcessExportDTO> getProcessesForExport(
             String filter,
-            boolean showClosedProcesses,
-            boolean showInactiveProjects,
+            boolean includeClosed,
+            boolean includeInactiveProjects,
             int sessionClientId) {
 
         BeanQuery query = new BeanQuery(Process.class);
@@ -2401,10 +2404,10 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         if (StringUtils.isNotBlank(filter)) {
             query.restrictWithUserFilterString(filter);
         }
-        if (!showClosedProcesses) {
+        if (!includeClosed) {
             query.restrictToNotCompletedProcesses();
         }
-        if (!showInactiveProjects) {
+        if (!includeInactiveProjects) {
             query.addBooleanRestriction("project.active", Boolean.TRUE);
         }
         query.restrictToClient(sessionClientId);


### PR DESCRIPTION
Addresses https://github.com/kitodo/kitodo-production/issues/6690

One of the reasons the Excel export takes a long time right now is that it fetches data which is not actually needed for the exported file (e.g. comments). This results in a large number of (batched) queries to retrieve unnecessary data.

I made an initial attempt to fix this by introducing a DTO that holds only the required data, populated by a single SQL query. The query count is reduced massively.

I suppose there are ways to hydrate the DTOs directly without going through intermediary objects, which might improve query performance further. The more severe problem, however, is that we are holding a large number of objects in memory when generating Excel files with more than 100,000 entries.

Maybe @henning-gerhardt  can give this a try to see whether the change already improves loading times. There are certainly more efficient ways to generate these Excel files. (using SXSSFWorkbook and streaming the DB result in batches).

 