### PR TITLE
[3.9] Fix layout of 'Add metadata' popup dialog on mass import page

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/addMetadata.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/massImport/dialogs/addMetadata.xhtml
@@ -38,6 +38,7 @@
                             <p:selectOneMenu id="metadataType"
                                              converter="#{processDetailConverter}"
                                              value="#{MassImportForm.addMetadataDialog.metadataDetail}"
+                                             autoWidth="false"
                                              title="#{msgs.type}">
                                 <f:selectItems value="#{MassImportForm.addMetadataDialog.allMetadataTypes}"
                                                var="metadataType"


### PR DESCRIPTION
Backport of #7040 for Kitodo.Production 3.9.x