### PR TITLE
Change Servlet Mapping and fix SVG exceptions

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -107,7 +107,7 @@
     <!-- extension mapping -->
     <servlet-mapping>
         <servlet-name>Faces Servlet</servlet-name>
-        <url-pattern>/*</url-pattern>
+        <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
 
     <session-config>


### PR DESCRIPTION
Fixes: https://github.com/kitodo/kitodo-production/issues/6965
Fixes: https://github.com/kitodo/kitodo-production/issues/6957

To fix different problems with SVGs in Kitodo in the latest tech stack it is necessary to make the servlet mapping setting more explicit so that SVG files are not handled as JSF pages. This change switches the mapping to `*.xhtml`, ensuring that only JSF views are handled by the FacesServlet, while static resources are served directly by the servlet container.

