### PR TITLE
Remove custom Chrome installation from Github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,6 @@ jobs:
     runs-on: ubuntu-24.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: update chrome to latest stable
-        run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-          sudo apt-get update
-          sudo apt-get --only-upgrade install google-chrome-stable
-
       - name: install imagemagick (convert command required by kitodo-image-management)
         run: |
           sudo apt-get update


### PR DESCRIPTION
Since some time we experience build failures in the current Main branch. Those build failures also appear for older commits which never failed during CI before. 

While inspecting the CI logs i noticed the following message:

>2026-06-07T20:42:58.7946983Z WARNING: The chromedriver version (148.0.7778.178) detected in PATH at /usr/bin/chromedriver might not be compatible with the detected chrome version (149.0.7827.53); currently, chromedriver 149.0.7827.54 is recommended for chrome 149.*, so it is advised to delete the driver in PATH and retry 

It seems like those version differences between the chrome browser and the chromedriver lead to Selenium/UI interaction failures during test execution which let the Selenium tests for searching fail (`SearchingST`):

> 2026-06-07T20:44:03.8789246Z [ERROR] 2026-06-07 20:44:03.798 [main] Page - Clicking on button with id search-form:search was not successful. Retrying now.
2026-06-07T20:45:05.2561926Z [ERROR] 2026-06-07 20:45:05.188 [main] Page - Clicking on button with id search-form:search was not successful. Retrying now. 

Our current Github workflow manually installs/updates the Chrome binary, which seems to lead to the version problems above:

https://github.com/kitodo/kitodo-production/blob/d0675458a87a3e4f698629abf9afd171ffb61a8f/.github/workflows/main.yml#L25-L28

Since PR https://github.com/kitodo/kitodo-production/pull/6947 we delegated a lot of the setup for the Selenium tests to the Selenium engine, which is capable of managing the whole stack now:

> Automated browser management
> TL;DR: Selenium Manager automatically discovers, downloads, and caches the browsers driven with Selenium (Chrome, Firefox, and Edge) when these browsers are not installed in the local system.
> As of Selenium 4.11.0, Selenium Manager also implements automated browser management. With this feature, Selenium Manager allows us to discover, download, and cache the different browser releases, making them seamlessly available for Selenium. Internally, Selenium Manager uses an equivalent management procedure explained in the section before, but this time, for browser releases.

https://www.selenium.dev/documentation/selenium_manager/#automated-browser-management

The manual update of the Chrome browser in the Github workflow is an artefact of the old manual way to manage these dependencies and it seems like that it can lead to version conflicts. I therefore removed the manual install in the workflow.


