### PR TITLE
Remove reliance on bidirectional association in task-user relation

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -828,18 +828,6 @@ public class CurrentTaskForm extends BaseForm {
     }
 
     /**
-     * Retrieve and return the list of tasks that are assigned to the user that are
-     * currently in progress.
-     *
-     * @return list of tasks that are currently assigned to the user that are
-     *         currently in progress.
-     */
-    public List<Task> getTasksInProgress() {
-        Stopwatch stopwatch = new Stopwatch(this, "getTasksInProgress");
-        return stopwatch.stop(ServiceManager.getUserService().getTasksInProgress(this.user));
-    }
-
-    /**
      * Get taskListPath.
      *
      * @return value of taskListPath

--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -259,7 +259,22 @@ public class UserForm extends BaseForm {
      *         are "INWORK" and belong to process, not template
      */
     public List<Task> getTasksInProgress(User user) {
-        return ServiceManager.getUserService().getTasksInProgress(user);
+        return ServiceManager.getTaskService().getTasksInProgress(user);
+    }
+
+    /**
+     * Check whether the user has tasks that are "INWORK" and belong to a process.
+     *
+     * @param user the user to check
+     * @return true if the user has at least one task in progress
+     */
+    public boolean hasTasksInProgress(User user) {
+        try {
+            return ServiceManager.getTaskService().hasTasksInProgress(user);
+        } catch (DAOException e) {
+            Helper.setErrorMessage("Unable to check tasks in progress for user.", logger, e);
+            return false;
+        }
     }
 
     /**
@@ -288,7 +303,7 @@ public class UserForm extends BaseForm {
      * user from a connected LDAP service.
      */
     public void checkAndDelete() {
-        if (getTasksInProgress(userObject).isEmpty()) {
+        if (!hasTasksInProgress(userObject)) {
             deleteUser(userObject);
         } else {
             PrimeFaces.current().ajax().update("usersTabView:confirmResetTasksDialog");

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -819,6 +819,23 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
     }
 
     /**
+     * Returns whether the user has at least one task in progress.
+     * @param user the processing user
+     * @return true if the user has tasks in progress, otherwise false
+     */
+    public boolean hasTasksInProgress(User user) throws DAOException {
+        String hql = "FROM Task t "
+                + "WHERE t.processingUser = :user "
+                + "AND t.processingStatus = :status "
+                + "AND t.process IS NOT NULL";
+
+        return dao.has(hql, Map.of(
+                "user", user,
+                "status", TaskStatus.INWORK
+        ));
+    }
+
+    /**
      * Compute and return list of tasks that are eligible as 'currentTask' for a new correction comment.
      *
      * @return list of current task options for new correction comment

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -460,17 +460,6 @@ public class UserService extends BaseBeanService<User, UserDAO> implements UserD
     }
 
     /**
-     * Retrieve and return the list of tasks that are assigned to the user and
-     * that are "INWORK" and belong to process, not template.
-     *
-     * @return list of tasks that are currently assigned to the user and that
-     *         are "INWORK" and belong to process, not template
-     */
-    public List<Task> getTasksInProgress(User user) {
-        return ServiceManager.getTaskService().getTasksInProgress(user);
-    }
-
-    /**
      * Changes the password for given User object.
      *
      * @param user

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/userList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/userList.xhtml
@@ -138,13 +138,13 @@
 
                 <h:panelGroup styleClass="action"
                               rendered="#{SecurityAccessController.hasAuthorityToUnassignTasks()}"
-                              title="#{empty UserForm.getTasksInProgress(item) ? msgs.userWithoutTasks : msgs.unassignTasks}">
+                              title="#{UserForm.hasTasksInProgress(item) ? msgs.unassignTasks : msgs.userWithoutTasks}">
                     <p:commandLink id="unassignTasks"
                                    action="#{UserForm.resetTasksToOpen(item)}"
-                                   styleClass="#{empty UserForm.getTasksInProgress(item) ? 'ui-state-disabled' : ''}"
-                                   disabled="#{empty UserForm.getTasksInProgress(item)}"
+                                   styleClass="#{UserForm.hasTasksInProgress(item) ? '' : 'ui-state-disabled'}"
+                                   disabled="#{not UserForm.hasTasksInProgress(item)}"
                                    update="@this">
-                        <h:outputText><i class="fa fa-user-times"/></h:outputText>
+                    <h:outputText><i class="fa fa-user-times"/></h:outputText>
                         <p:confirm message=" #{msgs.confirmUnassignTasks}" header="#{msgs.confirmRelease}"/>
                     </p:commandLink>
                 </h:panelGroup>

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/UserServiceIT.java
@@ -229,7 +229,7 @@ public class UserServiceIT {
     @Test
     public void shouldGetUserTasksInProgress() throws DAOException {
         User user = userService.getByLdapLoginOrLogin("nowakLDP");
-        List<Task> tasks = userService.getTasksInProgress(user);
+        List<Task> tasks = ServiceManager.getTaskService().getTasksInProgress(user);
         assertEquals(1, tasks.size(), "Number of tasks in process is incorrect!");
         assertEquals("Progress", tasks.get(0).getTitle(), "Title of task is incorrect!");
     }


### PR DESCRIPTION
Adresses https://github.com/kitodo/kitodo-production/issues/5813 (But no full fix of the described memory usage since this probably requires more changes)

As outlined in https://github.com/kitodo/kitodo-production/issues/5813#issuecomment-3617287774 bidrectional access to the non owning side of a relation can be problematic if the collections are too large. I would prefer if we remove the collection property. 

```java
@OneToMany(mappedBy = "processingUser", cascade = CascadeType.PERSIST)
private List<Task> processingTasks;
```

to not encourage access to and hydration of potential large collections. But we use those accessors in tests so i only replaced the application-level usage of it with an HQL query. Since the `processingTasks` accessor is no longer used at runtime, we do not need to maintain manual synchronization between both sides of the association.