### PR TITLE
Update Spring Web MVC to latest bugfix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -822,7 +822,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>6.2.18</version>
+                <version>6.2.19</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars</groupId>


### PR DESCRIPTION
Update Spring Web MVC to latest bugfix version 6.2.19 to fix potential security vulnerabilities.