### PR TITLE
[3.8] Add optional parameter to 'searchForMedia' to control which subfolders are traversed

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -414,7 +414,7 @@ public class DataEditorForm implements MetadataTreeTableInterface, RulesetSetupI
             workpiece.setId(process.getId().toString());
         }
         metadataFileLoadingError = "";
-        return ServiceManager.getFileService().searchForMedia(process, workpiece);
+        return ServiceManager.getFileService().searchForMedia(process, workpiece, false);
     }
 
     private void init() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/PaginationPanel.java
@@ -78,7 +78,7 @@ public class PaginationPanel {
         boolean mediaReferencesChanged = false;
         try {
             mediaReferencesChanged = ServiceManager.getFileService().searchForMedia(dataEditor.getProcess(),
-                    dataEditor.getWorkpiece());
+                    dataEditor.getWorkpiece(), false);
         } catch (InvalidImagesException e) {
             Helper.setErrorMessage(e.getLocalizedMessage());
         } catch (MediaNotFoundException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/UploadFileDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/UploadFileDialog.java
@@ -388,7 +388,7 @@ public class UploadFileDialog {
     }
 
     private void addMediaToWorkpiece() throws InvalidImagesException, MediaNotFoundException {
-        ServiceManager.getFileService().searchForMedia(dataEditor.getProcess(), dataEditor.getWorkpiece());
+        ServiceManager.getFileService().searchForMedia(dataEditor.getProcess(), dataEditor.getWorkpiece(), false);
 
         List<View> views = selectedMedia.stream()
                 .map(v -> MetadataEditor.createUnrestrictedViewOn(v.getKey()))

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/ImportingProcess.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/ImportingProcess.java
@@ -504,7 +504,7 @@ final class ImportingProcess {
             link.setUri(processService.getProcessURI(importedChildProcess.processId));
             addLinkInDatabase(process, importedChildProcess.processId);
         }
-        fileService.searchForMedia(process, workpiece);
+        fileService.searchForMedia(process, workpiece, false);
         Path outputMetsFile = outputDir.resolve(META_FILE_NAME);
         metsService.saveWorkpiece(workpiece, outputMetsFile.toUri());
         logger.info("Wrote METS file " + outputMetsFile);

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/KitodoScriptService.java
@@ -228,7 +228,9 @@ public class KitodoScriptService {
                 generateImages(processes, mode, foldersList);
                 break;
             case "searchForMedia":
-                searchForMedia(processes);
+                String subfolders = parameters.get("subfolders");
+                boolean configuredOnly = "configured".equals(subfolders);
+                searchForMedia(processes, configuredOnly);
                 break;
             case "importProcesses":
                 String indir = parameters.get("indir");
@@ -438,7 +440,7 @@ public class KitodoScriptService {
         }
     }
 
-    private void searchForMedia(List<Process> processes)
+    private void searchForMedia(List<Process> processes, boolean configuredFoldersOnly)
             throws IOException, InvalidImagesException, MediaNotFoundException {
         FileService fileService = ServiceManager.getFileService();
         MetsService metsService = ServiceManager.getMetsService();
@@ -447,7 +449,7 @@ public class KitodoScriptService {
         for (Process process : processes) {
             URI metadataFileUri = processService.getMetadataFileUri(process);
             Workpiece workpiece = metsService.loadWorkpiece(metadataFileUri);
-            fileService.searchForMedia(process, workpiece);
+            fileService.searchForMedia(process, workpiece, configuredFoldersOnly);
             metsService.saveWorkpiece(workpiece, metadataFileUri);
         }
     }

--- a/Kitodo/src/test/java/org/kitodo/production/services/file/FileServiceTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/file/FileServiceTest.java
@@ -178,7 +178,7 @@ public class FileServiceTest {
         URI testmeta = Paths.get("./src/test/resources/metadata/metadataFiles/testmeta.xml").toUri();
         Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(testmeta);
 
-        assertThrows(MediaNotFoundException.class, () -> fileService.searchForMedia(process, workpiece));
+        assertThrows(MediaNotFoundException.class, () -> fileService.searchForMedia(process, workpiece, false));
     }
 
     @Test


### PR DESCRIPTION
This pull request adds a new _optional_ paramter `subfolders` to KitodoScript `searchForMedia`. By setting this parameter to the value `configured` the project folder settings are taken into account. This restricts the script to those process subfolders whose contents are set to be linked in the `meta.xml` file via the project folder settings. Without this parameter (or setting it to any other value than "configured") retains the current behavior where the contents of _all_ process subfolders are linked in the `meta.xml` file when calling the script `searchForMedia`.

Thus fixes #6862 for Kitodo `3.8.x` (contrary to recent announcements this means there will probably be at least one more bugfix release for version 3.8 of Kitodo)