### PR TITLE
Fix page navigation clicking on task bell in process list

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListView.java
@@ -13,6 +13,7 @@ package org.kitodo.production.forms.process;
 
 import static java.util.Map.entry;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -37,9 +38,12 @@ import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Task;
+import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
+import org.kitodo.exceptions.FileStructureValidationException;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.filters.FilterMenu;
+import org.kitodo.production.forms.task.TaskWorkView;
 import org.kitodo.production.helper.CustomListColumnInitializer;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.services.ServiceManager;
@@ -53,6 +57,7 @@ import org.primefaces.event.SelectEvent;
 import org.primefaces.event.UnselectEvent;
 import org.primefaces.model.SortMeta;
 import org.primefaces.model.SortOrder;
+import org.xml.sax.SAXException;
 
 @Named("ProcessListView")
 @ViewScoped
@@ -521,5 +526,43 @@ public class ProcessListView extends ProcessListBaseView {
             "id", "title", "progressCombined", "lastEditingUser", "processingBeginLastTask", 
             "processingEndLastTask", "correctionCommentStatus", "project.title", "creationDate"
         );
+    }
+
+    /**
+     * Take over task by user which calls this method.
+     *
+     * @param task the task that is supposed to be taken over
+     * @return the view path
+     */
+    public String takeOverTask(Task task) {
+        Stopwatch stopwatch = new Stopwatch(this, "takeOverTask");
+        if (task.getProcessingStatus() != TaskStatus.OPEN) {
+            Helper.setErrorMessage("stepInWorkError");
+            return stopwatch.stop(this.stayOnCurrentPage);
+        } else {
+            try {
+                if (task.isTypeAcceptClose()) {
+                    this.workflowControllerService.close(task);
+                    return stopwatch.stop(VIEW_PATH + "&" + getCombinedListOptions());
+                } else {
+                    this.workflowControllerService.assignTaskToUser(task);
+                    ServiceManager.getTaskService().save(task);
+                }
+            } catch (DAOException | IOException | SAXException | FileStructureValidationException e) {
+                Helper.setErrorMessage(ERROR_SAVING, new Object[] {ObjectType.TASK.getTranslationSingular() }, logger,
+                    e);
+            }
+        }
+        return stopwatch.stop(TaskWorkView.getViewPath(task, "processes", getCombinedListOptions()));
+    }
+
+    /**
+     * Returns the view path to navigate to the "work on" task view.
+     *
+     * @param task the task to work on
+     * @return the view path
+     */
+    public String workOnTask(Task task) {
+          return TaskWorkView.getViewPath(task, "processes", getCombinedListOptions());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListView.java
@@ -563,6 +563,6 @@ public class ProcessListView extends ProcessListBaseView {
      * @return the view path
      */
     public String workOnTask(Task task) {
-          return TaskWorkView.getViewPath(task, "processes", getCombinedListOptions());
+        return TaskWorkView.getViewPath(task, "processes", getCombinedListOptions());
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskListView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskListView.java
@@ -155,7 +155,9 @@ public class TaskListView extends BaseListView {
     /**
      * Take over task by user which calls this method.
      *
-     * @return page
+     * @param task the task that is supposed to be taken over
+     * @param referrer the current page (either "tasks" or "desktop")
+     * @return view path
      */
     public String takeOverTask(Task task, String referrer) {
         Stopwatch stopwatch = new Stopwatch(this, "takeOverTask");

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -75,7 +75,7 @@ public class TaskWorkView extends ValidatableForm {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("id", task.getId().toString());
         queryParams.put("referer", referrer);
-        if (Objects.nonNull(referrer) && referrer.equals("tasks")) {
+        if (Objects.nonNull(referrer) && (referrer.equals("tasks") || referrer.equals("processes"))) {
             queryParams.put("referrerListOptions", "_" + URLEncoder.encode(referrerListOptions, StandardCharsets.UTF_8));
         }
         return VIEW_PATH + "&" + queryParams.entrySet().stream()

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -36,6 +36,7 @@ import org.kitodo.export.TiffHeader;
 import org.kitodo.production.enums.GenerationMode;
 import org.kitodo.production.enums.ObjectType;
 import org.kitodo.production.forms.ValidatableForm;
+import org.kitodo.production.forms.process.ProcessListView;
 import org.kitodo.production.helper.Helper;
 import org.kitodo.production.helper.tasks.TaskManager;
 import org.kitodo.production.metadata.MetadataLock;
@@ -344,6 +345,8 @@ public class TaskWorkView extends ValidatableForm {
     public void setReferrerFromTemplate(String referrer) {
         if ("desktop".equals(referrer)) {
             this.referrer = "desktop";
+        } else if ("processes".equals(referrer)) {
+            this.referrer = "processes";
         } else {
             this.referrer = "tasks";
         }
@@ -355,10 +358,11 @@ public class TaskWorkView extends ValidatableForm {
      * @return the view path
      */
     private String getReferrerViewPath() {
-        if (this.referrer.equals("tasks")) {
-            return TaskListView.getViewPath() + "&" + getReferrerListOptions();
-        }
-        return "desktop";
+        return switch (this.referrer) {
+            case "tasks" -> TaskListView.getViewPath();
+            case "processes" -> ProcessListView.getViewPath();
+            default -> "desktop";
+        };
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -359,8 +359,8 @@ public class TaskWorkView extends ValidatableForm {
      */
     private String getReferrerViewPath() {
         return switch (this.referrer) {
-            case "tasks" -> TaskListView.getViewPath();
-            case "processes" -> ProcessListView.getViewPath();
+            case "tasks" -> TaskListView.getViewPath() + "&" + getReferrerListOptions();
+            case "processes" -> ProcessListView.getViewPath() + "&" + getReferrerListOptions();
             default -> "desktop";
         };
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -353,16 +353,21 @@ public class TaskWorkView extends ValidatableForm {
     }
 
     /**
-     * Return the view path to the referring view, which can be either the desktop view or task list.
+     * Return the view path to the referring view, which can be the desktop view, the process list or task list.
      * 
      * @return the view path
      */
     private String getReferrerViewPath() {
-        return switch (this.referrer) {
-            case "tasks" -> TaskListView.getViewPath() + "&" + getReferrerListOptions();
-            case "processes" -> ProcessListView.getViewPath() + "&" + getReferrerListOptions();
+        String base = switch (this.referrer) {
+            case "tasks" -> TaskListView.getViewPath();
+            case "processes" -> ProcessListView.getViewPath();
             default -> "desktop";
         };
+        String options = getReferrerListOptions();
+        if (Objects.isNull(options) || options.isBlank()) {
+            return base;
+        }
+        return base + "&" + options;
     }
 
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/task/TaskWorkView.java
@@ -361,7 +361,7 @@ public class TaskWorkView extends ValidatableForm {
         String base = switch (this.referrer) {
             case "tasks" -> TaskListView.getViewPath();
             case "processes" -> ProcessListView.getViewPath();
-            default -> "desktop";
+            default -> "desktop?faces-redirect=true";
         };
         String options = getReferrerListOptions();
         if (Objects.isNull(options) || options.isBlank()) {

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -232,7 +232,7 @@
                             <h:outputText value="#{task.title}"/>
                                 <!-- assign task -->
                                 <p:commandLink id="take"
-                                               action="#{TaskListView.takeOverTask(task, 'processes')}"
+                                               action="#{ProcessListView.takeOverTask(task)}"
                                                styleClass="action"
                                                rendered="#{(task.processingStatus == 'OPEN' and !task.batchStep) || (task.processingStatus == 'OPEN' and task.batchStep and !task.batchAvailable)}"
                                                process="@this"
@@ -241,7 +241,7 @@
                                 </p:commandLink>
                                 <!-- already assigned task (this user) -->
                                 <p:commandLink id="editOwnTask"
-                                               action="#{TaskListView.workOnTask(task, 'processes')}"
+                                               action="#{ProcessListView.workOnTask(task)}"
                                                styleClass="action"
                                                process="@this"
                                                rendered="#{(task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and !task.batchStep) || (task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and task.batchStep and !task.batchAvailable)}"
@@ -250,7 +250,7 @@
                                 </p:commandLink>
                                 <!-- already assigned task (different user) -->
                                 <p:commandLink id="editOtherTask"
-                                               action="#{TaskListView.workOnTask(task, 'processes')}"
+                                               action="#{ProcessListView.workOnTask(task)}"
                                                styleClass="action"
                                                process="@this"
                                                rendered="#{task.processingStatus == 'INWORK' and task.processingUser.id != LoginForm.loggedUser.id and (!task.batchStep || !task.batchAvailable)}"

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/processList.xhtml
@@ -232,7 +232,7 @@
                             <h:outputText value="#{task.title}"/>
                                 <!-- assign task -->
                                 <p:commandLink id="take"
-                                               action="#{TaskListView.takeOverTask(task)}"
+                                               action="#{TaskListView.takeOverTask(task, 'processes')}"
                                                styleClass="action"
                                                rendered="#{(task.processingStatus == 'OPEN' and !task.batchStep) || (task.processingStatus == 'OPEN' and task.batchStep and !task.batchAvailable)}"
                                                process="@this"
@@ -241,7 +241,7 @@
                                 </p:commandLink>
                                 <!-- already assigned task (this user) -->
                                 <p:commandLink id="editOwnTask"
-                                               action="#{TaskListView.workOnTask(task)}"
+                                               action="#{TaskListView.workOnTask(task, 'processes')}"
                                                styleClass="action"
                                                process="@this"
                                                rendered="#{(task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and !task.batchStep) || (task.processingStatus == 'INWORK' and task.processingUser.id == LoginForm.loggedUser.id and task.batchStep and !task.batchAvailable)}"
@@ -250,7 +250,7 @@
                                 </p:commandLink>
                                 <!-- already assigned task (different user) -->
                                 <p:commandLink id="editOtherTask"
-                                               action="#{TaskListView.workOnTask(task)}"
+                                               action="#{TaskListView.workOnTask(task, 'processes')}"
                                                styleClass="action"
                                                process="@this"
                                                rendered="#{task.processingStatus == 'INWORK' and task.processingUser.id != LoginForm.loggedUser.id and (!task.batchStep || !task.batchAvailable)}"


### PR DESCRIPTION
This PR extends #7007 and fixes #6327.

The problem with #7007 is that non-static methods from the `TaskListView` are being referenced inside the `processList.xhtml` template. However, the task list is not being initialized when viewing the process list, and any list state changes (filter / sorting) are only available in `ProcessListView`. 

Because of that, I had to essentially copy the methods `takeOverTask` and `workOnTask` from `TaskListView` to `ProcessListView`. Unfortuantely, there doesn't really seem to be a reasonable way to refactor them into a single static method or a common workflow function.