### PR TITLE
Optimize list row count

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyProcessModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyProcessModel.java
@@ -110,6 +110,12 @@ public class LazyProcessModel extends LazyBeanModel {
     }
 
     @Override
+    public int count(Map<String, FilterMeta> filterBy) {
+        // count handled via load() + setRowCount()
+        return 0;
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public List<Object> load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filters) {
         String sortField = "";

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyTaskModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyTaskModel.java
@@ -71,6 +71,12 @@ public class LazyTaskModel extends LazyBeanModel {
     }
 
     @Override
+    public int count(Map<String, FilterMeta> filterBy) {
+        // count handled via load() + setRowCount()
+        return 0;
+    }
+
+    @Override
     public List<Object> load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filters) {
         String sortField = null;
         SortOrder sortOrder = SortOrder.ASCENDING;


### PR DESCRIPTION
Adresses https://github.com/kitodo/kitodo-production/issues/6704

In accordance with the offical Primefaces documentation (https://primefaces.github.io/primefaces/12_0_0/#/components/datatable?id=lazy-loading), i overrode the `count` method in `LazyProcessModel` and `LazyTaskModel` and delegate the actual counting to the `load()`-method. 