### PR TITLE
[3.9] Fix search for number in search field

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -410,7 +410,9 @@ public class FilterService extends BaseBeanService<Filter, FilterDAO> {
         }
 
         Matcher idSearch = ID_SEARCH_PATTERN.matcher(value);
-        if (idSearch.matches() && !filterField.equals(FilterField.PROCESS_TITLE)) {
+        if (idSearch.matches()
+                && !filterField.equals(FilterField.PROCESS_TITLE)
+                && !filterField.equals(FilterField.SEARCH)) {
             return new DatabaseIdQueryPart(filterField, idSearch.group(1), idSearch.group(2), operand);
         }
 


### PR DESCRIPTION
When using a number in the top left search field, Kitodo 3.9.1 right now breaks, because Kitodo assumes an (database based) ID query which is not allowed for global search:

The condition to restrict the application of pure ID filter queries has to be extended to exclude search queries .

<img width="1764" height="507" alt="image" src="https://github.com/user-attachments/assets/73d89392-0f2b-499f-b51a-c91686c2f6d7" />
