### PR TITLE
Change tokenization for more coherent search

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
@@ -92,25 +92,25 @@ public class ProcessKeywords {
      */
     public ProcessKeywords(Process process) {
         // keywords for title search + default search
-        this.titleKeywords = filterMinLength(initTitleKeywords(process.getTitle()), LENGTH_MIN_DEFAULT);
+        this.titleKeywords = filterMinLength(initTitleKeywords(process.getTitle()));
 
         // keywords for project search in default search
         String projectTitle = Objects.nonNull(process.getProject()) ? process.getProject().getTitle() : "";
-        this.projectKeywords = filterMinLength(initSimpleKeywords(projectTitle, true), LENGTH_MIN_DEFAULT);
+        this.projectKeywords = filterMinLength(initSimpleKeywords(projectTitle, true));
 
         // keywords for batch search + default search
-        this.batchKeywords = filterMinLength(initBatchKeywords(process.getBatches()), LENGTH_MIN_DEFAULT);
+        this.batchKeywords = filterMinLength(initBatchKeywords(process.getBatches()));
 
         // keywords for task search in default search
-        this.taskKeywords = filterMinLength(initTaskKeywords(process.getTasksUnmodified()), LENGTH_MIN_DEFAULT);
+        this.taskKeywords = filterMinLength(initTaskKeywords(process.getTasksUnmodified()));
 
         // more keywords for default search only
         this.defaultKeywords = new HashSet<String>();
         if (Objects.nonNull(process.getId())) {
             defaultKeywords.add(process.getId().toString());
         }
-        defaultKeywords.addAll(filterMinLength(initCommentKeywords(process.getComments()), LENGTH_MIN_DEFAULT));
-        defaultKeywords.addAll(filterMinLength(initMetadataKeywords(process), LENGTH_MIN_DEFAULT));
+        defaultKeywords.addAll(filterMinLength(initCommentKeywords(process.getComments())));
+        defaultKeywords.addAll(filterMinLength(initMetadataKeywords(process)));
 
         if (logger.isTraceEnabled()) {
             logKeywords(process.getId());
@@ -343,16 +343,13 @@ public class ProcessKeywords {
      * Filter minimum-length tokens. Only tokens at least three characters long
      * should be indexed, because you'll never search for tokens that are too
      * short anyway, but it would bloat the index a lot.
-     * 
-     * @param tokens
-     *            input set, is changed!
-     * @param minLength
-     *            minimum length of contained strings
+     *
+     * @param tokens input set, is changed!
      * @return input set
      */
-    private static Set<String> filterMinLength(Set<String> tokens, int minLength) {
+    private static Set<String> filterMinLength(Set<String> tokens) {
         for (Iterator<String> iterator = tokens.iterator(); iterator.hasNext();) {
-            if (iterator.next().length() < minLength) {
+            if (iterator.next().length() < ProcessKeywords.LENGTH_MIN_DEFAULT) {
                 iterator.remove();
             }
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
@@ -24,45 +24,44 @@ import org.kitodo.data.database.enums.TaskStatus;
  * Constants for known search field names in filters.
  */
 enum FilterField {
-    SEARCH(null, null, null, null, null, null, "search", ProcessKeywords.LENGTH_MIN_DEFAULT),
-    PROCESS_ID(null, null, null, "id", "process.id", null, null, -1),
-    PARENT_PROCESS_ID(null, null, null, "parent.id", "process.parent.id", null, null, -1),
-    PROCESS_TITLE("title", "process.title", LikeSearch.NO, null, null, null, "searchTitle",
-            ProcessKeywords.LENGTH_MIN_DEFAULT),
+    SEARCH(null, null, null, null, null, null, "search"),
+    PROCESS_ID(null, null, null, "id", "process.id", null, null),
+    PARENT_PROCESS_ID(null, null, null, "parent.id", "process.parent.id", null, null),
+    PROCESS_TITLE("title", "process.title", LikeSearch.NO, null, null, null, "searchTitle"),
     PROJECT("project.title", "process.project.title", LikeSearch.ALLOWED, "project.id", "process.project.id", null,
-            null, -1),
+            null),
     PROJECT_LOOSE("project.title", "process.project.title", LikeSearch.ALWAYS_RIGHT, "project.id", "process.project.id",
-            null, null, -1),
+            null, null),
     BATCH("process.batches AS batch WITH batch.title", "process.batches AS batch WITH batch.title",
-            LikeSearch.NO, "batches AS batch WITH batch.id", "process.batches AS batch WITH batch.id", null, null, -1),
-    TASK("tasks AS task WITH task.title", "title", LikeSearch.NO, "tasks AS task WITH task.id", "id", null, null, -1),
+            LikeSearch.NO, "batches AS batch WITH batch.id", "process.batches AS batch WITH batch.id", null, null),
+    TASK("tasks AS task WITH task.title", "title", LikeSearch.NO, "tasks AS task WITH task.id", "id", null, null),
     TASK_AUTOMATIC("tasks AS task WITH task.typeAutomatic = :queryObject AND task.title",
             "~.typeAutomatic = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.typeAutomatic = :queryObject AND task.id", "typeAutomatic = :queryObject AND id",
-            Boolean.TRUE, null, -1),
+            Boolean.TRUE, null),
     TASK_UNREADY("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.LOCKED, null, -1),
+            "processingStatus = :queryObject AND id", TaskStatus.LOCKED, null),
     TASK_READY("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.OPEN, null, -1),
+            "processingStatus = :queryObject AND id", TaskStatus.OPEN, null),
     TASK_ONGOING("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.INWORK, null, -1),
+            "processingStatus = :queryObject AND id", TaskStatus.INWORK, null),
     TASK_FINISHED("tasks AS task WITH task.processingStatus = :queryObject AND task.title",
             "~.processingStatus = :queryObject AND ~.title", LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.id",
-            "processingStatus = :queryObject AND id", TaskStatus.DONE, null, -1),
+            "processingStatus = :queryObject AND id", TaskStatus.DONE, null),
     TASK_FINISHED_USER(
             "tasks AS task WITH task.processingStatus = :queryObject AND (task.processingUser.name = # OR task.processingUser.surname = # "
                     .concat("OR task.processingUser.login = # OR task.processingUser.ldapLogin = #)"),
             "~.processingStatus = :queryObject AND (~.processingUser.name = # OR ~.processingUser.surname = # "
                     .concat("OR ~.processingUser.login = # OR ~.processingUser.ldapLogin = #)"), LikeSearch.NO,
             "tasks AS task WITH task.processingStatus = :queryObject AND task.processingUser.id",
-            "processingStatus = :queryObject AND processingUser.id", TaskStatus.DONE, null, -1);
+            "processingStatus = :queryObject AND processingUser.id", TaskStatus.DONE, null);
 
     /**
      * Here the string search field names (user input) are mapped to the
@@ -121,7 +120,6 @@ enum FilterField {
     private final String taskIdQuery;
     private final Object queryObject;
     private final String searchField;
-    private final int minTokenLength;
 
     /**
      * Creates a filter field enum constant.
@@ -140,11 +138,9 @@ enum FilterField {
      *            object {@code :queryObject}, if used in the query
      * @param searchField
      *            search field for index search
-     * @param minTokenLength
-     *            minimum length of searchable token
      */
     FilterField(String processTitleQuery, String taskTitleQuery, LikeSearch likeSearch, String processIdQuery,
-            String taskIdQuery, Object queryObject, String searchField, int minTokenLength) {
+            String taskIdQuery, Object queryObject, String searchField) {
         this.processTitleQuery = processTitleQuery;
         this.taskTitleQuery = taskTitleQuery;
         this.likeSearch = likeSearch;
@@ -152,7 +148,6 @@ enum FilterField {
         this.taskIdQuery = taskIdQuery;
         this.queryObject = queryObject;
         this.searchField = searchField;
-        this.minTokenLength = minTokenLength;
     }
 
     private static FilterField getTaskFinishedUser() {
@@ -238,16 +233,4 @@ enum FilterField {
         return searchField;
     }
 
-    /**
-     * Minimum length for searchable tokens. Tokens that are too short are not
-     * indexed because they bloat the index and quickly lead to all candidate
-     * matches, resulting in unnecessary computing and no benefit. Therefore,
-     * they must be filtered out of the query; otherwise, searching for them
-     * will return 0 matches.
-     * 
-     * @return minimum length of searchable token
-     */
-    int getMinTokenLength() {
-        return minTokenLength;
-    }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryPart.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryPart.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.kitodo.data.database.beans.ProcessKeywords;
 
 /**
  * A portion of the filter entered by the user that is resolved through the
@@ -45,7 +46,7 @@ class IndexQueryPart implements UserSpecifiedFilter {
     IndexQueryPart(FilterField filterField, String values, boolean operand) {
         this.filterField = filterField;
         for (String value : splitValues(values)) {
-            if (value.length() >= filterField.getMinTokenLength()) {
+            if (value.length() >= ProcessKeywords.LENGTH_MIN_DEFAULT) {
                 this.lookfor.add(normalize(value));
             }
         }


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/6709

This addresses point 3) of https://github.com/kitodo/kitodo-production/issues/6743

This is a very small change which requires a longer explanation. As discussed extensively in the linked issue, the Kitodo search for process titles behaves different when searching a title in a search over `all` fields vs. a search in the `process title` field in the index.

The reason for that is, that Kitodo tokenizes the input string different at search time depending on which field is searched. In the `process title search` the Kitodo search effectively drops all tokens with a length of less then three.

So `Heutwia_898482011-1794081501_01-s` is effectively searched as `Heutwia_898482011-1794081501`. This works, because at index time the same happens. 

The behaviour when searching over all fields however is different. When searching over all fields Kitodo drops no token and searches for `Heutwia_898482011-1794081501_01-s`. This is however not what was indexed (only `Heutwia_898482011-1794081501`). As result the user gets no hits when searching this process title over all fields, which is super confusing.

The reason for this implementation was that when searching `projects` over all fields, it was considered necessary that "project A" can be differentiated from "project B". Therefor the tokenization for the project terms in the `all` field determines the search time tokenization of all other fields which leads to the confusing behavior. (See: https://github.com/kitodo/kitodo-production/pull/6618#issuecomment-3113657079)

As we already have a quite sophisticated `project` field search the @kitodo/kitodo-community-board decided after consulatation with @matthias-ronge, that this special tokenization behaviour is not necessary. We opt for using the same **default** tokenization rules for all fields indexed in the global search field and to drop the special constant. 
 