### PR TITLE
[3.9] Make parsedFilter regex broader

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/filters/ParsedFilter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/ParsedFilter.java
@@ -43,7 +43,7 @@ public class ParsedFilter {
      * @return the category without surrounding quotation marks or leading dash
      */
     public String getCategory() {
-        Pattern pattern = Pattern.compile("[a-zA-Z]+:");
+        Pattern pattern =  Pattern.compile("[\\p{L}0-9_\\-() ]+:");
         Matcher matcher = pattern.matcher(plainFilter.replaceFirst("^\"?-?", ""));
         if (matcher.find()) {
             return matcher.group();


### PR DESCRIPTION
Right now, when searching for e.g. "project_loose:Projekt", we loose parts of the string and only "loose:Projekt" is displayed. 

<img width="1760" height="66" alt="image" src="https://github.com/user-attachments/assets/c2e077cb-2de2-4279-b56d-fb31ce251003" />

<img width="1763" height="177" alt="image" src="https://github.com/user-attachments/assets/cdcf2469-e04d-4831-902e-df01a378c80e" />

In order to conserve the original filter input we should make the regex broader to correctly display things like:

process:	
slub_ownerOrig:
LDP-Projekt:
Digitale Kollektionen:	
Besitzer der Vorlage (Körperschaft):

