### PR TITLE
Update to Spring security 7.0.x components

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/security/DynamicAuthenticationProvider.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/DynamicAuthenticationProvider.java
@@ -146,8 +146,7 @@ public class DynamicAuthenticationProvider implements AuthenticationProvider {
     }
 
     private void activateDatabaseAuthentication() {
-        DaoAuthenticationProvider daoAuthenticationProvider = new DaoAuthenticationProvider();
-        daoAuthenticationProvider.setUserDetailsService(ServiceManager.getUserService());
+        DaoAuthenticationProvider daoAuthenticationProvider = new DaoAuthenticationProvider(ServiceManager.getUserService());
         daoAuthenticationProvider.setPasswordEncoder(new SecurityPasswordEncoder());
         this.daoAuthenticationProvider = daoAuthenticationProvider;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
@@ -22,7 +22,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 /**
@@ -124,7 +125,7 @@ public class SecurityConfig {
         // more general rules should be at end
         authorizeGeneralPages(http);
 
-        http.addFilterAfter(new SecurityObjectAccessFilter(), FilterSecurityInterceptor.class);
+        http.addFilterAfter(new SecurityObjectAccessFilter(), AuthorizationFilter.class);
 
         handleFormLogin(http);
 
@@ -163,8 +164,8 @@ public class SecurityConfig {
 
     private void authorizeGeneralPages(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(requests -> requests
-            .requestMatchers("/pages/images/**").permitAll()
-            .requestMatchers("/jakarta.faces.resource/**", "**/resources/**").permitAll()
+            .requestMatchers(PathPatternRequestMatcher.pathPattern("/pages/images/**")).permitAll()
+            .requestMatchers(PathPatternRequestMatcher.pathPattern("/jakarta.faces.resource/**")).permitAll()
             .requestMatchers("/js/modeler.js").permitAll()
             .requestMatchers("/js/toggle.js").permitAll()
             .anyRequest().authenticated()

--- a/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
+++ b/Kitodo/src/main/java/org/kitodo/production/security/SecurityConfig.java
@@ -23,7 +23,6 @@ import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
-import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 /**
@@ -164,8 +163,8 @@ public class SecurityConfig {
 
     private void authorizeGeneralPages(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(requests -> requests
-            .requestMatchers(PathPatternRequestMatcher.pathPattern("/pages/images/**")).permitAll()
-            .requestMatchers(PathPatternRequestMatcher.pathPattern("/jakarta.faces.resource/**")).permitAll()
+            .requestMatchers("/pages/images/**").permitAll()
+            .requestMatchers("/jakarta.faces.resource/**").permitAll()
             .requestMatchers("/js/modeler.js").permitAll()
             .requestMatchers("/js/toggle.js").permitAll()
             .anyRequest().authenticated()

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <mockito.version>5.21.0</mockito.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <selenium.version>4.40.0</selenium.version>
-        <spring.security.version>7.0.4</spring.security.version>
+        <spring.security.version>7.0.5</spring.security.version>
         <flyway-maven-plugin.version>12.3.0</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <mockito.version>5.21.0</mockito.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <selenium.version>4.40.0</selenium.version>
-        <spring.security.version>6.5.9</spring.security.version>
+        <spring.security.version>7.0.4</spring.security.version>
         <flyway-maven-plugin.version>12.3.0</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>


### PR DESCRIPTION
Update to most recent 7.0.x Spring security components which include:

- Replacing some deprecated method calls with more recent usage
- Using `PathPatternRequestMatcher` for URI with `**` patterns
- Remove unused / old request pattern