### PR TITLE
Use multiple field/value terms in ES query

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,7 +63,7 @@ public class BeanQuery {
     private final List<String> restrictionAlternatives = new ArrayList<>();
     private boolean indexFiltersAsAlternatives = false;
     private Pair<String, String> sorting;
-    private final Map<String, Pair<FilterField, String>> indexQueries = new HashMap<>();
+    private final List<Pair<FilterField, String>> indexQueries = new ArrayList<>();
     private final Map<String, Object> parameters = new HashMap<>();
 
     /**
@@ -232,16 +231,39 @@ public class BeanQuery {
     }
 
     /**
-     * Searches the index and inserts the IDs into the HQL query parameters.
+     * Applies a restriction based on index search results to the given field.
+     *
+     * <p>If index queries were defined, this performs a search in the index and
+     * restricts the query to the resulting IDs. If the index search yields no hits,
+     * a non-matching ID set is applied to ensure the query returns no results.</p>
+     *
+     * <p>If no index queries were defined, no restriction is added.</p>
+     *
+     * @param field the entity field to restrict (e.g. "id" or "process.id")
      */
-    public void performIndexSearches() {
-        for (var iterator = indexQueries.entrySet().iterator(); iterator.hasNext();) {
-            Entry<String, Pair<FilterField, String>> entry = iterator.next();
-            Collection<Integer> ids = indexingService.searchIds(Process.class, entry.getValue().getLeft()
-                    .getSearchField(), entry.getValue().getRight());
-            parameters.put(entry.getKey(), ids.isEmpty() ? NO_HIT : ids);
-            iterator.remove();
+    public void applyIndexRestriction(String field) {
+        if (indexQueries.isEmpty()) {
+            return;
         }
+        Collection<Integer> ids = performIndexSearches();
+        addInCollectionRestriction(field, ids);
+    }
+
+    /**
+     * Executes all collected index query terms as a single combined index search
+     * and returns the matching process IDs. If no hits are found, a non-matching
+     * ID collection is returned by the caller.
+     */
+    private Collection<Integer> performIndexSearches() {
+        List<Pair<String,String>> terms = new ArrayList<>();
+        for (var entry : indexQueries) {
+            String field = entry.getLeft().getSearchField();
+            String token = entry.getRight();
+            terms.add(Pair.of(field, token));
+        }
+        indexQueries.clear();
+        Collection<Integer> ids = indexingService.searchIds(Process.class, terms);
+        return ids.isEmpty() ? NO_HIT : ids;
     }
 
     /**
@@ -344,9 +366,7 @@ public class BeanQuery {
                     }
                 } else {
                     IndexQueryPart indexQueryPart = (IndexQueryPart) searchFilter;
-                    indexQueryPart.putQueryParameters(varName, parameterName, (className.equals("Process") ? "id"
-                            : "process.id"), indexQueries, indexFiltersAsAlternatives ? restrictionAlternatives
-                                    : restrictions);
+                    indexQueryPart.putQueryParameters(indexQueries);
                 }
             }
             if (groupFilters.size() == 1) {

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
@@ -63,7 +63,7 @@ public class BeanQuery {
     private final List<String> restrictionAlternatives = new ArrayList<>();
     private boolean indexFiltersAsAlternatives = false;
     private Pair<String, String> sorting;
-    private final List<Pair<FilterField, String>> indexQueries = new ArrayList<>();
+    private final List<IndexQueryTerm> indexQueries = new ArrayList<>();
     private final Map<String, Object> parameters = new HashMap<>();
 
     /**
@@ -255,14 +255,9 @@ public class BeanQuery {
      * ID collection is returned by the caller.
      */
     private Collection<Integer> performIndexSearches() {
-        List<Pair<String,String>> terms = new ArrayList<>();
-        for (var entry : indexQueries) {
-            String field = entry.getLeft().getSearchField();
-            String token = entry.getRight();
-            terms.add(Pair.of(field, token));
-        }
+        Collection<Integer> ids =
+                indexingService.searchIds(Process.class, indexQueries);
         indexQueries.clear();
-        Collection<Integer> ids = indexingService.searchIds(Process.class, terms);
         return ids.isEmpty() ? NO_HIT : ids;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryPart.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryPart.java
@@ -13,9 +13,7 @@ package org.kitodo.production.services.data;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.data.database.beans.ProcessKeywords;
@@ -25,8 +23,6 @@ import org.kitodo.data.database.beans.ProcessKeywords;
  * search index.
  */
 class IndexQueryPart implements UserSpecifiedFilter {
-
-    private static final String UNIQUE_PARAMETER_EXTENSION = "query";
 
     private static final char VALUE_SEPARATOR = 'q';
     private final List<String> lookfor = new ArrayList<>();
@@ -88,33 +84,14 @@ class IndexQueryPart implements UserSpecifiedFilter {
     }
 
     /**
-     * Inserts the search parameters into the database query logic.
-     * 
-     * @param varName
-     *            variable name of the HQL search
-     * @param parameterName
-     *            name of the search parameter for the results
-     * @param idField
-     *            field name of the process ID
+     * Adds the prepared index search terms for this filter to the list of index queries.
+     *
      * @param indexQueries
      *            puts the prepared tokens for the search queries here
-     * @param restrictions
-     *            puts the HQL restrictions here
      */
-    void putQueryParameters(String varName, String parameterName, String idField,
-            Map<String, Pair<FilterField, String>> indexQueries,
-            Collection<String> restrictions) {
-        if (lookfor.size() == 1) {
-            restrictions.add(varName + "." + idField + (operand ? " IN (:" : " NOT IN (:") + parameterName + ')');
-            indexQueries.put(parameterName, Pair.of(filterField, lookfor.getFirst()));
-        } else if (lookfor.size() >= 1) {
-            int queryCount = 0;
-            for (String lookingFor : lookfor) {
-                queryCount++;
-                String uniqueParameterName = parameterName + UNIQUE_PARAMETER_EXTENSION + queryCount;
-                restrictions.add(varName + "." + idField + (operand ? " IN (:" : " NOT IN (:") + uniqueParameterName + ')');
-                indexQueries.put(uniqueParameterName, Pair.of(filterField, lookingFor));
-            }
+    void putQueryParameters(List<Pair<FilterField, String>> indexQueries) {
+        for (String lookingFor : lookfor) {
+            indexQueries.add(Pair.of(filterField, lookingFor));
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryPart.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryPart.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.data.database.beans.ProcessKeywords;
 
 /**
@@ -89,9 +88,9 @@ class IndexQueryPart implements UserSpecifiedFilter {
      * @param indexQueries
      *            puts the prepared tokens for the search queries here
      */
-    void putQueryParameters(List<Pair<FilterField, String>> indexQueries) {
+    void putQueryParameters(List<IndexQueryTerm> indexQueries) {
         for (String lookingFor : lookfor) {
-            indexQueries.add(Pair.of(filterField, lookingFor));
+            indexQueries.add(new IndexQueryTerm(filterField.getSearchField(), lookingFor, operand));
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryTerm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/IndexQueryTerm.java
@@ -1,0 +1,18 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.data;
+
+public record IndexQueryTerm(
+        String field,
+        String token,
+        boolean operand) {
+}

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -142,6 +142,7 @@ import org.xml.sax.SAXException;
 public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
 
     private static final Map<String, String> SORT_FIELD_MAPPING;
+    private static final String FIELD_ID = "id";
 
     static {
         SORT_FIELD_MAPPING = new HashMap<>();
@@ -305,7 +306,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         if (!showInactiveProjects) {
             query.addBooleanRestriction("project.active", Boolean.TRUE);
         }
-        query.applyIndexRestriction("id");
+        query.applyIndexRestriction(FIELD_ID);
         return query;
     }
 
@@ -480,7 +481,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         query.restrictWithUserFilterString(metadata.entrySet().stream().map(entry -> '"' + entry.getKey() + ':' + entry
                 .getValue() + '"').collect(Collectors.joining(" ")));
         query.setUnordered();
-        query.applyIndexRestriction("id");
+        query.applyIndexRestriction(FIELD_ID);
         return getByQuery(query.formQueryForAll(), query.getQueryParameters());
     }
 
@@ -511,7 +512,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         query.restrictWithUserFilterString(metadata.entrySet().stream().map(entry -> '"' + entry.getKey() + ':' + entry
                 .getValue() + '"').collect(Collectors.joining(" ")));
         query.setUnordered();
-        query.applyIndexRestriction("id");
+        query.applyIndexRestriction(FIELD_ID);
         return getByQuery(query.formQueryForAll(), query.getQueryParameters());
     }
 
@@ -676,7 +677,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
                 .filter(project -> showInactiveProjects || project.isActive()).map(Project::getId)
                 .collect(Collectors.toList());
         query.restrictToProjects(projectIDs);
-        query.applyIndexRestriction("id");
+        query.applyIndexRestriction(FIELD_ID);
         return getByQuery(query.formQueryForAll(), query.getQueryParameters());
     }
 
@@ -2571,7 +2572,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         }
 
         query.restrictToClient(sessionClientId);
-        query.applyIndexRestriction("id");
+        query.applyIndexRestriction(FIELD_ID);
         query.addInnerJoin("project proj");
         query.defineSorting("id", SortOrder.ASCENDING);
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -305,7 +305,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         if (!showInactiveProjects) {
             query.addBooleanRestriction("project.active", Boolean.TRUE);
         }
-        query.performIndexSearches();
+        query.applyIndexRestriction("id");
         return query;
     }
 
@@ -480,7 +480,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         query.restrictWithUserFilterString(metadata.entrySet().stream().map(entry -> '"' + entry.getKey() + ':' + entry
                 .getValue() + '"').collect(Collectors.joining(" ")));
         query.setUnordered();
-        query.performIndexSearches();
+        query.applyIndexRestriction("id");
         return getByQuery(query.formQueryForAll(), query.getQueryParameters());
     }
 
@@ -511,7 +511,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         query.restrictWithUserFilterString(metadata.entrySet().stream().map(entry -> '"' + entry.getKey() + ':' + entry
                 .getValue() + '"').collect(Collectors.joining(" ")));
         query.setUnordered();
-        query.performIndexSearches();
+        query.applyIndexRestriction("id");
         return getByQuery(query.formQueryForAll(), query.getQueryParameters());
     }
 
@@ -676,7 +676,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
                 .filter(project -> showInactiveProjects || project.isActive()).map(Project::getId)
                 .collect(Collectors.toList());
         query.restrictToProjects(projectIDs);
-        query.performIndexSearches();
+        query.applyIndexRestriction("id");
         return getByQuery(query.formQueryForAll(), query.getQueryParameters());
     }
 
@@ -2571,7 +2571,7 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         }
 
         query.restrictToClient(sessionClientId);
-        query.performIndexSearches();
+        query.applyIndexRestriction("id");
         query.addInnerJoin("project proj");
         query.defineSorting("id", SortOrder.ASCENDING);
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -177,7 +177,7 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
             boolean showAutomaticTasks, List<TaskStatus> taskStatus) throws DAOException {
 
         BeanQuery query = formBeanQuery(filters, onlyOwnTasks, hideCorrectionTasks, showAutomaticTasks, taskStatus);
-        query.performIndexSearches();
+        query.applyIndexRestriction("process.id");
         return count(query.formCountQuery(), query.getQueryParameters());
     }
 
@@ -258,7 +258,7 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
 
         BeanQuery query = formBeanQuery(filters, onlyOwnTasks, hideCorrectionTasks, showAutomaticTasks, taskStatus);
         query.defineSorting(SORT_FIELD_MAPPING.get(sortField), sortOrder);
-        query.performIndexSearches();
+        query.applyIndexRestriction("process.id");
         return getByQuery(query.formQueryForAll(), query.getQueryParameters(), offset, limit);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -74,6 +74,7 @@ import org.xml.sax.SAXException;
 public class TaskService extends BaseBeanService<Task, TaskDAO> {
 
     private static final Map<String, String> SORT_FIELD_MAPPING;
+    private static final String FIELD_PROCESS_ID = "process.id";
 
     static {
         SORT_FIELD_MAPPING = new HashMap<>();
@@ -177,7 +178,7 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
             boolean showAutomaticTasks, List<TaskStatus> taskStatus) throws DAOException {
 
         BeanQuery query = formBeanQuery(filters, onlyOwnTasks, hideCorrectionTasks, showAutomaticTasks, taskStatus);
-        query.applyIndexRestriction("process.id");
+        query.applyIndexRestriction(FIELD_PROCESS_ID);
         return count(query.formCountQuery(), query.getQueryParameters());
     }
 
@@ -258,7 +259,7 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
 
         BeanQuery query = formBeanQuery(filters, onlyOwnTasks, hideCorrectionTasks, showAutomaticTasks, taskStatus);
         query.defineSorting(SORT_FIELD_MAPPING.get(sortField), sortOrder);
-        query.applyIndexRestriction("process.id");
+        query.applyIndexRestriction(FIELD_PROCESS_ID);
         return getByQuery(query.formQueryForAll(), query.getQueryParameters(), offset, limit);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -16,13 +16,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
 import org.hibernate.exception.DataException;
 import org.hibernate.search.engine.search.projection.SearchProjection;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
@@ -35,6 +33,7 @@ import org.kitodo.data.database.persistence.HibernateUtil;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.BeanQuery;
+import org.kitodo.production.services.data.IndexQueryTerm;
 
 public class IndexingService {
 
@@ -139,15 +138,21 @@ public class IndexingService {
     }
 
     /**
-     * Searches for entities matching all given field/value terms and returns their IDs.
+     * Searches for entities matching the given index query terms and returns their IDs.
+     *
+     * <p>The terms are combined into a single boolean Elasticsearch query.
+     * Positive terms are added as filter predicates, negated terms as exclusion
+     * predicates.</p>
      *
      * @param beanClass
      *            class of beans to search for
      * @param terms
-     *            list of field/value pairs to match (AND-combined)
+     *            index query terms to combine in the search query
      * @return ids of the found beans
      */
-    public Collection<Integer> searchIds(Class<? extends BaseBean> beanClass, List<Pair<String, String>> terms) {
+    public Collection<Integer> searchIds(
+            Class<? extends BaseBean> beanClass,
+            List<IndexQueryTerm> terms) {
         try (Session ormSession = HibernateUtil.getSession()) {
             SearchSession searchSession = Search.session(ormSession);
             SearchProjection<Integer> idField = searchSession.scope(beanClass).projection().field("id", Integer.class)
@@ -156,12 +161,17 @@ public class IndexingService {
                     .select(idField)
                     .where(searchPredicateFactory -> {
                         var booleanPredicate = searchPredicateFactory.bool();
-                        for (Pair<String, String> term : terms) {
-                            booleanPredicate.filter(
-                                    searchPredicateFactory.match()
-                                            .field(term.getLeft())
-                                            .matching(term.getRight())
-                            );
+                        for (IndexQueryTerm term : terms) {
+
+                            var predicate = searchPredicateFactory.match()
+                                    .field(term.field())
+                                    .matching(term.token());
+
+                            if (term.operand()) {
+                                booleanPredicate.filter(predicate);
+                            } else {
+                                booleanPredicate.mustNot(predicate);
+                            }
                         }
                         return booleanPredicate;
                     });
@@ -170,7 +180,7 @@ public class IndexingService {
             String termSummary = String.join(", ",
                     terms.stream()
                             .distinct()
-                            .map(t -> t.getLeft() + "=\"" + t.getRight() + "\"")
+                            .map(t -> t.field() + "=\"" + t.token() + "\"")
                             .toList());
             logger.debug(
                     "Searching {} IDs with terms {}: {} hits",

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -16,11 +16,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
 import org.hibernate.exception.DataException;
 import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
@@ -137,25 +139,45 @@ public class IndexingService {
     }
 
     /**
-     * Searches for a search term in a search field and returns the hit IDs.
-     * 
+     * Searches for entities matching all given field/value terms and returns their IDs.
+     *
      * @param beanClass
      *            class of beans to search for
-     * @param searchField
-     *            search field to search on
-     * @param value
-     *            value to be found in the search field
+     * @param terms
+     *            list of field/value pairs to match (AND-combined)
      * @return ids of the found beans
      */
-    public Collection<Integer> searchIds(Class<? extends BaseBean> beanClass, String searchField, String value) {
+    public Collection<Integer> searchIds(Class<? extends BaseBean> beanClass, List<Pair<String, String>> terms) {
         try (Session ormSession = HibernateUtil.getSession()) {
             SearchSession searchSession = Search.session(ormSession);
             SearchProjection<Integer> idField = searchSession.scope(beanClass).projection().field("id", Integer.class)
                     .toProjection();
-            List<Integer> ids = searchSession.search(beanClass).select(idField).where(function -> function.match().field(
-                    searchField).matching(value)).fetchAll().hits();
-            logger.debug("Searching {} IDs in field \"{}\" for \"{}\": {} hits", beanClass.getSimpleName(), searchField,
-                    value, ids.size());
+            var query = searchSession.search(beanClass)
+                    .select(idField)
+                    .where(searchPredicateFactory -> {
+                        var booleanPredicate = searchPredicateFactory.bool();
+                        for (Pair<String, String> term : terms) {
+                            booleanPredicate.filter(
+                                    searchPredicateFactory.match()
+                                            .field(term.getLeft())
+                                            .matching(term.getRight())
+                            );
+                        }
+                        return booleanPredicate;
+                    });
+            List<Integer> ids = query.fetchAll().hits();
+
+            String termSummary = String.join(", ",
+                    terms.stream()
+                            .distinct()
+                            .map(t -> t.getLeft() + "=\"" + t.getRight() + "\"")
+                            .toList());
+            logger.debug(
+                    "Searching {} IDs with terms {}: {} hits",
+                    beanClass.getSimpleName(),
+                    termSummary,
+                    ids.size()
+            );
             return ids;
         }
     }

--- a/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/command/KitodoScriptServiceIT.java
@@ -554,7 +554,7 @@ public class KitodoScriptServiceIT {
         assertEquals(6, process.getSortHelperMetadata());
         assertEquals(2, process.getSortHelperDocstructs());
 
-        String script = "action:addData " + "key:" + metadataKey + " value:legal note;" + "key:" + metadataKey + " value:secondNote";
+        String script = "action:addData key:" + metadataKey + " \"value:legal note\"; key:" + metadataKey + " \"value:secondNote\"";
         List<Process> processes = new ArrayList<>();
         processes.add(process);
         KitodoScriptService kitodoScript = ServiceManager.getKitodoScriptService();


### PR DESCRIPTION
This PR addresses point 8) of https://github.com/kitodo/kitodo-production/issues/6743. The problem with the current implementation is, that when you have a search like` projectname:MDP_LIK `to retrieve all processes which have a metadata value of "MDP_LIK" in the project field, Kitodo first tokenizes the term to "MDP" and "LIK" and then issues **two** requests for Elasticsearch. 
Both requests return independent sets of IDs. And when both sets do not intersect we might get less hits then we actually have.

For each token constructed at query time we inject the list of IDs (retrieved from the Index) into SQL, so at the end we have sth like `WHERE id IN (x,y,z) and ID in (a,b,c)`. The individual ID lists might be huge because they contain all results which just contain the fragment "MDP".

My change does ensure that only one query is sent to the search index and only one list of IDs is returned, so we do not get multiple contradicting ID lists. It also in many cases ensures that the ID lists are way shorter because we already intersect at the Elasticsearch level and not just pass huge ID lists to the database which are not relevant.

This also frees us from having to construct complex SQL restrictions for multiple returned ID list. Since we only have one list we can just append a simple `WHERE id in (<list od ids>)`.
 