### PR TITLE
Log 'load workpiece' message at debug level

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataformat/MetsService.java
@@ -194,7 +194,7 @@ public class MetsService {
      */
     public void saveWorkpiece(Workpiece workpiece, URI uri) throws IOException {
         try (OutputStream outputStream = ServiceManager.getFileService().write(uri)) {
-            logger.info("Saving {}", uri.toString());
+            logger.debug("Saving {}", uri.toString());
             save(workpiece, outputStream);
         }
     }


### PR DESCRIPTION
I have seen numerous Kitodo installations where the log files are _flooded_ with log messages about reading metadata files:
```
[INFO ] 2026-01-09 16:43:59.991 [http-nio-8080-exec-4] MetsService - Reading 21/meta.xml
```
Since Kitodo still needs to open the metadata file of each process in the list view, this can snowball to huge log files without any significant value (since this message merely signals the _successful_ loading of the metadata file). Therefore I propose to only log this message on level `DEBUG`, instead of `INFO`, for when some error occurs and the admin wants to actively increases the log level in the server settings.