### PR TITLE
Fix default child import configuration

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Project.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Project.java
@@ -750,7 +750,7 @@ public class Project extends BaseBean implements Comparable<Project> {
      * @return value of defaultChildProcessImportConfiguration
      */
     public ImportConfiguration getDefaultChildProcessImportConfiguration() {
-        initialize(new ProjectDAO(), defaultImportConfiguration);
+        initialize(new ProjectDAO(), defaultChildProcessImportConfiguration);
         return defaultChildProcessImportConfiguration;
     }
 


### PR DESCRIPTION
This should fix the exception which is thrown, when a `defaultChildProcessImportConfiguration` is configured and a child process gets created.
When no default Child import configuration is setup Kitodo 3.9 and 4.0 throw no error, so i suppose this is issue has not surfaced so far.

This setting is here:
<img width="962" height="275" alt="image" src="https://github.com/user-attachments/assets/76a67a70-fec0-4bf5-9b7e-8b64519dcdc5" />


Fixes https://github.com/kitodo/kitodo-production/issues/6811