### PR TITLE
Refactor some code for potential performance optimizations

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/validation/longtermpreservation/LtpValidationResult.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/validation/longtermpreservation/LtpValidationResult.java
@@ -133,11 +133,11 @@ public class LtpValidationResult {
         String joinedConditionResults = StringUtils
                 .join(conditionResults.stream().map((r) -> r.toString()).collect(Collectors.toList()), ", ");
         String joinedMessages = StringUtils.join(additionalMessages, ", ");
-        builder.append("LtpValidationResult " + super.toString() + "\n");
-        builder.append("- state: " + state.name() + "\n");
-        builder.append("- errors: " + joinedErrors + "\n");
-        builder.append("- conditionResults: " + joinedConditionResults + "\n");
-        builder.append("- addtionalMessages: " + joinedMessages + "\n");
+        builder.append("LtpValidationResult ").append(super.toString()).append("\n");
+        builder.append("- state: ").append(state.name()).append("\n");
+        builder.append("- errors: ").append(joinedErrors).append("\n");
+        builder.append("- conditionResults: ").append(joinedConditionResults).append("\n");
+        builder.append("- addtionalMessages: ").append(joinedMessages).append("\n");
         return builder.toString();
     }
 

--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveRepInfoParser.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveRepInfoParser.java
@@ -127,10 +127,7 @@ public class KitodoJhoveRepInfoParser {
             if (propertyArity == PropertyArity.SCALAR) {
                 if (propertyValue instanceof NisoImageMetadata) {
                     NisoImageMetadata metadata = (NisoImageMetadata) propertyValue;
-                    for (Map.Entry<String, String> e : KitodoJhoveNisoImageMetadataHelper
-                            .nisoImageMetadataToMap(metadata).entrySet()) {
-                        propertyMap.put(e.getKey(), e.getValue());
-                    }
+                    propertyMap.putAll(KitodoJhoveNisoImageMetadataHelper.nisoImageMetadataToMap(metadata));
                 } else {
                     propertyMap.put(propertyKey, String.valueOf(propertyValue));
                 }
@@ -173,7 +170,7 @@ public class KitodoJhoveRepInfoParser {
     private static String propertiesToString(Map<String, Property> properties) {
         StringBuilder builder = new StringBuilder();
         for (Map.Entry<String, String> entry : hierarchicalPropertiesToSimpleMap(properties).entrySet()) {
-            builder.append("- " + entry.getKey() + ": " + entry.getValue() + "\n");
+            builder.append("- ").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
         }
         return builder.toString();
     }
@@ -247,29 +244,29 @@ public class KitodoJhoveRepInfoParser {
         List<String> checksums = info.getChecksum().stream().map((c) -> c.getType() + ":" + c.getValue())
                 .collect(Collectors.toList());
 
-        builder.append("RepInfo object " + info.toString() + "\n");
-        builder.append("URI: " + info.getUri() + "\n");
-        builder.append("Format: " + info.getFormat() + "\n");
-        builder.append("MimeType: " + info.getMimeType() + "\n");
-        builder.append("Note: " + info.getNote() + "\n");
-        builder.append("Size: " + info.getSize() + "\n");
-        builder.append("Valid: " + info.getValid() + "\n");
-        builder.append("Version: " + info.getVersion() + "\n");
-        builder.append("Well-Formed: " + info.getWellFormed() + "\n");
-        builder.append("CheckSums: " + StringUtils.join(checksums, ",") + "\n");
-        builder.append("Created: " + info.getCreated() + "\n");
-        builder.append("Last-Modified: " + info.getLastModified() + "\n");
+        builder.append("RepInfo object ").append(info).append("\n");
+        builder.append("URI: ").append(info.getUri()).append("\n");
+        builder.append("Format: ").append(info.getFormat()).append("\n");
+        builder.append("MimeType: ").append(info.getMimeType()).append("\n");
+        builder.append("Note: ").append(info.getNote()).append("\n");
+        builder.append("Size: ").append(info.getSize()).append("\n");
+        builder.append("Valid: ").append(info.getValid()).append("\n");
+        builder.append("Version: ").append(info.getVersion()).append("\n");
+        builder.append("Well-Formed: ").append(info.getWellFormed()).append("\n");
+        builder.append("CheckSums: ").append(StringUtils.join(checksums, ",")).append("\n");
+        builder.append("Created: ").append(info.getCreated()).append("\n");
+        builder.append("Last-Modified: ").append(info.getLastModified()).append("\n");
         builder.append("Messages:\n");
         for (Message message : info.getMessage()) {
-            builder.append("- Message: " + message.getMessage() + "\n");
-            builder.append("  - Submessage: " + message.getSubMessage() + "\n");
+            builder.append("- Message: ").append(message.getMessage()).append("\n");
+            builder.append("  - Submessage: ").append(message.getSubMessage()).append("\n");
         }
-        builder.append("Profiles: " + StringUtils.join(info.getProfile(), ",") + "\n");
+        builder.append("Profiles: ").append(StringUtils.join(info.getProfile(), ",")).append("\n");
         builder.append("Properties:\n");
         builder.append(propertiesToString(info.getProperty()));
-        builder.append("SigMatches: " + StringUtils.join(info.getSigMatch(), ",") + "\n");
-        builder.append("URLFlag: " + info.getURLFlag() + "\n");
-        builder.append("isConsistent: " + info.isConsistent() + "\n");
+        builder.append("SigMatches: ").append(StringUtils.join(info.getSigMatch(), ",")).append("\n");
+        builder.append("URLFlag: ").append(info.getURLFlag()).append("\n");
+        builder.append("isConsistent: ").append(info.isConsistent()).append("\n");
         return builder.toString();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationReportDialog.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationReportDialog.java
@@ -127,7 +127,7 @@ public class LtpValidationReportDialog implements Serializable {
             return 0;
         }
         return resultsByFolder.values().stream().reduce(0,
-            (sum, resultsByFile) -> sum + (int) resultsByFile.values().stream().count(), Integer::sum);
+            (sum, resultsByFile) -> sum + resultsByFile.size(), Integer::sum);
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -389,7 +389,7 @@ public class StructurePanel implements Serializable {
      */
     public void setSelectedLogicalNodes(List<TreeNode<Object>> selected) {
         if (Objects.nonNull(selected)) {
-            this.setSelectedLogicalNodesAsArray(selected.toArray(new TreeNode[selected.size()]));
+            this.setSelectedLogicalNodesAsArray(selected.toArray(new TreeNode[0]));
         }
     }
 
@@ -451,7 +451,7 @@ public class StructurePanel implements Serializable {
      */
     public void setSelectedPhysicalNodes(List<TreeNode<Object>> selected) {
         if (Objects.nonNull(selected)) {
-            this.setSelectedPhysicalNodesAsArray(selected.toArray(new TreeNode[selected.size()]));
+            this.setSelectedPhysicalNodesAsArray(selected.toArray(new TreeNode[0]));
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/Subfolder.java
@@ -262,7 +262,7 @@ public class Subfolder {
      */
     public URI getUri(String canonical) {
         List<String> uriComponents = getUriComponents(canonical);
-        return Paths.get(ConfigCore.getKitodoDataDirectory(), uriComponents.toArray(new String[uriComponents.size()]))
+        return Paths.get(ConfigCore.getKitodoDataDirectory(), uriComponents.toArray(new String[0]))
                 .toUri();
     }
 


### PR DESCRIPTION
This pull request refactors some code parts for some potential performance improvements:
- replace String concatinations parameters of `StringBuilder.append` calls with chained `append` calls to save the cost of extra builder allocations
- replace iterated `Map.put` calls with `Map.putAll`
- replace Stream API calls that end with `count()` that first iterate over all relevant objects to count them, with calls to `size()` that forgoes the actual loading of objects that are then counted 