### PR TITLE
Update JUnit to 6.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <primefaces.extensions.version>12.0.11</primefaces.extensions.version>
         <saxon.version>9.9.1-8</saxon.version>
         <log4j.version>2.25.4</log4j.version>
-        <junit.version>5.13.4</junit.version>
+        <junit.version>6.0.3</junit.version>
         <opensearch.version>2.15.0</opensearch.version>
         <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
 


### PR DESCRIPTION
Update from JUnit 5 to JUnit 6 is simple as major change was the JVM 8 to JVM 17 change. See https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-6.0