### PR TITLE
Replace some deprecated methods

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Labeled.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/Labeled.java
@@ -177,7 +177,7 @@ public class Labeled {
             if (langAttribute.isPresent()) {
                 labelMap.put(langAttribute.get(), label.getValue());
             } else {
-                labelMap.put(new Locale(ruleset.getDefaultLang()), label.getValue());
+                labelMap.put(Locale.of(ruleset.getDefaultLang()), label.getValue());
                 labelMap.put(UNDEFINED_LOCALE, label.getValue());
             }
         }

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 import jakarta.persistence.PersistenceException;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Hibernate;
@@ -222,7 +222,7 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
             debugLogQuery(query, parameters);
             Query<T> q = session.createQuery(query);
             addParameters(q, parameters);
-            if (logger.isTraceEnabled() && !StringUtils.containsIgnoreCase(query, " WHERE ")) {
+            if (logger.isTraceEnabled() && !Strings.CI.contains(query, " WHERE ")) {
                 logger.trace("Probable performance issue:", new Throwable(
                         "Location where the code loads ALL object instances"));
             }
@@ -248,7 +248,7 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
         try (Session session = HibernateUtil.getSession()) {
             debugLogQuery(query, Collections.emptyMap());
             Query<T> queryObject = session.createQuery(query);
-            if (logger.isTraceEnabled() && !StringUtils.containsIgnoreCase(query, " WHERE ")) {
+            if (logger.isTraceEnabled() && !Strings.CI.contains(query, " WHERE ")) {
                 logger.trace("Probable performance issue:", new Throwable(
                         "Location where the code loads ALL object instances"));
             }
@@ -276,7 +276,7 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
             debugLogQuery(query, parameters);
             Query<String> queryObject = session.createQuery(query);
             addParameters(queryObject, parameters);
-            if (logger.isTraceEnabled() && !StringUtils.containsIgnoreCase(query, " WHERE ")) {
+            if (logger.isTraceEnabled() && !Strings.CI.contains(query, " WHERE ")) {
                 logger.trace("Probable performance issue:", new Throwable(
                         "Location where the code loads ALL object instances"));
             }
@@ -496,7 +496,7 @@ public abstract class BaseDAO<T extends BaseBean> implements Serializable {
         try (Session session = HibernateUtil.getSession()) {
             String query = String.format("FROM %s ORDER BY id ASC", cls.getSimpleName());
             debugLogQuery(query, Collections.emptyMap());
-            if (logger.isTraceEnabled() && !StringUtils.containsIgnoreCase(query, " WHERE ")) {
+            if (logger.isTraceEnabled() && !Strings.CI.contains(query, " WHERE ")) {
                 logger.trace("Probable performance issue:", new Throwable(
                         "Location where the code loads ALL object instances"));
             }

--- a/Kitodo/src/main/java/org/kitodo/config/ConfigProject.java
+++ b/Kitodo/src/main/java/org/kitodo/config/ConfigProject.java
@@ -32,7 +32,7 @@ import org.apache.commons.configuration2.builder.ReloadingFileBasedConfiguration
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.config.enums.KitodoConfigFile;
@@ -323,22 +323,22 @@ public class ConfigProject {
      * <dl>
      * <dt>{@code isDocType.equals("") && isNotDocType.equals("")}</dt>
      * <dd>nothing was specified</dd>
-     * <dt>{@code isNotDocType.equals("") && StringUtils.containsIgnoreCase(isDocType, docType)}</dt>
+     * <dt>{@code isNotDocType.equals("") && Strings.CI.contains(isDocType, docType)}</dt>
      * <dd>only duty was specified</dd>
-     * <dt>{@code isDocType.equals("") && !StringUtils.containsIgnoreCase(isNotDocType, docType)}</dt>
+     * <dt>{@code isDocType.equals("") && !Strings.CI.contains(isNotDocType, docType)}</dt>
      * <dd>only may not was specified</dd>
-     * <dt>{@code !isDocType.equals("") && !isNotDocType.equals("") && StringUtils.containsIgnoreCase(isDocType, docType)
-     *                 && !StringUtils.containsIgnoreCase(isNotDocType, docType)}</dt>
+     * <dt>{@code !isDocType.equals("") && !isNotDocType.equals("") && Strings.CI.contains(isDocType, docType)
+     *                 && !Strings.CI.contains(isNotDocType, docType)}</dt>
      * <dd>both were specified</dd>
      * </dl>
      */
     private String findTitleDefinition(String title, String docType, String isDocType, String isNotDocType) {
         if ((isDocType.isEmpty()
-                && (isNotDocType.isEmpty() || !StringUtils.containsIgnoreCase(isNotDocType, docType)))
+                && (isNotDocType.isEmpty() || !Strings.CI.contains(isNotDocType, docType)))
                 || (!isDocType.isEmpty() && !isNotDocType.isEmpty()
-                        && StringUtils.containsIgnoreCase(isDocType, docType)
-                        && !StringUtils.containsIgnoreCase(isNotDocType, docType))
-                || (isNotDocType.isEmpty() && StringUtils.containsIgnoreCase(isDocType, docType))) {
+                        && Strings.CI.contains(isDocType, docType)
+                        && !Strings.CI.contains(isNotDocType, docType))
+                || (isNotDocType.isEmpty() && Strings.CI.contains(isDocType, docType))) {
             return title;
         }
         return "";

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -466,7 +466,7 @@ public class Helper {
                 errorMessages.put(language, Error.getResourceBundle("messages.errors", "errors", language));
             }
         } else {
-            Locale defaultLocale = new Locale("EN");
+            Locale defaultLocale = Locale.of("EN");
             commonMessages.put(defaultLocale, Message.getResourceBundle("messages.messages", "messages", defaultLocale));
             errorMessages.put(defaultLocale, Error.getResourceBundle("messages.errors", "errors", defaultLocale));
         }

--- a/Kitodo/src/main/java/org/kitodo/production/process/field/AdditionalField.java
+++ b/Kitodo/src/main/java/org/kitodo/production/process/field/AdditionalField.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import jakarta.faces.model.SelectItem;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 public class AdditionalField {
 
@@ -334,11 +335,11 @@ public class AdditionalField {
         }
 
         // if obligatory was specified
-        if (!this.isDocType.isEmpty() && !StringUtils.containsIgnoreCase(this.isDocType, this.docType)) {
+        if (!this.isDocType.isEmpty() && !Strings.CI.contains(this.isDocType, this.docType)) {
             return false;
         }
 
         // if only "may not" was specified
-        return !(!this.isNotDoctype.isEmpty() && StringUtils.containsIgnoreCase(this.isNotDoctype, this.docType));
+        return !(!this.isNotDoctype.isEmpty() && Strings.CI.contains(this.isNotDoctype, this.docType));
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -40,6 +40,7 @@ import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.bidimap.DualHashBidiMap;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.api.command.CommandResult;
@@ -1466,7 +1467,7 @@ public class FileService {
                         // add new mapping otherwise
                         filenameMapping.put(fileUri, tmpUri);
                     }
-                    URI targetUri = new URI(StringUtils.removeStart(StringUtils.removeEnd(tmpUri.toString(),
+                    URI targetUri = new URI(Strings.CS.removeStart(Strings.CS.removeEnd(tmpUri.toString(),
                             TEMP_EXTENSION), process.getId() + SLASH));
                     page.getMediaFiles().put(variantURIEntry.getKey(), targetUri);
                     numberOfRenamedMedia++;
@@ -1480,7 +1481,7 @@ public class FileService {
             String tempFilenameString = tempFilename.toString();
             // skip filename mappings from last renaming round that have not been renamed again
             if (tempFilenameString.endsWith(TEMP_EXTENSION)) {
-                String newFilepath = StringUtils.removeEnd(tempFilename.toString(), TEMP_EXTENSION);
+                String newFilepath = Strings.CS.removeEnd(tempFilename.toString(), TEMP_EXTENSION);
                 filenameMapping.put(renamingEntry.getKey(), fileManagementModule.rename(tempFilename, newFilepath));
             }
         }
@@ -1565,7 +1566,7 @@ public class FileService {
                 }
             }
             for (URI tempUri : tempUris) {
-                fileManagementModule.rename(tempUri, StringUtils.removeEnd(tempUri.toString(), TEMP_EXTENSION));
+                fileManagementModule.rename(tempUri, Strings.CS.removeEnd(tempUri.toString(), TEMP_EXTENSION));
             }
         } catch (IOException e) {
             logger.error(e);

--- a/Kitodo/src/main/java/org/kitodo/production/services/ocr/OcrdWorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/ocr/OcrdWorkflowService.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -81,7 +82,7 @@ public class OcrdWorkflowService {
     private static Pair<?, ?> getImmutablePairFromPath(Path filePath, Path ocrdWorkflowsDirectory) {
         String path = filePath.toString();
         path = path.replace(ocrdWorkflowsDirectory.toString(), StringUtils.EMPTY);
-        path = StringUtils.removeStart(path, "/");
+        path = Strings.CS.removeStart(path, "/");
         return ImmutablePair.of(path, path);
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/helper/messages/ErrorTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/messages/ErrorTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 public class ErrorTest {
 
-    private final Locale locale = new Locale("EN");
+    private final Locale locale = Locale.of("EN");
     private final String customBundle = "test_errors";
     private final String defaultBundle = "messages.errors";
 

--- a/Kitodo/src/test/java/org/kitodo/production/helper/messages/MessageTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/messages/MessageTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 public class MessageTest {
 
-    private final Locale locale = new Locale("EN");
+    private final Locale locale = Locale.of("EN");
     private final String customBundle = "test_messages";
     private final String defaultBundle = "messages.messages";
 


### PR DESCRIPTION
This PR replaces occurrences of the following methods, that are deprecated in Java 21, with non-deprecated alternatives:
- `new Locale` ➡️  `Locale.of`
- `StringUtils.containsIgnoreCase` ➡️ `Strings.CI.contains`
- `StringUtils.removeStart` ➡️ `Strings.CS.removeStart`
- `StringUtils.removeEnd` ➡️ `Strings.CS.removeEnd`