### PR TITLE
Update and remove obsolete plexus dependencies

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -123,10 +123,6 @@
             <artifactId>plexus-archiver</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -482,26 +482,8 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-archiver</artifactId>
-                <version>4.10.0</version>
+                <version>4.11.0</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-io</artifactId>
-                        <groupId>commons-io</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-container-default</artifactId>
-                <version>1.7.1</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>plexus-utils</artifactId>
-                        <groupId>org.codehaus.plexus</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <!-- hibernate caching dependency -->


### PR DESCRIPTION
- Update `plexus-archiver` to version `4.11.0`
- Remove obsolete `plexus-container-default` dependency