### PR TITLE
Fix outdated reference to ProcessForm in processFromTemplate.xhtml

### DIFF
--- a/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
+++ b/Kitodo/src/main/webapp/pages/processFromTemplate.xhtml
@@ -151,8 +151,7 @@
     <ui:define name="breadcrumbs">
         <p:menuitem value="#{msgs.desktop}" url="desktop" icon="fa fa-home"/>
         <p:menuitem value="#{msgs.projects}" url="projects" icon="fa fa-archive"/>
-        <p:menuitem value="#{msgs.editProcess}" rendered="#{not empty ProcessForm.process.title}" icon="fa fa-clipboard"/>
-        <p:menuitem value="#{msgs.newProcess}" rendered="#{empty ProcessForm.process.title}" icon="fa fa-clipboard"/>
+        <p:menuitem value="#{msgs.newProcess}" icon="fa fa-clipboard"/>
     </ui:define>
 
     <ui:define name="page-scripts">


### PR DESCRIPTION
Improves upon #6903 and removes outdated reference to ProcessForm.

There doesn't seem to be a way to open the "processFromTemplate" page with an existing process in some kind of "edit mode", so distinguishing between the breadcrumb "Edit Process" and "New Process" doesn't seem necessary here.