### PR TITLE
Move 'unlink process' option to end of context menu

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/logicalStructure.xhtml
@@ -253,20 +253,6 @@
                         update="uploadFileDialog"
                         disabled="#{readOnly}"
                         process="@this"/>
-            <p:menuitem value="#{DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.data.linked ? msgs.unlinkProcess : msgs.removeElement}"
-                        rendered="#{DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.data.dataObject ne null and DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.type ne StructurePanel.VIEW_NODE_TYPE and DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.type ne StructurePanel.MEDIA_PARTIAL_NODE_TYPE}"
-                        icon="fa fa-trash fa-sm"
-                        styleClass="plain unlink-process"
-                        disabled="#{readOnly}"
-                        onclick="$('#loadingScreen').show()"
-                        oncomplete="$('#loadingScreen').hide()"
-                        action="#{DataEditorForm.deleteStructure()}"
-                        process="@this"
-                        update="logicalTree
-                                paginationForm:paginationWrapperPanel
-                                metadataAccordion:logicalMetadataHeader
-                                metadataAccordion:logicalMetadataWrapperPanel
-                                galleryWrapperPanel"/>
             <p:menuitem value="#{msgs['metadataEdit']}"
                         rendered="#{DataEditorForm.structurePanel.isMetadataEditingPossible()}"
                         disabled="#{!DataEditorForm.canLinkedProcessBeOpenedInMetadataEditor()}"
@@ -311,6 +297,20 @@
                         process="@this"
                         update="numberOfScans
                                 logicalTree
+                                paginationForm:paginationWrapperPanel
+                                metadataAccordion:logicalMetadataHeader
+                                metadataAccordion:logicalMetadataWrapperPanel
+                                galleryWrapperPanel"/>
+            <p:menuitem value="#{DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.data.linked ? msgs.unlinkProcess : msgs.removeElement}"
+                        rendered="#{DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.data.dataObject ne null and DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.type ne StructurePanel.VIEW_NODE_TYPE and DataEditorForm.structurePanel.selectedLogicalNodeIfSingle.type ne StructurePanel.MEDIA_PARTIAL_NODE_TYPE}"
+                        icon="fa fa-trash fa-sm"
+                        styleClass="plain unlink-process"
+                        disabled="#{readOnly}"
+                        onclick="$('#loadingScreen').show()"
+                        oncomplete="$('#loadingScreen').hide()"
+                        action="#{DataEditorForm.deleteStructure()}"
+                        process="@this"
+                        update="logicalTree
                                 paginationForm:paginationWrapperPanel
                                 metadataAccordion:logicalMetadataHeader
                                 metadataAccordion:logicalMetadataWrapperPanel


### PR DESCRIPTION
The context menu of tree nodes representing linked sub processes in the structure panel of the metadata editor offers an option to _unlink_ the linked process. This option is currently listed as the _first_ option in the context menu:

<img width="595" height="301" alt="Bildschirmfoto 2026-03-11 um 13 28 41" src="https://github.com/user-attachments/assets/7f35e92f-bb21-4572-b4af-acde22667e20" />

This can be confusing because options to delete or remove objects are usually positioned at the _end_ of option lists, and Kitodo normally follows this guideline:

_Removing structure nodes:_
<img width="410" height="227" alt="Bildschirmfoto 2026-03-11 um 13 30 19" src="https://github.com/user-attachments/assets/37ae38b4-1ec3-4b38-8292-42dbaeafca2d" />

_Deleting processes:_
<img width="331" height="257" alt="Bildschirmfoto 2026-03-11 um 13 33 12" src="https://github.com/user-attachments/assets/0b6b900b-a108-4a79-9a70-38c230c8550a" />

Thus, this pull request moves the option to unlink linked processes to the _last_ position in the context menu of the structure tree to allign it to the rest of the UI:
<img width="601" height="289" alt="Bildschirmfoto 2026-03-11 um 13 30 33" src="https://github.com/user-attachments/assets/2793f33c-92b3-4ef9-8602-cf0be519c371" />
