### PR TITLE
Add missing final modifier to enum and static fields

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/config/enums/KitodoConfigFile.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/enums/KitodoConfigFile.java
@@ -38,8 +38,8 @@ public enum KitodoConfigFile {
      */
     LOGIN_BLACKLIST("kitodo_loginBlacklist.txt");
 
-    private String name;
-    private File file;
+    private final String name;
+    private final File file;
 
     /**
      * Private constructor for KitodoConfigFile enum.

--- a/Kitodo-API/src/main/java/org/kitodo/config/enums/ParameterAPI.java
+++ b/Kitodo-API/src/main/java/org/kitodo/config/enums/ParameterAPI.java
@@ -34,7 +34,7 @@ public enum ParameterAPI implements ParameterInterface {
      */
     DIR_XML_CONFIG("directory.config");
 
-    private String name;
+    private final String name;
 
     /**
      * Private constructor to hide the implicit public one.

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/config/enums/ParameterDataEditor.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/config/enums/ParameterDataEditor.java
@@ -15,7 +15,7 @@ public enum ParameterDataEditor implements ParameterInterface {
 
     METS_EDITOR_DEFAULT_PAGINATION("MetsEditorDefaultPagination");
 
-    private String name;
+    private final String name;
 
     /**
      * Private constructor to hide the implicit public one.

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoConverter.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoConverter.java
@@ -36,7 +36,8 @@ import org.kitodo.utils.JAXBContextCache;
 public class MetsKitodoConverter {
 
     private static final Logger logger = LogManager.getLogger(MetsKitodoConverter.class);
-    private static FileManagementInterface fileManagementModule = new KitodoServiceLoader<>(FileManagementInterface.class).loadModule();
+    private static final FileManagementInterface fileManagementModule = new KitodoServiceLoader<>(
+            FileManagementInterface.class).loadModule();
 
     /**
      * Private constructor to hide the implicit public one.

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/VersionProvider.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/VersionProvider.java
@@ -26,7 +26,7 @@ import org.kitodo.dataformat.DataFormatVersionProvider;
  * Provides methods to get information about module or data format.
  */
 public class VersionProvider {
-    private static DataFormatVersionProvider dataFormatVersionProvider = new DataFormatVersionProvider();
+    private static final DataFormatVersionProvider dataFormatVersionProvider = new DataFormatVersionProvider();
     private static final Logger logger = LogManager.getLogger(VersionProvider.class);
 
     /**

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/PasswordEncryption.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/PasswordEncryption.java
@@ -19,8 +19,8 @@ public enum PasswordEncryption {
     SHA(0, "SHA"),
     MD5(1, "MD5");
 
-    private int value;
-    private String title;
+    private final int value;
+    private final String title;
 
     /**
      * Private constructor, initializes integer value.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/PropertyType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/PropertyType.java
@@ -24,8 +24,8 @@ public enum PropertyType {
     MESSAGE_ERROR(4, "messageError"),
     STRING(5, "String");
 
-    private int id;
-    private String name;
+    private final int id;
+    private final String name;
 
     PropertyType(int id, String inName) {
         this.id = id;

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/TaskEditType.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/TaskEditType.java
@@ -50,8 +50,8 @@ public enum TaskEditType {
      */
     QUEUE(5, "queue");
 
-    private int value;
-    private String title;
+    private final int value;
+    private final String title;
 
     /**
      * Private constructor, initializes integer value and title.

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/TaskStatus.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/enums/TaskStatus.java
@@ -34,9 +34,9 @@ public enum TaskStatus {
      */
     DONE(3, "statusDone", "stepdone");
 
-    private int value;
-    private String title;
-    private String searchString;
+    private final int value;
+    private final String title;
+    private final String searchString;
 
     /**
      * Private constructor, initializes integer value, title and big

--- a/Kitodo-FileManagement/src/main/java/org/kitodo/config/enums/ParameterFileManagement.java
+++ b/Kitodo-FileManagement/src/main/java/org/kitodo/config/enums/ParameterFileManagement.java
@@ -22,7 +22,7 @@ public enum ParameterFileManagement implements ParameterInterface {
     CREATE_SOURCE_FOLDER("createSourceFolder"),
     FILE_MAX_WAIT_MILLISECONDS("file.maxWaitMilliseconds");
 
-    private String name;
+    private final String name;
 
     /**
      * Private constructor to hide the implicit public one.

--- a/Kitodo-ImageManagement/src/main/java/org/kitodo/config/enums/ParameterImageManagement.java
+++ b/Kitodo-ImageManagement/src/main/java/org/kitodo/config/enums/ParameterImageManagement.java
@@ -18,7 +18,7 @@ public enum ParameterImageManagement implements ParameterInterface {
     TIMEOUT_SEC("ImageManagement.timeoutSec"),
     SSH_HOST("ImageManagement.sshHosts");
 
-    private String name;
+    private final String name;
 
     /**
      * Private constructor to hide the implicit public one.


### PR DESCRIPTION
- Add final to VersionProvider.dataFormatVersionProvider
- Add final to MetsKitodoConverter.fileManagementModule
- Add final to PasswordEncryption.value and PasswordEncryption.title
- Add final to PropertyType.id and PropertyType.name
- Add final to TaskEditType.value and TaskEditType.title
- Add final to TaskStatus.value, TaskStatus.title and TaskStatus.searchString
- Add final to KitodoConfigFile.name and KitodoConfigFile.file
- Add final to ParameterAPI.name
- Add final to ParameterDataEditor.name
- Add final to ParameterFileManagement.name
- Add final to ParameterImageManagement.name

Assisted-by: OpenCode + minimax-m2.7 (MiniMax)