### PR TITLE
Re-enable text selection in process table

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -30,7 +30,7 @@
                      lazy="true"
                      paginator="true"
                      resizableColumns="true"
-                     rowSelectMode="checkbox"
+                     rowSelectMode="none"
                      liveResize="true"
                      sortBy="#{ProcessForm.sortBy}"
                      rows="#{LoginForm.loggedUser.tableSize}"


### PR DESCRIPTION
Fixes: https://github.com/kitodo/kitodo-production/issues/6844 
Fixes: https://github.com/kitodo/kitodo-production/issues/6718

As documented here:
https://github.com/primefaces/primefaces/blob/master/docs/12_0_0/components/datatable.md
Valid values for rowSelectMode are now "new", "add" and "none".

"None" should give the desired behavior (Row is only selected when clicking the checkbox)