### PR TITLE
Fix empty list columns when creating new client

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/ClientEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ClientEditView.java
@@ -49,6 +49,7 @@ public class ClientEditView extends BaseEditView {
     @PostConstruct
     public void init() {
         client = new Client();
+        client.setListColumns(ServiceManager.getListColumnService().getAllStandardListColumns());
         rolesForClient = new ArrayList<>();
         try {
             allClients = ServiceManager.getClientService().getAll();

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ClientEditViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ClientEditViewIT.java
@@ -79,7 +79,7 @@ public class ClientEditViewIT {
      * Test that when creating new clients, standard list columns are assigned.
      */
     @Test
-    public void testListColumnsForNewClients() throws Exception {
+    public void testListColumnsForNewClients() {
         ClientEditView clientEditView = new ClientEditView();
         clientEditView.init();
         

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ClientEditViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ClientEditViewIT.java
@@ -12,17 +12,19 @@
 package org.kitodo.production.forms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kitodo.MockDatabase;
+import org.kitodo.data.database.beans.ListColumn;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
 
 public class ClientEditViewIT {
-
-    private final ClientEditView clientEditView = new ClientEditView();
 
     /**
      * Setup Database and start elasticsearch.
@@ -51,6 +53,7 @@ public class ClientEditViewIT {
      */
     @Test
     public void testRoleAdding() throws DAOException {
+        ClientEditView clientEditView = new ClientEditView();
         clientEditView.load(1);
         int numberOfRolesForFirstClient = ServiceManager.getRoleService().getAllRolesByClientId(1).size();
         final int numberOfAuthoritiesToCopy = ServiceManager.getRoleService().getAllRolesByClientId(2).getFirst().getAuthorities()
@@ -71,5 +74,17 @@ public class ClientEditViewIT {
         assertEquals(11, numberOfRolesForFirstClient, "Role was not added");
         assertEquals(numberOfOldAuthorities, numberOfNewAuthorities, "Authorities were not added");
         assertEquals(numberOfAuthoritiesToCopy, numberOfOldAuthorities, "Authorities were removed from second client");
+    }
+
+    /**
+     * Test that when creating new clients, standard list columns are assigned.
+     */
+    @Test
+    public void testListColumnsForNewClients() throws Exception {
+        ClientEditView clientEditView = new ClientEditView();
+        clientEditView.init();
+        
+        List<ListColumn> standardListColumns = ServiceManager.getListColumnService().getAllStandardListColumns();
+        assertEquals(clientEditView.getClient().getListColumns(), standardListColumns);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ClientEditViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ClientEditViewIT.java
@@ -12,7 +12,6 @@
 package org.kitodo.production.forms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 


### PR DESCRIPTION
This PR fixes the problem that no list columns are assigned when creating a new client. This problem was probably introduced by #6770, which misses this line in the new `ClientEditView.java`: https://github.com/kitodo/kitodo-production/blob/ee7cb3fe62ab49f926dd88dd637c32de25113d5c/Kitodo/src/main/java/org/kitodo/production/forms/ClientForm.java#L95

This PR is related to:
- #7046
- #7060 