### PR TITLE
Refactor: decouple ExportDms from ExportMets 

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -40,6 +40,7 @@ import org.kitodo.production.helper.VariableReplacer;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyDocStructHelperInterface;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetadataHelper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
 import org.kitodo.production.helper.tasks.EmptyTask;
 import org.kitodo.production.helper.tasks.ExportDmsTask;
 import org.kitodo.production.helper.tasks.TaskManager;
@@ -53,13 +54,15 @@ import org.kitodo.production.services.file.FileService;
 import org.kitodo.production.services.workflow.WorkflowControllerService;
 import org.xml.sax.SAXException;
 
-public class ExportDms extends ExportMets {
+public class ExportDms {
     private static final Logger logger = LogManager.getLogger(ExportDms.class);
     private static final String EXPORT_DIR_DELETE = "errorDirectoryDeleting";
     private static final String ERROR_EXPORT = "errorExport";
 
     private final FileService fileService = ServiceManager.getFileService();
     private final ProcessService processService = ServiceManager.getProcessService();
+    private EmptyTask exportDmsTask = null;
+    private final ExportMets exportMets = new ExportMets();
 
     private boolean exportWithImages = true;
     private boolean optimisticExportFlagSet = false;
@@ -100,7 +103,6 @@ public class ExportDms extends ExportMets {
      * @param process
      *            Process object
      */
-    @Override
     public boolean startExport(Process process) throws DAOException {
         if (!exportCompletedChildren(process.getChildren())) {
             return false;
@@ -132,7 +134,6 @@ public class ExportDms extends ExportMets {
      * @param unused
      *            user home directory
      */
-    @Override
     public boolean startExport(Process process, URI unused) {
         if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.ASYNCHRONOUS_AUTOMATIC_EXPORT)) {
             TaskManager.addTask(new ExportDmsTask(this, process));
@@ -184,9 +185,9 @@ public class ExportDms extends ExportMets {
     private boolean startExport(Process process, LegacyMetsModsDigitalDocumentHelper newFile)
             throws IOException, DAOException, SAXException, FileStructureValidationException {
 
-        this.myPrefs = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
+        LegacyPrefsHelper prefs = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
 
-        LegacyMetsModsDigitalDocumentHelper gdzfile = readDocument(process, newFile);
+        LegacyMetsModsDigitalDocumentHelper gdzfile = readDocument(process, newFile, prefs);
         if (Objects.isNull(gdzfile)) {
             return false;
         }
@@ -200,7 +201,7 @@ public class ExportDms extends ExportMets {
 
         // validate metadata
         if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.USE_META_DATA_VALIDATION)
-                && !ServiceManager.getMetadataValidationService().validate(gdzfile, this.myPrefs)) {
+                && !ServiceManager.getMetadataValidationService().validate(gdzfile, prefs)) {
             if (Objects.nonNull(exportDmsTask)) {
                 exportDmsTask.setException(new MetadataException("metadata validation failed", null));
             }
@@ -298,10 +299,11 @@ public class ExportDms extends ExportMets {
         return true;
     }
 
-    private LegacyMetsModsDigitalDocumentHelper readDocument(Process process, LegacyMetsModsDigitalDocumentHelper newFile) {
+    private LegacyMetsModsDigitalDocumentHelper readDocument(Process process, LegacyMetsModsDigitalDocumentHelper newFile,
+                                                             LegacyPrefsHelper prefs) {
         LegacyMetsModsDigitalDocumentHelper gdzfile;
         try {
-            gdzfile = new LegacyMetsModsDigitalDocumentHelper(this.myPrefs.getRuleset());
+            gdzfile = new LegacyMetsModsDigitalDocumentHelper(prefs.getRuleset());
             gdzfile.setDigitalDocument(newFile);
             return gdzfile;
         } catch (RuntimeException e) {
@@ -322,7 +324,7 @@ public class ExportDms extends ExportMets {
         if (Objects.nonNull(exportDmsTask)) {
             exportDmsTask.setWorkDetail(atsPpnBand + ".xml");
         }
-        boolean metsFileWrittenSuccesful = writeMetsFile(process, fileService.createResource(userHome,
+        boolean metsFileWrittenSuccesful = exportMets.writeMetsFile(process, fileService.createResource(userHome,
                 File.separator + atsPpnBand + ".xml"), gdzfile);
 
         if (Objects.nonNull(exportDmsTask)) {

--- a/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
@@ -44,97 +44,17 @@ import org.kitodo.api.dataformat.Workpiece;
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
-import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.exceptions.FileStructureValidationException;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
-import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyPrefsHelper;
-import org.kitodo.production.helper.tasks.EmptyTask;
 import org.kitodo.production.services.ServiceManager;
-import org.kitodo.production.services.file.FileService;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 public class ExportMets {
-    private final FileService fileService = ServiceManager.getFileService();
-    protected LegacyPrefsHelper myPrefs;
-
     private static final Logger logger = LogManager.getLogger(ExportMets.class);
-
-    /**
-     * The field exportDmsTask holds an optional task instance. Its progress and
-     * its errors will be passed to the task manager screen (if available) for
-     * visualization.
-     */
-    protected EmptyTask exportDmsTask = null;
-
-    /**
-     * DMS-Export in das Benutzer-Homeverzeichnis.
-     *
-     * @param process
-     *            Process object
-     */
-    public boolean startExport(Process process) throws DAOException, IOException, SAXException, FileStructureValidationException {
-        User user = ServiceManager.getUserService().getAuthenticatedUser();
-        URI userHome = ServiceManager.getUserService().getHomeDirectory(user);
-        boolean exportSuccessful = startExport(process, userHome);
-        if (exportSuccessful) {
-            if (Objects.nonNull(process.getParent())) {
-                startExport(process.getParent());
-            }
-        }
-        return exportSuccessful;
-    }
-
-    /**
-     * DMS-Export an eine gewünschte Stelle.
-     *
-     * @param process
-     *            Process object
-     * @param userHome
-     *            String
-     */
-    public boolean startExport(Process process, URI userHome) throws IOException, DAOException, SAXException,
-            FileStructureValidationException {
-
-        /*
-         * Read Document
-         */
-        this.myPrefs = ServiceManager.getRulesetService().getPreferences(process.getRuleset());
-        String atsPpnBand = Helper.getNormalizedTitle(process.getTitle());
-        LegacyMetsModsDigitalDocumentHelper gdzfile = ServiceManager.getProcessService().readMetadataFile(process);
-
-        if (ServiceManager.getProcessService().handleExceptionsForConfiguration(gdzfile, process)) {
-            return false;
-        }
-
-        prepareUserDirectory(userHome);
-
-        String targetFileName = atsPpnBand + "_mets.xml";
-        URI metaFile = userHome.resolve(userHome.getRawPath() + "/" + targetFileName);
-        return writeMetsFile(process, metaFile, gdzfile);
-    }
-
-    /**
-     * prepare user directory.
-     *
-     * @param targetFolder
-     *            the folder to prove and maybe create it
-     */
-    protected void prepareUserDirectory(URI targetFolder) {
-        User user = ServiceManager.getUserService().getAuthenticatedUser();
-        try {
-            fileService.createDirectoryForUser(targetFolder, user.getLogin());
-        } catch (IOException | RuntimeException e) {
-            if (Objects.nonNull(exportDmsTask)) {
-                exportDmsTask.setException(e);
-            }
-            Helper.setErrorMessage("Export canceled, could not create destination directory: " + targetFolder, logger,
-                e);
-        }
-    }
 
     /**
      * write MetsFile to given Path.
@@ -147,16 +67,13 @@ public class ExportMets {
      *            the FileFormat-Object to use for Mets-Writing
      * @return true or false
      */
-    protected boolean writeMetsFile(Process process, URI metaFile, LegacyMetsModsDigitalDocumentHelper gdzfile)
+    public boolean writeMetsFile(Process process, URI metaFile, LegacyMetsModsDigitalDocumentHelper gdzfile)
             throws IOException, DAOException, SAXException, FileStructureValidationException {
 
         Workpiece workpiece = gdzfile.getWorkpiece();
         try {
             ServiceManager.getSchemaService().tempConvert(workpiece, process);
         } catch (URISyntaxException e) {
-            if (Objects.nonNull(exportDmsTask)) {
-                exportDmsTask.setException(e);
-            }
             Helper.setErrorMessage("Writing METS file failed!", e.getLocalizedMessage(), logger, e);
             return false;
         }
@@ -183,9 +100,6 @@ public class ExportMets {
                     bufferedOutputStream.write(transformedBytes);
                     enrichInternalLabelsIfNeeded(process, transformedBytes);
                 } catch (FileNotFoundException | TransformerException e) {
-                    if (Objects.nonNull(exportDmsTask)) {
-                        exportDmsTask.setException(e);
-                    }
                     Helper.setErrorMessage("Writing METS file failed!", e.getLocalizedMessage(), logger, e);
                     return false;
                 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/DesktopForm.java
@@ -43,6 +43,7 @@ import org.kitodo.production.helper.WebDav;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ProcessService;
 import org.kitodo.production.services.data.ProjectService;
+import org.kitodo.production.services.export.MetsExportService;
 import org.primefaces.model.SortOrder;
 import org.xml.sax.SAXException;
 
@@ -207,7 +208,7 @@ public class DesktopForm extends BaseForm {
      */
     public void exportMets(int processId) {
         try {
-            ProcessService.exportMets(processId);
+            MetsExportService.exportToUserHome(ServiceManager.getProcessService().getById(processId));
         } catch (DAOException | IOException | SAXException | FileStructureValidationException e) {
             Helper.setErrorMessage("An error occurred while trying to export METS file for process "
                     + processId, logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListBaseView.java
@@ -42,6 +42,7 @@ import org.kitodo.production.helper.WebDav;
 import org.kitodo.production.model.LazyProcessModel;
 import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ProcessService;
+import org.kitodo.production.services.export.MetsExportService;
 import org.kitodo.utils.Stopwatch;
 import org.primefaces.PrimeFaces;
 import org.primefaces.event.data.PageEvent;
@@ -493,7 +494,7 @@ public class ProcessListBaseView extends BaseListView {
     public void exportMets(int processId) {
         Stopwatch stopwatch = new Stopwatch(this.getClass(), processId, "exportMets");
         try {
-            ProcessService.exportMets(processId);
+            MetsExportService.exportToUserHome(ServiceManager.getProcessService().getById(processId));
         } catch (DAOException | IOException | SAXException | FileStructureValidationException e) {
             Helper.setErrorMessage("An error occurred while trying to export METS file for process "
                     + processId, logger, e);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1940,28 +1940,6 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
     }
 
     /**
-     * Export Mets.
-     *
-     * @param processId
-     *            Id of which process should be exported
-     * @throws DAOException
-     *             Thrown on database error
-     * @throws DAOException
-     *             Thrown on index error
-     * @throws IOException
-     *             Thrown on I/O error
-     * @throws SAXException
-     *             When starting the export fails
-     * @throws FileStructureValidationException
-     *             when XML validation of process metadata file fails during export
-     */
-    public static void exportMets(int processId) throws DAOException, IOException, SAXException, FileStructureValidationException {
-        Process process = ServiceManager.getProcessService().getById(processId);
-        ExportMets export = new ExportMets();
-        export.startExport(process);
-    }
-
-    /**
      * Link a list of given processes to user home directory.
      *
      * @param processes List of processes

--- a/Kitodo/src/main/java/org/kitodo/production/services/export/MetsExportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/export/MetsExportService.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.production.services.export;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.beans.User;
+import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.exceptions.FileStructureValidationException;
+import org.kitodo.export.ExportMets;
+import org.kitodo.production.helper.Helper;
+import org.kitodo.production.helper.metadata.legacytypeimplementations.LegacyMetsModsDigitalDocumentHelper;
+import org.kitodo.production.services.ServiceManager;
+import org.xml.sax.SAXException;
+
+public class MetsExportService {
+
+    /**
+     * Exports the METS file of the given process to the authenticated user's home directory.
+     *
+     * @param process the process to export
+     */
+    public static void exportToUserHome(Process process)
+            throws DAOException, IOException, SAXException, FileStructureValidationException {
+
+        User user = ServiceManager.getUserService().getAuthenticatedUser();
+        URI userHome = ServiceManager.getUserService().getHomeDirectory(user);
+
+        LegacyMetsModsDigitalDocumentHelper gdzfile =
+                ServiceManager.getProcessService().readMetadataFile(process);
+        if (ServiceManager.getProcessService()
+                .handleExceptionsForConfiguration(gdzfile, process)) {
+            return;
+        }
+        try {
+            ServiceManager.getFileService()
+                    .createDirectoryForUser(userHome, user.getLogin());
+        } catch (IOException | RuntimeException e) {
+            Helper.setErrorMessage("Export canceled, could not create destination directory: " + userHome, e.getMessage());
+            return;
+        }
+        String fileName = Helper.getNormalizedTitle(process.getTitle()) + "_mets.xml";
+        URI target = userHome.resolve(userHome.getRawPath() + "/" + fileName);
+        new ExportMets().writeMetsFile(process, target, gdzfile);
+    }
+}

--- a/Kitodo/src/test/java/org/kitodo/production/exporter/download/ExportMetsIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/exporter/download/ExportMetsIT.java
@@ -37,6 +37,7 @@ import org.kitodo.data.database.beans.User;
 import org.kitodo.export.ExportMets;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
+import org.kitodo.production.services.export.MetsExportService;
 import org.kitodo.production.services.file.FileService;
 
 public class ExportMetsIT {
@@ -101,7 +102,7 @@ public class ExportMetsIT {
             fileService.createDirectory(ConfigCore.getUriParameter(ParameterCore.DIR_USERS), userDirectory);
         }
 
-        exportMets.startExport(process);
+        MetsExportService.exportToUserHome(process);
         List<String> strings = Files.readAllLines(Paths.get(ConfigCore.getParameter(ParameterCore.DIR_USERS) + userDirectory
                 + "/" + Helper.getNormalizedTitle(process.getTitle()) + "_mets.xml"));
         assertTrue(strings.toString().contains("<kitodo:metadata name=\"singleDigCollection\">test collection</kitodo:metadata>"), "Export of metadata 'singleDigCollection' was wrong");


### PR DESCRIPTION
`ExportDms` currently extends `ExportMets`, introducing unnecessary coupling that makes further refactoring of the DMS export logic difficult.

This PR removes the inheritance relationship and refactors the code so that `ExportDms` uses `ExportMets` via composition instead. In addition, the `startExport` methods in `ExportMets` are removed, as they contributed to confusion about the relationship between both classes.

A dedicated `MetsExportService` is introduced to handle orchestration concerns (e.g. resolving user home, preparing directories, loading metadata), while `ExportMets` is reduced to a focused helper for writing METS files.