### PR TITLE
Rename misleading class variable

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListBaseView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessListBaseView.java
@@ -64,7 +64,7 @@ public class ProcessListBaseView extends BaseListView {
 
     boolean allSelected = false;
     HashSet<Integer> excludedProcessIds = new HashSet<>();
-    private final ProcessProgressHelper progressService = new ProcessProgressHelper();
+    private final ProcessProgressHelper processProgressHelper = new ProcessProgressHelper();
 
     /**
      * Constructor.
@@ -152,7 +152,7 @@ public class ProcessListBaseView extends BaseListView {
      * @return true if at least one task exists, otherwise false
      */
     public boolean hasAnyTasks(Process process) {
-        return progressService.hasAnyTasks(getCachedTaskStatusCounts(process));
+        return processProgressHelper.hasAnyTasks(getCachedTaskStatusCounts(process));
     }
 
     /**
@@ -184,7 +184,7 @@ public class ProcessListBaseView extends BaseListView {
      * @return formatted task titles or an empty string if none exist
      */
     public String getCurrentTaskTitles(Process process) {
-        return progressService.buildTaskTitleTooltip(
+        return processProgressHelper.buildTaskTitleTooltip(
                 getLazyProcessModel().getTaskTitleCache().get(process.getId())
         );
     }
@@ -221,7 +221,7 @@ public class ProcessListBaseView extends BaseListView {
      * @return progress percentage for the given status
      */
     public double progress(Process process, TaskStatus status) {
-        return progressService.progress(
+        return processProgressHelper.progress(
                 getCachedTaskStatusCounts(process),
                 status
         );
@@ -236,7 +236,7 @@ public class ProcessListBaseView extends BaseListView {
      * @return percentage of tasks completed
      */
     public double progressClosed(Process process) {
-        return progressService.progressClosed(getCachedTaskStatusCounts(process));
+        return processProgressHelper.progressClosed(getCachedTaskStatusCounts(process));
     }
 
     /**
@@ -248,7 +248,7 @@ public class ProcessListBaseView extends BaseListView {
      * @return percentage of tasks in progress
      */
     public double progressInProcessing(Process process) {
-        return progressService.progressInProcessing(
+        return processProgressHelper.progressInProcessing(
                 getCachedTaskStatusCounts(process)
         );
     }
@@ -263,7 +263,7 @@ public class ProcessListBaseView extends BaseListView {
      * @return percentage of startable tasks
      */
     public double progressOpen(Process process) {
-        return progressService.progressOpen(
+        return processProgressHelper.progressOpen(
                 getCachedTaskStatusCounts(process)
         );
     }


### PR DESCRIPTION
Instance of class `ProcessProgressHelper` was used with `progressService` as class variable name. Both classes had different objects in use and variable naming should respect this.