### PR TITLE
[3.8] Prevent IndexOutOfBoundsException in addNewMediaToWorkpiece by clamping the insertion index

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1298,10 +1298,12 @@ public class FileService {
                         break;
                     }
                 }
-                workpiece.getPhysicalStructure().getChildren().add(insertionPoint, physicalDivision);
-                actualLogicalRoot.getViews().add(insertionPoint, view);
-                view.getPhysicalDivision().getLogicalDivisions().add(actualLogicalRoot);
-                canonicals.add(insertionPoint, entry.getKey());
+                int safeIndexChildren = Math.min(insertionPoint, workpiece.getPhysicalStructure().getChildren().size());
+                int safeIndexViews = Math.min(insertionPoint, actualLogicalRoot.getViews().size());
+                int safeIndexCanonicals = Math.min(insertionPoint, canonicals.size());
+                workpiece.getPhysicalStructure().getChildren().add(safeIndexChildren, physicalDivision);
+                actualLogicalRoot.getViews().add(safeIndexViews, view);
+                canonicals.add(safeIndexCanonicals, entry.getKey());
             }
         }
     }


### PR DESCRIPTION
Backport of https://github.com/kitodo/kitodo-production/pull/6756