### PR TITLE
Remove reliance on bidirectional association in task-user relation

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/CurrentTaskForm.java
@@ -834,18 +834,6 @@ public class CurrentTaskForm extends ValidatableForm {
     }
 
     /**
-     * Retrieve and return the list of tasks that are assigned to the user that are
-     * currently in progress.
-     *
-     * @return list of tasks that are currently assigned to the user that are
-     *         currently in progress.
-     */
-    public List<Task> getTasksInProgress() {
-        Stopwatch stopwatch = new Stopwatch(this, "getTasksInProgress");
-        return stopwatch.stop(ServiceManager.getUserService().getTasksInProgress(this.user));
-    }
-
-    /**
      * Get taskListPath.
      *
      * @return value of taskListPath

--- a/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/UserForm.java
@@ -271,7 +271,7 @@ public class UserForm extends BaseForm {
      *         are "INWORK" and belong to process, not template
      */
     public List<Task> getTasksInProgress(User user) {
-        return ServiceManager.getUserService().getTasksInProgress(user);
+        return ServiceManager.getTaskService().getTasksInProgress(user);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -306,22 +306,35 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
      */
     public void replaceProcessingUser(Task task, User user) {
         User currentProcessingUser = task.getProcessingUser();
-
         if (Objects.isNull(user) && Objects.isNull(currentProcessingUser)) {
             logger.info("do nothing - there is neither a new nor an old user");
         } else if (Objects.isNull(user)) {
-            currentProcessingUser.getProcessingTasks().remove(task);
             task.setProcessingUser(null);
         } else if (Objects.isNull(currentProcessingUser)) {
-            user.getProcessingTasks().add(task);
             task.setProcessingUser(user);
         } else if (Objects.equals(currentProcessingUser.getId(), user.getId())) {
             logger.info("do nothing - both are the same");
         } else {
-            currentProcessingUser.getProcessingTasks().remove(task);
-            user.getProcessingTasks().add(task);
             task.setProcessingUser(user);
         }
+    }
+
+    /**
+     * Retrieve and return all tasks assigned to the given user
+     * that are currently in progress and linked to a process.
+     *
+     * @param user the processing user
+     * @return list of tasks in progress for the given user
+     */
+    public List<Task> getTasksInProgress(User user) {
+        String hql = "FROM Task t WHERE t.processingUser = :user "
+                + "AND t.processingStatus = :status "
+                + "AND t.process IS NOT NULL";
+        Map<String, Object> params = Map.of(
+                "user", user,
+                "status", TaskStatus.INWORK
+        );
+        return dao.getByQuery(hql, params);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -461,20 +461,6 @@ public class UserService extends BaseBeanService<User, UserDAO> implements UserD
     }
 
     /**
-     * Retrieve and return the list of tasks that are assigned to the user and
-     * that are "INWORK" and belong to process, not template.
-     *
-     * @return list of tasks that are currently assigned to the user and that
-     *         are "INWORK" and belong to process, not template
-     */
-    public List<Task> getTasksInProgress(User user) {
-        return user.getProcessingTasks().stream()
-                .filter(
-                    task -> task.getProcessingStatus().equals(TaskStatus.INWORK) && Objects.nonNull(task.getProcess()))
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Changes the password for given User object.
      *
      * @param user

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/UserServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/UserServiceIT.java
@@ -235,7 +235,7 @@ public class UserServiceIT {
     @Test
     public void shouldGetUserTasksInProgress() throws DAOException {
         User user = userService.getByLdapLoginOrLogin("nowakLDP");
-        List<Task> tasks = userService.getTasksInProgress(user);
+        List<Task> tasks = ServiceManager.getTaskService().getTasksInProgress(user);
         assertEquals(1, tasks.size(), "Number of tasks in process is incorrect!");
         assertEquals("Progress", tasks.get(0).getTitle(), "Title of task is incorrect!");
     }


### PR DESCRIPTION
Supersedes: https://github.com/kitodo/kitodo-production/pull/6802
Adresses https://github.com/kitodo/kitodo-production/issues/5813 (But no full fix of the described memory usage since this probably requires more changes)

As outlined in https://github.com/kitodo/kitodo-production/issues/5813#issuecomment-3617287774 bidrectional access to the non owning side of a relation can be problematic if the collections are too large. I would prefer if we remove the collection property.

```java
@OneToMany(mappedBy = "processingUser", cascade = CascadeType.PERSIST)
private List<Task> processingTasks;
```

to not encourage access to and hydration of potential large collections. But we use those accessors in tests so i only replaced the application-level usage of it with an HQL query. Since the processingTasks accessor is no longer used at runtime, we do not need to maintain manual synchronization between both sides of the association.