### PR TITLE
Fix issues to generate valid METS structures

### DIFF
--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/DivXmlElementAccess.java
@@ -316,6 +316,8 @@ public class DivXmlElementAccess extends LogicalDivision {
         xmlData.getAny().add(new JAXBElement<>(KITODO_QNAME, KitodoType.class, kitodoType));
         MdWrap mdWrap = new MdWrap();
         mdWrap.setXmlData(xmlData);
+        mdWrap.setMDTYPE("OTHER");
+        mdWrap.setOTHERMDTYPE("KITODO");
         MdSecType dmdSec = new MdSecType();
         dmdSec.setMdWrap(mdWrap);
         return Optional.of(dmdSec);

--- a/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
+++ b/Kitodo-DataFormat/src/main/java/org/kitodo/dataformat/access/MetsXmlElementAccess.java
@@ -272,7 +272,12 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         mets.setMetsHdr(generateMetsHdr());
 
         Map<URI, FileType> mediaFilesToIDFiles = new HashMap<>();
-        mets.setFileSec(generateFileSec(mediaFilesToIDFiles));
+        FileSec fileSec = generateFileSec(mediaFilesToIDFiles);
+
+        // Omit empty fileSecs as they are not valid in METS
+        if (!fileSec.getFileGrp().isEmpty()) {
+            mets.setFileSec(fileSec);
+        }
 
         Map<PhysicalDivision, String> physicalDivisionIDs = new HashMap<>();
         mets.getStructMap().add(generatePhysicalStructMap(mediaFilesToIDFiles, physicalDivisionIDs, mets));
@@ -283,7 +288,10 @@ public class MetsXmlElementAccess implements MetsXmlElementAccessInterface {
         logical.setDiv(new DivXmlElementAccess(workpiece.getLogicalStructure()).toDiv(physicalDivisionIDs, smLinkData, mets));
         mets.getStructMap().add(logical);
 
-        mets.setStructLink(createStructLink(smLinkData));
+        // Omit empty structLinks as they are not valid in METS
+        if (!smLinkData.isEmpty()) {
+            mets.setStructLink(createStructLink(smLinkData));
+        }
         return mets;
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/metadata/MetadataEditorIT.java
@@ -93,7 +93,7 @@ public class MetadataEditorIT {
 
         MetadataEditor.addLink(ServiceManager.getProcessService().getById(parentId), "0", childId);
 
-        assertTrue(isInternalMetsLink(FileUtils.readLines(metaXmlFile, StandardCharsets.UTF_8).get(36), childId), "The link was not added correctly!");
+        assertTrue(isInternalMetsLink(FileUtils.readLines(metaXmlFile, StandardCharsets.UTF_8).get(38), childId), "The link was not added correctly!");
 
         FileUtils.writeLines(metaXmlFile, StandardCharsets.UTF_8.toString(), metaXmlContentBefore);
         FileUtils.deleteQuietly(new File(METADATA_BASE_DIR + parentId + "/meta.xml.1"));


### PR DESCRIPTION
Fixes #6714 

**Note**: this pull request only adds changes ensuring that _new_ processes will contain valid METS structures. A function to fix the structure of existing processes should be developed separately.