### PR TITLE
Show process ID on task details page

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
@@ -15,7 +15,9 @@
         xmlns:h="http://xmlns.jcp.org/jsf/html"
         xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
         xmlns:p="http://primefaces.org/ui">
-    <p:dataTable var="item" value="#{TaskWorkView.task}">
+    <p:dataTable id="taskDetails"
+                 var="item"
+                 value="#{TaskWorkView.task}">
         <p:column headerText="#{msgs.title}">
             <h:outputText value="#{TaskWorkView.task.localizedTitle}"/>
         </p:column>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/currentTasksEdit/taskBoxDetails.xhtml
@@ -22,6 +22,9 @@
         <p:column headerText="#{msgs.processTitle}">
             <h:outputText value="#{item.process.title}"/>
         </p:column>
+        <p:column headerText="#{msgs.processId}">
+            <h:outputText value="#{item.process.id}"/>
+        </p:column>
         <p:column headerText="#{msgs.order}">
             <h:outputText value="#{item.ordering}"/>
         </p:column>

--- a/Kitodo/src/test/java/org/kitodo/selenium/ListingST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/ListingST.java
@@ -28,12 +28,15 @@ import org.kitodo.production.services.ServiceManager;
 import org.kitodo.selenium.testframework.BaseTestSelenium;
 import org.kitodo.selenium.testframework.Browser;
 import org.kitodo.selenium.testframework.Pages;
+import org.kitodo.selenium.testframework.pages.CurrentTasksEditPage;
 import org.kitodo.selenium.testframework.pages.DesktopPage;
 import org.kitodo.selenium.testframework.pages.ProcessesPage;
 import org.kitodo.selenium.testframework.pages.ProjectsPage;
 import org.kitodo.selenium.testframework.pages.TasksPage;
 import org.kitodo.selenium.testframework.pages.TemplateEditPage;
 import org.kitodo.selenium.testframework.pages.UsersPage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 public class ListingST extends BaseTestSelenium {
 
@@ -42,6 +45,7 @@ public class ListingST extends BaseTestSelenium {
     private static ProjectsPage projectsPage;
     private static TasksPage tasksPage;
     private static UsersPage usersPage;
+    private static CurrentTasksEditPage currentTasksEditPage;
 
     @BeforeAll
     public static void setup() throws Exception {
@@ -50,6 +54,7 @@ public class ListingST extends BaseTestSelenium {
         projectsPage = Pages.getProjectsPage();
         tasksPage = Pages.getTasksPage();
         usersPage = Pages.getUsersPage();
+        currentTasksEditPage = Pages.getCurrentTasksEditPage();
     }
 
     @BeforeEach
@@ -270,5 +275,36 @@ public class ListingST extends BaseTestSelenium {
         projectsPage.goToTemplateTab();
         projectsPage.toggleHiddenTemplates();
         assertEquals(2, projectsPage.getTemplateTitles().size(), "Wrong number of templates after toggling hidden templates");
+    }
+
+    /**
+     * Verify that all details are shown on the 'current task' page.
+     *
+     * @throws Exception when thread is interrupted or tasks cannot be loaded.
+     */
+    @Test
+    public void listCurrentTaskDetailsTest() throws Exception {
+        tasksPage.goTo().takeOpenTask("Open", "First process");
+        pollAssertTrue(() -> Browser.getDriver().findElement(By.id("tasksTabView")).isDisplayed());
+
+        // first check table headers
+        List<WebElement> taskDetailHeaders = Browser.getDriver().findElements(By.cssSelector("#tasksTabView\\:taskDetails_head th"));
+        assertEquals(6, taskDetailHeaders.size(), "Wrong number of task details headers");
+        assertEquals("Titel", taskDetailHeaders.get(0).getText(), "Wrong first task details header");
+        assertEquals("Vorgangstitel", taskDetailHeaders.get(1).getText(), "Wrong second task details header");
+        assertEquals("Vorgangs-ID", taskDetailHeaders.get(2).getText(), "Wrong third task details header");
+        assertEquals("Reihenfolge", taskDetailHeaders.get(3).getText(), "Wrong fourth task details header");
+        assertEquals("Korrektur", taskDetailHeaders.get(4).getText(), "Wrong fifth task details header");
+        assertEquals("Status", taskDetailHeaders.get(5).getText(), "Wrong sixth task details header");
+
+        // then check table contents
+        List<WebElement> taskDetails = Browser.getDriver().findElements(By.cssSelector("#tasksTabView\\:taskDetails td[role='gridcell']"));
+        assertEquals(6, taskDetails.size(), "Wrong number of task details");
+        assertEquals("Open", taskDetails.get(0).getText(), "Wrong task title");
+        assertEquals("First process", taskDetails.get(1).getText(), "Wrong process title");
+        assertEquals("1", taskDetails.get(2).getText(), "Wrong process ID");
+        assertEquals("4", taskDetails.get(3).getText(), "Wrong task order");
+        assertEquals("", taskDetails.get(4).getText(), "Wrong task correction status");
+        assertEquals("In Bearbeitung", taskDetails.get(5).getText(), "Wrong task status");
     }
 }


### PR DESCRIPTION
There have been quite a few times when I needed the ID of a specific process when self-assigning a task of that process, but the process ID wasn't displayed on the "current task details" page (where you are forwarded when clicking the "bell" button in the task list), which made things cumbersome. So I decided to add it:

<img width="1902" height="918" alt="Bildschirmfoto 2026-04-29 um 10 15 17" src="https://github.com/user-attachments/assets/fcccfb13-aea3-442f-87c0-1f3ad8cd95ad" />
