### PR TITLE
[3.9] Harden XMLUtils EAD/XML upload parsers against XXE

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
@@ -60,6 +60,10 @@ import org.xml.sax.SAXException;
  */
 public class XMLUtils {
 
+    private static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+
     /**
      * Private constructor to hide the implicit public one.
      */
@@ -291,10 +295,6 @@ public class XMLUtils {
         }
         return count;
     }
-
-    private static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
-    private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
-    private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
 
     /**
      * Disable DOCTYPE declarations and external entity resolution on the given

--- a/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/XMLUtils.java
@@ -179,6 +179,7 @@ public class XMLUtils {
             SAXException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
+        disableExternalEntities(factory);
         DocumentBuilder builder = factory.newDocumentBuilder();
         xmlString = removeBom(xmlString);
         return builder.parse(new InputSource(new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8))));
@@ -276,6 +277,8 @@ public class XMLUtils {
     public static int getNumberOfEADElements(String xmlString, String eadLevel) throws XMLStreamException {
         int count = 0;
         XMLInputFactory factory = XMLInputFactory.newInstance();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(xmlString));
         while (reader.hasNext()) {
             int event = reader.next();
@@ -289,4 +292,25 @@ public class XMLUtils {
         return count;
     }
 
+    private static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+
+    /**
+     * Disable DOCTYPE declarations and external entity resolution on the given
+     * factory to prevent XML External Entity (XXE) injection. This mirrors the
+     * secure configuration already used by {@link #load(InputStream)} and the
+     * external-catalog response parsers.
+     *
+     * @param factory the DocumentBuilderFactory to harden
+     * @throws ParserConfigurationException if a feature cannot be set
+     */
+    private static void disableExternalEntities(DocumentBuilderFactory factory) throws ParserConfigurationException {
+        factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+        factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+        factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+    }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
@@ -91,10 +91,7 @@ public class XMLUtilsTest {
 
     @Test
     public void parseXMLStringShouldNotResolveExternalEntities() throws Exception {
-        Path secretPath = Files.createTempFile("xxe-canary", ".txt");
-        File secret = secretPath.toFile();
-        secret.deleteOnExit();
-        Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));
+        File secret = createTestFile();
         String payload = "<?xml version=\"1.0\"?>\n"
                 + "<!DOCTYPE foo [ <!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>\n"
                 + "<foo>&xxe;</foo>";
@@ -107,10 +104,7 @@ public class XMLUtilsTest {
 
     @Test
     public void getNumberOfEADElementsShouldNotResolveExternalEntities() throws Exception {
-        Path secretPath = Files.createTempFile("xxe-canary", ".txt");
-        File secret = secretPath.toFile();
-        secret.deleteOnExit();
-        Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));
+        File secret = createTestFile();
         String payload = "<?xml version=\"1.0\"?>\n"
                 + "<!DOCTYPE ead [ <!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>\n"
                 + "<ead><c level=\"file\">&xxe;</c></ead>";
@@ -130,5 +124,13 @@ public class XMLUtilsTest {
         XPathExpressionException exception = Assertions.assertThrows(XPathExpressionException.class,
                 () -> XMLUtils.validateXPathSyntax(INVALID_XPATH));
         Assertions.assertEquals(EXPECTED_EXCEPTION_MESSAGE, exception.getMessage());
+    }
+
+    private File createTestFile() throws IOException {
+        Path secretPath = Files.createTempFile("xxe-canary", ".txt");
+        File secret = secretPath.toFile();
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));
+        return secret;
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
@@ -19,14 +19,18 @@ import org.kitodo.production.model.bibliography.course.Course;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
+import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Locale;
 
 public class XMLUtilsTest {
@@ -82,6 +86,35 @@ public class XMLUtilsTest {
     @Test
     public void shouldParseXMLString() {
         Assertions.assertDoesNotThrow(() -> XMLUtils.parseXMLString(XML_STRING));
+    }
+
+    @Test
+    public void parseXMLStringShouldNotResolveExternalEntities() throws Exception {
+        File secret = File.createTempFile("xxe-canary", ".txt");
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));
+        String payload = "<?xml version=\"1.0\"?>\n"
+                + "<!DOCTYPE foo [ <!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>\n"
+                + "<foo>&xxe;</foo>";
+        // With DOCTYPE declarations disallowed, parsing must fail rather than
+        // expand the external entity and disclose the file content.
+        SAXException exception = Assertions.assertThrows(SAXException.class,
+                () -> XMLUtils.parseXMLString(payload));
+        Assertions.assertFalse(exception.getMessage().contains("XXE-CANARY-SECRET"));
+    }
+
+    @Test
+    public void getNumberOfEADElementsShouldNotResolveExternalEntities() throws Exception {
+        File secret = File.createTempFile("xxe-canary", ".txt");
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));
+        String payload = "<?xml version=\"1.0\"?>\n"
+                + "<!DOCTYPE ead [ <!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>\n"
+                + "<ead><c level=\"file\">&xxe;</c></ead>";
+        // With DTD support disabled, the StAX reader must reject the DOCTYPE
+        // instead of resolving the external entity.
+        Assertions.assertThrows(XMLStreamException.class,
+                () -> XMLUtils.getNumberOfEADElements(payload, "file"));
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.kitodo.production.model.bibliography.course.Course;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -44,6 +45,9 @@ public class XMLUtilsTest {
     private static final String EXPECTED_EXCEPTION_MESSAGE = "javax.xml.transform.TransformerException: "
             + "A location step was expected following the '/' or '//' token.";
     private static Locale originalDefaultLocale;
+
+    @TempDir
+    Path tempDir;
 
     @BeforeAll
     public static void setLocaleToEnglish() {
@@ -127,7 +131,7 @@ public class XMLUtilsTest {
     }
 
     private File createTestFile() throws IOException {
-        Path secretPath = Files.createTempFile("xxe-canary", ".txt");
+        Path secretPath = Files.createTempFile(tempDir, "xxe-canary", ".txt");
         File secret = secretPath.toFile();
         secret.deleteOnExit();
         Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));

--- a/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/XMLUtilsTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
 
 public class XMLUtilsTest {
@@ -90,7 +91,8 @@ public class XMLUtilsTest {
 
     @Test
     public void parseXMLStringShouldNotResolveExternalEntities() throws Exception {
-        File secret = File.createTempFile("xxe-canary", ".txt");
+        Path secretPath = Files.createTempFile("xxe-canary", ".txt");
+        File secret = secretPath.toFile();
         secret.deleteOnExit();
         Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));
         String payload = "<?xml version=\"1.0\"?>\n"
@@ -105,7 +107,8 @@ public class XMLUtilsTest {
 
     @Test
     public void getNumberOfEADElementsShouldNotResolveExternalEntities() throws Exception {
-        File secret = File.createTempFile("xxe-canary", ".txt");
+        Path secretPath = Files.createTempFile("xxe-canary", ".txt");
+        File secret = secretPath.toFile();
         secret.deleteOnExit();
         Files.write(secret.toPath(), "XXE-CANARY-SECRET".getBytes(StandardCharsets.UTF_8));
         String payload = "<?xml version=\"1.0\"?>\n"


### PR DESCRIPTION
The parseXMLString and getNumberOfEADElements helpers built their JAXP factories with the default configuration, which resolves external entities and external DTDs. These helpers parse XML uploaded through the Create-process file-upload dialog, so a crafted document allowed local file disclosure and outbound SSRF (XXE / CWE-611).

Disable DOCTYPE declarations and external entity resolution on both factories, reusing the same secure configuration the load() and newDocument() siblings and the external-catalog response parsers (XmlResponseHandler, QueryURLImport) already apply. Add regression tests that confirm the two entry points reject a DOCTYPE / external-entity payload instead of expanding it.

Credit: @tonghuaroot