### PR TITLE
Submit search terms in Selenium Test using Enter Key and harden further Selenium tests

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/Page.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/Page.java
@@ -23,8 +23,8 @@ import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kitodo.selenium.testframework.Browser;
-import org.kitodo.selenium.testframework.Pages;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
@@ -285,6 +285,6 @@ public abstract class Page<T> {
     public void searchInSearchField(String query) throws Exception {
         searchField.clear();
         searchField.sendKeys(query);
-        clickButtonAndWaitForRedirect(searchButton, Pages.getProcessesPage().getUrl());
+        searchField.sendKeys(Keys.ENTER);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProjectsPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProjectsPage.java
@@ -344,8 +344,18 @@ public class ProjectsPage extends Page<ProjectsPage> {
 
     public List<String> getTemplateDetails() {
         int index = triggerRowToggle(templatesTable, "Fourth template");
-        WebElement detailsTable = Browser.getDriver()
-                .findElement(By.id(TEMPLATE_TABLE + ":" + index + ":templateRowExpansionTable"));
+        String elementId =
+                TEMPLATE_TABLE + ":" + index + ":templateRowExpansionTable";
+        await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() ->
+                        assertTrue(
+                                Browser.getDriver()
+                                        .findElement(By.id(elementId))
+                                        .isDisplayed()));
+        WebElement detailsTable =
+                Browser.getDriver().findElement(By.id(elementId));
+
         return getGridData(detailsTable);
     }
 


### PR DESCRIPTION
The Searching Selenium Tests (`SearchingST`) are still flaky in CI  (Locally not reproducable). Instrumentation showed several failing runs where Selenium successfully entered text into the search field and clicked the search button, but the backing JSF action `SearchResultForm.searchForProcessesBySearchQuery()` was never invoked. (Especially when CI uses Chrome 149 - always fails -, with Chrome 148 this is more stable - mostly succeeds -. Github sometimes uses 148 and sometimes 149)

I suspect that this might be caused by a failed execution of the search form (combining an `disabled` attribute and an update action on "keyup") which might be affected by race conditions, although i could not really nail down the root cause. 

https://github.com/kitodo/kitodo-production/blob/d8e68f13d45445262ef3a99c6f4506a95b6492b5/Kitodo/src/main/webapp/WEB-INF/templates/includes/header/search.xhtml#L28-L37

This PR tries to adress this by using the Enter key to submit the form. In addition to that another Selenium accessor method is made more resilient.

