### PR TITLE
Enable exact process title search on database

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/FilterString.java
@@ -25,6 +25,7 @@ public enum FilterString {
     ID("id:", "id:"),
     PARENTPROCESSID("parentprocessid:", "elternprozessid:"),
     PROCESS("process:", "prozess:"),
+    PROCESS_LOOSE("process_loose:", "prozess_unscharf:"),
     BATCH("batch:", "gruppe:"),
     TASKAUTOMATIC("stepautomatic:", "schrittautomatisch:"),
     PROPERTY("property:","eigenschaft:"),

--- a/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
@@ -44,6 +44,7 @@ public class FilterMenu {
             FilterString.ID,
             FilterString.PARENTPROCESSID,
             FilterString.PROCESS,
+            FilterString.PROCESS_LOOSE,
             FilterString.BATCH,
             FilterString.PROPERTY
     );
@@ -55,6 +56,7 @@ public class FilterMenu {
             FilterString.PROJECT_LOOSE,
             FilterString.ID,
             FilterString.PROCESS,
+            FilterString.PROCESS_LOOSE,
             FilterString.BATCH,
             FilterString.PROPERTY
     );

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterField.java
@@ -25,7 +25,8 @@ enum FilterField {
     SEARCH(null, null, null, null, null, null, "search", ProcessKeywords.LENGTH_MIN_REASONABLE),
     PROCESS_ID(null, null, null, "id", "process.id", null, null, -1),
     PARENT_PROCESS_ID(null, null, null, "parent.id", "process.parent.id", null, null, -1),
-    PROCESS_TITLE("title", "process.title", LikeSearch.NO, null, null, null, "searchTitle",
+    PROCESS_TITLE("title", "process.title",LikeSearch.NO,"id", "process.id", null, null, -1),
+    PROCESS_TITLE_LOOSE("title", "process.title", LikeSearch.NO, null, null, null, "searchTitle",
             ProcessKeywords.LENGTH_MIN_DEFAULT),
     PROJECT("project.title", "process.project.title", LikeSearch.ALLOWED, "project.id", "process.project.id", null,
             null, -1),
@@ -80,6 +81,7 @@ enum FilterField {
             case "parentprocessid":
                 return PARENT_PROCESS_ID;
             case "process": return PROCESS_TITLE;
+            case "process_loose": return PROCESS_TITLE_LOOSE;
             case "search": return SEARCH;
             case "project": return PROJECT;
             case "project_loose":

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -410,7 +410,8 @@ public class FilterService extends BaseBeanService<Filter, FilterDAO> {
         }
 
         Matcher idSearch = ID_SEARCH_PATTERN.matcher(value);
-        if (idSearch.matches() && !filterField.equals(FilterField.PROCESS_TITLE)) {
+        if (idSearch.matches() && (!filterField.equals(FilterField.PROCESS_TITLE)
+                && !filterField.equals(FilterField.PROCESS_TITLE_LOOSE))) {
             return new DatabaseIdQueryPart(filterField, idSearch.group(1), idSearch.group(2), operand);
         }
 


### PR DESCRIPTION
This PR adresses point 4) of https://github.com/kitodo/kitodo-production/issues/6743 and conceptually builds upon https://github.com/kitodo/kitodo-production/pull/6764 and https://github.com/kitodo/kitodo-production/pull/6763. 

Right now it is impossible to search for an exact process title so when searching a title search it is always a **loose** search finding similar titles. As it has has been elaborated by the @kitodo/kitodo-community-board the expectation of a `process:` search is a search for a precise title in the database. I added `process_loose` to map to the existing `title` field in the search index.

To be precise:

`process:Heutwia_898482011-1794081501_01-s` will after this PR only find `Heutwia_898482011-1794081501_01-s`. `process_loose:Heutwia_898482011-1794081501_01-s` will also find `Heutwia_898482011-1794081501_02-s` etc.
 