### PR TITLE
Simplify Web driver handling

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/Browser.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -11,22 +11,13 @@
 
 package org.kitodo.selenium.testframework.helper;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Objects;
-
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
Pull Request https://github.com/kitodo/kitodo-production/pull/6872 introduced Selenium 4, which also introduced Selenium Manager for more straightforward handling of browser drivers:
https://www.selenium.dev/documentation/selenium_manager

I think this allows us to massively simplify our handling of the Chrome Driver, which seems to solve the CI issues for me  @solth.