### PR TITLE
Fix project deletion

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProjectService.java
@@ -330,6 +330,6 @@ public class ProjectService extends BaseBeanService<Project, ProjectDAO> {
             template.getProjects().remove(project);
             ServiceManager.getTemplateService().save(template);
         }
-        ServiceManager.getProjectService().remove(project);
+        ServiceManager.getProjectService().remove(projectID);
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ProcessListViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ProcessListViewIT.java
@@ -11,8 +11,12 @@
 
 package org.kitodo.production.forms;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Date;
 import java.time.LocalDate;
@@ -27,10 +31,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
+import org.kitodo.data.database.beans.Folder;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.Template;
+import org.kitodo.data.database.beans.User;
+import org.kitodo.data.database.enums.LinkingMode;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.enums.ProcessState;
@@ -137,5 +144,109 @@ public class ProcessListViewIT {
 
         Process updated = ServiceManager.getProcessService().getById(process.getId());
         assertNotEquals(ProcessState.COMPLETED.getValue(), updated.getSortHelperStatus());
+    }
+
+    @Test
+    public void shouldDeleteSimpleProjectFromListView() throws Exception {
+        Project project = new Project();
+        project.setTitle("Simple project to delete");
+        ServiceManager.getProjectService().save(project);
+
+        int projectId = project.getId();
+
+        assertEquals(projectId, ServiceManager.getProjectService().getById(projectId).getId());
+
+        ProjectListView projectListView = new ProjectListView();
+
+        assertDoesNotThrow(() -> projectListView.delete(projectId));
+
+        assertThrows(DAOException.class, () -> ServiceManager.getProjectService().getById(projectId));
+    }
+
+    @Test
+    public void shouldDeleteProjectWithTemplateFoldersAndUsersFromListView() throws Exception {
+        User user = ServiceManager.getUserService().getById(1);
+
+        Project project = new Project();
+        project.setTitle("Complex project to delete");
+        project.setClient(ServiceManager.getClientService().getById(1));
+        project.getUsers().add(user);
+        ServiceManager.getProjectService().save(project);
+
+        user.getProjects().add(project);
+        ServiceManager.getUserService().save(user);
+
+        Template template = new Template();
+        template.setTitle("Template of complex project to delete");
+        template.setClient(project.getClient());
+        template.setDocket(ServiceManager.getDocketService().getById(1));
+        template.setRuleset(ServiceManager.getRulesetService().getById(1));
+        template.getProjects().add(project);
+        ServiceManager.getTemplateService().save(template);
+
+        project.getTemplates().add(template);
+
+        Folder mediaFolder = new Folder();
+        mediaFolder.setFileGroup("DEFAULT");
+        mediaFolder.setMimeType("image/jpeg");
+        mediaFolder.setPath("images/default");
+        mediaFolder.setCopyFolder(true);
+        mediaFolder.setCreateFolder(true);
+        mediaFolder.setLinkingMode(LinkingMode.ALL);
+        mediaFolder.setProject(project);
+        project.getFolders().add(mediaFolder);
+        project.setMediaView(mediaFolder);
+
+        Folder sourceFolder = new Folder();
+        sourceFolder.setFileGroup("SOURCE");
+        sourceFolder.setMimeType("image/tiff");
+        sourceFolder.setPath("images/source");
+        sourceFolder.setCopyFolder(false);
+        sourceFolder.setCreateFolder(true);
+        sourceFolder.setLinkingMode(LinkingMode.NO);
+        sourceFolder.setProject(project);
+        project.getFolders().add(sourceFolder);
+        project.setGeneratorSource(sourceFolder);
+
+        ServiceManager.getProjectService().save(project);
+
+        int projectId = project.getId();
+        int userId = user.getId();
+        int templateId = template.getId();
+
+        Project savedProject = ServiceManager.getProjectService().getById(projectId);
+
+        List<Integer> folderIds = savedProject.getFolders()
+                .stream()
+                .map(Folder::getId)
+                .toList();
+
+        assertEquals(projectId, savedProject.getId());
+        assertEquals(2, folderIds.size());
+        assertTrue(ServiceManager.getUserService().getById(userId).getProjects()
+                .stream()
+                .anyMatch(userProject -> userProject.getId().equals(projectId)));
+        assertTrue(ServiceManager.getTemplateService().getById(templateId).getProjects()
+                .stream()
+                .anyMatch(templateProject -> templateProject.getId().equals(projectId)));
+
+        for (Integer folderId : folderIds) {
+            assertEquals(folderId, ServiceManager.getFolderService().getById(folderId).getId());
+        }
+
+        ProjectListView projectListView = new ProjectListView();
+        assertDoesNotThrow(() -> projectListView.delete(projectId));
+        assertThrows(DAOException.class, () -> ServiceManager.getProjectService().getById(projectId));
+
+        for (Integer folderId : folderIds) {
+            assertThrows(DAOException.class, () -> ServiceManager.getFolderService().getById(folderId));
+        }
+
+        assertFalse(ServiceManager.getUserService().getById(userId).getProjects()
+                .stream()
+                .anyMatch(userProject -> userProject.getId().equals(projectId)));
+        assertFalse(ServiceManager.getTemplateService().getById(templateId).getProjects()
+                .stream()
+                .anyMatch(templateProject -> templateProject.getId().equals(projectId)));
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/forms/ProcessListViewIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/ProcessListViewIT.java
@@ -11,12 +11,8 @@
 
 package org.kitodo.production.forms;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Date;
 import java.time.LocalDate;
@@ -31,13 +27,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
-import org.kitodo.data.database.beans.Folder;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.beans.Project;
 import org.kitodo.data.database.beans.Task;
 import org.kitodo.data.database.beans.Template;
-import org.kitodo.data.database.beans.User;
-import org.kitodo.data.database.enums.LinkingMode;
 import org.kitodo.data.database.enums.TaskStatus;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.enums.ProcessState;
@@ -144,109 +137,5 @@ public class ProcessListViewIT {
 
         Process updated = ServiceManager.getProcessService().getById(process.getId());
         assertNotEquals(ProcessState.COMPLETED.getValue(), updated.getSortHelperStatus());
-    }
-
-    @Test
-    public void shouldDeleteSimpleProjectFromListView() throws Exception {
-        Project project = new Project();
-        project.setTitle("Simple project to delete");
-        ServiceManager.getProjectService().save(project);
-
-        int projectId = project.getId();
-
-        assertEquals(projectId, ServiceManager.getProjectService().getById(projectId).getId());
-
-        ProjectListView projectListView = new ProjectListView();
-
-        assertDoesNotThrow(() -> projectListView.delete(projectId));
-
-        assertThrows(DAOException.class, () -> ServiceManager.getProjectService().getById(projectId));
-    }
-
-    @Test
-    public void shouldDeleteProjectWithTemplateFoldersAndUsersFromListView() throws Exception {
-        User user = ServiceManager.getUserService().getById(1);
-
-        Project project = new Project();
-        project.setTitle("Complex project to delete");
-        project.setClient(ServiceManager.getClientService().getById(1));
-        project.getUsers().add(user);
-        ServiceManager.getProjectService().save(project);
-
-        user.getProjects().add(project);
-        ServiceManager.getUserService().save(user);
-
-        Template template = new Template();
-        template.setTitle("Template of complex project to delete");
-        template.setClient(project.getClient());
-        template.setDocket(ServiceManager.getDocketService().getById(1));
-        template.setRuleset(ServiceManager.getRulesetService().getById(1));
-        template.getProjects().add(project);
-        ServiceManager.getTemplateService().save(template);
-
-        project.getTemplates().add(template);
-
-        Folder mediaFolder = new Folder();
-        mediaFolder.setFileGroup("DEFAULT");
-        mediaFolder.setMimeType("image/jpeg");
-        mediaFolder.setPath("images/default");
-        mediaFolder.setCopyFolder(true);
-        mediaFolder.setCreateFolder(true);
-        mediaFolder.setLinkingMode(LinkingMode.ALL);
-        mediaFolder.setProject(project);
-        project.getFolders().add(mediaFolder);
-        project.setMediaView(mediaFolder);
-
-        Folder sourceFolder = new Folder();
-        sourceFolder.setFileGroup("SOURCE");
-        sourceFolder.setMimeType("image/tiff");
-        sourceFolder.setPath("images/source");
-        sourceFolder.setCopyFolder(false);
-        sourceFolder.setCreateFolder(true);
-        sourceFolder.setLinkingMode(LinkingMode.NO);
-        sourceFolder.setProject(project);
-        project.getFolders().add(sourceFolder);
-        project.setGeneratorSource(sourceFolder);
-
-        ServiceManager.getProjectService().save(project);
-
-        int projectId = project.getId();
-        int userId = user.getId();
-        int templateId = template.getId();
-
-        Project savedProject = ServiceManager.getProjectService().getById(projectId);
-
-        List<Integer> folderIds = savedProject.getFolders()
-                .stream()
-                .map(Folder::getId)
-                .toList();
-
-        assertEquals(projectId, savedProject.getId());
-        assertEquals(2, folderIds.size());
-        assertTrue(ServiceManager.getUserService().getById(userId).getProjects()
-                .stream()
-                .anyMatch(userProject -> userProject.getId().equals(projectId)));
-        assertTrue(ServiceManager.getTemplateService().getById(templateId).getProjects()
-                .stream()
-                .anyMatch(templateProject -> templateProject.getId().equals(projectId)));
-
-        for (Integer folderId : folderIds) {
-            assertEquals(folderId, ServiceManager.getFolderService().getById(folderId).getId());
-        }
-
-        ProjectListView projectListView = new ProjectListView();
-        assertDoesNotThrow(() -> projectListView.delete(projectId));
-        assertThrows(DAOException.class, () -> ServiceManager.getProjectService().getById(projectId));
-
-        for (Integer folderId : folderIds) {
-            assertThrows(DAOException.class, () -> ServiceManager.getFolderService().getById(folderId));
-        }
-
-        assertFalse(ServiceManager.getUserService().getById(userId).getProjects()
-                .stream()
-                .anyMatch(userProject -> userProject.getId().equals(projectId)));
-        assertFalse(ServiceManager.getTemplateService().getById(templateId).getProjects()
-                .stream()
-                .anyMatch(templateProject -> templateProject.getId().equals(projectId)));
     }
 }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProjectServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProjectServiceIT.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 import java.util.Collections;
 import java.util.List;
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProjectServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProjectServiceIT.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+
 import java.util.Collections;
 import java.util.List;
 
@@ -26,8 +27,11 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kitodo.MockDatabase;
 import org.kitodo.SecurityTestUtils;
+import org.kitodo.data.database.beans.Folder;
 import org.kitodo.data.database.beans.Project;
+import org.kitodo.data.database.beans.Template;
 import org.kitodo.data.database.beans.User;
+import org.kitodo.data.database.enums.LinkingMode;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.services.ServiceManager;
 
@@ -193,5 +197,111 @@ public class ProjectServiceIT {
         Project project = projectService.getById(1);
         boolean result = projectService.hasProcesses(project.getId());
         assertTrue(result, "Project with processes incorrectly reported as empty!");
+    }
+
+    @Test
+    public void shouldDeleteSimpleProject() throws Exception {
+        Project project = new Project();
+        project.setTitle("Simple project to delete");
+        ServiceManager.getProjectService().save(project);
+
+        int projectId = project.getId();
+
+        assertEquals(projectId, ServiceManager.getProjectService().getById(projectId).getId());
+
+        ServiceManager.getProjectService().remove(projectId);
+
+        assertThrows(DAOException.class, () -> ServiceManager.getProjectService().getById(projectId));
+    }
+
+    @Test
+    public void shouldDeleteProjectWithTemplateFoldersAndUsers() throws Exception {
+        User user = ServiceManager.getUserService().getById(1);
+
+        Project project = new Project();
+        project.setTitle("Complex project to delete");
+        project.setClient(ServiceManager.getClientService().getById(1));
+        project.getUsers().add(user);
+        ServiceManager.getProjectService().save(project);
+
+        user.getProjects().add(project);
+        ServiceManager.getUserService().save(user);
+
+        Template template = new Template();
+        template.setTitle("Template of complex project to delete");
+        template.setClient(project.getClient());
+        template.setDocket(ServiceManager.getDocketService().getById(1));
+        template.setRuleset(ServiceManager.getRulesetService().getById(1));
+        template.getProjects().add(project);
+        ServiceManager.getTemplateService().save(template);
+
+        project.getTemplates().add(template);
+
+        Folder mediaFolder = new Folder();
+        mediaFolder.setFileGroup("DEFAULT");
+        mediaFolder.setMimeType("image/jpeg");
+        mediaFolder.setPath("images/default");
+        mediaFolder.setCopyFolder(true);
+        mediaFolder.setCreateFolder(true);
+        mediaFolder.setLinkingMode(LinkingMode.ALL);
+        mediaFolder.setProject(project);
+        project.getFolders().add(mediaFolder);
+        project.setMediaView(mediaFolder);
+
+        Folder sourceFolder = new Folder();
+        sourceFolder.setFileGroup("SOURCE");
+        sourceFolder.setMimeType("image/tiff");
+        sourceFolder.setPath("images/source");
+        sourceFolder.setCopyFolder(false);
+        sourceFolder.setCreateFolder(true);
+        sourceFolder.setLinkingMode(LinkingMode.NO);
+        sourceFolder.setProject(project);
+        project.getFolders().add(sourceFolder);
+        project.setGeneratorSource(sourceFolder);
+
+        ServiceManager.getProjectService().save(project);
+
+        int projectId = project.getId();
+        int userId = user.getId();
+        int templateId = template.getId();
+
+        Project savedProject = ServiceManager.getProjectService().getById(projectId);
+
+        List<Integer> folderIds = savedProject.getFolders()
+                .stream()
+                .map(Folder::getId)
+                .toList();
+
+        assertEquals(projectId, savedProject.getId());
+        assertEquals(2, folderIds.size());
+        assertTrue(ServiceManager.getUserService().getById(userId).getProjects()
+                .stream()
+                .anyMatch(userProject -> userProject.getId().equals(projectId)));
+        assertTrue(ServiceManager.getTemplateService().getById(templateId).getProjects()
+                .stream()
+                .anyMatch(templateProject -> templateProject.getId().equals(projectId)));
+
+        for (Integer folderId : folderIds) {
+            assertEquals(folderId, ServiceManager.getFolderService().getById(folderId).getId());
+        }
+
+        ProjectService.delete(projectId);
+
+        assertThrows(
+                DAOException.class,
+                () -> ServiceManager.getProjectService().getById(projectId)
+        );
+
+        for (Integer folderId : folderIds) {
+            assertThrows(DAOException.class,
+                    () -> ServiceManager.getFolderService().getById(folderId));
+        }
+
+        assertFalse(ServiceManager.getUserService().getById(userId).getProjects()
+                .stream()
+                .anyMatch(userProject -> userProject.getId().equals(projectId)));
+        assertFalse(ServiceManager.getTemplateService().getById(templateId).getProjects()
+                .stream()
+                .anyMatch(templateProject -> templateProject.getId().equals(projectId)));
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/kitodo/kitodo-production/issues/7116

Deleting the project by ID and not by passing the object fixes the issue for me. The problem seem to stem from the usage of the `session.merge(baseBean)` call in the `remove-`method, 

https://github.com/kitodo/kitodo-production/blob/d4c3c4f67fd3fae0ee99a069822b1d9025393bb4/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java#L130

which leads to an Hibernate exception because it tries to resave already deleted entities. The usage of the `merge`-pattern has been discussed in general already (https://github.com/kitodo/kitodo-production/issues/5813#issuecomment-3628433955) and i think Hibernate 6 became more strict here in some regard. 

Deletion by ID uses another code path which does not rely on `session.merge()`:

https://github.com/kitodo/kitodo-production/blob/d4c3c4f67fd3fae0ee99a069822b1d9025393bb4/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/BaseDAO.java#L380

 