### PR TITLE
Add missing form for 'metadata locked' dialogs 'ok' button

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/metadataLocked.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/dialogs/metadataLocked.xhtml
@@ -34,15 +34,17 @@
                               rendered="#{not empty DataEditorForm.blockingUser}"/>
             </h:panelGroup>
         </h:panelGroup>
-        <h:panelGroup layout="block"
-                      styleClass="dialogButtonWrapper">
-            <p:commandButton action="#{DataEditorForm.confirmMetadataLocked()}"
-                             onclick="setConfirmUnload(false);PF('metadataLockedDialog').hide()"
-                             value="#{msgs['ok']}"
-                             id="okButton"
-                             styleClass="primary right"
-                             icon="fa fa-close"
-                             iconPos="right"/>
-        </h:panelGroup>
+        <h:form id="metadataLockedButtonForm">
+            <h:panelGroup layout="block"
+                          styleClass="dialogButtonWrapper">
+                <p:commandButton action="#{DataEditorForm.confirmMetadataLocked()}"
+                                 onclick="setConfirmUnload(false);PF('metadataLockedDialog').hide()"
+                                 value="#{msgs['ok']}"
+                                 id="okButton"
+                                 styleClass="primary right"
+                                 icon="fa fa-close"
+                                 iconPos="right"/>
+            </h:panelGroup>
+        </h:form>
     </p:dialog>
 </ui:composition>


### PR DESCRIPTION
Similar to #6842, this adds another missing form element, this time for the "Ok" button in the "Metadata locked" popup dialog.