### PR TITLE
ci: Replace Java distribution adopt by temurin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: run build
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: check java version
         run:
             java --version


### PR DESCRIPTION
This fixes build notices:

    AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions
    please consider changing to the 'temurin' distribution type in your setup-java configuration.