### PR TITLE
Replace explicit type argument with `<>`

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/JaxbXmlUtils.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/JaxbXmlUtils.java
@@ -60,8 +60,7 @@ public class JaxbXmlUtils {
      * @return The Result of the transformation as String object.
      */
     static String transformXmlByXslt(URI xmlFile, URI xslFile) throws TransformerException, IOException {
-        FileManagementInterface fileManagementModule = new KitodoServiceLoader<FileManagementInterface>(
-                FileManagementInterface.class).loadModule();
+        FileManagementInterface fileManagementModule = new KitodoServiceLoader<>(FileManagementInterface.class).loadModule();
         TransformerFactory factory = TransformerFactory.newInstance();
         StreamSource styleSource = new StreamSource(xslFile.getPath());
         Transformer transformer = factory.newTransformer(styleSource);

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoConverter.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoConverter.java
@@ -36,8 +36,7 @@ import org.kitodo.utils.JAXBContextCache;
 public class MetsKitodoConverter {
 
     private static final Logger logger = LogManager.getLogger(MetsKitodoConverter.class);
-    private static FileManagementInterface fileManagementModule = new KitodoServiceLoader<FileManagementInterface>(
-            FileManagementInterface.class).loadModule();
+    private static FileManagementInterface fileManagementModule = new KitodoServiceLoader<>(FileManagementInterface.class).loadModule();
 
     /**
      * Private constructor to hide the implicit public one.

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoReader.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoReader.java
@@ -68,8 +68,7 @@ class MetsKitodoReader {
      * @return The Mets object in mets-kitodo format.
      */
     static Mets readUriToMets(URI xmlFile) throws JAXBException, IOException {
-        FileManagementInterface fileManagementModule = new KitodoServiceLoader<FileManagementInterface>(
-                FileManagementInterface.class).loadModule();
+        FileManagementInterface fileManagementModule = new KitodoServiceLoader<>(FileManagementInterface.class).loadModule();
         if (fileManagementModule.fileExist(xmlFile)) {
             JAXBContext jaxbMetsContext = JAXBContextCache.getJAXBContext(Mets.class);
             Unmarshaller jaxbUnmarshaller = jaxbMetsContext.createUnmarshaller();

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
@@ -105,7 +105,7 @@ public class ProcessKeywords {
         this.taskKeywords = filterMinLength(initTaskKeywords(process.getTasksUnmodified()));
 
         // more keywords for default search only
-        this.defaultKeywords = new HashSet<String>();
+        this.defaultKeywords = new HashSet<>();
         if (Objects.nonNull(process.getId())) {
             defaultKeywords.add(process.getId().toString());
         }

--- a/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
+++ b/Kitodo-FileManagement/src/main/java/org/kitodo/filemanagement/FileManagement.java
@@ -47,7 +47,7 @@ public class FileManagement implements FileManagementInterface {
 
     private static final String IMAGES_DIRECTORY_NAME = "images";
 
-    private final CommandInterface commandService = new KitodoServiceLoader<CommandInterface>(CommandInterface.class)
+    private final CommandInterface commandService = new KitodoServiceLoader<>(CommandInterface.class)
             .loadModule();
 
     @Override

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CatalogImportDialog.java
@@ -119,7 +119,7 @@ public class CatalogImportDialog  extends MetadataImportDialog implements Serial
             if (skipHitList(createProcessForm.getCurrentImportConfiguration(), getSelectedField())) {
                 getRecordById(getSearchTerm());
             } else {
-                Map<String, SortMeta> sortBy = new HashMap<String, SortMeta>();
+                Map<String, SortMeta> sortBy = new HashMap<>();
                 List<?> hits = hitModel.load(0, 10, sortBy, Collections.EMPTY_MAP);
                 if (hits.size() == 1) {
                     getRecordById(((SingleHit) hits.get(0)).getIdentifier());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -112,7 +112,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
      */
     public ProcessFieldedMetadata() {
         super(null, null);
-        this.treeNode = new DefaultTreeNode<Object>();
+        this.treeNode = new DefaultTreeNode<>();
         treeNode.setExpanded(true);
         this.metadata = new HashSet<>();
         this.hiddenMetadata = Collections.emptyList();
@@ -154,7 +154,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     }
 
     private void buildTreeNodeAndCreateMetadataTable() {
-        treeNode = new DefaultTreeNode<Object>();
+        treeNode = new DefaultTreeNode<>();
         treeNode.setExpanded(true);
         createMetadataTable();
     }
@@ -202,7 +202,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                 new HashSet<>(template.metadata));
         copy = true;
         hiddenMetadata = template.hiddenMetadata;
-        treeNode = new DefaultTreeNode<Object>(this, template.getTreeNode().getParent());
+        treeNode = new DefaultTreeNode<>(this, template.getTreeNode().getParent());
         createMetadataTable();
         treeNode.setExpanded(true);
     }
@@ -330,7 +330,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                         + metadataKey + "\" in a single row. Must be 0 or 1 per row.");
         }
         ProcessFieldedMetadata metadata = new ProcessFieldedMetadata(this, complexMetadataView, value);
-        metadata.treeNode = new DefaultTreeNode<Object>(metadata, treeNode);
+        metadata.treeNode = new DefaultTreeNode<>(metadata, treeNode);
         metadata.createMetadataTable();
         metadata.treeNode.setExpanded(true);
     }
@@ -386,7 +386,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
         } catch (IllegalStateException e) {
             logger.catching(Level.WARN, e);
             ProcessFieldedMetadata metadata = new ProcessFieldedMetadata(this, oneValue(values, MetadataGroup.class));
-            metadata.treeNode = new DefaultTreeNode<Object>(metadata, treeNode);
+            metadata.treeNode = new DefaultTreeNode<>(metadata, treeNode);
             metadata.createUndefinedMetadataTable();
             metadata.treeNode.setExpanded(true);
         }
@@ -516,7 +516,7 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                 TreeNode<Object> copy = null;
                 if (childData instanceof ProcessSimpleMetadata) {
                     ProcessSimpleMetadata copyData = ((ProcessSimpleMetadata) childData).getClone();
-                    copy = new DefaultTreeNode<Object>(copyData, treeNode);
+                    copy = new DefaultTreeNode<>(copyData, treeNode);
                     copy.setExpanded(child.isExpanded());
                 } else if (childData instanceof ProcessFieldedMetadata) {
                     ProcessFieldedMetadata copyData = new ProcessFieldedMetadata((ProcessFieldedMetadata) childData);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -642,7 +642,7 @@ public class StructurePanel implements Serializable {
      *         the tree
      */
     private DefaultTreeNode<Object> buildStructureTree() {
-        DefaultTreeNode<Object> invisibleRootNode = new DefaultTreeNode<Object>();
+        DefaultTreeNode<Object> invisibleRootNode = new DefaultTreeNode<>();
         invisibleRootNode.setExpanded(true);
         invisibleRootNode.setType(STRUCTURE_NODE_TYPE);
         addParentLinksRecursive(dataEditor.getProcess(), invisibleRootNode);
@@ -732,7 +732,7 @@ public class StructurePanel implements Serializable {
          * appends it to the parent as a child. That’s the logic of the JSF
          * framework. So you do not have to add the result anywhere.
          */
-        DefaultTreeNode<Object> parent = new DefaultTreeNode<Object>(STRUCTURE_NODE_TYPE, node, result);
+        DefaultTreeNode<Object> parent = new DefaultTreeNode<>(STRUCTURE_NODE_TYPE, node, result);
         if (logicalNodeStateUnknown(this.previousExpansionStatesLogicalTree, parent)) {
             parent.setExpanded(true);
         }
@@ -895,8 +895,7 @@ public class StructurePanel implements Serializable {
      */
     private DefaultTreeNode<Object> addTreeNode(String label, boolean undefined, boolean linked, Object dataObject,
             DefaultTreeNode<Object> parent) {
-        DefaultTreeNode<Object> node = new DefaultTreeNode<Object>(new StructureTreeNode(label, null, undefined, linked, dataObject),
-                parent);
+        DefaultTreeNode<Object> node = new DefaultTreeNode<>(new StructureTreeNode(label, null, undefined, linked, dataObject), parent);
         if (dataObject instanceof PhysicalDivision && physicalNodeStateUnknown(this.previousExpansionStatesPhysicalTree, node)
                 || dataObject instanceof LogicalDivision
                 && logicalNodeStateUnknown(this.previousExpansionStatesLogicalTree, node)) {
@@ -975,7 +974,7 @@ public class StructurePanel implements Serializable {
      *         added as a result of calling `addParentLinksRecursive`.
      */
     public Integer getNumberOfParentLinkRootNodesAdded() {
-        DefaultTreeNode<Object> node = new DefaultTreeNode<Object>();
+        DefaultTreeNode<Object> node = new DefaultTreeNode<>();
         addParentLinksRecursive(dataEditor.getProcess(), node);
         return node.getChildCount();
     }
@@ -988,7 +987,7 @@ public class StructurePanel implements Serializable {
      * @return the media tree
      */
     private DefaultTreeNode<Object> buildMediaTree(PhysicalDivision mediaRoot) {
-        DefaultTreeNode<Object> rootTreeNode = new DefaultTreeNode<Object>();
+        DefaultTreeNode<Object> rootTreeNode = new DefaultTreeNode<>();
         rootTreeNode.setType(PHYS_STRUCTURE_NODE_TYPE);
         if (physicalNodeStateUnknown(this.previousExpansionStatesPhysicalTree, rootTreeNode)) {
             rootTreeNode.setExpanded(true);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
@@ -35,7 +35,7 @@ abstract class CustomResourceBundle extends ResourceBundle {
 
     private static final Logger logger = LogManager.getLogger(CustomResourceBundle.class);
     private static URLClassLoader urlClassLoader;
-    private static Map<String, Boolean> propertiesFileExistsMap = new HashMap<String, Boolean>();
+    private static Map<String, Boolean> propertiesFileExistsMap = new HashMap<>();
 
     @Override
     public Enumeration<String> getKeys() {

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/CommandService.java
@@ -33,7 +33,7 @@ public class CommandService {
      * Initialize Command Service.
      */
     public CommandService() {
-        commandModule = new KitodoServiceLoader<CommandInterface>(CommandInterface.class).loadModule();
+        commandModule = new KitodoServiceLoader<>(CommandInterface.class).loadModule();
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/ImportProcesses.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/ImportProcesses.java
@@ -324,8 +324,8 @@ public final class ImportProcesses extends EmptyTask {
              * that when the parents are imported, the process ID of
              * the children is already known and can be written down
              * in the METS file. */
-            TreeSet<ImportingProcess> childrenFirst = new TreeSet<ImportingProcess>(
-                    Comparator.comparingInt(ImportingProcess::childDepth).thenComparing(ImportingProcess::toString));
+            TreeSet<ImportingProcess> childrenFirst = new TreeSet<>(Comparator.comparingInt(ImportingProcess::childDepth)
+                    .thenComparing(ImportingProcess::toString));
             childrenFirst.addAll(importingProcesses.values());
             importingProcessesIterator = childrenFirst.iterator();
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/image/ImageService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/image/ImageService.java
@@ -30,7 +30,7 @@ public class ImageService {
     private static volatile ImageService instance = null;
 
     private ImageService() {
-        imageManagement = new KitodoServiceLoader<ImageManagementInterface>(ImageManagementInterface.class)
+        imageManagement = new KitodoServiceLoader<>(ImageManagementInterface.class)
                 .loadModule();
     }
 


### PR DESCRIPTION
Replace unncessary explict type arguments with "diamond operator" ("`<>`") to reduce clutter and improve readability. (available since Java 7; see https://docs.oracle.com/javase/7/docs/technotes/guides/language/type-inference-generic-instance-creation.html for details)