### PR TITLE
Use commons-collections4

### DIFF
--- a/Kitodo-DataManagement/pom.xml
+++ b/Kitodo-DataManagement/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Process.java
@@ -35,7 +35,7 @@ import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.LazyInitializationException;
 import org.hibernate.annotations.BatchSize;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Project.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Project.java
@@ -36,7 +36,7 @@ import jakarta.persistence.PostLoad;
 import jakarta.persistence.PostUpdate;
 import jakarta.persistence.Table;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hibernate.LazyInitializationException;
 import org.kitodo.data.database.enums.PreviewHoverMode;
 import org.kitodo.data.database.persistence.FolderDAO;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Template.java
@@ -28,7 +28,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.kitodo.data.database.persistence.TemplateDAO;
 
 @Entity

--- a/pom.xml
+++ b/pom.xml
@@ -348,16 +348,6 @@ from system library in Java 11+ -->
                 <groupId>org.apache.myfaces.core</groupId>
                 <artifactId>myfaces-impl</artifactId>
                 <version>${myfaces.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-beanutils</groupId>
-                        <artifactId>commons-beanutils</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-collections</groupId>
-                        <artifactId>commons-collections</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,9 +164,9 @@
                 <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Used dependency `org.apache.poi:poi-ooxml` already used `commons-collections4` but our code was still using old `commons-collections`. Switching to new `commons-collection4` is more or less an in-place change.

I removed the exclusion entry for `myfaces-impl` as both exclusions are not valid anymore and one of them was the old `commons-collections