### PR TITLE
Add columns for workflow and docket to template list

### DIFF
--- a/Kitodo-DataManagement/src/main/resources/db/migration/V2_144__Add_list_columns_for_template_docket_and_workflow.sql
+++ b/Kitodo-DataManagement/src/main/resources/db/migration/V2_144__Add_list_columns_for_template_docket_and_workflow.sql
@@ -1,0 +1,21 @@
+--
+-- (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+--
+-- This file is part of the Kitodo project.
+--
+-- It is licensed under GNU General Public License version 3 or later.
+--
+-- For the full copyright and license information, please read the
+-- GPL3-License.txt file that was distributed with this source code.
+--
+
+-- Add list columns for the template docket and workflow
+INSERT INTO listcolumn (title) VALUES ('template.docket');
+INSERT INTO listcolumn (title) VALUES ('template.workflow');
+
+-- Add the new columns to the client_x_listColumn table
+INSERT INTO client_x_listcolumn (client_id, column_id)
+SELECT client.id, listcolumn.id
+FROM client
+         CROSS JOIN listcolumn
+WHERE listcolumn.title IN ('template.docket', 'template.workflow');

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
@@ -59,6 +59,20 @@
                           title="#{item.ruleset.title}"/>
         </p:column>
 
+        <p:column headerText="#{msgs.docket}"
+                  sortBy="#{item.docket.title}"
+                  rendered="#{TemplateListView.showColumn('template.docket')}">
+            <h:outputText value="#{item.docket.title}"
+                          title="#{item.docket.title}"/>
+        </p:column>
+
+        <p:column headerText="#{msgs.workflow}"
+                  sortBy="#{item.workflow.title}"
+                  rendered="#{TemplateListView.showColumn('template.workflow')}">
+            <h:outputText value="#{item.workflow.title}"
+                          title="#{item.workflow.title}"/>
+        </p:column>
+
         <p:column headerText="#{msgs.active}"
                   styleClass="checkboxColumn"
                   sortBy="#{item.active}">
@@ -148,10 +162,6 @@
                                  styleClass="expansion-column"
                                  columns="2"
                                  columnClasses="label, value">
-                        <h:outputText value="#{msgs.workflow}:"/>
-                        <h:outputText title="#{item.workflow.title}"
-                                      value="#{item.workflow.title}"/>
-
                         <h:outputText value="#{msgs.docket}:"/>
                         <h:outputText title="#{item.docket.title}"
                                       value="#{item.docket.title}"/>
@@ -159,6 +169,10 @@
                         <h:outputText value="#{msgs.ruleset}:"/>
                         <h:outputText title="#{item.ruleset.title}"
                                       value="#{item.ruleset.title}"/>
+
+                        <h:outputText value="#{msgs.workflow}:"/>
+                        <h:outputText title="#{item.workflow.title}"
+                                      value="#{item.workflow.title}"/>
                     </p:panelGrid>
 
                     <p:panelGrid id="templateProjectsTable"


### PR DESCRIPTION
Currently the template list only shows the ruleset of each template in a column, but hides the workflow and docket of a template in the row expansion:
<img width="1430" height="461" alt="Bildschirmfoto 2026-03-10 um 12 21 59" src="https://github.com/user-attachments/assets/3a00a0f0-e6d4-4a5d-b92e-5ed31c23e594" />


This pull request adds columns for workflow and docket to the template list and changes the order of workflow, ruleset and docket in the row expansion to move the workflow title closer to the corresponding diagram:
<img width="1432" height="460" alt="Bildschirmfoto 2026-03-10 um 12 19 56" src="https://github.com/user-attachments/assets/c677c2ac-fd8a-4ed8-b917-3a61790420cc" />
