### PR TITLE
[3.8] Remove not needed IOException call

### DIFF
--- a/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/CommandService.java
+++ b/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/CommandService.java
@@ -12,7 +12,6 @@
 package org.kitodo.filemanagement;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.kitodo.api.command.CommandInterface;
@@ -29,19 +28,14 @@ class CommandService {
      *            parameter1 parameter2 ...).
      * @return CommandResult objects
      */
-    CommandResult runCommand(String script) throws IOException {
+    CommandResult runCommand(String script) {
         if (script == null) {
             return null;
         }
         KitodoServiceLoader<CommandInterface> serviceLoader = new KitodoServiceLoader<>(CommandInterface.class);
         CommandInterface command = serviceLoader.loadModule();
 
-        CommandResult commandResult = command.runCommand(script);
-        List<String> commandResultMessages = commandResult.getMessages();
-        if (!commandResultMessages.isEmpty() && commandResultMessages.get(0).contains("IOException")) {
-            throw new IOException(commandResultMessages.get(1));
-        }
-        return commandResult;
+        return command.runCommand(script);
     }
 
     /**
@@ -53,7 +47,7 @@ class CommandService {
      *            script parameters
      * @return CommandResult object
      */
-    CommandResult runCommand(File scriptFile, List<String> parameter) throws IOException {
+    CommandResult runCommand(File scriptFile, List<String> parameter) {
         if (scriptFile == null) {
             return null;
         }

--- a/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
+++ b/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
@@ -508,8 +508,6 @@ public class FileManagement implements FileManagementInterface {
             return false;
         }
 
-        String command = KitodoConfig.getParameter("script_createSymLink");
-        CommandService commandService = new CommandService();
         List<String> parameters = new ArrayList<>();
         parameters.add(imagePath.getAbsolutePath());
         parameters.add(userHome.getAbsolutePath());
@@ -520,15 +518,9 @@ public class FileManagement implements FileManagementInterface {
             parameters.add(userLogin);
         }
 
-        try {
-            return commandService.runCommand(new File(command), parameters).isSuccessful();
-        } catch (FileNotFoundException e) {
-            logger.error("FileNotFoundException in createSymLink", e);
-            return false;
-        } catch (IOException e) {
-            logger.error("IOException in createSymLink", e);
-            return false;
-        }
+        String command = KitodoConfig.getParameter("script_createSymLink");
+        CommandService commandService = new CommandService();
+        return commandService.runCommand(new File(command), parameters).isSuccessful();
     }
 
     @Override
@@ -541,11 +533,8 @@ public class FileManagement implements FileManagementInterface {
         try {
             parameters.add(URLDecoder.decode(homeFile.getAbsolutePath(), StandardCharsets.UTF_8.name()));
             return commandService.runCommand(new File(command), parameters).isSuccessful();
-        } catch (FileNotFoundException e) {
-            logger.error("FileNotFoundException in deleteSymLink", e);
-            return false;
-        } catch (IOException e) {
-            logger.error("IOException in deleteSymLink", e);
+        } catch (UnsupportedEncodingException e) {
+            logger.error("UnsupportedEncodingException in deleteSymLink", e);
             return false;
         }
     }


### PR DESCRIPTION
Remove 
- historical "IOException" catch from external program execution
- never thrown `FileNotFoundException`