### PR TITLE
[main] Update CodeQL action to version 4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -77,6 +77,6 @@ jobs:
         mvn clean install -B '-P!development' -DskipTests=true
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
According to https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/ the change is in December 2026 but CodeQL actions are failing right now at the SLUB fork. Maybe GitHub has enabled this first on a few repositories.

If wanted I can open pull requests against 3.8.x and 3.9.x branch.