### PR TITLE
Prevent error for undefined metadata groups

### DIFF
--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import org.kitodo.api.Metadata;
+import org.kitodo.api.MetadataGroup;
 import org.kitodo.api.dataeditor.rulesetmanagement.ComplexMetadataViewInterface;
 import org.kitodo.api.dataeditor.rulesetmanagement.Domain;
 import org.kitodo.api.dataeditor.rulesetmanagement.MetadataViewInterface;
@@ -380,6 +381,24 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
     }
 
     /**
+     * Creates a metadata view for one line of the auxiliary table.
+     * This method takes metadata groups into account that are not defined in the ruleset.
+     *
+     * @param row row to make a view for
+     * @param index index of the metadata object in the row
+     * @return metadata view
+     */
+    private MetadataViewInterface rowToView(AuxiliaryTableRow row, int index) {
+        if (row.getKey().isUndefined()) {
+            Collection<Metadata> metadataObjects = row.getDataObjects(index);
+            if (!metadataObjects.isEmpty() && metadataObjects.iterator().next() instanceof MetadataGroup) {
+                return getNestedKeyView(row.getId());
+            }
+        }
+        return rowToView(row);
+    }
+
+    /**
      * Creates a key view for a grouped key. This is the case when when
      * {@code <key>} elements occur within another {@code <key>} element in the
      * ruleset.
@@ -424,7 +443,7 @@ class NestedKeyView<D extends KeyDeclaration> extends AbstractKeyView<D> impleme
                 excludedDataObjects.addAll(auxiliaryTableRow.getDataObjects(0));
             } else {
                 for (int i = 0; i < auxiliaryTableRow.getNumberOfTypeViewsToGenerate(); i++) {
-                    Optional<MetadataViewInterface> definedTypeView = Optional.of(rowToView(auxiliaryTableRow));
+                    Optional<MetadataViewInterface> definedTypeView = Optional.of(rowToView(auxiliaryTableRow, i));
                     sortedVisibleMetadata.add(new FormRow(definedTypeView, auxiliaryTableRow.getDataObjects(i)));
                 }
             }


### PR DESCRIPTION
Metadata keys not defined in the ruleset are displayed but marked with a warning sign. However, this does not apply to metadata groups not defined in the ruleset. In combination with metadata entries inside of an undefined group a stack trace can appear. 
 
The cause seems to be a bug:
The method `NestedKeyView.rowToView(AuxiliaryTableRow row)` ([NestedKeyView.java](https://github.com/effective-webwork/kitodo-production/blob/afae96512fe45cefea2a4bbe75cc636c06e6b05c/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/ruleset/NestedKeyView.java#L378)) uses the method `isComplexKey()` to determine whether a `NestedKeyView` or a `KeyView` should be created. Since this method always returns `false` for undefined keys, a `KeyView` is always created.

(For displaying a metadata entry as child of a group some fields of the group are accessed. This fails, when the group is undefined and thus handled as a simple metadata entry without the necessary fields.)

To address this, I added a check that verifies the actual type of metadata when the metadata key is undefined, and creates a NestedKeyView for metadata groups.

With this change undefined metadata groups can be displayed in the metadata editor and metadata import. They are marked with a warning sign like the metadata entries are:
<img width="688" height="209" alt="Unknown metadata group and metadata entry in the metadata editor" src="https://github.com/user-attachments/assets/220f1d39-2cd0-403f-be56-faf45b26e4cb" />

Fixes #3762 
Fixes #5217 