### PR TITLE
Update commons-configuration2 to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <awaitility.version>4.0.3</awaitility.version>
         <com.h2database.h2.version>2.2.224</com.h2database.h2.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <commons-io.version>2.14.0</commons-io.version>
+        <commons-io.version>2.22.0</commons-io.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-net.version>3.9.0</commons-net.version>
         <font-awesome.version>4.7.0</font-awesome.version>
@@ -171,7 +171,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.10.1</version>
+                <version>2.15.0</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Commons-configuration2 2.15.0 need at least commons-io 2.17.0 and commons-io switched from optional to required dependency for commons-configuration2. This should be fixed in commons-configuration2 version 2.15.1 (or later).

Supersede https://github.com/kitodo/kitodo-production/pull/7045