### PR TITLE
Fix use of returnless function in `scroll.js`

### DIFF
--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/scroll.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/scroll.js
@@ -63,7 +63,7 @@ var scrollUp = function (elementID, triggerCompleteFunction) {
     if (triggerCompleteFunction) {
         scrollableContent.animate({
             scrollTop: scrollableContent.scrollTop() - SCROLL_SPEED
-        }, 90, null, checkScrollPosition(scrollableContent));
+        }, 90, null, () => checkScrollPosition(scrollableContent));
     } else {
         scrollableContent.animate({
             scrollTop: scrollableContent.scrollTop() - SCROLL_SPEED
@@ -76,7 +76,7 @@ var scrollDown = function (elementID, triggerCompleteFunction) {
     if (triggerCompleteFunction) {
         scrollableContent.animate({
             scrollTop: scrollableContent.scrollTop() + SCROLL_SPEED
-        }, 90, null, checkScrollPosition(scrollableContent));
+        }, 90, null, () => checkScrollPosition(scrollableContent));
     } else {
         scrollableContent.animate({
             scrollTop: scrollableContent.scrollTop() + SCROLL_SPEED


### PR DESCRIPTION
This PR fixes the use of a returnless method as a callback function in the file `scroll.js`.

Reported by CodeQL: "_the function checkScrollPosition does not return anything, yet the return value is used._"

