### PR TITLE
[3.9] Fix duplicate LTP validation configuration retrieval in Hibernate 5

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LtpValidationConfigurationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LtpValidationConfigurationService.java
@@ -50,7 +50,7 @@ public class LtpValidationConfigurationService
     }
 
     /**
-     * Return a ltp validation configuration for a specific id but also load the list of attched folders,
+     * Return a ltp validation configuration for a specific id but also load the list of attached folders,
      * which is not loaded by default due to the lazy fetch strategy.
      * 
      * @param id the id of the validation configuration that is supposed to be loaded
@@ -58,8 +58,10 @@ public class LtpValidationConfigurationService
      * @throws DAOException in case something goes wrong
      */
     public LtpValidationConfiguration getByIdWithFolders(int id) throws DAOException {
+        // DISTINCT is required for Hibernate 5.x because a fetch join on the folders
+        // collection may otherwise return the same configuration multiple times.
         List<LtpValidationConfiguration> results = dao.getByQuery(
-            "SELECT c FROM LtpValidationConfiguration c LEFT JOIN FETCH c.folders WHERE c.id = :id", 
+            "SELECT DISTINCT c FROM LtpValidationConfiguration c LEFT JOIN FETCH c.folders WHERE c.id = :id",
             Collections.singletonMap("id", id)
         );
         if (results.size() != 1) {


### PR DESCRIPTION
Fixes: https://github.com/kitodo/kitodo-production/issues/7065