### PR TITLE
Update flyway to version 12.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <selenium.version>4.40.0</selenium.version>
         <spring.security.version>6.5.9</spring.security.version>
-        <flyway-maven-plugin.version>9.22.3</flyway-maven-plugin.version>
+        <flyway-maven-plugin.version>12.3.0</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>
         <pitest.version>1.4.10</pitest.version>


### PR DESCRIPTION
Updating your 2 years old version of flyway to the latest version. 

I tested this version with MariaDB (GitHub is using MySQL) in version  `10.11` (Debian 12) and `11.8` (Debian 13, Gentoo) without any issue. There is a warning that only MariaDB `11.7` is supported but after reading some comments on their GitHub issue repo this warning can be omitted.

I saw that there are message like `DB: Integer display width is deprecated and will be removed in a future release. (SQL State: HY000 - Error Code: 1681)` displayed in the GitHub workflow but they are results in the MySQL usage as they did not appear with MariaDB on my systems. Resolving them would result in changing all existing migration files which then made it difficult for everyone how is using flyway to maintain the database as the checksums must be updated and may result in a different database schema.