### PR TITLE
Skip metadata assignment for untyped divisions

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -45,6 +45,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.SimpleMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterface;
 import org.kitodo.api.dataformat.Division;
+import org.kitodo.api.dataformat.LogicalDivision;
 import org.kitodo.exceptions.InvalidMetadataValueException;
 import org.kitodo.exceptions.NoSuchMetadataFieldException;
 import org.kitodo.production.services.dataeditor.DataEditorService;
@@ -672,6 +673,10 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     @Override
     public void preserve() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         try {
+            if (isDivisionUntyped()) {
+                logger.warn("Skipping metadata preservation for untyped division.");
+                return;
+            }
             if (Objects.nonNull(division)) {
                 division.getContentIds().clear();
                 division.setOrderlabel(null);
@@ -715,6 +720,18 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
             container.metadata.add(metadataGroup);
             copy = false;
         }
+    }
+
+    private boolean isDivisionUntyped() {
+        if (division instanceof LogicalDivision logicalDivision) {
+            if (Objects.isNull(logicalDivision.getType()) || logicalDivision.getType().isBlank()) {
+                logicalDivision.getContentIds().clear();
+                logicalDivision.setOrderlabel(null);
+                logicalDivision.setLabel(null);
+                return true;
+            }
+        }
+        return false;
     }
 
     private void updateDivisionFromProcessDetail(String key, ProcessSimpleMetadata processDetail) throws InvalidMetadataValueException {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -673,9 +673,8 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     @Override
     public void preserve() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         try {
-            if (isDivisionUntyped()) {
-                return;
-            }
+            boolean untyped = isDivisionUntyped();
+
             if (Objects.nonNull(division)) {
                 division.getContentIds().clear();
                 division.setOrderlabel(null);
@@ -688,9 +687,13 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                 if (row instanceof ProcessSimpleMetadata && specialFields.contains(id)
                         && ((ProcessSimpleMetadata) row).getSettings()
                         .getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
-                    updateDivisionFromProcessDetail(id, (ProcessSimpleMetadata) row);
+                    if (!untyped || METADATA_KEY_LABEL.equals(id) || METADATA_KEY_ORDERLABEL.equals(id)) {
+                        updateDivisionFromProcessDetail(id, (ProcessSimpleMetadata) row);
+                    }
                 } else {
-                    metadata.addAll(row.getMetadataWithFilledValues());
+                    if (!untyped) {
+                        metadata.addAll(row.getMetadataWithFilledValues());
+                    }
                 }
             }
             if (Objects.nonNull(hiddenMetadata) && !hiddenMetadata.isEmpty()) {
@@ -721,14 +724,23 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
         }
     }
 
+    public void filterToStructuralFields() {
+        treeNode.getChildren().removeIf(child -> {
+            ProcessDetail row = (ProcessDetail) child.getData();
+            String key = row.getMetadataID();
+
+            return !isStructuralKey(key);
+        });
+    }
+
+    private boolean isStructuralKey(String key) {
+        return METADATA_KEY_LABEL.equals(key)
+                || METADATA_KEY_ORDERLABEL.equals(key);
+    }
+
     private boolean isDivisionUntyped() {
         if (division instanceof LogicalDivision logicalDivision) {
-            if (Objects.isNull(logicalDivision.getType()) || logicalDivision.getType().isBlank()) {
-                logicalDivision.getContentIds().clear();
-                logicalDivision.setOrderlabel(null);
-                logicalDivision.setLabel(null);
-                return true;
-            }
+            return Objects.isNull(logicalDivision.getType()) || logicalDivision.getType().isBlank();
         }
         return false;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -674,7 +674,6 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     public void preserve() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         try {
             if (isDivisionUntyped()) {
-                logger.warn("Skipping metadata preservation for untyped division.");
                 return;
             }
             if (Objects.nonNull(division)) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -681,12 +681,10 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                 String id = row.getMetadataID();
                 if (row instanceof ProcessSimpleMetadata && specialFields.contains(id)
                         && ((ProcessSimpleMetadata) row).getSettings()
-                        .getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV) && !untyped) {
+                        .getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
                     updateDivisionFromProcessDetail(id, (ProcessSimpleMetadata) row);
-                } else {
-                    if (!untyped) {
-                        metadata.addAll(row.getMetadataWithFilledValues());
-                    }
+                } else if (!untyped) {
+                    metadata.addAll(row.getMetadataWithFilledValues());
                 }
             }
             if (Objects.nonNull(hiddenMetadata) && !hiddenMetadata.isEmpty()) {
@@ -698,7 +696,9 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
                         }
                     }
                 }
-                metadata.addAll(hiddenMetadata);
+                if (!untyped) {
+                    metadata.addAll(hiddenMetadata);
+                }
             }
         } catch (InvalidMetadataValueException invalidValueException) {
             if (Objects.isNull(division)) {
@@ -729,17 +729,8 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
      * Restricts the visible metadata fields of this element to structural metadata only.
      */
     public void filterToStructuralFields() {
-        treeNode.getChildren().removeIf(child -> {
-            ProcessDetail row = (ProcessDetail) child.getData();
-            String key = row.getMetadataID();
-
-            return !isStructuralKey(key);
-        });
-    }
-
-    private boolean isStructuralKey(String key) {
-        return METADATA_KEY_LABEL.equals(key)
-                || METADATA_KEY_ORDERLABEL.equals(key);
+        treeNode.getChildren().removeIf(child ->
+                !specialFields.contains(((ProcessDetail) child.getData()).getMetadataID()));
     }
 
     private boolean isDivisionUntyped() {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/ProcessFieldedMetadata.java
@@ -674,22 +674,15 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
     public void preserve() throws InvalidMetadataValueException, NoSuchMetadataFieldException {
         try {
             boolean untyped = isDivisionUntyped();
-
-            if (Objects.nonNull(division)) {
-                division.getContentIds().clear();
-                division.setOrderlabel(null);
-                division.setLabel(null);
-            }
+            resetDivision();
             metadata.clear();
             for (TreeNode<Object> child : treeNode.getChildren()) {
                 ProcessDetail row = (ProcessDetail) child.getData();
                 String id = row.getMetadataID();
                 if (row instanceof ProcessSimpleMetadata && specialFields.contains(id)
                         && ((ProcessSimpleMetadata) row).getSettings()
-                        .getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV)) {
-                    if (!untyped || METADATA_KEY_LABEL.equals(id) || METADATA_KEY_ORDERLABEL.equals(id)) {
-                        updateDivisionFromProcessDetail(id, (ProcessSimpleMetadata) row);
-                    }
+                        .getDomain().orElse(Domain.DESCRIPTION).equals(Domain.METS_DIV) && !untyped) {
+                    updateDivisionFromProcessDetail(id, (ProcessSimpleMetadata) row);
                 } else {
                     if (!untyped) {
                         metadata.addAll(row.getMetadataWithFilledValues());
@@ -724,6 +717,17 @@ public class ProcessFieldedMetadata extends ProcessDetail implements Serializabl
         }
     }
 
+    private void resetDivision() {
+        if (Objects.nonNull(division)) {
+            division.getContentIds().clear();
+            division.setOrderlabel(null);
+            division.setLabel(null);
+        }
+    }
+
+    /**
+     * Restricts the visible metadata fields of this element to structural metadata only.
+     */
     public void filterToStructuralFields() {
         treeNode.getChildren().removeIf(child -> {
             ProcessDetail row = (ProcessDetail) child.getData();

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
@@ -147,16 +147,29 @@ public class MetadataPanel implements Serializable {
     }
 
     void showLogical(Optional<LogicalDivision> optionalStructure) {
-        if (optionalStructure.isPresent() && Objects.isNull(optionalStructure.get().getLink())
-                && Objects.nonNull(optionalStructure.get().getType())
-                && !optionalStructure.get().getType().isBlank())  {
+        if (optionalStructure.isPresent() && Objects.isNull(optionalStructure.get().getLink())) {
+
             logicalMetadataTable = createProcessFieldedMetadata(optionalStructure.get());
+
+            if (isDivisionUntyped(optionalStructure.get())) {
+                logicalMetadataTable.filterToStructuralFields(); // 👈 NEW
+            }
+
             dataEditorForm.getAddMetadataDialog().prepareAddableMetadataForStructure(
                     getLogicalMetadataRows().getChildren());
+
         } else {
             logicalMetadataTable = ProcessFieldedMetadata.EMPTY;
         }
     }
+
+    private boolean isDivisionUntyped(LogicalDivision division) {
+        if (division instanceof LogicalDivision logicalDivision) {
+            return Objects.isNull(logicalDivision.getType()) || logicalDivision.getType().isBlank();
+        }
+        return false;
+    }
+
 
     void showPageInLogical(PhysicalDivision physicalDivision) {
         if (Objects.nonNull(physicalDivision)) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
@@ -147,7 +147,9 @@ public class MetadataPanel implements Serializable {
     }
 
     void showLogical(Optional<LogicalDivision> optionalStructure) {
-        if (optionalStructure.isPresent() && Objects.isNull(optionalStructure.get().getLink())) {
+        if (optionalStructure.isPresent() && Objects.isNull(optionalStructure.get().getLink())
+                && Objects.nonNull(optionalStructure.get().getType())
+                && !optionalStructure.get().getType().isBlank())  {
             logicalMetadataTable = createProcessFieldedMetadata(optionalStructure.get());
             dataEditorForm.getAddMetadataDialog().prepareAddableMetadataForStructure(
                     getLogicalMetadataRows().getChildren());

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
@@ -152,7 +152,7 @@ public class MetadataPanel implements Serializable {
             logicalMetadataTable = createProcessFieldedMetadata(optionalStructure.get());
 
             if (isDivisionUntyped(optionalStructure.get())) {
-                logicalMetadataTable.filterToStructuralFields(); // 👈 NEW
+                logicalMetadataTable.filterToStructuralFields();
             }
 
             dataEditorForm.getAddMetadataDialog().prepareAddableMetadataForStructure(

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MetadataPanel.java
@@ -164,12 +164,8 @@ public class MetadataPanel implements Serializable {
     }
 
     private boolean isDivisionUntyped(LogicalDivision division) {
-        if (division instanceof LogicalDivision logicalDivision) {
-            return Objects.isNull(logicalDivision.getType()) || logicalDivision.getType().isBlank();
-        }
-        return false;
+        return Objects.isNull(division.getType()) || division.getType().isBlank();
     }
-
 
     void showPageInLogical(PhysicalDivision physicalDivision) {
         if (Objects.nonNull(physicalDivision)) {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -460,14 +460,17 @@ public class ProcessHelper {
     public static void addAllowedMetadataRecursive(Division<?> division, Collection<String> keys, String value,
                                                    RulesetManagementInterface rulesetManagement, String acquisitionStage,
                                                    List<Locale.LanguageRange> priorityList) {
-        StructuralElementViewInterface divisionView = rulesetManagement.getStructuralElementView(division.getType(),
-                acquisitionStage, priorityList);
-        for (MetadataViewInterface metadataView : divisionView.getAllowedMetadata()) {
-            if (metadataView instanceof SimpleMetadataViewInterface && keys.contains(metadataView.getId())
-                    && division.getMetadata().parallelStream()
-                    .filter(metadata -> metadataView.getId().equals(metadata.getKey()))
-                    .count() < metadataView.getMaxOccurs()) {
-                MetadataEditor.writeMetadataEntry(division, (SimpleMetadataViewInterface) metadataView, value);
+        String type = division.getType();
+        if (Objects.nonNull(type) && !type.isEmpty()) {
+            StructuralElementViewInterface divisionView = rulesetManagement.getStructuralElementView(type,
+                    acquisitionStage, priorityList);
+            for (MetadataViewInterface metadataView : divisionView.getAllowedMetadata()) {
+                if (metadataView instanceof SimpleMetadataViewInterface && keys.contains(metadataView.getId())
+                        && division.getMetadata().parallelStream()
+                        .filter(metadata -> metadataView.getId().equals(metadata.getKey()))
+                        .count() < metadataView.getMaxOccurs()) {
+                    MetadataEditor.writeMetadataEntry(division, (SimpleMetadataViewInterface) metadataView, value);
+                }
             }
         }
         for (Division<?> child : division.getChildren()) {
@@ -509,8 +512,6 @@ public class ProcessHelper {
         Collection<String> processTitleKeys = rulesetManagement.getFunctionalKeys(FunctionalMetadata.PROCESS_TITLE);
         if (!processTitleKeys.isEmpty()) {
             ProcessHelper.addAllowedMetadataRecursive(workpiece.getLogicalStructure(), processTitleKeys, processTitle,
-                    rulesetManagement, acquisitionStage, priorityList);
-            ProcessHelper.addAllowedMetadataRecursive(workpiece.getPhysicalStructure(), processTitleKeys, processTitle,
                     rulesetManagement, acquisitionStage, priorityList);
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/ProcessHelper.java
@@ -461,7 +461,7 @@ public class ProcessHelper {
                                                    RulesetManagementInterface rulesetManagement, String acquisitionStage,
                                                    List<Locale.LanguageRange> priorityList) {
         String type = division.getType();
-        if (Objects.nonNull(type) && !type.isEmpty()) {
+        if (Objects.nonNull(type) && !type.isBlank()) {
             StructuralElementViewInterface divisionView = rulesetManagement.getStructuralElementView(type,
                     acquisitionStage, priorityList);
             for (MetadataViewInterface metadataView : divisionView.getAllowedMetadata()) {


### PR DESCRIPTION
This Pull request addresses the issue that Kitodo right now often injects unwanted metadata into the METS file. The issue has been described in different places, e.g. 

https://github.com/kitodo/kitodo-production/issues/4362#issuecomment-4073939262
or
https://github.com/kitodo/kitodo-production/issues/6024#issuecomment-2061639760

The problem is, that right now it is not mandatory to define special rules in the ruleset which prevent the uncontrolled insertion of e.g. the `processTitle`:

```xml
<restriction division="" unspecified="forbidden">
    <permit division="page"/>
    <permit division="track"/>
    <permit division="other"/>
</restriction>

<restriction division="page" unspecified="forbidden">
     <permit key="ORDERLABEL" maxOccurs="1"/>
</restriction>
```

If the institution does not have those rules in place, `page` elements or `unspecified` (untyped) elements which are created for newspaper issues might get unwanted metadata injections.
My fix therefor does two things:
- If the type of a logical section is undefined, do not inject metadata there. (And in consequence inject unwanted DMDSecs)
- Do not inject unwanted metadata into pysical pages

If both things are wanted it has to be implemented in a safer way. We cannot guarantee that all institutions know about those settings and have them in place. The behavior should therefor by default prevent unwanted insertions.