### PR TITLE
Update GitHub actions to version which support NodeJS 24

### DIFF
--- a/.github/workflows/check_file_encodings.yml
+++ b/.github/workflows/check_file_encodings.yml
@@ -11,28 +11,28 @@ jobs:
   check-encoding:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
 
       - name: Check file encodings
         run: |
           #!/bin/bash
           set -euo pipefail
-          
+
           EXIT_CODE=0
-          
+
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             # Skip if file is binary or doesn't exist (was deleted)
             if [[ ! -f "$file" ]] || [[ -z "$(grep -Il '.' "$file")" ]]; then
               continue
             fi
-            
+
             # Try to detect encoding using file command
             encoding=$(file -i "$file" | grep -oP "charset=\K.*")
-            
+
             if [ "$encoding" != "utf-8" ] && [ "$encoding" != "us-ascii" ]; then
               echo "::error file=${file}::File is not UTF-8 encoded (detected: ${encoding})"
               EXIT_CODE=1
@@ -44,5 +44,5 @@ jobs:
               fi
             fi
           done
-          
+
           exit $EXIT_CODE

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y imagemagick
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: copy files
         run: |


### PR DESCRIPTION
If you look into the executed actions there are warnings for deprecated actions like this

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, tj-actions/changed-files@v45. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. ....
```

I try to back port this change to `3.9.x` and `3.8.x` branches too.