### PR TITLE
Prevent invalid folder settings in the UI

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Folder.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/Folder.java
@@ -456,6 +456,18 @@ public class Folder extends BaseBean {
         this.ltpValidationConfiguration = ltpValidationConfiguration;
     }
 
+    /**
+     * Returns whether image generation is configured for this folder.
+     *
+     * @return whether image generation is configured
+     */
+    @Transient
+    public boolean isGeneratedImageFolder() {
+        return Objects.nonNull(derivative)
+                || Objects.nonNull(dpi)
+                || Objects.nonNull(imageSize);
+    }
+
     @Override
     public boolean equals(Object object) {
         if (this == object) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -556,6 +556,34 @@ public class ProjectEditView extends BaseEditView {
     }
 
     /**
+     * Returns the selectable folders for the generator source.
+     *
+     * @return selectable folders for the generator source
+     */
+    public List<SelectItem> getSelectableGeneratorSourceFolders() {
+        return getFolderList().stream()
+                .map(folder -> {
+                    SelectItem item = new SelectItem(
+                            toUiFileGroup(folder.getFileGroup()),
+                            folder.toString());
+                    item.setDisabled(folder.isGeneratedImageFolder());
+                    return item;
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns whether the folder currently being edited is the configured generator source.
+     *
+     * @return whether the edited folder is the configured generator source
+     */
+    public boolean isGeneratorSourceFolder() {
+        return Objects.nonNull(editingFolder)
+                && Objects.nonNull(project.getGeneratorSource())
+                && editingFolder == project.getGeneratorSource();
+    }
+
+    /**
      * Checks if folder list contains audio folder.
      *
      * @return true if folder list contains audio folder

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -559,6 +559,33 @@ public class ProjectEditView extends BaseEditView {
     }
 
     /**
+     * Returns the selectable folders for the generator source.
+     *
+     * @return selectable folders for the generator source
+     */
+    public List<SelectItem> getSelectableGeneratorSourceFolders() {
+        return getFolderList().stream()
+                .map(folder -> {
+                    SelectItem item = new SelectItem(
+                            toUiFileGroup(folder.getFileGroup()),
+                            folder.toString());
+                    item.setDisabled(folder.isGeneratedImageFolder());
+                    return item;
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns whether the folder currently being edited is the configured generator source.
+     *
+     * @return whether the edited folder is the configured generator source
+     */
+    public boolean isGeneratorSourceFolder() {
+        return Objects.nonNull(editingFolder)
+            && editingFolder == project.getGeneratorSource();
+    }
+
+    /**
      * Checks if folder list contains audio folder.
      *
      * @return true if folder list contains audio folder

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMets.xhtml
@@ -244,7 +244,7 @@
                              disabled="#{ProjectEditView.locked}">
                 <f:selectItem itemLabel="#{msgs['folderUse.generatorSource.disabled']}" itemValue="#{null}"
                               noSelectionOption="true"/>
-                <f:selectItems value="#{ProjectEditView.selectableFolders}"/>
+                <f:selectItems value="#{ProjectEditView.selectableGeneratorSourceFolders}"/>
                 <p:ajax event="change" oncomplete="toggleSave()"/>
             </p:selectOneMenu>
 

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMetsPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMetsPopup.xhtml
@@ -65,7 +65,9 @@
                         <p:row>
                             <p:column styleClass="half-width">
                                 <p:outputLabel for="generator" value="#{msgs['editFolderDialog.generator']}"/>
-                                <p:selectOneMenu id="generator" value="#{ProjectEditView.generator.method}">
+                                <p:selectOneMenu id="generator"
+                                                 value="#{ProjectEditView.generator.method}"
+                                                 disabled="#{ProjectEditView.generatorSourceFolder}">
                                     <f:selectItem itemLabel="#{msgs.notSelected}" itemValue=""/>
                                     <f:selectItem itemLabel="#{msgs['editFolderDialog.generator.dpi']}"
                                                   itemValue="changeDpi"/>

--- a/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMetsPopup.xhtml
+++ b/Kitodo/src/main/webapp/WEB-INF/templates/includes/projectEdit/projectEditMetsPopup.xhtml
@@ -65,14 +65,18 @@
                         <p:row>
                             <p:column styleClass="half-width">
                                 <p:outputLabel for="generator" value="#{msgs['editFolderDialog.generator']}"/>
-                                <p:selectOneMenu id="generator" value="#{ProjectEditView.generator.method}">
+                                <p:selectOneMenu id="generator"
+                                                 value="#{ProjectEditView.generator.method}">
                                     <f:selectItem itemLabel="#{msgs.notSelected}" itemValue=""/>
                                     <f:selectItem itemLabel="#{msgs['editFolderDialog.generator.dpi']}"
-                                                  itemValue="changeDpi"/>
+                                                  itemValue="changeDpi"
+                                                  itemDisabled="#{ProjectEditView.generatorSourceFolder}"/>
                                     <f:selectItem itemLabel="#{msgs['editFolderDialog.generator.derivative']}"
-                                                  itemValue="createDerivative"/>
+                                                  itemValue="createDerivative"
+                                                  itemDisabled="#{ProjectEditView.generatorSourceFolder}"/>
                                     <f:selectItem itemLabel="#{msgs['editFolderDialog.generator.imageSize']}"
-                                                  itemValue="getSizedWebImage"/>
+                                                  itemValue="getSizedWebImage"
+                                                  itemDisabled="#{ProjectEditView.generatorSourceFolder}"/>
                                     <p:ajax process="@form" update="@form"/>
                                 </p:selectOneMenu>
                             </p:column>


### PR DESCRIPTION
This Pull Request adresses the UI related parts of the problems described in https://github.com/kitodo/kitodo-production/issues/6680 by preventing invalid values.

Two things are prevented:

a) A folder configured as source for image generation can not at the same time have its images generated:

<img width="629" height="98" alt="image" src="https://github.com/user-attachments/assets/1054a397-19fc-4791-8bca-69d197d091f7" />

<img width="663" height="452" alt="image" src="https://github.com/user-attachments/assets/abbf6168-da2a-44bd-ad70-b1f0d71ee8bd" />

b) A folder which images are generated from another source cannot be setup to be used as a source for image generation. 

<img width="711" height="761" alt="image" src="https://github.com/user-attachments/assets/76459c2f-a01e-460f-b126-0b50fbd5852d" />

<img width="621" height="215" alt="image" src="https://github.com/user-attachments/assets/37003d9d-2d79-4707-9c8d-ed9c873b8a75" />

Configurations which were invalid before can still be edited, but if they are changed they can only be changed to a valid configuration.
