### PR TITLE
Fix problems in workflow editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
@@ -312,15 +312,17 @@ public class WorkflowEditView extends BaseEditView {
      * @return true if save, false if not
      */
     private boolean saveFiles() throws IOException, WorkflowException {
-        Map<String, String> requestParameterMap = FacesContext.getCurrentInstance().getExternalContext()
-                .getRequestParameterMap();
-
+        FacesContext context = FacesContext.getCurrentInstance();
         Map<String, URI> diagramsUris = getDiagramUris();
 
         URI svgDiagramURI = diagramsUris.get(SVG_DIAGRAM_URI);
         URI xmlDiagramURI = diagramsUris.get(XML_DIAGRAM_URI);
 
-        xmlDiagram = requestParameterMap.get("editForm:workflowTabView:xmlDiagram");
+        if (Objects.nonNull(context)) {
+            xmlDiagram = context.getExternalContext()
+                    .getRequestParameterMap()
+                    .get("editForm:workflowTabView:xmlDiagram");
+        }
         if (Objects.nonNull(xmlDiagram)) {
             svgDiagram = StringUtils.substringAfter(xmlDiagram, "kitodo-diagram-separator");
             xmlDiagram = StringUtils.substringBefore(xmlDiagram, "kitodo-diagram-separator");

--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
@@ -175,6 +175,20 @@ public class WorkflowEditView extends BaseEditView {
         }
     }
 
+    /**
+     * Handles renaming of diagram files when the workflow title changes.
+     *
+     * <p>XML files are treated as authoritative and will be replaced if a new version exists.</p>
+     *
+     * <p>SVG handling depends on whether a new (non empty) SVG-diagram was submitted:
+     * <ul>
+     *   <li>If no SVG was submitted (e.g. editor did not modify it), the existing SVG is moved to the new filename.</li>
+     *   <li>If a new SVG was submitted and successfully written, the old SVG is deleted.</li>
+     * </ul>
+     *
+     * <p>This logic avoids unnecessary data loss and ensures that existing diagrams are preserved
+     * when no changes were made in the editor.</p>
+     */
     private void handleDiagramFilesAfterTitleChange() {
         if (Objects.isNull(originalTitle) || originalTitle.equals(workflow.getTitle())) {
             return;
@@ -189,7 +203,6 @@ public class WorkflowEditView extends BaseEditView {
             if (fileService.fileExist(oldXml) && fileService.fileExist(newXml)) {
                 fileService.delete(oldXml);
             }
-            // SVG: move or delete depending on edit
             if (fileService.fileExist(oldSvg)) {
                 if (StringUtils.isBlank(svgDiagram)) {
                     fileService.moveFile(oldSvg, newSvg);

--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
@@ -142,7 +142,7 @@ public class WorkflowEditView extends BaseEditView {
             return this.stayOnCurrentPage;
         }
         try {
-            if (workflow.getId() == null
+            if (!workflow.getTitle().equals(originalTitle)
                     && ServiceManager.getWorkflowService()
                     .workflowTitleExists(workflow.getTitle())) {
                 Helper.setErrorMessage(
@@ -160,9 +160,7 @@ public class WorkflowEditView extends BaseEditView {
                     migration = false;
                     return MIGRATION_FORM_PATH + "&workflowId=" + workflow.getId();
                 }
-                if (Objects.nonNull(originalTitle) && !originalTitle.equals(workflow.getTitle())) {
-                    handleDiagramFilesAfterTitleChange();
-                }
+                handleDiagramFilesAfterTitleChange();
                 return WorkflowListView.VIEW_PATH + "&" + getReferrerListOptions();
             } else {
                 return this.stayOnCurrentPage;
@@ -188,7 +186,6 @@ public class WorkflowEditView extends BaseEditView {
             URI oldSvg = oldUris.get(SVG_DIAGRAM_URI);
             URI newXml = newUris.get(XML_DIAGRAM_URI);
             URI newSvg = newUris.get(SVG_DIAGRAM_URI);
-            // XML: delete only if new one exists
             if (fileService.fileExist(oldXml) && fileService.fileExist(newXml)) {
                 fileService.delete(oldXml);
             }
@@ -326,8 +323,10 @@ public class WorkflowEditView extends BaseEditView {
         if (Objects.nonNull(xmlDiagram)) {
             svgDiagram = StringUtils.substringAfter(xmlDiagram, "kitodo-diagram-separator");
             xmlDiagram = StringUtils.substringBefore(xmlDiagram, "kitodo-diagram-separator");
-            if (Objects.isNull(xmlDiagram) || StringUtils.isBlank(xmlDiagram)) {
-                Helper.setErrorMessage("Workflow diagram is missing.");
+            if (StringUtils.isBlank(xmlDiagram)) {
+                Helper.setErrorMessage(
+                        Helper.getTranslation("errorWorkflowDiagramMissing")
+                );
                 return false;
             }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
@@ -141,6 +141,14 @@ public class WorkflowEditView extends BaseEditView {
             return this.stayOnCurrentPage;
         }
         try {
+            if (workflow.getId() == null
+                    && ServiceManager.getWorkflowService()
+                    .workflowTitleExists(workflow.getTitle())) {
+                Helper.setErrorMessage(
+                        Helper.getTranslation("duplicateWorkflowTitle", workflow.getTitle())
+                );
+                return this.stayOnCurrentPage;
+            }
             if (saveFiles()) {
                 this.workflow.setStatus(this.workflowStatus);
                 saveWorkflow();
@@ -283,14 +291,19 @@ public class WorkflowEditView extends BaseEditView {
         if (Objects.nonNull(xmlDiagram)) {
             svgDiagram = StringUtils.substringAfter(xmlDiagram, "kitodo-diagram-separator");
             xmlDiagram = StringUtils.substringBefore(xmlDiagram, "kitodo-diagram-separator");
+            if (Objects.isNull(xmlDiagram) || StringUtils.isBlank(xmlDiagram)) {
+                Helper.setErrorMessage("Workflow diagram is missing.");
+                return false;
+            }
 
             Reader reader = new Reader(new ByteArrayInputStream(xmlDiagram.getBytes(StandardCharsets.UTF_8)));
             reader.validateWorkflowTasks();
 
             Converter converter = new Converter(new ByteArrayInputStream(xmlDiagram.getBytes(StandardCharsets.UTF_8)));
             converter.validateWorkflowTaskList();
-
-            saveFile(svgDiagramURI, svgDiagram);
+            if (StringUtils.isNotBlank(svgDiagram)) {
+                saveFile(svgDiagramURI, svgDiagram);
+            }
             saveFile(xmlDiagramURI, xmlDiagram);
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/WorkflowEditView.java
@@ -72,6 +72,7 @@ public class WorkflowEditView extends BaseEditView {
     private String svgDiagram;
     private boolean dataEditorSettingsDefined = false;
     private String xmlDiagram;
+    private String originalTitle;
     private WorkflowStatus workflowStatus;
     private static final String BPMN_EXTENSION = ".bpmn20.xml";
     public static final String SVG_EXTENSION = ".svg";
@@ -159,6 +160,9 @@ public class WorkflowEditView extends BaseEditView {
                     migration = false;
                     return MIGRATION_FORM_PATH + "&workflowId=" + workflow.getId();
                 }
+                if (Objects.nonNull(originalTitle) && !originalTitle.equals(workflow.getTitle())) {
+                    handleDiagramFilesAfterTitleChange();
+                }
                 return WorkflowListView.VIEW_PATH + "&" + getReferrerListOptions();
             } else {
                 return this.stayOnCurrentPage;
@@ -170,6 +174,35 @@ public class WorkflowEditView extends BaseEditView {
             Helper.setErrorMessage("errorDiagramTask", new Object[] {this.workflow.getTitle(), e.getMessage() }, logger,
                 e);
             return this.stayOnCurrentPage;
+        }
+    }
+
+    private void handleDiagramFilesAfterTitleChange() {
+        if (Objects.isNull(originalTitle) || originalTitle.equals(workflow.getTitle())) {
+            return;
+        }
+        try {
+            Map<String, URI> oldUris = getDiagramUris(originalTitle);
+            Map<String, URI> newUris = getDiagramUris(workflow.getTitle());
+            URI oldXml = oldUris.get(XML_DIAGRAM_URI);
+            URI oldSvg = oldUris.get(SVG_DIAGRAM_URI);
+            URI newXml = newUris.get(XML_DIAGRAM_URI);
+            URI newSvg = newUris.get(SVG_DIAGRAM_URI);
+            // XML: delete only if new one exists
+            if (fileService.fileExist(oldXml) && fileService.fileExist(newXml)) {
+                fileService.delete(oldXml);
+            }
+            // SVG: move or delete depending on edit
+            if (fileService.fileExist(oldSvg)) {
+                if (StringUtils.isBlank(svgDiagram)) {
+                    fileService.moveFile(oldSvg, newSvg);
+                } else if (fileService.fileExist(newSvg)) {
+                    fileService.delete(oldSvg);
+                }
+            }
+        } catch (IOException e) {
+            Helper.setErrorMessage("errorHandlingWorkflowFiles",
+                    new Object[] { originalTitle }, logger, e);
         }
     }
 
@@ -307,7 +340,7 @@ public class WorkflowEditView extends BaseEditView {
             saveFile(xmlDiagramURI, xmlDiagram);
         }
 
-        return fileService.fileExist(xmlDiagramURI) && fileService.fileExist(svgDiagramURI);
+        return fileService.fileExist(xmlDiagramURI);
     }
 
     private Map<String, URI> getDiagramUris() {
@@ -429,6 +462,7 @@ public class WorkflowEditView extends BaseEditView {
                 try {
                     Workflow workflow = ServiceManager.getWorkflowService().getById(id);
                     setWorkflow(workflow);
+                    this.originalTitle = workflow.getTitle();
                     setWorkflowStatus(workflow.getStatus());
                     readXMLDiagram();
                     this.dataEditorSettingsDefined = this.dataEditorSettingService.areDataEditorSettingsDefinedForWorkflow(workflow);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/WorkflowService.java
@@ -127,6 +127,16 @@ public class WorkflowService extends BaseBeanService<Workflow, WorkflowDAO> {
     }
 
     /**
+     * Returns whether a workflow with the given title already exists.
+     *
+     * @param title the title to check
+     * @return true if a workflow with this title exists
+     */
+    public boolean workflowTitleExists(String title) {
+        return !getByTitle(title).isEmpty();
+    }
+
+    /**
      * Save given workflow if it is an existing workflow (e.g. if it does have an ID)
      * or if it is a new workflow and no workflow with the same name exists.
      *

--- a/Kitodo/src/main/resources/messages/errors_de.properties
+++ b/Kitodo/src/main/resources/messages/errors_de.properties
@@ -53,6 +53,7 @@ errorDatabaseReading=Fehler beim Datenbanklesen von ''{0}'' with ID {1}.
 errorDeleting=Fehler beim Löschen von ''{0}''
 errorDiagramConvert=Fehler für das Diagramm, das dem Workflow mit dem Titel ''{0}'' zugewiesen wurde. In dem angegebenen Diagramm erstellte Aufgaben können nicht in die Produktionsvorlagenaufgaben konvertiert werden.
 errorDiagramFile=Fehler für das Diagramm, das dem Workflow mit dem Titel ''{0}'' zugewiesen wurde. Es fehlt eine Datei für das angegebene Diagramm.
+errorDiagramMissing=Es wurde kein Workflow-Diagramm übermittelt. Bitte erstellen oder laden Sie ein Diagramm, bevor Sie speichern.
 errorDiagramTask=Fehler für das Diagramm, das dem Workflow mit dem Titel ''{0}'' zugewiesen wurde. Die Aufgaben sind nicht korrekt definiert. Das Problem: {1}
 errorDiagram=Fehler beim Speichern von Workflow ''{0}'': {1}
 errorDirectoryDeleting=Fehler beim Löschen von ''{0}'' Verzeichnis.

--- a/Kitodo/src/main/resources/messages/errors_en.properties
+++ b/Kitodo/src/main/resources/messages/errors_en.properties
@@ -54,6 +54,7 @@ errorDatabaseReading=Error on reading database for ''{0}'' with ID {1}.
 errorDeleting=Error deleting ''{0}''
 errorDiagramConvert=Error for diagram assigned to workflow with title ''{0}''. Tasks created in the given diagram cannot be converted to the template tasks.
 errorDiagramFile=Error for diagram assigned to workflow with title ''{0}''. There is missing file for the given diagram.
+errorDiagramMissing=No workflow diagram was provided. Please create or load a diagram before saving.
 errorDiagramTask=Error for diagram assigned to workflow with title ''{0}''. Tasks are defined incorrectly. Problem: {1}
 errorDiagram=Error saving workflow ''{0}'': {1}
 errorDirectoryDeleting=''{0}'' directory could not be deleted.

--- a/Kitodo/src/main/resources/messages/errors_es.properties
+++ b/Kitodo/src/main/resources/messages/errors_es.properties
@@ -53,6 +53,8 @@ errorDatabaseReading=Error al leer ''{0}'' con ID {1} de la base de datos.
 errorDeleting=Error al borrar ''{0}''
 errorDiagramConvert=Error para el diagrama asignado al flujo de trabajo titulado ''{0}''. Las tareas creadas en el diagrama especificado no se pueden convertir en las tareas de la plantilla de producción.
 errorDiagramFile=Error para el diagrama asignado al flujo de trabajo titulado ''{0}''. Falta un archivo para el diagrama especificado.
+# translated by DeepL, please check!
+errorDiagramMissing=No se ha enviado ningún diagrama de flujo de trabajo. Cree o cargue un diagrama antes de guardar.
 errorDiagramTask=Error para el diagrama asignado al flujo de trabajo titulado ''{0}''. Las tareas no están definidas correctamente. El problema: {1}
 errorDiagram=Error al guardar el flujo de trabajo ''{0}'': {1}
 errorDirectoryDeleting=Error al borrar del ''{0}'' directorio.

--- a/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
@@ -189,9 +189,9 @@ public class WorkflowFormIT {
 
         File newSvg = new File(diagramDir + newTitle + ".svg");
         File newXML = new File(diagramDir + newTitle + ".bpmn20.xml");
-        assertFalse(oldSvg.exists(), "Old SVG should be moved");
+        assertFalse(oldSvg.exists(), "Old SVG should have been removed");
         assertTrue(newSvg.exists(), "New SVG should exist");
-        assertFalse(oldXml.exists(), "Old XML should be moved");
+        assertFalse(oldXml.exists(), "Old XML should have been removed");
         assertTrue(newXML.exists(), "New XML should exist");
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
@@ -15,13 +15,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kitodo.MockDatabase;
+import org.kitodo.config.ConfigCore;
 import org.kitodo.data.database.beans.DataEditorSetting;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.Template;
@@ -36,6 +42,7 @@ import org.kitodo.production.services.data.TaskService;
 public class WorkflowFormIT {
 
     private final WorkflowEditView currentWorkflowForm = new WorkflowEditView();
+    private final List<String> workflowTitlesToClean = new ArrayList<>();
     private static final TaskService taskService = ServiceManager.getTaskService();
     private static final DataEditorSettingService dataEditorSettingService = ServiceManager.getDataEditorSettingService();
 
@@ -62,6 +69,18 @@ public class WorkflowFormIT {
     public static void cleanDatabase() throws Exception {
         MockDatabase.stopNode();
         MockDatabase.cleanDatabase();
+    }
+
+    @AfterEach
+    public void cleanupWorkflowDiagramFiles() throws Exception {
+        String diagramDir = ConfigCore.getKitodoDiagramDirectory();
+        for (String workflowTitle : workflowTitlesToClean) {
+            File svgFile = new File(diagramDir + workflowTitle + ".svg");
+            File xmlFile = new File(diagramDir + workflowTitle + ".bpmn20.xml");
+            ServiceManager.getFileService().delete(svgFile.toURI());
+            ServiceManager.getFileService().delete(xmlFile.toURI());
+        }
+        workflowTitlesToClean.clear();
     }
 
     /**
@@ -139,4 +158,74 @@ public class WorkflowFormIT {
         dataEditorSettingService.save(dataEditorSetting);
     }
 
+    @Test
+    public void shouldMoveFilesOnWorkflowTitleChange() throws Exception {
+        String oldTitle = "to_be_renamed_workflow";
+        String newTitle = "newTitle";
+
+        workflowTitlesToClean.add(oldTitle);
+        workflowTitlesToClean.add(newTitle);
+
+        Workflow workflow = new Workflow(oldTitle);
+        ServiceManager.getWorkflowService().save(workflow);
+
+        currentWorkflowForm.load(workflow.getId(), false);
+
+        String diagramDir = ConfigCore.getKitodoDiagramDirectory();
+        File oldSvg = new File(diagramDir + oldTitle + ".svg");
+        File oldXml = new File(diagramDir + oldTitle + ".bpmn20.xml");
+        String validXmlWorkflow = Files.readString(
+                new File(diagramDir + "one_step_workflow.bpmn20.xml").toPath(),
+                StandardCharsets.UTF_8
+        );
+        oldSvg.createNewFile();
+        oldXml.createNewFile();
+        assertTrue(oldSvg.exists(), "Old SVG should exist");
+        assertTrue(oldXml.exists(), "Old XML should exist");
+
+        currentWorkflowForm.setWorkflow(workflow);
+        currentWorkflowForm.getWorkflow().setTitle(newTitle);
+        currentWorkflowForm.setXmlDiagram(validXmlWorkflow + "kitodo-diagram-separator");
+        currentWorkflowForm.saveAndRedirect();
+
+        File newSvg = new File(diagramDir + newTitle + ".svg");
+        File newXML = new File(diagramDir + newTitle + ".bpmn20.xml");
+        assertFalse(oldSvg.exists(), "Old SVG should be moved");
+        assertTrue(newSvg.exists(), "New SVG should exist");
+        assertFalse(oldXml.exists(), "Old XML should be moved");
+        assertTrue(newXML.exists(), "New XML should exist");
+    }
+
+    @Test
+    public void shouldKeepExistingSvgWhenNoSvgIsSubmitted() throws Exception {
+        String workflowTitle = "to_be_changed_workflow";
+        workflowTitlesToClean.add(workflowTitle);
+
+        Workflow workflow = new Workflow(workflowTitle);
+        ServiceManager.getWorkflowService().save(workflow);
+        currentWorkflowForm.load(workflow.getId(), false);
+
+        String diagramDir = ConfigCore.getKitodoDiagramDirectory();
+        File workflowSvg = new File(diagramDir + workflowTitle + ".svg");
+        File workflowXml = new File(diagramDir + workflowTitle + ".bpmn20.xml");
+
+        String validXmlWorkflow = Files.readString(
+                new File(diagramDir + "one_step_workflow.bpmn20.xml").toPath(),
+                StandardCharsets.UTF_8
+        );
+        String existingSvgContent = Files.readString(
+                new File(diagramDir + "one_step_workflow.svg").toPath(),
+                StandardCharsets.UTF_8
+        );
+
+        Files.writeString(workflowXml.toPath(), validXmlWorkflow, StandardCharsets.UTF_8);
+        Files.writeString(workflowSvg.toPath(), existingSvgContent, StandardCharsets.UTF_8);
+
+        currentWorkflowForm.setWorkflow(workflow);
+        currentWorkflowForm.setXmlDiagram(validXmlWorkflow + "kitodo-diagram-separator");
+        currentWorkflowForm.saveAndRedirect();
+
+        String resultingSvgContent = Files.readString(workflowSvg.toPath(), StandardCharsets.UTF_8);
+        assertEquals(existingSvgContent, resultingSvgContent, "Existing SVG should remain unchanged");
+    }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
@@ -227,4 +227,59 @@ public class WorkflowFormIT {
         String resultingSvgContent = Files.readString(workflowSvg.toPath(), StandardCharsets.UTF_8);
         assertEquals(existingSvgContent, resultingSvgContent, "Existing SVG should remain unchanged");
     }
+
+    @Test
+    public void shouldNotModifyFilesWhenWorkflowTitleIsDuplicate() throws Exception {
+        String titleA = "workflowA";
+        String titleB = "workflowB";
+
+        workflowTitlesToClean.add(titleA);
+        workflowTitlesToClean.add(titleB);
+
+        // Create two workflows
+        Workflow workflowA = new Workflow(titleA);
+        Workflow workflowB = new Workflow(titleB);
+        ServiceManager.getWorkflowService().save(workflowA);
+        ServiceManager.getWorkflowService().save(workflowB);
+
+        currentWorkflowForm.load(workflowA.getId(), false);
+
+        String diagramDir = ConfigCore.getKitodoDiagramDirectory();
+
+        File xmlA = new File(diagramDir + titleA + ".bpmn20.xml");
+        File svgA = new File(diagramDir + titleA + ".svg");
+
+        String validXmlWorkflow = Files.readString(
+                new File(diagramDir + "one_step_workflow.bpmn20.xml").toPath(),
+                StandardCharsets.UTF_8
+        );
+
+        // Prepare original files
+        Files.writeString(xmlA.toPath(), validXmlWorkflow, StandardCharsets.UTF_8);
+        assertTrue(svgA.createNewFile() || svgA.exists(), "Could not prepare SVG file");
+
+        String originalXmlContent = Files.readString(xmlA.toPath(), StandardCharsets.UTF_8);
+
+        // Attempt rename to duplicate title
+        currentWorkflowForm.setWorkflow(workflowA);
+        currentWorkflowForm.getWorkflow().setTitle(titleB); // duplicate!
+        currentWorkflowForm.setXmlDiagram(validXmlWorkflow + "kitodo-diagram-separator");
+
+        currentWorkflowForm.saveAndRedirect();
+
+        // Assert: original files unchanged
+        assertTrue(xmlA.exists(), "Original XML should still exist");
+        assertTrue(svgA.exists(), "Original SVG should still exist");
+
+        String resultingXmlContent = Files.readString(xmlA.toPath(), StandardCharsets.UTF_8);
+        assertEquals(originalXmlContent, resultingXmlContent,
+                "XML content should not have changed");
+
+        // Assert: no new files created for duplicate title
+        File xmlB = new File(diagramDir + titleB + ".bpmn20.xml");
+        File svgB = new File(diagramDir + titleB + ".svg");
+
+        assertFalse(xmlB.exists(), "No XML should be created for duplicate title");
+        assertFalse(svgB.exists(), "No SVG should be created for duplicate title");
+    }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
@@ -178,11 +178,8 @@ public class WorkflowFormIT {
                 new File(diagramDir + "one_step_workflow.bpmn20.xml").toPath(),
                 StandardCharsets.UTF_8
         );
-        boolean svgCreated = oldSvg.createNewFile();
-        boolean xmlCreated = oldXml.createNewFile();
-
-        assertTrue(svgCreated || oldSvg.exists(), "Old SVG should exist");
-        assertTrue(xmlCreated || oldXml.exists(), "Old XML should exist");
+        assertTrue(oldSvg.createNewFile() || oldSvg.exists(), "Could not prepare SVG file");
+        assertTrue(oldXml.createNewFile() || oldXml.exists(), "Could not prepare XML file");
 
         Files.writeString(oldXml.toPath(), validXmlWorkflow, StandardCharsets.UTF_8);
         currentWorkflowForm.setWorkflow(workflow);

--- a/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/WorkflowFormIT.java
@@ -178,11 +178,13 @@ public class WorkflowFormIT {
                 new File(diagramDir + "one_step_workflow.bpmn20.xml").toPath(),
                 StandardCharsets.UTF_8
         );
-        oldSvg.createNewFile();
-        oldXml.createNewFile();
-        assertTrue(oldSvg.exists(), "Old SVG should exist");
-        assertTrue(oldXml.exists(), "Old XML should exist");
+        boolean svgCreated = oldSvg.createNewFile();
+        boolean xmlCreated = oldXml.createNewFile();
 
+        assertTrue(svgCreated || oldSvg.exists(), "Old SVG should exist");
+        assertTrue(xmlCreated || oldXml.exists(), "Old XML should exist");
+
+        Files.writeString(oldXml.toPath(), validXmlWorkflow, StandardCharsets.UTF_8);
         currentWorkflowForm.setWorkflow(workflow);
         currentWorkflowForm.getWorkflow().setTitle(newTitle);
         currentWorkflowForm.setXmlDiagram(validXmlWorkflow + "kitodo-diagram-separator");


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/6290
Adresses https://github.com/kitodo/kitodo-production/pull/6355#issuecomment-2627106319

Supersedes https://github.com/kitodo/kitodo-production/pull/6408

Working with the workflow editor already had some problems (see above) in the past. It seems like the switch to `ViewScoped` exposed additional problems:
When you create a new workflow, set a title but do not define anything else:

<img width="1840" height="609" alt="image" src="https://github.com/user-attachments/assets/a6bb0e02-24a7-4f2a-9558-ad04c6eda4ad" />

saving now leads to an error page:

> Oops!
> 
> A problem occurred during processing the ajax request. Subsequently, another problem occurred during processing the error page which should inform you about that problem.
> 
> If you are the responsible web developer, it's time to read the server logs about the bug in the error page itself.

This PR tries to adress this problem and the other problems in the following (linked) issues:

- Saving an existing workflow without any changes stores an empty SVG file (https://github.com/kitodo/kitodo-production/issues/6290)
- It is not prevented that a new workflow with an already used name is created. (https://github.com/kitodo/kitodo-production/pull/6355#issuecomment-2627106319)

In addition to that the PR also deletes old files when a workflow is renamed and stores the files under the new workflow title.