### PR TITLE
[3.9] Skip form validation of 'Change docstruct type' dialog when clicking 'Cancel' button

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/changeDocStrucType.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/changeDocStrucType.xhtml
@@ -55,6 +55,7 @@
                     <p:commandButton value="#{msgs.cancel}"
                                      icon="fa fa-times fa-lg"
                                      iconPos="right"
+                                     process="@this"
                                      styleClass="secondary right"
                                      onclick="PF('dialogEditDocStrucType').hide();"/>
                 </h:panelGroup>


### PR DESCRIPTION
Backport of #6840 for Kitodo.Production `3.9`