### PR TITLE
Scroll through list of IDs from Search index

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
@@ -224,10 +224,17 @@ public class BeanQuery {
      * Searches the index and inserts the IDs into the HQL query parameters.
      */
     public void performIndexSearches() {
+        performIndexSearches(false);
+    }
+
+    /**
+     * Searches the index and inserts the IDs into the HQL query parameters.
+     */
+    public void performIndexSearches(boolean useScroll) {
         for (var iterator = indexQueries.entrySet().iterator(); iterator.hasNext();) {
             Entry<String, Pair<FilterField, String>> entry = iterator.next();
             Collection<Integer> ids = indexingService.searchIds(Process.class, entry.getValue().getLeft()
-                    .getSearchField(), entry.getValue().getRight());
+                    .getSearchField(), entry.getValue().getRight(), useScroll);
             parameters.put(entry.getKey(), ids.isEmpty() ? NO_HIT : ids);
             iterator.remove();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -2411,7 +2411,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
             query.addBooleanRestriction("project.active", Boolean.TRUE);
         }
         query.restrictToClient(sessionClientId);
-        query.performIndexSearches();
+        query.performIndexSearches(true);
 
         query.addInnerJoin("project proj");
         query.defineSorting("id", SortOrder.ASCENDING);


### PR DESCRIPTION
One of the problems with the current Hibernate Search based setup is that it relies on the following flow:
- First use the provided filter fields to search the Search backend (e.g. Elasticsearch) for a specific term (`TitleDocMain:Rhein`). 
- Use the returned IDs to restrict the database query, which contains the actual results, to the ones coming from the search query

Because of the hard limit of 10.000 results (from Elasticsearch/Opensearch) in a Search response the ID list might not contain all relevant (or IDs of non active processes) so the returned result from the DB is wrong. This experimental PR uses for the Excel export result set scrolling to retrieve all IDs.

