### PR TITLE
Show task element ID in error message when task has no title

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/workflow/model/Converter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/workflow/model/Converter.java
@@ -122,6 +122,7 @@ public class Converter {
             task.setWorkflowCondition(new WorkflowCondition(kitodoTask.getConditionType(), kitodoTask.getConditionValue()));
         }
 
+        String taskLabel = Objects.nonNull(task.getTitle()) ? task.getTitle() : kitodoTask.getWorkflowId();
         try {
             String[] userRoleIds = kitodoTask.getUserRoles().split(",");
             for (String userRoleString : userRoleIds) {
@@ -130,12 +131,12 @@ public class Converter {
                     task.getRoles().add(ServiceManager.getRoleService().getById(userRoleId));
                 } catch (DAOException e) {
                     throw new WorkflowException(Helper.getTranslation("workflowExceptionRoleNotFound",
-                        task.getTitle()));
+                        taskLabel));
                 }
             }
         } catch (NullPointerException e) {
             throw new WorkflowException(Helper.getTranslation("workflowExceptionMissingRoleAssignment",
-                task.getTitle()));
+                taskLabel));
         }
 
         if (workflowTask instanceof ScriptTask) {

--- a/Kitodo/src/main/java/org/kitodo/production/workflow/model/Converter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/workflow/model/Converter.java
@@ -123,6 +123,19 @@ public class Converter {
         }
 
         String taskLabel = Objects.nonNull(task.getTitle()) ? task.getTitle() : kitodoTask.getWorkflowId();
+        addRoles(task, kitodoTask, taskLabel);
+
+        if (workflowTask instanceof ScriptTask) {
+            KitodoScriptTask kitodoScriptTask = new KitodoScriptTask((ScriptTask) workflowTask);
+            task.setScriptName(kitodoScriptTask.getScriptName());
+            task.setScriptPath(kitodoScriptTask.getScriptPath());
+        }
+
+        return task;
+    }
+
+    private void addRoles(org.kitodo.data.database.beans.Task task, KitodoTask kitodoTask, String taskLabel)
+            throws WorkflowException {
         try {
             String[] userRoleIds = kitodoTask.getUserRoles().split(",");
             for (String userRoleString : userRoleIds) {
@@ -138,13 +151,5 @@ public class Converter {
             throw new WorkflowException(Helper.getTranslation("workflowExceptionMissingRoleAssignment",
                 taskLabel));
         }
-
-        if (workflowTask instanceof ScriptTask) {
-            KitodoScriptTask kitodoScriptTask = new KitodoScriptTask((ScriptTask) workflowTask);
-            task.setScriptName(kitodoScriptTask.getScriptName());
-            task.setScriptPath(kitodoScriptTask.getScriptPath());
-        }
-
-        return task;
     }
 }


### PR DESCRIPTION
This PR fixes a small bug when a task has not yet been named.

If the title of a task is not set validation error messages can not use it so the resulting message has the string null in it.

![null](https://github.com/user-attachments/assets/645973e2-5850-424f-bf00-b6b05d81a675)

If there's no title we could display the ID at least. ID is a mandatory field so it will not be empty when saving.

![taskID](https://github.com/user-attachments/assets/77cd01fd-ea6a-4f3f-a5aa-c583e2822698)

(Screenshots are from the new UI of #6928 but the fix is independent from that.)