### PR TITLE
Fix layout of popup dialog button wrappers

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/base/indexWarningDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/base/indexWarningDialog.xhtml
@@ -43,8 +43,8 @@
 
         <p:panelGrid columns="1">
             <h:form id="retryForm">
-                <p:panelGrid>
-                    <p:row>
+                <p:panelGrid columns="1">
+                    <p:column>
                         <p:button href="#{request.contextPath}/logout"
                                   id="logoutButton"
                                   value="#{msgs.logout}"
@@ -59,7 +59,7 @@
                                          action="#{LoginForm.performPostLoginChecks()}"
                                          update="messageWrapper"
                                          styleClass="secondary right"/>
-                    </p:row>
+                    </p:column>
                 </p:panelGrid>
             </h:form>
         </p:panelGrid>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/massImportResults.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/massImportResults.xhtml
@@ -83,8 +83,8 @@
             </p:accordionPanel>
         </h:form>
         <div class="select-selector">
-            <p:panelGrid>
-                <p:row>
+            <p:panelGrid columns="1">
+                <p:column>
                     <h:form id="massImportResultDialogButtonForm">
                         <p:button id="goToProcesses"
                                   value="#{msgs['processes']}"
@@ -95,7 +95,7 @@
                                          styleClass="secondary right"
                                          onclick="PF('massImportResultDialog').hide();"/>
                     </h:form>
-                </p:row>
+                </p:column>
             </p:panelGrid>
         </div>
     </p:dialog>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/errorPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/errorPopup.xhtml
@@ -36,8 +36,8 @@
             </div>
         </h:panelGroup>
 
-        <p:panelGrid>
-            <p:row>
+        <p:panelGrid columns="1">
+            <p:column>
                 <h:form>
                     <p:commandButton id="closeButton"
                                      icon="fa fa-close fa-lg"
@@ -47,7 +47,7 @@
                                      style="margin-right: var(--default-double-size);"
                                      styleClass="secondary right"/>
                 </h:form>
-            </p:row>
+            </p:column>
         </p:panelGrid>
     </p:dialog>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/selectProject.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processFromTemplate/dialogs/selectProject.xhtml
@@ -44,8 +44,8 @@
                         <p:ajax update="selectProjectForm:setProjectButton"/>
                     </p:selectOneMenu>
                 </p>
-                <p:panelGrid>
-                    <p:row>
+                <p:panelGrid columns="1">
+                    <p:column>
                         <p:commandButton id="setProjectButton"
                                          action="#{SelectProjectDialogView.createProcessFromTemplate()}"
                                          styleClass="primary right"
@@ -60,7 +60,7 @@
                                          styleClass="secondary right"
                                          icon="fa fa-close"
                                          iconPos="right"/>
-                    </p:row>
+                    </p:column>
                 </p:panelGrid>
             </h:panelGroup>
         </h:form>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/deleteChildrenDialog.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/deleteChildrenDialog.xhtml
@@ -29,8 +29,8 @@
         <p><h:outputFormat value="#{msgs['deleteProcessChildren']}">
             <f:param value="#{ProcessListView.deleteProcessDialog.process.children.size()}" />
         </h:outputFormat></p>
-        <p:panelGrid>
-            <p:row>
+        <p:panelGrid columns="1">
+            <p:column>
                 <h:form id="deleteChildrenForm">
                     <p:commandButton id="deleteChildrenButton"
                                      action="#{ProcessListView.deleteProcessDialog.deleteWithChildren}"
@@ -55,7 +55,7 @@
                                      styleClass="secondary right"
                                      onclick="PF('deleteChildrenDialog').hide();"/>
                 </h:form>
-            </p:row>
+            </p:column>
         </p:panelGrid>
     </p:dialog>
 </ui:composition>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/errorPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/processes/errorPopup.xhtml
@@ -33,15 +33,15 @@
 
         <p:panelGrid columns="1">
             <h:form id="buttonForm">
-                <p:panelGrid>
-                    <p:row>
+                <p:panelGrid columns="1">
+                    <p:column>
                         <p:commandButton id="okButton"
                                          value="#{msgs.ok}"
                                          update="messageWrapper"
                                          style="margin-right: 32px;"
                                          onclick="PF('errorDialog').hide();"
                                          styleClass="primary right"/>
-                    </p:row>
+                    </p:column>
                 </p:panelGrid>
             </h:form>
         </p:panelGrid>


### PR DESCRIPTION
Similar to #7016 fixes the layout of buttons in some dialogs that were broken after the latest PrimeFaces update (#6991):

_Error dialog on process list page:_
<img width="508" height="284" alt="Bildschirmfoto 2026-04-28 um 12 10 57" src="https://github.com/user-attachments/assets/8deecd7e-80e7-4aba-bf90-419e3edefe0b" />

_Mass import result dialog:_
<img width="1030" height="443" alt="Bildschirmfoto 2026-04-28 um 12 10 27" src="https://github.com/user-attachments/assets/eceb38f8-45e1-4acc-8972-2b54ef06605d" />

_Select project dialog:_
<img width="483" height="329" alt="Bildschirmfoto 2026-04-28 um 12 09 45" src="https://github.com/user-attachments/assets/9b40fbbc-c81a-4dd5-a766-aed2760e7ee2" />

_Error dialog on create process page:_
<img width="510" height="242" alt="Bildschirmfoto 2026-04-28 um 10 44 26" src="https://github.com/user-attachments/assets/98118d90-87eb-49fe-8ff0-b5d3b05c41ff" />
