### PR TITLE
Replace deprecated URL constructor

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormatConversion.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormatConversion.java
@@ -13,6 +13,7 @@ package org.kitodo.api.schemaconverter;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,7 +47,7 @@ public enum MetadataFormatConversion {
     MetadataFormatConversion(String filename, String source, MetadataFormat targetFormat) {
         this.fileName = filename;
         try {
-            this.source = new URL(source);
+            this.source = Paths.get("xslt/" + source).toUri().toURL();
         } catch (MalformedURLException e) {
             this.source = null;
         }

--- a/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormatConversion.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/schemaconverter/MetadataFormatConversion.java
@@ -12,8 +12,9 @@
 package org.kitodo.api.schemaconverter;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,8 +48,8 @@ public enum MetadataFormatConversion {
     MetadataFormatConversion(String filename, String source, MetadataFormat targetFormat) {
         this.fileName = filename;
         try {
-            this.source = Paths.get("xslt/" + source).toUri().toURL();
-        } catch (MalformedURLException e) {
+            this.source = new URI(source).toURL();
+        } catch (NullPointerException | MalformedURLException | URISyntaxException e) {
             this.source = null;
         }
         this.targetFormat = targetFormat;

--- a/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
+++ b/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
@@ -148,7 +148,7 @@ public class KitodoServiceLoader<T> {
                 try (JarFile jarFile = new JarFile(f.toString())) {
                     if (hasFrontendFiles(jarFile)) {
                         Enumeration<JarEntry> entries = jarFile.entries();
-                        URL[] urls = {new URL("jar:file:" + f + "!/") };
+                        URL[] urls = {Paths.get("jar:file:" + f + "!/").toUri().toURL() };
                         try (URLClassLoader cl = URLClassLoader.newInstance(urls)) {
                             while (entries.hasMoreElements()) {
                                 JarEntry je = entries.nextElement();

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -75,14 +75,16 @@ public class WebDriverProvider {
         if (SystemUtils.IS_OS_WINDOWS) {
             geckoDriverFileName = "geckodriver.exe";
             File geckoDriverZipFile = new File(downloadFolder + "geckodriver.zip");
-            FileUtils.copyURLToFile(new URI(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-win64.zip").toURL(),
-                    geckoDriverZipFile);
+            URL geckoUrl = new URI(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-win64.zip").toURL();
+            logger.info("Downloading GeckoDriver for Windows from {}", geckoUrl);
+            FileUtils.copyURLToFile(geckoUrl, geckoDriverZipFile);
             extractZipFileToFolder(geckoDriverZipFile, new File(extractFolder));
         } else if (SystemUtils.IS_OS_MAC_OSX) {
             geckoDriverFileName = "geckodriver";
             File geckoDriverTarFile = new File(downloadFolder + "geckodriver.tar.gz");
-            FileUtils.copyURLToFile(new URI(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-macos.tar.gz").toURL(),
-                    geckoDriverTarFile);
+            URL geckoUrl = new URI(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-macos.tar.gz").toURL();
+            logger.info("Downloading GeckoDriver for MACOS from {}", geckoUrl);
+            FileUtils.copyURLToFile(geckoUrl, geckoDriverTarFile);
             File theDir = new File(extractFolder);
             if (!theDir.mkdir()) {
                 logger.error("Unable to create directory '" + theDir.getPath() + "'!");
@@ -91,8 +93,9 @@ public class WebDriverProvider {
         } else {
             geckoDriverFileName = "geckodriver";
             File geckoDriverTarFile = new File(downloadFolder + "geckodriver.tar.gz");
-            FileUtils.copyURLToFile(new URI(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-linux64.tar.gz").toURL(),
-                    geckoDriverTarFile);
+            URL geckoUrl = new URI(geckoDriverUrl + "geckodriver-v" + geckoDriverVersion + "-linux64.tar.gz").toURL();
+            logger.info("Downloading GeckoDriver for Linux from {}", geckoUrl);
+            FileUtils.copyURLToFile(geckoUrl, geckoDriverTarFile);
             extractTarFileToFolder(geckoDriverTarFile, new File(extractFolder));
         }
         File geckoDriverFile = new File(extractFolder, geckoDriverFileName);


### PR DESCRIPTION
Replacing `URL.URL` constructor, which has been deprecated in Java 21, with
- `Paths.get(String).toUrl()` for local files
- `new URI(String).toURL()` for online resources