### PR TITLE
Improve folder editing form

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -476,7 +476,9 @@ public class ProjectEditView extends BaseEditView {
      * @return modified ArrayList
      */
     public List<SelectItem> getSelectableFolders() {
-        return getFolderList().stream().map(folder -> new SelectItem(folder.getFileGroup(), folder.toString()))
+        return getFolderList().stream()
+                .filter(folder -> Objects.nonNull(folder.getId()))   // exclude transient
+                .map(folder -> new SelectItem(folder.getFileGroup(), folder.toString()))
                 .collect(Collectors.toList());
     }
 
@@ -501,6 +503,7 @@ public class ProjectEditView extends BaseEditView {
     private Map<String, Folder> getFolderMap() {
         return getFolderList().stream()
                 .filter(folder -> StringUtils.isNotBlank(folder.getFileGroup()))
+                .filter(folder -> Objects.nonNull(folder.getId())) //do not include transient folders
                 .collect(Collectors.toMap(
                         Folder::getFileGroup,
                         Function.identity(),

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -494,7 +494,13 @@ public class ProjectEditView extends BaseEditView {
     }
 
     private Map<String, Folder> getFolderMap() {
-        return getFolderList().parallelStream().collect(Collectors.toMap(Folder::getFileGroup, Function.identity()));
+        return getFolderList().stream()
+                .filter(folder -> StringUtils.isNotBlank(folder.getFileGroup()))
+                .collect(Collectors.toMap(
+                        Folder::getFileGroup,
+                        Function.identity(),
+                        (existing, replacement) -> existing
+                ));
     }
 
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -184,6 +184,11 @@ public class ProjectEditView extends BaseEditView {
         }
     }
 
+    /**
+     * Sync project folders with workingFolders using fileGroup as key.
+     * Removes folders deleted in UI and replaces existing ones with same fileGroup.
+     * Ensures exactly one folder per fileGroup is persisted.
+     */
     private void syncFoldersToProject() {
         // remove folders whose fileGroup is no longer present
         project.getFolders().removeIf(projectFolder ->
@@ -512,7 +517,7 @@ public class ProjectEditView extends BaseEditView {
                         Folder::getFileGroup,
                         Function.identity(),
                         (existing, replacement) ->
-                                existing.getId() != null ? existing : replacement
+                                Objects.nonNull(existing.getId()) ? existing : replacement
                 ));
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -70,7 +70,7 @@ public class ProjectEditView extends BaseEditView {
     private boolean locked = true;
     private static final String TITLE_USED = "projectTitleAlreadyInUse";
     private Boolean hasProcesses;
-
+    private String originalFileGroup;
     private Project baseProject;
     /**
      * The folder currently under edit in the pop-up dialog.
@@ -123,6 +123,7 @@ public class ProjectEditView extends BaseEditView {
      */
     public void setEditingFolder(Folder folder) {
         this.editingFolder = folder;
+        this.originalFileGroup = Objects.nonNull(folder) ? folder.getFileGroup() : null;
         this.generator = new FolderGenerator(folder);
     }
 
@@ -282,6 +283,7 @@ public class ProjectEditView extends BaseEditView {
                         && Objects.equals(folder.getFileGroup(), editingFolder.getFileGroup()));
         if (duplicate) {
             Helper.setErrorMessage("errorDuplicateFilegroup", new Object[] {ObjectType.FOLDER.getTranslationPlural()});
+            editingFolder.setFileGroup(originalFileGroup);
             return;
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -185,11 +185,17 @@ public class ProjectEditView extends BaseEditView {
     }
 
     private void syncFoldersToProject() {
-        project.getFolders().removeIf(folder -> !workingFolders.contains(folder));
+        // remove folders whose fileGroup is no longer present
+        project.getFolders().removeIf(projectFolder ->
+                workingFolders.stream()
+                        .noneMatch(wf -> Objects.equals(wf.getFileGroup(), projectFolder.getFileGroup()))
+        );
+        // add or replace by fileGroup
         for (Folder workingFolder : workingFolders) {
-            if (!project.getFolders().contains(workingFolder)) {
-                project.getFolders().add(workingFolder);
-            }
+            project.getFolders().removeIf(pf ->
+                    Objects.equals(pf.getFileGroup(), workingFolder.getFileGroup())
+            );
+            project.getFolders().add(workingFolder);
         }
     }
 
@@ -477,7 +483,6 @@ public class ProjectEditView extends BaseEditView {
      */
     public List<SelectItem> getSelectableFolders() {
         return getFolderList().stream()
-                .filter(folder -> Objects.nonNull(folder.getId()))   // exclude transient
                 .map(folder -> new SelectItem(folder.getFileGroup(), folder.toString()))
                 .collect(Collectors.toList());
     }
@@ -503,11 +508,11 @@ public class ProjectEditView extends BaseEditView {
     private Map<String, Folder> getFolderMap() {
         return getFolderList().stream()
                 .filter(folder -> StringUtils.isNotBlank(folder.getFileGroup()))
-                .filter(folder -> Objects.nonNull(folder.getId())) //do not include transient folders
                 .collect(Collectors.toMap(
                         Folder::getFileGroup,
                         Function.identity(),
-                        (existing, replacement) -> existing
+                        (existing, replacement) ->
+                                existing.getId() != null ? existing : replacement
                 ));
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -282,7 +282,10 @@ public class ProjectEditView extends BaseEditView {
                 .anyMatch(folder -> folder != editingFolder
                         && Objects.equals(folder.getFileGroup(), editingFolder.getFileGroup()));
         if (duplicate) {
-            Helper.setErrorMessage("errorDuplicateFilegroup", new Object[] {ObjectType.FOLDER.getTranslationPlural()});
+            Helper.setErrorMessage(
+                    "errorDuplicateFilegroup",
+                    new Object[] { editingFolder.getFileGroup() }
+            );
             editingFolder.setFileGroup(originalFileGroup);
             return;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -512,8 +512,7 @@ public class ProjectEditView extends BaseEditView {
 
     private Map<String, Folder> getFolderMap() {
         return getFolderList().stream()
-                .filter(folder -> StringUtils.isNotBlank(folder.getFileGroup()))
-                .collect(Collectors.toMap(
+               .collect(Collectors.toMap(
                         Folder::getFileGroup,
                         Function.identity(),
                         (existing, replacement) ->

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -196,19 +196,57 @@ public class ProjectEditView extends BaseEditView {
      * Ensures exactly one folder per fileGroup is persisted.
      */
     private void syncFoldersToProject() {
-        // remove folders whose fileGroup is no longer present
-        project.getFolders().removeIf(projectFolder ->
-                workingFolders.stream()
-                        .noneMatch(wf -> Objects.equals(wf.getFileGroup(), projectFolder.getFileGroup()))
-        );
-        // add or replace by fileGroup
+
+        List<Folder> removedFolders = project.getFolders().stream()
+                .filter(projectFolder ->
+                        workingFolders.stream().noneMatch(workingFolder ->
+                                Objects.equals(projectFolder.getId(), workingFolder.getId())
+                                        || projectFolder == workingFolder
+                        )
+                )
+                .toList();
+
+        removedFolders.forEach(this::clearFolderReferences);
+
+        project.getFolders().removeAll(removedFolders);
+
         for (Folder workingFolder : workingFolders) {
-            project.getFolders().removeIf(pf ->
-                    Objects.equals(pf.getFileGroup(), workingFolder.getFileGroup())
-            );
-            project.getFolders().add(workingFolder);
+            boolean exists = project.getFolders().stream()
+                    .anyMatch(projectFolder ->
+                            Objects.equals(projectFolder.getId(), workingFolder.getId())
+                                    || projectFolder == workingFolder
+                    );
+            if (!exists) {
+                project.getFolders().add(workingFolder);
+            }
         }
     }
+
+    private void clearFolderReferences(Folder folder) {
+        if (Objects.equals(project.getPreview(), folder)) {
+            project.setPreview(null);
+        }
+        if (Objects.equals(project.getAudioPreview(), folder)) {
+            project.setAudioPreview(null);
+        }
+        if (Objects.equals(project.getVideoPreview(), folder)) {
+            project.setVideoPreview(null);
+        }
+        if (Objects.equals(project.getMediaView(), folder)) {
+            project.setMediaView(null);
+        }
+        if (Objects.equals(project.getAudioMediaView(), folder)) {
+            project.setAudioMediaView(null);
+        }
+        if (Objects.equals(project.getVideoMediaView(), folder)) {
+            project.setVideoMediaView(null);
+        }
+        if (Objects.equals(project.getGeneratorSource(), folder)) {
+            project.setGeneratorSource(null);
+        }
+    }
+
+
 
     private void commitTemplates() throws DAOException {
         if (copyTemplates) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -296,8 +296,11 @@ public class ProjectEditView extends BaseEditView {
             return;
         }
         boolean duplicate = workingFolders.stream()
-                .anyMatch(folder -> folder != editingFolder
-                        && Objects.equals(folder.getFileGroup(), editingFolder.getFileGroup()));
+                .anyMatch(folder ->
+                        !Objects.equals(folder.getId(), editingFolder.getId())
+                                && folder != editingFolder
+                                && Objects.equals(folder.getFileGroup(), editingFolder.getFileGroup())
+                );
         if (duplicate) {
             Helper.setErrorMessage(
                     "errorDuplicateFilegroup",
@@ -309,7 +312,9 @@ public class ProjectEditView extends BaseEditView {
 
         boolean exists = workingFolders.stream()
                 .anyMatch(folder ->
-                        Objects.equals(folder.getId(), editingFolder.getId())
+                        (Objects.nonNull(folder.getId())
+                                && Objects.equals(folder.getId(), editingFolder.getId()))
+                                || folder == editingFolder
                 );
 
         if (!exists) {
@@ -768,8 +773,7 @@ public class ProjectEditView extends BaseEditView {
      *         video preview folder
      */
     public void setVideoPreview(String videoPreview) {
-        project.setVideoPreview(getFolderMap().get(videoPreview)
-        );
+        project.setVideoPreview(getFolderMap().get(videoPreview));
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -336,11 +336,18 @@ public class ProjectEditView extends BaseEditView {
         if (Objects.isNull(editingFolder)) {
             return;
         }
+        editingFolder.setFileGroup(
+                StringUtils.trimToEmpty(editingFolder.getFileGroup())
+        );
         boolean duplicate = workingFolders.stream()
                 .filter(folder -> folder != editingFolder)
                 .map(Folder::getFileGroup)
+                .map(StringUtils::trimToEmpty)
                 .anyMatch(fileGroup ->
-                        Objects.equals(fileGroup, editingFolder.getFileGroup())
+                        Objects.equals(
+                                fileGroup,
+                                StringUtils.trimToEmpty(editingFolder.getFileGroup())
+                        )
                 );
 
         if (duplicate) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -200,7 +200,8 @@ public class ProjectEditView extends BaseEditView {
         List<Folder> removedFolders = project.getFolders().stream()
                 .filter(projectFolder ->
                         workingFolders.stream().noneMatch(workingFolder ->
-                                Objects.equals(projectFolder.getId(), workingFolder.getId())
+                                (Objects.nonNull(projectFolder.getId())
+                                        && Objects.equals(projectFolder.getId(), workingFolder.getId()))
                                         || projectFolder == workingFolder
                         )
                 )
@@ -213,9 +214,11 @@ public class ProjectEditView extends BaseEditView {
         for (Folder workingFolder : workingFolders) {
             boolean exists = project.getFolders().stream()
                     .anyMatch(projectFolder ->
-                            Objects.equals(projectFolder.getId(), workingFolder.getId())
+                            (Objects.nonNull(projectFolder.getId())
+                                    && Objects.equals(projectFolder.getId(), workingFolder.getId()))
                                     || projectFolder == workingFolder
                     );
+
             if (!exists) {
                 project.getFolders().add(workingFolder);
             }
@@ -334,11 +337,12 @@ public class ProjectEditView extends BaseEditView {
             return;
         }
         boolean duplicate = workingFolders.stream()
-                .anyMatch(folder ->
-                        !Objects.equals(folder.getId(), editingFolder.getId())
-                                && folder != editingFolder
-                                && Objects.equals(folder.getFileGroup(), editingFolder.getFileGroup())
+                .filter(folder -> folder != editingFolder)
+                .map(Folder::getFileGroup)
+                .anyMatch(fileGroup ->
+                        Objects.equals(fileGroup, editingFolder.getFileGroup())
                 );
+
         if (duplicate) {
             Helper.setErrorMessage(
                     "errorDuplicateFilegroup",
@@ -348,11 +352,11 @@ public class ProjectEditView extends BaseEditView {
             return;
         }
 
-        boolean exists = workingFolders.stream()
-                .anyMatch(folder ->
-                        (Objects.nonNull(folder.getId())
-                                && Objects.equals(folder.getId(), editingFolder.getId()))
-                                || folder == editingFolder
+        boolean exists = project.getFolders().stream()
+                .anyMatch(projectFolder ->
+                        (Objects.nonNull(projectFolder.getId())
+                                && Objects.equals(projectFolder.getId(), editingFolder.getId()))
+                                || projectFolder == editingFolder
                 );
 
         if (!exists) {
@@ -581,14 +585,6 @@ public class ProjectEditView extends BaseEditView {
                 ? EMPTY_FILE_GROUP_SENTINEL
                 : fileGroup;
     }
-
-    private String fromUiFileGroup(String fileGroup) {
-        return EMPTY_FILE_GROUP_SENTINEL.equals(fileGroup)
-                ? ""
-                : fileGroup;
-    }
-
-
 
     /**
      * Returns an encapsulation to access the generator properties of the folder

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -72,6 +72,9 @@ public class ProjectEditView extends BaseEditView {
     private Boolean hasProcesses;
     private String originalFileGroup;
     private Project baseProject;
+
+    private static final String EMPTY_FILE_GROUP_SENTINEL = "__EMPTY_FILE_GROUP__";
+
     /**
      * The folder currently under edit in the pop-up dialog.
      */
@@ -132,9 +135,12 @@ public class ProjectEditView extends BaseEditView {
      */
     public Collection<String> getAvailableFileGroups() {
         Collection<String> fileGroups = Folder.getDefaultFileGroups();
-        if (Objects.nonNull(editingFolder) && StringUtils.isNotBlank(editingFolder.getFileGroup())) {
+
+        if (Objects.nonNull(editingFolder)
+                && Objects.nonNull(editingFolder.getFileGroup())) {
             fileGroups.add(editingFolder.getFileGroup());
         }
+
         return fileGroups;
     }
 
@@ -301,7 +307,12 @@ public class ProjectEditView extends BaseEditView {
             return;
         }
 
-        if (!workingFolders.contains(editingFolder)) {
+        boolean exists = workingFolders.stream()
+                .anyMatch(folder ->
+                        Objects.equals(folder.getId(), editingFolder.getId())
+                );
+
+        if (!exists) {
             workingFolders.add(editingFolder);
         }
     }
@@ -488,7 +499,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public List<SelectItem> getSelectableFolders() {
         return getFolderList().stream()
-                .map(folder -> new SelectItem(folder.getFileGroup(), folder.toString()))
+                .map(folder -> new SelectItem(
+                        toUiFileGroup(folder.getFileGroup()),
+                        folder.toString()))
                 .collect(Collectors.toList());
     }
 
@@ -512,12 +525,24 @@ public class ProjectEditView extends BaseEditView {
 
     private Map<String, Folder> getFolderMap() {
         return getFolderList().stream()
-               .collect(Collectors.toMap(
-                        Folder::getFileGroup,
+                .collect(Collectors.toMap(
+                        folder -> toUiFileGroup(folder.getFileGroup()),
                         Function.identity(),
                         (existing, replacement) ->
                                 Objects.nonNull(existing.getId()) ? existing : replacement
                 ));
+    }
+
+    private String toUiFileGroup(String fileGroup) {
+        return StringUtils.isEmpty(fileGroup)
+                ? EMPTY_FILE_GROUP_SENTINEL
+                : fileGroup;
+    }
+
+    private String fromUiFileGroup(String fileGroup) {
+        return EMPTY_FILE_GROUP_SENTINEL.equals(fileGroup)
+                ? ""
+                : fileGroup;
     }
 
 
@@ -561,7 +586,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public String getGeneratorSource() {
         Folder source = project.getGeneratorSource();
-        return Objects.isNull(source) ? null : source.getFileGroup();
+        return Objects.isNull(source)
+                ? null
+                : toUiFileGroup(source.getFileGroup());
     }
 
     /**
@@ -582,7 +609,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public String getMediaView() {
         Folder mediaView = project.getMediaView();
-        return Objects.isNull(mediaView) ? null : mediaView.getFileGroup();
+        return Objects.isNull(mediaView)
+                ? null
+                : toUiFileGroup(mediaView.getFileGroup());
     }
 
     /**
@@ -602,7 +631,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public String getAudioMediaView() {
         Folder audioMediaView = project.getAudioMediaView();
-        return Objects.isNull(audioMediaView) ? null : audioMediaView.getFileGroup();
+        return Objects.isNull(audioMediaView)
+                ? null
+                : toUiFileGroup(audioMediaView.getFileGroup());
     }
 
     /**
@@ -641,7 +672,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public String getVideoMediaView() {
         Folder videoMediaView = project.getVideoMediaView();
-        return Objects.isNull(videoMediaView) ? null : videoMediaView.getFileGroup();
+        return Objects.isNull(videoMediaView)
+                ? null
+                : toUiFileGroup(videoMediaView.getFileGroup());
     }
 
     /**
@@ -661,7 +694,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public String getPreview() {
         Folder preview = project.getPreview();
-        return Objects.isNull(preview) ? null : preview.getFileGroup();
+        return Objects.isNull(preview)
+                ? null
+                : toUiFileGroup(preview.getFileGroup());
     }
 
     /**
@@ -699,7 +734,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public String getAudioPreview() {
         Folder audioPreview = project.getAudioPreview();
-        return Objects.isNull(audioPreview) ? null : audioPreview.getFileGroup();
+        return Objects.isNull(audioPreview)
+                ? null
+                : toUiFileGroup(audioPreview.getFileGroup());
     }
 
     /**
@@ -719,7 +756,9 @@ public class ProjectEditView extends BaseEditView {
      */
     public String getVideoPreview() {
         Folder videoPreview = project.getVideoPreview();
-        return Objects.isNull(videoPreview) ? null : videoPreview.getFileGroup();
+        return Objects.isNull(videoPreview)
+                ? null
+                : toUiFileGroup(videoPreview.getFileGroup());
     }
 
     /**
@@ -729,7 +768,8 @@ public class ProjectEditView extends BaseEditView {
      *         video preview folder
      */
     public void setVideoPreview(String videoPreview) {
-        project.setVideoPreview(getFolderMap().get(videoPreview));
+        project.setVideoPreview(getFolderMap().get(videoPreview)
+        );
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -352,12 +352,8 @@ public class ProjectEditView extends BaseEditView {
             return;
         }
 
-        boolean exists = project.getFolders().stream()
-                .anyMatch(projectFolder ->
-                        (Objects.nonNull(projectFolder.getId())
-                                && Objects.equals(projectFolder.getId(), editingFolder.getId()))
-                                || projectFolder == editingFolder
-                );
+        boolean exists = workingFolders.stream()
+                .anyMatch(folder -> folder == editingFolder);
 
         if (!exists) {
             workingFolders.add(editingFolder);

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
@@ -137,8 +137,7 @@
                                title="#{msgs.fileGroupDelete}"
                                oncomplete="toggleSave()"
                                styleClass="buttonset plain"
-                               disabled="#{ProjectEditView.locked}"
-                               immediate="true">
+                               disabled="#{ProjectEditView.locked}">
                     <h:outputText><i class="fa fa-trash fa-lg"/></h:outputText>
                     <f:setPropertyActionListener target="#{ProjectEditView.editingFolder}" value="#{folder}"/>
                     <p:confirm header="#{msgs.confirmDelete}"
@@ -154,8 +153,7 @@
                          styleClass="callto"
                          icon="fa fa-plus-circle fa-lg"
                          iconPos="right"
-                         disabled="#{ProjectEditView.locked}"
-                         immediate="true">
+                         disabled="#{ProjectEditView.locked}">
             <f:setPropertyActionListener target="#{ProjectEditView.stayOnCurrentPage}" value="/pages/projectEditMetsPopup"/>
         </p:commandButton>
     </p:panel>

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ProjectEditViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ProjectEditViewIT.java
@@ -255,4 +255,55 @@ public class ProjectEditViewIT {
         assertEquals("GROUP_B",
                 updated.getGeneratorSource().getFileGroup());
     }
+
+    @Test
+    public void shouldRejectChangingFileGroupToDuplicateEmptyValue() throws Exception {
+
+        ProjectEditView view = new ProjectEditView();
+
+        Project project = ServiceManager.getProjectService()
+                .getProjectWithFolders(1)
+                .orElseThrow();
+
+        view.loadProject(project.getId(), false);
+
+        /*
+         * Create folder with empty group
+         */
+        view.addFolder();
+        Folder emptyFolder = view.getEditingFolder();
+        emptyFolder.setFileGroup("");
+        emptyFolder.setMimeType("image/jpeg");
+        view.saveFolder();
+
+        /*
+         * Create folder with non-empty group
+         */
+        view.addFolder();
+        Folder maxFolder = view.getEditingFolder();
+        maxFolder.setFileGroup("MAX");
+        maxFolder.setMimeType("image/jpeg");
+        view.saveFolder();
+
+        /*
+         * Delete original empty group folder
+         */
+        view.setEditingFolder(emptyFolder);
+        view.deleteFolder();
+
+        /*
+         * Edit MAX -> empty
+         */
+        view.setEditingFolder(maxFolder);
+        maxFolder.setFileGroup("");
+        view.saveFolder();
+
+        long emptyCount = view.getFolderList().stream()
+                .map(Folder::getFileGroup)
+                .map(group -> group == null ? "" : group.trim())
+                .filter(String::isEmpty)
+                .count();
+
+        assertEquals(1, emptyCount);
+    }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ProjectEditViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ProjectEditViewIT.java
@@ -300,7 +300,7 @@ public class ProjectEditViewIT {
 
         long emptyCount = view.getFolderList().stream()
                 .map(Folder::getFileGroup)
-                .map(group -> group == null ? "" : group.trim())
+                .map(group -> Objects.isNull(group) ? "" : group.trim())
                 .filter(String::isEmpty)
                 .count();
 

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ProjectEditViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ProjectEditViewIT.java
@@ -20,6 +20,8 @@ import org.kitodo.data.database.beans.Project;
 import org.kitodo.production.services.ServiceManager;
 
 
+import java.util.Objects;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,5 +92,167 @@ public class ProjectEditViewIT {
         assertEquals(initialSize + 1, view.getFolderList().size());
         view.cancel();
         assertEquals(initialSize, view.getFolderList().size(), "Sandbox should have reset to original entity state");
+    }
+
+    @Test
+    public void shouldRejectDuplicateTransientFileGroup() throws Exception {
+        ProjectEditView view = new ProjectEditView();
+        Project project = ServiceManager.getProjectService()
+                .getProjectWithFolders(1)
+                .orElseThrow();
+
+        view.loadProject(project.getId(), false);
+
+        view.addFolder();
+        Folder first = view.getEditingFolder();
+        first.setFileGroup("DUPLICATE");
+        first.setMimeType("image/jpeg");
+        view.saveFolder();
+
+        assertEquals(1,
+                view.getFolderList().stream()
+                        .filter(f -> "DUPLICATE".equals(f.getFileGroup()))
+                        .count());
+
+        view.addFolder();
+        Folder second = view.getEditingFolder();
+        second.setFileGroup("DUPLICATE");
+        second.setMimeType("image/jpeg");
+
+        view.saveFolder();
+
+        assertEquals(1,
+                view.getFolderList().stream()
+                        .filter(f -> "DUPLICATE".equals(f.getFileGroup()))
+                        .count());
+    }
+
+    @Test
+    public void shouldRejectDuplicateEmptyFileGroup() throws Exception {
+        ProjectEditView view = new ProjectEditView();
+        Project project = ServiceManager.getProjectService()
+                .getProjectWithFolders(1)
+                .orElseThrow();
+
+        view.loadProject(project.getId(), false);
+
+        view.addFolder();
+        Folder first = view.getEditingFolder();
+        first.setFileGroup("");
+        first.setMimeType("image/jpeg");
+        view.saveFolder();
+
+        view.addFolder();
+        Folder second = view.getEditingFolder();
+        second.setFileGroup("");
+        second.setMimeType("image/jpeg");
+        view.saveFolder();
+
+        long emptyCount = view.getFolderList().stream()
+                .filter(f -> Objects.nonNull(f.getFileGroup())
+                        && f.getFileGroup().isEmpty())
+                .count();
+
+        assertEquals(1, emptyCount);
+    }
+
+    @Test
+    public void shouldHandleFolderLifecycleAcrossMultipleSaves() throws Exception {
+        /*
+         * STEP 1
+         * Load + add folders
+         */
+        ProjectEditView view = new ProjectEditView();
+
+        Project project = ServiceManager.getProjectService()
+                .getProjectWithFolders(1)
+                .orElseThrow();
+
+        view.loadProject(project.getId(), false);
+
+        view.addFolder();
+        Folder folderA = view.getEditingFolder();
+        folderA.setFileGroup("GROUP_A");
+        folderA.setMimeType("image/jpeg");
+        folderA.setPath("folderA");
+        view.saveFolder();
+
+        view.addFolder();
+        Folder folderB = view.getEditingFolder();
+        folderB.setFileGroup("GROUP_B");
+        folderB.setMimeType("image/jpeg");
+        folderB.setPath("folderB");
+        view.saveFolder();
+
+        view.save();
+
+        /*
+         * STEP 2
+         * Reload + assign usages
+         */
+        view = new ProjectEditView();
+
+        project = ServiceManager.getProjectService()
+                .getProjectWithFolders(project.getId())
+                .orElseThrow();
+
+        view.loadProject(project.getId(), false);
+
+        view.setPreview("GROUP_A");
+        view.setMediaView("GROUP_A");
+        view.setGeneratorSource("GROUP_A");
+
+        view.save();
+
+        /*
+         * STEP 3
+         * Reload + delete referenced folder
+         */
+        view = new ProjectEditView();
+
+        project = ServiceManager.getProjectService()
+                .getProjectWithFolders(project.getId())
+                .orElseThrow();
+
+        view.loadProject(project.getId(), false);
+
+        Folder folderAFromReload = view.getFolderList().stream()
+                .filter(folder -> "GROUP_A".equals(folder.getFileGroup()))
+                .findFirst()
+                .orElseThrow();
+       /*
+         * Reassign usages
+         */
+        view.setPreview("GROUP_B");
+        view.setMediaView("GROUP_B");
+        view.setGeneratorSource("GROUP_B");
+
+        /*
+         * Delete old folder
+         */
+        view.setEditingFolder(folderAFromReload);
+        view.deleteFolder();
+
+        view.save();
+
+        /*
+         * STEP 4
+         * Verify persisted state
+         */
+        Project updated = ServiceManager.getProjectService()
+                .getProjectWithFolders(project.getId())
+                .orElseThrow();
+
+        assertTrue(updated.getFolders().stream()
+                .noneMatch(folder -> "GROUP_A".equals(folder.getFileGroup())));
+
+        assertEquals("GROUP_B",
+                updated.getPreview().getFileGroup());
+
+        assertEquals("GROUP_B",
+                updated.getMediaView().getFileGroup());
+
+        assertEquals("GROUP_B",
+                updated.getGeneratorSource().getFileGroup());
     }
 }


### PR DESCRIPTION
This PR improves upon https://github.com/kitodo/kitodo-production/pull/6946.
When i edit folders and in the same UI interaction session also edit the folder usage (Which folder is used to show thumbnails etc.) sometimes the screen gets stuck on Save. It seems to me as if using "parallel stream" is not safe here and has unwanted effects. After my changes i can edit both the general folder settings as well as their usage.

I also improve the file group handling insofar as when a filegroup of an existing folder is changed to the filegroup of another folder and an error indicates a duplicate file group we do not switch to the rejected file group in the UI.
