### PR TITLE
Fix MassIndexing error in MariaDB

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -120,8 +120,18 @@ public class IndexingService {
             if (Objects.nonNull(monitor)) {
                 massIndexer.monitor(monitor);
             }
-            massIndexer.idFetchSize(Integer.MIN_VALUE).batchSizeToLoadObjects(1000);
-            return massIndexer.start();
+            String driverName = ormSession
+                    .doReturningWork(c -> c.getMetaData().getDriverName());
+            String normalizedDriverName = Objects.isNull(driverName) ? "" : driverName.toLowerCase();
+            if (normalizedDriverName.contains("mysql") && !normalizedDriverName.contains("mariadb")) {
+                // MySQL needs a special setting for the fetch size
+                // See https://docs.hibernate.org/search/7.0/reference/en-US/html_single/#indexing-massindexer-basics
+                massIndexer.idFetchSize(Integer.MIN_VALUE);
+            } else {
+                // Other Databases
+                massIndexer.idFetchSize(500);
+            }
+            return massIndexer.batchSizeToLoadObjects(1000).start();
         }
     }
 


### PR DESCRIPTION
As elaborated in https://github.com/kitodo/kitodo-production/pull/6977#issuecomment-4289865450

When using newer driver versions of MariaDB JDBC driver the current MassIndexer settings in Kitodo fail because they are operating on a MySQL specific setting. I therefor now inspect the used driver and use a different strategy when the MySQL driver is used. 

I am not sure about the exact values here (500 idFetchSize, 1000 Batch Size). They seem to work and so far there have not be any complaints that the Kitodo MassIndexer fails in 3.9. One can however think of making those values configurable and have lower defaults in place. 