### PR TITLE
Add missing form components

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -84,17 +84,20 @@
             <o:highlight styleClass="ui-state-error" />
             <ui:fragment id="activityMonitors"
                          rendered="#{not empty SessionClientController.currentSessionClient and session.maxInactiveInterval gt 0}">
-                <p:idleMonitor timeout="#{(session.maxInactiveInterval - SessionClientController.getAutomaticLogoutWarningSeconds()) * 1000}"
-                               multiWindowSupport="true"
-                               onidle="PF('logoutTimer').start()"
-                               onactive="PF('logoutTimer').pause()">
-                    <p:ajax event="idle"
-                            listener="#{activityMonitor.onIdle}"/>
-                    <p:ajax event="active"
-                            oncomplete="PF('logoutTimer').currentTimeout = #{SessionClientController.getAutomaticLogoutWarningSeconds()};"
-                            listener="#{activityMonitor.onActive}"
-                            update="sticky-notifications"/>
-                </p:idleMonitor>
+                <h:form id="activityMonitorForm">
+                    <p:idleMonitor timeout="#{(session.maxInactiveInterval - SessionClientController.getAutomaticLogoutWarningSeconds()) * 1000}"
+                                   id="activityMonitor"
+                                   multiWindowSupport="true"
+                                   onidle="PF('logoutTimer').start()"
+                                   onactive="PF('logoutTimer').pause()">
+                        <p:ajax event="idle"
+                                listener="#{activityMonitor.onIdle}"/>
+                        <p:ajax event="active"
+                                oncomplete="PF('logoutTimer').currentTimeout = #{SessionClientController.getAutomaticLogoutWarningSeconds()};"
+                                listener="#{activityMonitor.onActive}"
+                                update="sticky-notifications"/>
+                    </p:idleMonitor>
+                </h:form>
                 <h:form id="timerForm">
                     <pe:timer id="timer"
                               resetValues="pause"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/filterMenu.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/filterMenu.xhtml
@@ -16,28 +16,34 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:a="http://xmlns.jcp.org/jsf/passthrough"
         xmlns:p="http://primefaces.org/ui">
-    <p:remoteCommand name="removeFilter"
-                     action="#{ProcessForm.filterMenu.removeFilter}"
-                     oncomplete="setFilterInputPadding()"
-                     update="processesTabView:processesForm:processesTable
+    <h:form id="filterCommands">
+        <p:remoteCommand name="removeFilter"
+                         id="removeFilterCommand"
+                         action="#{ProcessForm.filterMenu.removeFilter}"
+                         oncomplete="setFilterInputPadding()"
+                         update="processesTabView:processesForm:processesTable
                              parsedFiltersForm:parsedFilters
                              processCount"/>
-    <p:remoteCommand name="removeFilterForEdit"
-                     action="#{ProcessForm.filterMenu.removeFilter}"
-                     oncomplete="setFilterInputPadding()"
-                     update="parsedFiltersForm:parsedFilters"/>
-    <p:remoteCommand name="updateSuggestions"
-                     action="#{ProcessForm.filterMenu.updateSuggestions}"
-                     update="filterOptionsForm:suggestions"/>
-    <p:remoteCommand name="submitFilters"
-                     action="#{ProcessForm.filterMenu.submitFilters}"
-                     onstart="PF('processesTable').getPaginator().setPage(0);"
-                     oncomplete="setFilterInputPadding();"
-                     update="processesTabView:processesForm:processesTable
+        <p:remoteCommand name="removeFilterForEdit"
+                         id="removeFilterForEditCommand"
+                         action="#{ProcessForm.filterMenu.removeFilter}"
+                         oncomplete="setFilterInputPadding()"
+                         update="parsedFiltersForm:parsedFilters"/>
+        <p:remoteCommand name="updateSuggestions"
+                         id="updateSuggestionsCommand"
+                         action="#{ProcessForm.filterMenu.updateSuggestions}"
+                         update="filterOptionsForm:suggestions"/>
+        <p:remoteCommand name="submitFilters"
+                         id="submitFiltersCommand"
+                         action="#{ProcessForm.filterMenu.submitFilters}"
+                         onstart="PF('processesTable').getPaginator().setPage(0);"
+                         oncomplete="setFilterInputPadding();"
+                         update="processesTabView:processesForm:processesTable
                              processCount
                              filterInputForm:filterfield
                              parsedFiltersForm:parsedFilters
                              filterOptionsForm:suggestions"/>
+    </h:form>
     <div class="ui-inputgroup">
         <div class="input-wrapper">
             <h:form id="filterInputForm">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/importCatalogConfigurationsResult.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/importCatalogConfigurationsResult.xhtml
@@ -63,10 +63,13 @@
         </h:panelGroup>
         <h:panelGroup layout="block"
                       styleClass="dialogButtonWrapper">
-            <p:commandButton id="close"
-                             value="#{msgs.close}"
-                             styleClass="primary right"
-                             onclick="PF('catalogConfigurationImportResultDialog').hide();"/>
+            <h:form id="closeButtonForm"
+                    prependId="false">
+                <p:commandButton id="close"
+                                 value="#{msgs.close}"
+                                 styleClass="primary right"
+                                 onclick="PF('catalogConfigurationImportResultDialog').hide();"/>
+            </h:form>
         </h:panelGroup>
     </p:dialog>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/filterMenu.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/tasks/filterMenu.xhtml
@@ -17,25 +17,31 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:a="http://xmlns.jcp.org/jsf/passthrough"
         xmlns:p="http://primefaces.org/ui">
-    <p:remoteCommand name="removeFilter"
-                     action="#{CurrentTaskForm.filterMenu.removeFilter}"
-                     oncomplete="setFilterInputPadding()"
-                     update="tasksTabView:tasksForm:taskTable parsedFiltersForm:parsedFilters"/>
-    <p:remoteCommand name="removeFilterForEdit"
-                     action="#{CurrentTaskForm.filterMenu.removeFilter}"
-                     oncomplete="setFilterInputPadding()"
-                     update="parsedFiltersForm:parsedFilters"/>
-    <p:remoteCommand name="updateSuggestions"
-                     action="#{CurrentTaskForm.filterMenu.updateSuggestions}"
-                     update="filterOptionsForm:suggestions"/>
-    <p:remoteCommand name="submitFilters"
-                     action="#{CurrentTaskForm.filterMenu.submitFilters}"
-                     onstart="PF('taskTable').getPaginator().setPage(0);"
-                     oncomplete="setFilterInputPadding();"
-                     update="tasksTabView:tasksForm:taskTable
-                             filterInputForm:filterfield
-                             parsedFiltersForm:parsedFilters
-                             filterOptionsForm:suggestions"/>
+    <h:form id="filterCommands">
+        <p:remoteCommand name="removeFilter"
+                         id="removeFilterCommand"
+                         action="#{CurrentTaskForm.filterMenu.removeFilter}"
+                         oncomplete="setFilterInputPadding()"
+                         update="tasksTabView:tasksForm:taskTable parsedFiltersForm:parsedFilters"/>
+        <p:remoteCommand name="removeFilterForEdit"
+                         id="removeFilterForEditCommand"
+                         action="#{CurrentTaskForm.filterMenu.removeFilter}"
+                         oncomplete="setFilterInputPadding()"
+                         update="parsedFiltersForm:parsedFilters"/>
+        <p:remoteCommand name="updateSuggestions"
+                         id="updateSuggestionsCommand"
+                         action="#{CurrentTaskForm.filterMenu.updateSuggestions}"
+                         update="filterOptionsForm:suggestions"/>
+        <p:remoteCommand name="submitFilters"
+                         id="submitFiltersCommand"
+                         action="#{CurrentTaskForm.filterMenu.submitFilters}"
+                         onstart="PF('taskTable').getPaginator().setPage(0);"
+                         oncomplete="setFilterInputPadding();"
+                         update="tasksTabView:tasksForm:taskTable
+                                 filterInputForm:filterfield
+                                 parsedFiltersForm:parsedFilters
+                                 filterOptionsForm:suggestions"/>
+    </h:form>
     <div class="ui-inputgroup">
         <div class="input-wrapper">
             <h:form id="filterInputForm">

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/filterMenu.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/users/filterMenu.xhtml
@@ -16,25 +16,31 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:a="http://xmlns.jcp.org/jsf/passthrough"
         xmlns:p="http://primefaces.org/ui">
-    <p:remoteCommand name="removeFilter"
-                     action="#{UserForm.filterMenu.removeFilter}"
-                     oncomplete="setFilterInputPadding()"
-                     update="usersTabView:usersTable parsedFiltersForm:parsedFilters"/>
-    <p:remoteCommand name="removeFilterForEdit"
-                     action="#{UserForm.filterMenu.removeFilter}"
-                     oncomplete="setFilterInputPadding()"
-                     update="parsedFiltersForm:parsedFilters"/>
-    <p:remoteCommand name="updateSuggestions"
-                     action="#{UserForm.filterMenu.updateSuggestions}"
-                     update="filterOptionsForm:suggestions"/>
-    <p:remoteCommand name="submitFilters"
-                     action="#{UserForm.filterMenu.submitFilters}"
-                     onstart="PF('usersTable').getPaginator().setPage(0);"
-                     oncomplete="setFilterInputPadding();"
-                     update="usersTabView:usersTable
-                             filterInputForm:filterfield
-                             parsedFiltersForm:parsedFilters
-                             filterOptionsForm:suggestions"/>
+    <h:form id="filterCommands">
+        <p:remoteCommand name="removeFilter"
+                         id="removeFilterCommand"
+                         action="#{UserForm.filterMenu.removeFilter}"
+                         oncomplete="setFilterInputPadding()"
+                         update="usersTabView:usersTable parsedFiltersForm:parsedFilters"/>
+        <p:remoteCommand name="removeFilterForEdit"
+                         id="removeFilterForEdit"
+                         action="#{UserForm.filterMenu.removeFilter}"
+                         oncomplete="setFilterInputPadding()"
+                         update="parsedFiltersForm:parsedFilters"/>
+        <p:remoteCommand name="updateSuggestions"
+                         id="updateSuggestionsCommand"
+                         action="#{UserForm.filterMenu.updateSuggestions}"
+                         update="filterOptionsForm:suggestions"/>
+        <p:remoteCommand name="submitFilters"
+                         id="submitFiltersCommand"
+                         action="#{UserForm.filterMenu.submitFilters}"
+                         onstart="PF('usersTable').getPaginator().setPage(0);"
+                         oncomplete="setFilterInputPadding();"
+                         update="usersTabView:usersTable
+                                 filterInputForm:filterfield
+                                 parsedFiltersForm:parsedFilters
+                                 filterOptionsForm:suggestions"/>
+    </h:form>
     <div class="ui-inputgroup">
         <div class="input-wrapper">
             <h:form id="filterInputForm">


### PR DESCRIPTION
The server logs of Kitodo currently contain many messages like 
```
org.primefaces.util.AjaxRequestBuilder.form Component 'j_id_8a' should be inside a form or should reference a form via its form attribute. We will try to find a fallback form on the client side.
```
This pull request adds some of these missing forms, for example for filter menus and activity monitor, and thus reduces the number of log messages created.

Note that not _all_ such messages are resolved by the changes in this PR, since in some cases adding corresponding forms is a little more tricky and requires more elaborate refactoring.