### PR TITLE
Add missing form on desktop to prevent warning message

### DIFF
--- a/Kitodo/src/main/webapp/pages/desktop.xhtml
+++ b/Kitodo/src/main/webapp/pages/desktop.xhtml
@@ -55,12 +55,14 @@
                                         <p:ajax update="processTable" oncomplete="setScrollbarLayout()"/>
                                 </p:commandButton>
                             </h:form>
-                            <p:commandButton id="allProcesses"
-                                             value="#{msgs.allProcesses}"
-                                             action="#{ProcessForm.navigateToProcessesList(true)}"
-                                             process="@this"
-                                             icon="fa fa-search fa-lg"
-                                             iconPos="right" styleClass="secondary"/>
+                            <h:form id="allProcessesForm">
+                                <p:commandButton id="allProcesses"
+                                                 value="#{msgs.allProcesses}"
+                                                 action="#{ProcessForm.navigateToProcessesList(true)}"
+                                                 process="@this"
+                                                 icon="fa fa-search fa-lg"
+                                                 iconPos="right" styleClass="secondary"/>
+                            </h:form>
                         </div>
                     </div>
                     <div class="content-body">


### PR DESCRIPTION
Opening the desktop page of Kitodo currently logs the following message:

`org.primefaces.util.AjaxRequestBuilder.form Component 'allProcesses' should be inside a form or should reference a form via its form attribute. We will try to find a fallback form on the client side.`

This pull request adds the missing `form` element to resolve the issue (similary to what has already been fixed for other command components in #6848 and #6842)