### PR TITLE
Fix some typos (found by codespell)

### DIFF
--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/conditions/LtpValidationConditionEvaluator.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/conditions/LtpValidationConditionEvaluator.java
@@ -26,7 +26,7 @@ import org.kitodo.api.validation.longtermpreservation.LtpValidationConditionSeve
 import org.kitodo.api.validation.longtermpreservation.LtpValidationResultState;
 
 /**
- * Evalutes validation conditions by checking them against a map of extracted
+ * Evaluates validation conditions by checking them against a map of extracted
  * property values.
  */
 public class LtpValidationConditionEvaluator {
@@ -361,7 +361,7 @@ public class LtpValidationConditionEvaluator {
      *            the conditions that were checked
      * @param conditionResults
      *            the results for each condition
-     * @return the overall validation sucesss or failure state
+     * @return the overall validation success or failure state
      */
     public static LtpValidationResultState summarizeValidationState(
             List<? extends LtpValidationConditionInterface> conditions,

--- a/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/VariableReplacer.java
@@ -70,7 +70,7 @@ public class VariableReplacer {
      * This regular expression is used to search for placeholders that need to
      * be replaced.
      * 
-     * <p>Uses regular expression possesive quantifier ++ in order to prevent 
+     * <p>Uses regular expression possessive quantifier ++ in order to prevent
      * possible denial of service attack from user input.
      */
     private static final Pattern VARIABLE_FINDER_REGEX = Pattern.compile(
@@ -153,7 +153,7 @@ public class VariableReplacer {
     }
     
     /**
-     * Replace variables withing a string. Like an ant, run through the variables
+     * Replace variables within a string. Like an ant, run through the variables
      * and fetch them from the digital document. Filename variables are replaced using the filename parameter.
      * 
      * @param stringWithVariables

--- a/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
@@ -71,7 +71,7 @@ abstract class CustomResourceBundle extends ResourceBundle {
     }
 
     /**
-     * Checks if properties file for a specfiic external resource bundle does exist.
+     * Checks if properties file for a specific external resource bundle does exist.
      * Remembers existence in static map such that filesystem is not checked repeatedly.
      * 
      * <p>This check is required because resource bundles seem to always load if an URLClassLoader

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/DataEditorSettingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/DataEditorSettingService.java
@@ -34,7 +34,7 @@ public class DataEditorSettingService extends BaseBeanService<DataEditorSetting,
     }
 
     /**
-     * Return signleton variable of type DataEditorSettingService.
+     * Return singleton variable of type DataEditorSettingService.
      *
      * @return unique instance of DataEditorSettingService
      */

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -383,7 +383,7 @@ public class WorkflowControllerService {
     }
 
     /**
-     * Unassing user from task.
+     * Unassign user from task.
      *
      * @param task
      *            object

--- a/Kitodo/src/main/resources/xslt/MetsModsGoobi_to_MetsKitodo.xsl
+++ b/Kitodo/src/main/resources/xslt/MetsModsGoobi_to_MetsKitodo.xsl
@@ -253,7 +253,7 @@
         </kitodo:metadata>
     </xsl:template>
 
-    <!-- Transorm toplevel [@name='TitleDocMain']" to mets:div[@LABEL] -->
+    <!-- Transform toplevel [@name='TitleDocMain']" to mets:div[@LABEL] -->
         <xsl:template match="mets:structMap[@TYPE='LOGICAL']/mets:div[@DMDID='DMDLOG_0000']/@TYPE" mode="pass2">
         <xsl:variable name="TitleDocMain" select="/mets:mets/mets:dmdSec[@ID='DMDLOG_0000']/mets:mdWrap/mets:xmlData/kitodo:kitodo/goobi:metadata[@name='TitleDocMain']"/>
         <xsl:variable name="TitleDocMainShort" select="/mets:mets/mets:dmdSec[@ID='DMDLOG_0000']/mets:mdWrap/mets:xmlData/kitodo:kitodo/goobi:metadata[@name='TitleDocMainShort']"/>
@@ -268,7 +268,7 @@
             </xsl:copy>
     </xsl:template>
 
-    <!-- Transorm year-level [@name='TitleDocMain']" to mets:div[@LABEL] -->
+    <!-- Transform year-level [@name='TitleDocMain']" to mets:div[@LABEL] -->
     <xsl:template match="mets:structMap[@TYPE='LOGICAL']/mets:div/mets:div[@TYPE='NewspaperYear']/@TYPE" mode="pass2">
         <xsl:variable name="TitleDocMainShort" select="/mets:mets/mets:dmdSec[@ID='DMDLOG_0003']/mets:mdWrap/mets:xmlData/kitodo:kitodo/goobi:metadata[@name='TitleDocMainShort']"/>
         <xsl:variable name="TitleDocMainShort2" select="/mets:mets/mets:dmdSec[@ID='DMDLOG_0001']/mets:mdWrap/mets:xmlData/kitodo:kitodo/goobi:metadata[@name='TitleDocMainShort']"/>

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadata_editor.js
@@ -294,7 +294,7 @@ metadataEditor.gallery = {
         },
 
         /**
-         * Adds or removes single thumbnails to the current selection using the multi seletion style (ctrl key).
+         * Adds or removes single thumbnails to the current selection using the multi selection style (ctrl key).
          *
          * @param event the mouse event
          * @param target the thumbnail-container dom element of the clicked thumbnail as jquery object 
@@ -452,7 +452,7 @@ metadataEditor.gallery = {
         /**
          * Find all logical tree node ids for a list of order-values.
          * @param orderList the list order values
-         * @returns the correspoding tree node ids for each thumbnail identified by each order value
+         * @returns the corresponding tree node ids for each thumbnail identified by each order value
          */
         findTreeNodeIdsByOrderList(orderList) {
             let treeNodeIds = [];
@@ -480,7 +480,7 @@ metadataEditor.gallery = {
          */
         findLastSelectedTreeNodeId() {
             let thumbnail = $("#imagePreviewForm .thumbnail.last-selection");
-            if (thumbnail.lenght > 0) {
+            if (thumbnail.length > 0) {
                 return this.findTreeNodeIdByThumbnail(thumbnail);
             }
             return null;

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/tabView.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/tabView.js
@@ -22,7 +22,7 @@ kitodo.tabView = kitodo.tabView || {};
  * @param string tab the id of the new active tab (should match id attribute of the `p:tab` component)
  */
 kitodo.tabView.onTabChange = function(tabId) {
-    // write tabId into browser URL such that the page can be refreshed without loosing the active tab state
+    // write tabId into browser URL such that the page can be refreshed without losing the active tab state
     kitodo.updateQueryParameter('tab', tabId); 
 
     // remove URL query parameters related to list view pagination, sort state and filter state

--- a/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/workflow/WorkflowControllerServiceIT.java
@@ -437,7 +437,7 @@ public class WorkflowControllerServiceIT {
 
         workflowService.unassignTaskFromUser(task);
         assertNull(task.getProcessingUser(), "User was not unassigned from the task!");
-        assertEquals(TaskStatus.OPEN, task.getProcessingStatus(), "Task was not set up to open after unassing of the user!");
+        assertEquals(TaskStatus.OPEN, task.getProcessingStatus(), "Task was not set up to open after unassign of the user!");
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
@@ -475,7 +475,7 @@ public class MetadataST extends BaseTestSelenium {
      * Verifies that moving media to newly created, but unsaved structure element in the gallery using drag'n'drop works
      * as expected.
      *
-     * @throws Exception when page nagivation fails
+     * @throws Exception when page navigation fails
      */
     @Test
     public void movePagesToUnsavedStructureTest() throws Exception {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessesPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessesPage.java
@@ -445,7 +445,7 @@ public class ProcessesPage extends Page<ProcessesPage> {
     /**
      * Submits a filter query by typing some text into the input field and submitting the filter form.
      *
-     * <p>This method doesn't block until the filter is sucessfully applied.</p>
+     * <p>This method doesn't block until the filter is successfully applied.</p>
      *
      * @param filterQuery the query
      */

--- a/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
+++ b/Kitodo/src/test/resources/selenium/resources/kitodo_config.properties
@@ -99,7 +99,7 @@ useOrigFolder=true
 script_createDirUserHome=../../../../src/test/resources/scripts/script_createDirUserHome(.sh|.bat)
 # Script to create the directory for a new process
 script_createDirMeta=../../../../src/test/resources/scripts/script_createDirMeta(.sh|.bat)
-# Script to create a symbolic link in the user home direcory and set
+# Script to create a symbolic link in the user home directory and set
 # permissions for the user
 script_createSymLink=../../../../src/test/resources/scripts/script_createSymLink(.sh|.bat)
 # Script to remove the symbolic link from the user home directory
@@ -318,23 +318,23 @@ batches.logChangesToComments=false
 # 2000 ms.
 #taskManager.inspectionIntervalMillis=2000
 # Sets the maximum number of failed threads to keep around in RAM. Defaults to
-# 10. Keep in mind that zombie processes still occupy all their ressources and
+# 10. Keep in mind that zombie processes still occupy all their resources and
 # aren't available for garbage collection, so choose these values as
 # restrictive as possible.
 #taskManager.keepThreads.failed.count=10
 # Sets the maximum time to keep failed threads around in RAM. Defaults to
 # 250 minutes (4 hours, 10 minutes). Keep in mind that zombie processes still
-# occupy all their ressources and aren't available for garbage collection, so
+# occupy all their resources and aren't available for garbage collection, so
 # choose these values as restrictive as possible.
 #taskManager.keepThreads.failed.minutes=250
 # Sets the maximum number of successfully finished threads to keep around in
 # RAM. Defaults to 3. Keep in mind that zombie processes still occupy all
-# their ressources and aren't available for garbage collection, so choose
+# their resources and aren't available for garbage collection, so choose
 # these values as restrictive as possible.
 #taskManager.keepThreads.successful.count=3
 # Sets the maximum time to keep successfully finished threads around in RAM.
 # Defaults to 20 minutes. Keep in mind that zombie processes still occupy all
-# their ressources and aren't available for garbage collection, so choose
+# their resources and aren't available for garbage collection, so choose
 # these values as restrictive as possible.
 #taskManager.keepThreads.successful.minutes=20
 # Sets whether or not to show the task manager entry in the navigation sidebar.
@@ -467,7 +467,7 @@ useWebApi=true
 # your needs. 0 will disable the deletion of messages completely. (However,
 # the messages will only available on the Active MQ server if your
 # TopicSubscriber is online with the Active MQ server before the message is
-# sent. You migth therefore consider to configure the timeToLive for offline
+# sent. You might therefore consider to configure the timeToLive for offline
 # usage within the Active MQ server's activemq.xml file by adding a
 #
 #   <policyEntry topic="KitodoProduction.ResultMessages.Topic">

--- a/Kitodo/src/test/resources/xslt/MetsModsGoobi_to_MetsKitodo.xsl
+++ b/Kitodo/src/test/resources/xslt/MetsModsGoobi_to_MetsKitodo.xsl
@@ -84,7 +84,7 @@
             </xsl:for-each>
         </kitodo:metadataGroup>
     </xsl:template>
-    <!-- Transorm year-level [@name='TitleDocMain']" to mets:div[@LABEL] -->
+    <!-- Transform year-level [@name='TitleDocMain']" to mets:div[@LABEL] -->
     <xsl:template match="mets:structMap[@TYPE='LOGICAL']/mets:div/mets:div[@TYPE='NewspaperYear']/@TYPE" mode="pass2">
         <xsl:variable name="TitleDocMainShort" select="/mets:mets/mets:dmdSec[@ID='DMDLOG_0003']/mets:mdWrap/mets:xmlData/kitodo:kitodo/goobi:metadata[@name='TitleDocMainShort']"/>
         <xsl:variable name="TitleDocMainShort2" select="/mets:mets/mets:dmdSec[@ID='DMDLOG_0001']/mets:mdWrap/mets:xmlData/kitodo:kitodo/goobi:metadata[@name='TitleDocMainShort']"/>

--- a/docs/developer/api/activemq_jms_api.md
+++ b/docs/developer/api/activemq_jms_api.md
@@ -48,7 +48,7 @@ goobi_config.properties for configuration.
 
 ### Service processor skeleton sample
 
-	package org.goobi.mq.processores;
+	package org.goobi.mq.processors;
 
 	import org.goobi.mq.*;
 	import de.sub.goobi.config.ConfigCore;


### PR DESCRIPTION
Most typos are in code comments or documentation, but a few are also in code or error messages.