### PR TITLE
[3.9] Update ActiveMQ client to version 5.19.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
-                <version>5.19.0</version>
+                <version>5.19.4</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Backport of #6972 for Kitodo 3.9.x