### PR TITLE
[4.0] Update com.fasterxml.jackson.core dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,12 +462,12 @@ from system library in Java 11+ -->
 	        <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.18.6</version>
+                <version>2.18.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.17.2</version>
+                <version>2.21.5</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Update `com.fasterxml.jackson.core` artifacts
- `jackson-core`
- `jackson-databind`

to current versions for Kitodo.Production 4.0