### PR TITLE
Add logic for enriching LABELs on export

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
+++ b/Kitodo/src/main/java/org/kitodo/config/enums/ParameterCore.java
@@ -505,6 +505,12 @@ public enum ParameterCore implements ParameterInterface {
      */
     EXPORT_WITHOUT_TIME_LIMIT(new Parameter<>("exportWithoutTimeLimit", true)),
 
+    /**
+     * Whether to enrich the INTERNAL METS file with LABEL and ORDERLABEL generated during export,
+     * defaults to {@code true}.
+     */
+    EXPORT_ENRICH_LABELS(new Parameter<>("exportEnrichLabels", false)),
+
     /*
      * REMOTE SERVICES
      *

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -498,6 +498,8 @@ ExportValidateImages=true
 # if this parameter is missing or 'false' the old export mechanism is used,
 # otherwise there is no timelimit for export
 exportWithoutTimeLimit=true
+# If true, enriches internal meta.xml with LABEL and ORDERLABEL values extracted from the exported METS.
+exportEnrichLabels=false
 
 
 # =============================================================================

--- a/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
@@ -358,6 +358,9 @@ automaticExportWithOcr=true
 # if this parameter is missing or 'false' the old export mechanism is used,
 # otherwise there is no timelimit for export
 exportWithoutTimeLimit=true
+# If true, enriches internal meta.xml with LABEL and ORDERLABEL values extracted from the exported METS.
+exportEnrichLabels=false
+
 # =============================================================================
 #      REMOTE SERVICES
 # =============================================================================


### PR DESCRIPTION
This pull request adresses a set of long standing issue extensively discussed in https://github.com/kitodo/kitodo-production/discussions/6277

Kitodo currently does not automatically fill the METS attributes LABEL and ORDERLABEL, which are required by presentation systems.
Users therefore rely on various workarounds:

- Filling LABEL/ORDERLABEL during import via custom XSLT extracting values (e.g. from title) — ineffective for manually created processes.
- Filling them during export via XSLT — but this leaves parent processes without child labels, since the internal meta.xml remains unchanged.
- Running external scripts to post-process and patch meta.xml.

This PR introduces an optional export-time enrichment step that reuses the export XSLT output to write the derived LABEL and ORDERLABEL values back into the internal meta.xml.

Concept:

- The export XSLT remains the single source of truth for generating derived LABELs.
- During export, these LABELs are written back to the internal METS so that parent exports can include them automatically.
- Existing processes can be enriched simply by re-exporting — no manual metadata edits or scripts required.
- Once stored in meta.xml, the LABELs are available to all future exports, including parents.

There are some caveats here. Since the correct enrichment of the exported parent METS with child's labels relies on the existence of those labels in the internal XML of the files, it has to be ensured that the parent's export runs after the child's export. The only way to guarantee that right now is setting ` taskManager.autoRunLimit =1` in the `kitodo_config.properties ` file. There are other issues with task parallelism in Kitodo right now, which are discussed in https://github.com/kitodo/kitodo-production/discussions/6633. 

Draft PR for @andre-hohmann and @henning-gerhardt to test.
 

