### PR TITLE
Fix 'main' not building on Windows

### DIFF
--- a/Kitodo/src/test/resources/scripts/exit0_with_stderr.bat
+++ b/Kitodo/src/test/resources/scripts/exit0_with_stderr.bat
@@ -1,0 +1,14 @@
+::
+:: (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+::
+:: This file is part of the Kitodo project.
+::
+:: It is licensed under GNU General Public License version 3 or later.
+::
+:: For the full copyright and license information, please read the
+:: GPL3-License.txt file that was distributed with this source code.
+::
+@ECHO OFF
+
+ECHO Test StdOut output
+1>&2 ECHO Test StdErr output

--- a/Kitodo/src/test/resources/scripts/exit1_with_stderr.bat
+++ b/Kitodo/src/test/resources/scripts/exit1_with_stderr.bat
@@ -1,0 +1,15 @@
+::
+:: (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+::
+:: This file is part of the Kitodo project.
+::
+:: It is licensed under GNU General Public License version 3 or later.
+::
+:: For the full copyright and license information, please read the
+:: GPL3-License.txt file that was distributed with this source code.
+::
+@ECHO OFF
+
+ECHO Test StdOut output
+1>&2 ECHO Test StdErr output
+EXIT /B 1


### PR DESCRIPTION
'main' is not building on Windows because two BAT scripts were missing as test resources. This PR adds the missing scripts.

Fixes #6771