### PR TITLE
Update omnifaces to version 5.2.3

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -18,7 +18,7 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:p="http://primefaces.org/ui"
       xmlns:pe="http://primefaces.org/ui/extensions"
-      xmlns:o="http://omnifaces.org/ui">
+      xmlns:o="omnifaces">
 
     <f:view locale="#{LanguageForm.locale}">
         <h:head>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processEdit/taskList.xhtml
@@ -14,7 +14,7 @@
 <ui:composition
         xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
-        xmlns:o="http://omnifaces.org/ui"
+        xmlns:o="omnifaces"
         xmlns:p="http://primefaces.org/ui"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
     <!--@elvariable id="item" type="org.kitodo.data.database.beans.Task"-->

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/titleRecordLink.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/titleRecordLink.xhtml
@@ -16,7 +16,7 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:of="http://omnifaces.org/functions">
+                xmlns:o="omnifaces">
 
     <p:panelGrid id="titleRecordLinkTabContent"
                  layout="grid"
@@ -85,7 +85,7 @@
                         <h:outputLabel for="insertionPositionRadioButton"
                                        value="#{msgs.insertHere}"
                                        rendered="#{node.possibleInsertionPosition}"/>
-                        <h:outputText value="#{node.label} - #{of:joinCollection(node.tooltip, ', ')}" id="treeNodeText"
+                        <h:outputText value="#{node.label} - #{o:joinCollection(node.tooltip, ', ')}" id="treeNodeText"
                                        rendered="#{not node.possibleInsertionPosition}"/>
                     </p:treeNode>
                 </p:tree>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projects/templateList.xhtml
@@ -15,7 +15,7 @@
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:h="http://xmlns.jcp.org/jsf/html"
-        xmlns:o="http://omnifaces.org/ui"
+        xmlns:o="omnifaces"
         xmlns:p="http://primefaces.org/ui">
     <!--@elvariable id="item" type="org.kitodo.production.dto.TemplateDTO"-->
     <p:dataTable id="templateTable"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/taskList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/templateEdit/taskList.xhtml
@@ -13,7 +13,7 @@
 
 <ui:composition
         xmlns:h="http://xmlns.jcp.org/jsf/html"
-        xmlns:o="http://omnifaces.org/ui"
+        xmlns:o="omnifaces"
         xmlns:p="http://primefaces.org/ui"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
     <p:dataTable id="taskTable"

--- a/Kitodo/src/main/webapp/WEB-INF/web.xml
+++ b/Kitodo/src/main/webapp/WEB-INF/web.xml
@@ -114,15 +114,16 @@
         <session-timeout>120</session-timeout>
     </session-config>
 
-    <!-- gzip filter compressing resources -->
+    <!-- filter compressing resources -->
     <filter>
-        <filter-name>gzipResponseFilter</filter-name>
-        <filter-class>org.omnifaces.filter.GzipResponseFilter</filter-class>
+        <filter-name>compressedResponseFilter</filter-name>
+        <filter-class>org.omnifaces.filter.CompressedResponseFilter</filter-class>
     </filter>
     <filter-mapping>
-        <filter-name>gzipResponseFilter</filter-name>
+        <filter-name>compressedResponseFilter</filter-name>
         <url-pattern>/*</url-pattern>
         <dispatcher>REQUEST</dispatcher>
+        <dispatcher>ERROR</dispatcher>
     </filter-mapping>
 
     <!-- Welcome files -->

--- a/Kitodo/src/main/webapp/pages/error.xhtml
+++ b/Kitodo/src/main/webapp/pages/error.xhtml
@@ -16,7 +16,7 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:p="http://primefaces.org/ui"
-        xmlns:of="http://omnifaces.org/functions">
+        xmlns:o="omnifaces">
 
     <ui:define name="content">
 
@@ -31,7 +31,7 @@
 
             <h:panelGroup layout="block">
                 <ul id="errorDetails">
-                    <li>Date/time: #{of:formatDate(now, 'yyyy-MM-dd HH:mm:ss')}</li>
+                    <li>Date/time: #{o:formatDate(now, 'yyyy-MM-dd HH:mm:ss')}</li>
                     <li>User agent: #{header['user-agent']}</li>
                     <li>User IP: #{request.remoteAddr}</li>
                     <li>Request URI: #{requestScope['jakarta.servlet.error.request_uri']}</li>
@@ -41,7 +41,7 @@
                     <li>Exception message: #{requestScope['jakarta.servlet.error.message']}</li>
                     <li>Exception UUID: #{requestScope['org.omnifaces.exception_uuid']}</li>
                     <li>Stack trace:
-                        <pre>#{of:printStackTrace(requestScope['jakarta.servlet.error.exception'])}</pre>
+                        <pre>#{o:printStackTrace(requestScope['jakarta.servlet.error.exception'])}</pre>
                     </li>
                 </ul>
             </h:panelGroup>

--- a/Kitodo/src/main/webapp/pages/extendedSearch.xhtml
+++ b/Kitodo/src/main/webapp/pages/extendedSearch.xhtml
@@ -17,7 +17,7 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:p="http://primefaces.org/ui"
-        xmlns:o="http://omnifaces.org/ui">
+        xmlns:o="omnifaces">
     <ui:define name="contentHeader">
         <h3>#{msgs.extendedSearch}</h3>
 

--- a/Kitodo/src/main/webapp/pages/processes.xhtml
+++ b/Kitodo/src/main/webapp/pages/processes.xhtml
@@ -17,7 +17,7 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:p="http://primefaces.org/ui"
-        xmlns:o="http://omnifaces.org/ui">
+        xmlns:o="omnifaces">
     <f:metadata>
         <!--@elvariable id="tab" type="java.lang.String"-->
         <f:viewParam name="tab"/>

--- a/Kitodo/src/main/webapp/pages/tasks.xhtml
+++ b/Kitodo/src/main/webapp/pages/tasks.xhtml
@@ -17,7 +17,7 @@
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:f="http://xmlns.jcp.org/jsf/core"
         xmlns:p="http://primefaces.org/ui"
-        xmlns:o="http://omnifaces.org/ui">
+        xmlns:o="omnifaces">
     <f:metadata>
         <!--@elvariable id="firstRow" type="java.lang.Integer"-->
         <f:viewParam name="firstRow"/>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-net.version>3.9.0</commons-net.version>
         <font-awesome.version>4.7.0</font-awesome.version>
-        <omnifaces.version>4.7.1</omnifaces.version>
+        <omnifaces.version>5.2.3</omnifaces.version>
         <org.apache.xmlgraphics.version>2.8</org.apache.xmlgraphics.version>
         <org.apache.avalon.framework.version>4.3.1</org.apache.avalon.framework.version>
         <org.ehcache.version>3.10.9</org.ehcache.version>


### PR DESCRIPTION
Updating to latest release of omnifaces.

Changes needed as
- `org.omnifaces.filter.GzipResponseFilter` was deprecated and must be replaces with `org.omnifaces.filter.CompressedResponseFilter`
- Used namespace inside the `*.xhtml` files should be replaced (marked as deprecated in `5.x`) from URI to URN and the different namespaces are merged.