### PR TITLE
Improve log error message

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -251,7 +251,9 @@ public class WorkflowControllerService {
             if (task.isTypeMetadata()
                     && ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.USE_META_DATA_VALIDATION)
                     && !validateMetadata(task)) {
-                throw new DAOException("Error on metadata validation!");
+                String exceptionMessage = "Error on metadata validation on process %s (ID %s)!"
+                        .formatted(task.getProcess().getTitle(), task.getProcess().getId());
+                throw new DAOException(exceptionMessage);
             }
 
             // image file prefix validation (consecutive numbering)
@@ -259,14 +261,18 @@ public class WorkflowControllerService {
                 ImageHelper mih = new ImageHelper();
                 URI imageFolder = ServiceManager.getProcessService().getImagesOriginDirectory(false, task.getProcess());
                 if (!mih.checkIfImagesValid(task.getProcess().getTitle(), imageFolder)) {
-                    throw new DAOException("Error on validating image file prefix (consecutive numbering)!");
+                    String exceptionMessage = "Error on validating image file prefix (consecutive numbering) on process %s (ID %s)!"
+                            .formatted(task.getProcess().getTitle(), task.getProcess().getId());
+                    throw new DAOException(exceptionMessage);
                 }
             }
 
             // ltp validation
             if (task.isTypeValidateImages()) {
                 if (!LtpValidationHelper.validateImagesWhenFinishingTask(task)) {
-                    throw new DAOException("Error on long term preservation validation!");
+                    String exceptionMessage = "Error on long term preservation validation on process %s (ID %s)!"
+                            .formatted(task.getProcess().getTitle(), task.getProcess().getId());
+                    throw new DAOException(exceptionMessage);
                 }
             }
         }


### PR DESCRIPTION
While investigating an issue (meta data task was closed with invalid meta data and further workflow was not started) I found an improvable log message:

```
[ERROR] 2026-01-22 11:41:22,833 [http-nio-127.0.0.1-8080-exec-196] org.kitodo.production.forms.CurrentTaskForm - errorSaving
org.kitodo.data.exceptions.DataException: Error on metadata validation!
    at org.kitodo.production.services.workflow.WorkflowControllerService.closeTaskByUser(WorkflowControllerService.java:212) ~[classes/:3.8.4]
    at org.kitodo.production.forms.CurrentTaskForm.closeTaskByUser(CurrentTaskForm.java:294) ~[classes/:3.8.4]
    at jdk.internal.reflect.GeneratedMethodAccessor1185.invoke(Unknown Source) ~[?:?]
```

` Error on metadata validation!` is not really helpful as the message did not contain any additional information like process title to look into it, so I decide to improve this message and other error log messages on closing a task.
