### PR TITLE
Add fullscreen mode to metadata editor

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -39,6 +39,37 @@ body.first-visit {
     animation-name: slidein;
 }
 
+/* Hide header + footer */
+body.fullscreen-mode #portal-header,
+body.fullscreen-mode footer {
+    display: none !important;
+}
+
+/* Remove layout constraints */
+body.fullscreen-mode .flex-container {
+    height: 100vh;
+}
+
+/* Make main take full space */
+body.fullscreen-mode main.flex-item {
+    height: 100vh;
+    width: 100vw;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+/* Expand editor to full screen */
+body.fullscreen-mode #metadataEditorContainer {
+    margin: 0 !important;
+    padding: 0 !important;
+    height: 100%;
+}
+
+/* Remove wrapper spacing */
+body.fullscreen-mode #metadataEditorWrapper {
+    height: 100%;
+}
+
 .flex-container {
     height: 100%;
     overflow: auto;

--- a/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/css/kitodo.css
@@ -54,15 +54,12 @@ body.fullscreen-mode .flex-container {
 body.fullscreen-mode main.flex-item {
     height: 100vh;
     width: 100vw;
-    margin: 0 !important;
-    padding: 0 !important;
 }
 
 /* Expand editor to full screen */
 body.fullscreen-mode #metadataEditorContainer {
-    margin: 0 !important;
-    padding: 0 !important;
     height: 100%;
+    margin: 0;
 }
 
 /* Remove wrapper spacing */

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -16,6 +16,19 @@
 
 var metadataEditor = metadataEditor || {};
 
+metadataEditor.global = {
+    toggleFullscreenMode() {
+    document.body.classList.toggle('fullscreen-mode');
+    // Force layout recalculation
+    setTimeout(function () {
+        if (typeof window.setHeight === 'function') {
+            window.setHeight();
+        }
+        window.dispatchEvent(new Event('resize'));
+    }, 50);
+    }
+};
+
 metadataEditor.metadataTree = {
 
     /**

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -16,8 +16,7 @@
 
 var metadataEditor = metadataEditor || {};
 
-metadataEditor.global = {
-    toggleFullscreenMode() {
+metadataEditor.toggleFullscreenMode = function () {
     document.body.classList.toggle('fullscreen-mode');
     // Force layout recalculation
     setTimeout(function () {
@@ -26,8 +25,7 @@ metadataEditor.global = {
         }
         window.dispatchEvent(new Event('resize'));
     }, 50);
-    }
-};
+}
 
 metadataEditor.metadataTree = {
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
@@ -92,6 +92,10 @@
                              rendered="#{mayWrite}"
                              onclick="deactivateButtons();setUnsavedChanges(false);PF('sticky-notifications').renderMessage({'summary':'#{msgs.metadataSaving}','detail':'#{msgs.youWillBeRedirected}','severity':'info'});"
                              update="notifications"/>
+            <p:commandButton type="button"
+                             icon="pi pi-window-maximize"
+                             styleClass="fullscreen-btn"
+                             onclick="metadataEditor.global.toggleFullscreenMode()" />
         </h:form>
     </p:panel>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/metadataEditor/header.xhtml
@@ -95,7 +95,7 @@
             <p:commandButton type="button"
                              icon="pi pi-window-maximize"
                              styleClass="fullscreen-btn"
-                             onclick="metadataEditor.global.toggleFullscreenMode()" />
+                             onclick="metadataEditor.toggleFullscreenMode()" />
         </h:form>
     </p:panel>
 </ui:composition>

--- a/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
+++ b/Kitodo/src/main/webapp/pages/metadataEditor.xhtml
@@ -56,8 +56,7 @@
         <ui:param name="commentsNumber" value="#{CommentForm.getAllComments().size()}"/>
 
         <p:panel id="metadataEditorContainer"
-                 rendered="#{empty DataEditorForm.getMetadataFileLoadingError() and empty DataEditorForm.getMetadataFileValidationErrors()}"
-                 style="margin: auto 16px; padding: 0;">
+                 rendered="#{empty DataEditorForm.getMetadataFileLoadingError() and empty DataEditorForm.getMetadataFileValidationErrors()}">
 
             <p:panel id="metadataEditor">
                 <!-- Header -->


### PR DESCRIPTION
This PR adds a button to switch to "fullscreen" mode in the metadata editor, by hiding the header and the footer. The goal is to use more from the screen when working in the editor. This can be used in conjunction with normal browser fullscreen mode.

Normal view:

<img width="1917" height="960" alt="image" src="https://github.com/user-attachments/assets/9711abde-f181-4b06-aaf6-4b7fdbf12d11" />

Fullscreen view:

<img width="1917" height="960" alt="image" src="https://github.com/user-attachments/assets/588d7228-0648-4d5f-a154-7e877a226daf" />
