### PR TITLE
[3.9] Make displayed filters more coherent

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
@@ -27,7 +27,8 @@ public enum FilterString {
     PROCESS("process:", "prozess:"),
     BATCH("batch:", "gruppe:"),
     TASKAUTOMATIC("stepautomatic:", "schrittautomatisch:"),
-    PROPERTY("property:","eigenschaft:");
+    PROPERTY("property:","eigenschaft:"),
+    SEARCH("search:", "suche:");
 
     private final String filterEnglish;
     private final String filterGerman;

--- a/Kitodo/src/main/java/org/kitodo/production/filters/ParsedFilter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/ParsedFilter.java
@@ -48,7 +48,7 @@ public class ParsedFilter {
         if (matcher.find()) {
             return matcher.group();
         }
-        return FilterString.PROCESS.getFilterEnglish();
+        return FilterString.SEARCH.getFilterEnglish();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
@@ -80,6 +80,7 @@ enum FilterField {
             case "parentprocessid":
                 return PARENT_PROCESS_ID;
             case "process": return PROCESS_TITLE;
+            case "search": return SEARCH;
             case "project": return PROJECT;
             case "project_loose":
                 return PROJECT_LOOSE;

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -30,7 +30,7 @@
 
         <!--@elvariable id="input" type="java.lang.String"-->
         <f:viewParam name="input"/>
-        <o:viewAction action="#{ProcessForm.changeFilter('process:'.concat(input))}"
+        <o:viewAction action="#{ProcessForm.changeFilter('search:'.concat(input))}"
                       if="#{not empty input}"
                       update="parsedFiltersForm:parsedFilters"/>
     </f:metadata>


### PR DESCRIPTION
Addresses the UI aspects of https://github.com/kitodo/kitodo-production/issues/6709

This resolves points 1) and 2) in https://github.com/kitodo/kitodo-production/pull/6743

Right now the display of the filter box is not in line with what happens in the backend. I changed the logic to now display `search:` in front of a non prefixed search term; right now "process:" is added which does not actually represents what happens in the backend: a search over **all** fields.  (See https://github.com/kitodo/kitodo-production/pull/6618#issuecomment-3113657079)
To make things consistent: `search:XXX` can be used to search in all fields.

Before search:

<img width="1769" height="159" alt="image" src="https://github.com/user-attachments/assets/6f3acfca-b953-4b78-bab2-ba9d56c99c02" />

After search execution:

<img width="1804" height="195" alt="image" src="https://github.com/user-attachments/assets/f09648d1-5c92-45f1-9da2-4130f8b80d17" />

To bring the behaviour in line with previous versions of Kitodo, searches in the top left bar also resolve to "search:" now.

<img width="1857" height="140" alt="image" src="https://github.com/user-attachments/assets/79aa6b39-4804-4798-8fc9-846527e09dc6" />


Edit: This does NOT fix the problem of inconsistencies between process title search and global search. It only brings consistency to the UI.