### PR TITLE
[3.9] Deactivate error prone parallel task processing by default

### DIFF
--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -444,8 +444,10 @@ batches.logChangesToWikiField=false
 
 # Overrides the limit of tasks run in parallel. Defaults to the number of
 # available cores. Set to 1 to run tasks sequentially.
-# Running tasks in parallel can lead to HibernateExceptions (see https://github.com/kitodo/kitodo-production/issues/5357)
-# therefore it is recommended to set this value to 1 until the issue is resolved.
+# Running tasks in parallel does have some issues currently 
+# (see https://github.com/kitodo/kitodo-production/issues/5357 
+# and https://github.com/kitodo/kitodo-production/issues/6624)
+# therefore it is recommended to set this value to 1 until the issues are resolved.
 taskManager.autoRunLimit=1
 
 # Sets the time interval between two inspections of the task list. Defaults to


### PR DESCRIPTION
Backport of #6727 