### PR TITLE
Prevent exception during catalog import

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/TempProcess.java
@@ -273,10 +273,12 @@ public class TempProcess {
             if (catalogId.isEmpty() && Objects.nonNull(metadataNodes) && metadataNodes.getLength() > 0) {
                 for (int i = 0; i < metadataNodes.getLength(); i++) {
                     Node item = metadataNodes.item(i);
-                    Node name = item.getAttributes().getNamedItem("name");
-                    if (Objects.nonNull(name) && name.getTextContent().equals(identifierMetadata)) {
-                        catalogId = item.getTextContent();
-                        break;
+                    if (item.getNodeType() == Node.ELEMENT_NODE && Objects.nonNull(item.getAttributes())) {
+                        Node name = item.getAttributes().getNamedItem("name");
+                        if (Objects.nonNull(name) && name.getTextContent().equals(identifierMetadata)) {
+                            catalogId = item.getTextContent();
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request prevents an exception that could - and in my tests always would - occur during metadata import from remote catalog search interfaces (I tested with the [SRU interface of Kalliope](https://kalliope-verbund.info/de/support/sru.html))

I was unable to reproduce this error in Kitodo 3.9.0, but I am not sure where it was introduced afterwards. 

It seems the metadata nodes used to create a `TempProcess` contain _text_ nodes as well, which do not contain attributes and therefor provoke the exception mentioned above when trying to save a new process. Originally, only the `<kitodo:metadata name="...">` _element_ nodes where expected in the corresponding method. 

I now check for the node type before trying to retrieve the `name` attribute from it to prevent the exception.