### PR TITLE
[3.9] Update OmniFaces to latest bugfix version 3.14.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,7 +612,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.omnifaces</groupId>
                 <artifactId>omnifaces</artifactId>
-                <version>3.13.4</version>
+                <version>3.14.21</version>
             </dependency>
             <dependency>
                 <groupId>org.openpreservation.jhove</groupId>


### PR DESCRIPTION
Updates OmniFaces version to latest bugfix version for Kitodo `3.9.x`. As that Kitodo version does not yet use OmniFaces 4, I updated to the latest bugfix release of OmniFaces 3 instead, for which the known vulnerabilites are [fixed](https://mvnrepository.com/artifact/org.omnifaces/omnifaces/versions) as well. I checked the parts of the application using OmniFaces and they all continue to work as they did before this update.