### PR TITLE
Allow for serial processing of tasks in process list

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -36,6 +36,7 @@ import org.kitodo.export.TiffHeader;
 import org.kitodo.production.enums.GenerationMode;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.forms.ValidatableForm;
+import org.kitodo.production.forms.process.ProcessListView;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.tasks.TaskManager;
 import org.kitodo.production.metadata.MetadataLock;
@@ -344,6 +345,8 @@ public class TaskWorkView extends ValidatableForm {
     public void setReferrerFromTemplate(String referrer) {
         if ("desktop".equals(referrer)) {
             this.referrer = "desktop";
+        } else if ("processes".equals(referrer)) {
+            this.referrer = "processes";
         } else {
             this.referrer = "tasks";
         }
@@ -355,10 +358,11 @@ public class TaskWorkView extends ValidatableForm {
      * @return the view path
      */
     private String getReferrerViewPath() {
-        if (this.referrer.equals("tasks")) {
-            return TaskListView.getViewPath() + "&" + getReferrerListOptions();
-        }
-        return "desktop";
+        return switch (this.referrer) {
+            case "tasks" -> TaskListView.getViewPath();
+            case "processes" -> ProcessListView.getViewPath();
+            default -> "desktop";
+        };
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -359,8 +359,8 @@ public class TaskWorkView extends ValidatableForm {
      */
     private String getReferrerViewPath() {
         return switch (this.referrer) {
-            case "tasks" -> TaskListView.getViewPath();
-            case "processes" -> ProcessListView.getViewPath();
+            case "tasks" -> TaskListView.getViewPath() + "&" + getReferrerListOptions();
+            case "processes" -> ProcessListView.getViewPath() + "&" + getReferrerListOptions();
             default -> "desktop";
         };
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -353,16 +353,21 @@ public class TaskWorkView extends ValidatableForm {
     }
 
     /**
-     * Return the view path to the referring view, which can be either the desktop view or task list.
+     * Return the view path to the referring view, which can be the desktop view, the process list or task list.
      * 
      * @return the view path
      */
     private String getReferrerViewPath() {
-        return switch (this.referrer) {
-            case "tasks" -> TaskListView.getViewPath() + "&" + getReferrerListOptions();
-            case "processes" -> ProcessListView.getViewPath() + "&" + getReferrerListOptions();
+        String base = switch (this.referrer) {
+            case "tasks" -> TaskListView.getViewPath();
+            case "processes" -> ProcessListView.getViewPath();
             default -> "desktop";
         };
+        String options = getReferrerListOptions();
+        if (Objects.isNull(options) || options.isBlank()) {
+            return base;
+        }
+        return base + "&" + options;
     }
 
 }

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -232,7 +232,7 @@
                             <h:outputText value="#{task.title}"/>
                                 <!-- assign task -->
                                 <p:commandLink id="take"
-                                               action="#{TaskListView.takeOverTask(task)}"
+                                               action="#{TaskListView.takeOverTask(task, 'processes')}"
                                                styleClass="action"
                                                rendered="#{(task.processingStatus == 'OPEN' and !task.batchStep) || (task.processingStatus == 'OPEN' and task.batchStep and !task.batchAvailable)}"
                                                process="@this"
@@ -241,7 +241,7 @@
                                 </p:commandLink>
                                 <!-- already assigned task (this user) -->
                                 <p:commandLink id="editOwnTask"
-                                               action="#{TaskListView.workOnTask(task)}"
+                                               action="#{TaskListView.workOnTask(task, 'processes')}"
                                                styleClass="action"
                                                process="@this"
                                                rendered="#{(task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and !task.batchStep) || (task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and task.batchStep and !task.batchAvailable)}"
@@ -250,7 +250,7 @@
                                 </p:commandLink>
                                 <!-- already assigned task (different user) -->
                                 <p:commandLink id="editOtherTask"
-                                               action="#{TaskListView.workOnTask(task)}"
+                                               action="#{TaskListView.workOnTask(task, 'processes')}"
                                                styleClass="action"
                                                process="@this"
                                                rendered="#{task.processingStatus == 'INWORK' and task.processingUser.id != LoginForm.loggedUser.id and (!task.batchStep || !task.batchAvailable)}"


### PR DESCRIPTION
Fixes: https://github.com/kitodo/kitodo-production/issues/6327
Builds upon: https://github.com/kitodo/kitodo-production/pull/6999

When a task is taken over from the process list and finished, the UI should navigate back to the process list.