### PR TITLE
[3.9] Add missing Spanish translations

### DIFF
--- a/Kitodo/src/main/resources/messages/messages_es.properties
+++ b/Kitodo/src/main/resources/messages/messages_es.properties
@@ -686,7 +686,6 @@ jumpForwardOneMillisecond=Adelantar 1 milisegundo
 jumpForwardTenMilliseconds=Adelantar 10 milisegundos
 jumpForwardOneHundredMilliseconds=Adelantar 100 milisegundos
 jumpForwardOneSecond=Adelantar 1 segundo
-# Please verify automatic translation with Google Translate
 kitodoScript.contentDeleted=Contenido eliminado para {0}
 kitodoScript.processDeleted=Proceso {0} eliminado.
 kitodoScript.processSkipped=Se omitió el proceso {0}.


### PR DESCRIPTION
Add missing Spanish translations created with Google Translate.

@danilopenagos & @joergleh would you mind checking and potentially fixing these translations?