### PR TITLE
Show validation error dialog in metadata editor when updating catalog metadata

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ValidatableForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ValidatableForm.java
@@ -28,6 +28,7 @@ public class ValidatableForm extends BaseEditView {
     protected Collection<String> validationErrors = new ArrayList<>();
     protected String redirectionPath;
     protected String rulesetValidationError;
+    protected String validationErrorUpdateComponents = "editForm";
     protected boolean schemaValidationSkippable = false;
 
     /**
@@ -203,5 +204,14 @@ public class ValidatableForm extends BaseEditView {
         setSchemaValidationSkippable(exception.isExternalDataValidation());
         PrimeFaces.current().ajax().update("validationErrorsDialog");
         PrimeFaces.current().executeScript("PF('validationErrorsDialog').show();");
+    }
+
+    /**
+     * Get value of validationErrorUpdateComponents.
+     *
+     * @return value of validationErrorUpdateComponents
+     */
+    public String getValidationErrorUpdateComponents() {
+        return validationErrorUpdateComponents;
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -228,6 +228,7 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
 
     private String renamingError = "";
     private String metadataFileLoadingError = "";
+    private final Collection<String> metadataFileValidationErrors = new ArrayList<>();
 
     static final String GROWL_MESSAGE =
             "PF('notifications').renderMessage({'summary':'SUMMARY','detail':'DETAIL','severity':'SEVERITY'});";
@@ -236,6 +237,8 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
     private boolean taskLayoutLoaded = false;
     private Integer linkedProcessId = null;
     private boolean linkedProcessClicked = false;
+    @Inject
+    private UpdateMetadataDialog updateMetadataDialog;
 
     /**
      * Public constructor.
@@ -252,6 +255,7 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
         this.editPagesDialog = new EditPagesDialog(this);
         this.uploadFileDialog = new UploadFileDialog(this);
         this.linkProcessDialog = new LinkProcessDialog(this);
+        this.validationErrorUpdateComponents = "@none";
     }
 
     /**
@@ -318,6 +322,7 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
         } catch (FileNotFoundException | SAXException e) {
             metadataFileLoadingError = e.getMessage();
         } catch (FileStructureValidationException e) {
+            this.metadataFileValidationErrors.addAll(e.getValidationResult().getResultMessages());
             setValidationErrorTitle(Helper.getTranslation("validation.invalidMetadataFile"));
             showValidationExceptionDialog(e, this.referringView);
         } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException e) {
@@ -1298,6 +1303,15 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
     }
 
     /**
+     * Get potential metadata schema validation errors from validating metadata xml file.
+     *
+     * @return list of schema validation errors
+     */
+    public Collection<String> getMetadataFileValidationErrors() {
+        return metadataFileValidationErrors;
+    }
+
+    /**
      * Retrieve and return value of metadata configured as functional metadata 'recordIdentifier'.
      *
      * @return the 'recordIdentifier' metadata value of the current process
@@ -1519,5 +1533,10 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
      */
     public String getBlockingUser() {
         return blockingUserName;
+    }
+
+    @Override
+    public void proceed() {
+        updateMetadataDialog.updateCatalogMetadata(false);
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -491,6 +491,7 @@ public class ImportService {
      * @param recordId catalog identifier of data record to import
      * @param templateID ID of template to use when importing data record to TempProcess
      * @param projectID ID of project to which imported data record is assigned
+     * @param validateAgainstXmlSchema whether to validate imported XML against XML Schema
      * @return TempProcess containing imported data record
      * @throws UnsupportedFormatException when external data record contains data in unsupported format
      * @throws NoRecordFoundException when no record with given ID 'recordId' could be found
@@ -503,12 +504,12 @@ public class ImportService {
      * @throws TransformerException when loading internal format document fails
      */
     public TempProcess importTempProcess(ImportConfiguration importConfiguration, String recordId, int templateID,
-                                         int projectID)
+                                         int projectID, boolean validateAgainstXmlSchema)
             throws UnsupportedFormatException, NoRecordFoundException, XPathExpressionException,
             ProcessGenerationException, URISyntaxException, IOException, ParserConfigurationException, SAXException,
             TransformerException, FileStructureValidationException {
         DataRecord dataRecord = importExternalDataRecord(importConfiguration, recordId, false);
-        Document internalDocument = convertDataRecordToInternal(dataRecord, importConfiguration, false, true, recordId);
+        Document internalDocument = convertDataRecordToInternal(dataRecord, importConfiguration, false, validateAgainstXmlSchema, recordId);
         return createTempProcessFromDocument(importConfiguration, internalDocument, templateID, projectID);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/dataeditor/DataEditorService.java
@@ -401,6 +401,8 @@ public class DataEditorService {
      *          Workpiece of given process
      * @param oldMetadataSet
      *          Set containing old metadata
+     * @param validateXml
+     *          whether to validate XML or not
      * @return
      *          list of metadata comparisons
      * @throws IOException
@@ -431,7 +433,7 @@ public class DataEditorService {
     public static List<MetadataComparison> reimportCatalogMetadata(Process process, Workpiece workpiece,
                                                                    HashSet<Metadata> oldMetadataSet,
                                                                    List<Locale.LanguageRange> languages,
-                                                                   String selectedDivisionType)
+                                                                   String selectedDivisionType, boolean validateXml)
             throws IOException, UnsupportedFormatException, XPathExpressionException, NoRecordFoundException,
             ProcessGenerationException, ParserConfigurationException, URISyntaxException, TransformerException,
             InvalidMetadataValueException, NoSuchMetadataFieldException, SAXException, FileStructureValidationException {
@@ -443,7 +445,7 @@ public class DataEditorService {
             throw new MetadataException(errorMessage, null);
         }
         TempProcess updatedProcess = ServiceManager.getImportService().importTempProcess(importConfig, recordID,
-                process.getTemplate().getId(), process.getProject().getId());
+                process.getTemplate().getId(), process.getProject().getId(), validateXml);
         if (Objects.isNull(updatedProcess)) {
             throw new ProcessGenerationException("Unable to re-import data record for metadata update");
         } else {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/validationErrorsDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/validationErrorsDialog.xhtml
@@ -63,7 +63,7 @@
                                          process="@this"
                                          onclick='PF("validationErrorsDialog").hide();'
                                          rendered="#{validatableForm.isSchemaValidationSkippable()}"
-                                         update="editForm"
+                                         update="#{validatableForm.getValidationErrorUpdateComponents()}"
                                          value="#{msgs['validation.proceedAnyway']}"
                                          styleClass="primary right"/>
                         <p:commandButton id="cancelButton"

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -53,7 +53,7 @@
         <ui:param name="commentsNumber" value="#{CommentForm.getAllComments().size()}"/>
 
         <p:panel id="metadataEditorContainer"
-                 rendered="#{empty DataEditorForm.getMetadataFileLoadingError() and empty DataEditorForm.getValidationErrors()}"
+                 rendered="#{empty DataEditorForm.getMetadataFileLoadingError() and empty DataEditorForm.getMetadataFileValidationErrors()}"
                  style="margin: auto 16px; padding: 0;">
 
             <p:panel id="metadataEditor">

--- a/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/CatalogImportIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/catalogimport/CatalogImportIT.java
@@ -105,7 +105,7 @@ public class CatalogImportIT {
         testProcess.setImportConfiguration(configuration);
         HashSet<Metadata> existingMetadata = workpiece.getLogicalStructure().getMetadata();
         List<MetadataComparison> metadataComparisons = DataEditorService.reimportCatalogMetadata(testProcess, workpiece,
-                existingMetadata, languages, "Monograph");
+                existingMetadata, languages, "Monograph", true);
         assertFalse(metadataComparisons.isEmpty(), "List of metadata comparisons should not be empty");
         MetadataComparison firstComparison = metadataComparisons.getFirst();
         assertEquals(PUBLICATION_YEAR, firstComparison.getMetadataKey(),

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/DataEditorServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/DataEditorServiceIT.java
@@ -187,7 +187,7 @@ public class DataEditorServiceIT {
         URI processUri = ServiceManager.getProcessService().getMetadataFileUri(testProcess);
         Workpiece workpiece = ServiceManager.getMetsService().loadWorkpiece(processUri);
         MetadataException thrown = assertThrows(MetadataException.class, () -> DataEditorService.
-                reimportCatalogMetadata(testProcess, workpiece, null, languages, "Manuscript"));
+                reimportCatalogMetadata(testProcess, workpiece, null, languages, "Manuscript", true));
         assertEquals(thrown.getMessage(), String.format(EXPECTED_EXCEPTION_MESSAGE, testProcessId));
     }
 


### PR DESCRIPTION
Fixes #6881

Note that this only covers "**Updating** metadata", but not yet "**Adding** metadata". The later uses a slightly different architecture, therefor this fix unfortunately cannot be applied as-is for it, but probably has to be adapted/adjusted a little bit.