### PR TITLE
Allow restrictions with empty 'division' values in rulesets

### DIFF
--- a/Kitodo-DataEditor/src/test/resources/ruleset.xsd
+++ b/Kitodo-DataEditor/src/test/resources/ruleset.xsd
@@ -308,7 +308,7 @@
             <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
             <xs:element name="condition" minOccurs="0" maxOccurs="unbounded" type="ruleset:Condition"/>
         </xs:sequence>
-        <xs:attribute type="xs:NMTOKEN" name="division"/>
+        <xs:attribute type="xs:string" name="division"/>
         <xs:attribute type="xs:NMTOKEN" name="key"/>
         <xs:attribute type="xs:string" name="value"/>
         <xs:attribute type="xs:nonNegativeInteger" name="minOccurs"/>

--- a/Kitodo/rulesets/ruleset.xsd
+++ b/Kitodo/rulesets/ruleset.xsd
@@ -308,7 +308,7 @@
             <xs:element name="permit" minOccurs="0" maxOccurs="unbounded" type="ruleset:RestrictivePermit"/>
             <xs:element name="condition" minOccurs="0" maxOccurs="unbounded" type="ruleset:Condition"/>
         </xs:sequence>
-        <xs:attribute type="xs:NMTOKEN" name="division"/>
+        <xs:attribute type="xs:string" name="division"/>
         <xs:attribute type="xs:NMTOKEN" name="key"/>
         <xs:attribute type="xs:string" name="value"/>
         <xs:attribute type="xs:nonNegativeInteger" name="minOccurs"/>


### PR DESCRIPTION
Using the workaround described in https://github.com/kitodo/kitodo-production/issues/6024#issuecomment-2061639760 renders rulesets invalid with regard to the ruleset schema definition [ruleset.xsd](https://github.com/kitodo/kitodo-production/blob/db865cfe3ad4f00ee9bdf64f31a54c5407dff545/Kitodo/rulesets/ruleset.xsd). This pull request fixes that by adjusting the schema definition to allow empty strings as values for the `division` attribute of `restriction` elements in a ruleset. Thus fixes #6193 

This change is a prerequisite for continuing to work with rulesets that include the mentioned workaround after #6367 is implemented. (see https://github.com/kitodo/kitodo-production/issues/6367#issuecomment-3498172501 for details)