### PR TITLE
[3.9] Catch Count exception during indexing

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -175,6 +175,7 @@ public class IndexingService {
                     .where(f -> f.matchAll())
                     .fetchTotalHitCount();
         } catch (SearchException e) {
+            logger.debug("Search index temporarily unavailable during indexing initialization/rebuild.", e);
             // Index temporarily not available, just return 0
             return 0;
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -25,6 +25,7 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingMonitor;
+import org.hibernate.search.util.common.SearchException;
 import org.kitodo.data.database.beans.BaseBean;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.exceptions.DAOException;
@@ -170,8 +171,12 @@ public class IndexingService {
     public long getAllIndexed() {
         try (Session ormSession = HibernateUtil.getSession()) {
             SearchSession searchSession = Search.session(ormSession);
-            long allIndexed = searchSession.search(Process.class).where(f -> f.matchAll()).fetchTotalHitCount();
-            return allIndexed;
+            return searchSession.search(Process.class)
+                    .where(f -> f.matchAll())
+                    .fetchTotalHitCount();
+        } catch (SearchException e) {
+            // Index temporarily not available, just return 0
+            return 0;
         }
     }
 }


### PR DESCRIPTION
When indexing using the index page it might happen that an exception is thrown in the UI before the actual indexing begins. This is because before doing the indexing the destructive method `massIndexer.dropAndCreateSchemaOnStart(true);` is called which drops the index. When Kitodo tries to count in that moment, we get the Exception:

Request: GET /kitodo-process-read/_count with parameters {}
Response: 503 'Service Unavailable' from 'http://localhost:9200' with body 
{
  "error": {
    "root_cause": [
      {
        "type": "no_shard_available_action_exception",
        "reason": "[christoph-laptop][127.0.0.1:9300][indices:data/read/search[phase/query]]",
        "index_uuid": "AAMQB5gMQQO4L5tdDuXhAA",
        "shard": "0",
        "index": "kitodo-process-000001"
      }
    ],


When this exception is returned we can just return 0. 