### PR TITLE
Improve Selenium Test Reliability of MetadataST.updateMediaReferenceTest

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
@@ -267,6 +267,8 @@ public class MetadataST extends BaseTestSelenium {
     public void updateMediaReferencesTest() throws Exception {
         login("kowal");
         Pages.getProcessesPage().goTo().editMetadata(MockDatabase.MEDIA_REFERENCES_TEST_PROCESS_TITLE);
+        await().ignoreExceptions().pollDelay(300, TimeUnit.MILLISECONDS).atMost(5, TimeUnit.SECONDS)
+                .until(() -> Pages.getMetadataEditorPage().isFileReferencesUpdatedDialogVisible());
         assertTrue(Pages.getMetadataEditorPage()
                 .isFileReferencesUpdatedDialogVisible(), "Media references updated dialog not visible");
         Pages.getMetadataEditorPage().acknowledgeFileReferenceChanges();


### PR DESCRIPTION
Adds additional await statement before checking whether the dialog was opened.