### PR TITLE
[4.0] Bump org.springframework:spring-webmvc from 6.2.18 to 6.2.19 (#7140)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -822,7 +822,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>6.2.18</version>
+                <version>6.2.19</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars</groupId>


### PR DESCRIPTION
Backport of #7140 for Kitodo `4.0.x`

Bumps [org.springframework:spring-webmvc](https://github.com/spring-projects/spring-framework) from 6.2.18 to 6.2.19.
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v6.2.18...v6.2.19)

---
updated-dependencies:
- dependency-name: org.springframework:spring-webmvc dependency-version: 6.2.19 dependency-type: direct:production ...

