### PR TITLE
Fix typos in documentation and comments (found by codespell)

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Division.java
+++ b/Kitodo-API/src/main/java/org/kitodo/api/dataformat/Division.java
@@ -39,7 +39,7 @@ public abstract class Division<T extends Division<T>> {
     private List<URI> contentIds = new ArrayList<>(0);
 
     /**
-     * The label for this divison.
+     * The label for this division.
      */
     private String label;
 

--- a/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
+++ b/Kitodo-DataEditor/src/main/java/org/kitodo/dataeditor/MetsKitodoObjectFactory.java
@@ -110,7 +110,7 @@ public class MetsKitodoObjectFactory extends ObjectFactory {
     }
 
     /**
-     * Creates a DivType object for using as root div in mets physical sruct map.
+     * Creates a DivType object for using as root div in mets physical struct map.
      *
      * @return The DivType object.
      */
@@ -122,7 +122,7 @@ public class MetsKitodoObjectFactory extends ObjectFactory {
     }
 
     /**
-     * Creates a DivType object for using as root div in mets logical sruct map.
+     * Creates a DivType object for using as root div in mets logical struct map.
      *
      * @return The DivType object.
      */

--- a/Kitodo-DataEditor/src/test/resources/testAnExtensiveRulesetCanBeLoaded.xml
+++ b/Kitodo-DataEditor/src/test/resources/testAnExtensiveRulesetCanBeLoaded.xml
@@ -287,7 +287,7 @@
             'key' tag:
                 If present, declares the containing element to be a subclass of
                 kitodo:metadataGroup (otherwise the element is a subclass of
-                kitodo:metatadata). For attributes and member tags, the
+                kitodo:metadata). For attributes and member tags, the
                 definition given above applies, with the exception of the
                 domain, which can only be set on the very outer key tag and is
                 inherited by all sub-keys. A key that groups other keys should

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/LtpValidationCondition.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/LtpValidationCondition.java
@@ -189,7 +189,7 @@ public class LtpValidationCondition extends BaseBean implements LtpValidationCon
     }
 
     /**
-     * Hash code implementation based on all properties of this conditon.
+     * Hash code implementation based on all properties of this condition.
      */
     @Override
     public int hashCode() {

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/forms/FolderGenerator.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/forms/FolderGenerator.java
@@ -40,7 +40,7 @@ public class FolderGenerator {
     private static final double PERCENT = 100.0d;
 
     /**
-     * Image resoulution in DPI.
+     * Image resolution in DPI.
      */
     private int dpi = 300;
 
@@ -95,7 +95,7 @@ public class FolderGenerator {
     /**
      * Returns the selected generator method.
      *
-     * @return the generator methodd
+     * @return the generator method
      */
     public String getMethod() {
         if (folder.getDerivative().isPresent()) {

--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveBase.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveBase.java
@@ -42,7 +42,7 @@ import org.kitodo.longtermpreservationvalidation.conditions.LtpValidationConditi
  * <p>
  * The png module (PNG-gdm, "com.mcgath.jhove.module.PngModule") is disabled,
  * because it depends on the package "jhove-ext-modules". For some reason,
- * including this jar interfers with the xml processing in Kitodo.Production
+ * including this jar interferes with the xml processing in Kitodo.Production
  * somehow. Specifically, mods2kitodo schema conversion does not work correctly.
  * </p>
  */
@@ -122,7 +122,7 @@ public class KitodoJhoveBase {
      * Validates an existing file.
      * 
      * @param module
-     *            the JHove module that is used to validate the exsting file
+     *            the JHove module that is used to validate the existing file
      * @param file
      *            the existing file
      * @param conditions

--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveNisoImageMetadataHelper.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveNisoImageMetadataHelper.java
@@ -275,7 +275,7 @@ public class KitodoJhoveNisoImageMetadataHelper {
      * Extract indexed label properties and add them to the metadata map.
      * 
      * @param metadata
-     *            the niso image matadata
+     *            the niso image metadata
      * @param map
      *            the simple string map that is being filled
      */

--- a/Kitodo/rulesets/dfg-viewer.xml
+++ b/Kitodo/rulesets/dfg-viewer.xml
@@ -636,7 +636,7 @@
             'key' tag:
                 If present, declares the containing element to be a subclass of
                 kitodo:metadataGroup (otherwise the element is a subclass of
-                kitodo:metatadata). For attributes and member tags, the
+                kitodo:metadata). For attributes and member tags, the
                 definition given above applies, with the exception of the
                 domain, which can only be set on the very outer key tag and is
                 inherited by all sub-keys. A key that groups other keys should

--- a/Kitodo/rulesets/subhh.xml
+++ b/Kitodo/rulesets/subhh.xml
@@ -302,7 +302,7 @@
             'key' tag:
                 If present, declares the containing element to be a subclass of
                 kitodo:metadataGroup (otherwise the element is a subclass of
-                kitodo:metatadata). For attributes and member tags, the
+                kitodo:metadata). For attributes and member tags, the
                 definition given above applies, with the exception of the
                 domain, which can only be set on the very outer key tag and is
                 inherited by all sub-keys. A key that groups other keys should

--- a/Kitodo/src/main/java/org/kitodo/production/enums/GenerationMode.java
+++ b/Kitodo/src/main/java/org/kitodo/production/enums/GenerationMode.java
@@ -22,7 +22,7 @@ import org.kitodo.production.services.image.MissingOrDamagedImagesFilterPredicat
  */
 public enum GenerationMode {
     /**
-     * Gerenates all images.
+     * Generates all images.
      */
     ALL {
         @Override

--- a/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationConfigurationEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationConfigurationEditView.java
@@ -194,7 +194,7 @@ public class LtpValidationConfigurationEditView extends BaseEditView {
 
     /**
      * Adds an empty validation condition to the list of conditions if the user
-     * clicks on the add validation condition buttton.
+     * clicks on the add validation condition button.
      */
     public void addValidationCondition() {
         LtpValidationCondition condition = new LtpValidationCondition();
@@ -260,7 +260,7 @@ public class LtpValidationConfigurationEditView extends BaseEditView {
      * @param operation
      *            the expected operation
      * @return true if the condition is a condition matching the given property
-     *         and operation, indepedent of its value
+     *         and operation, independent of its value
      */
     private boolean isSimpleCondition(LtpValidationCondition condition, String property,
             LtpValidationConditionOperation operation) {
@@ -434,7 +434,7 @@ public class LtpValidationConfigurationEditView extends BaseEditView {
      * Sets the filename pattern that needs to match each file of a folder.
      * 
      * @param simpleFilenamePattern
-     *            the filname pattern
+     *            the filename pattern
      */
     public void setSimpleFilenamePattern(String simpleFilenamePattern) {
         this.simpleFilenamePattern = simpleFilenamePattern;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/MigrationForm.java
@@ -649,7 +649,7 @@ public class MigrationForm extends BaseForm {
     }
 
     /**
-     * Start updating internal meta information in separat tasks.
+     * Start updating internal meta information in separate tasks.
      */
     public void startUpdateInternalMetaInformation() {
         for (Project project : selectedProjects) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/ProjectEditView.java
@@ -476,7 +476,7 @@ public class ProjectEditView extends BaseEditView {
     /**
      * Gets the locked status of the form.
      *
-     * @return te value of locked
+     * @return the value of locked
      */
     public boolean isLocked() {
         return locked;

--- a/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/createprocess/CreateProcessForm.java
@@ -767,8 +767,8 @@ public class CreateProcessForm extends ValidatableForm implements MetadataTreeTa
 
 
     /**
-     * Saves the metadata files of the main process, all anchestors and children.
-     * We update all anchestors in the database and index as well.
+     * Saves the metadata files of the main process, all ancestors and children.
+     * We update all ancestors in the database and index as well.
      * If they already have a database entry, they are NOT updated automatically when saving the
      * main process.
      */

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -272,7 +272,7 @@ public class StructurePanel implements Serializable {
     }
 
     /**
-     * Delete all currently selected physical divisons.
+     * Delete all currently selected physical divisions.
      */
     public void deleteSelectedPhysicalDivisions() {
         if (Objects.nonNull(selectedPhysicalNodes)) {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/tasks/EmptyTask.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/tasks/EmptyTask.java
@@ -337,7 +337,7 @@ public class EmptyTask extends Thread {
     }
 
     /**
-     * Returns wether the start button shall be shown
+     * Returns whether the start button shall be shown
      * as read-only property "startable". A thread can be started as long as it
      * has not yet been started.
      *
@@ -348,8 +348,8 @@ public class EmptyTask extends Thread {
     }
 
     /**
-     * Returns wether the stop button shall be shown
-     * as read-only property "stopable". A thread can be stopped if it is
+     * Returns whether the stop button shall be shown
+     * as read-only property "stoppable". A thread can be stopped if it is
      * working.
      *
      * @return whether the stop button shall show

--- a/Kitodo/src/main/java/org/kitodo/production/metadata/copier/MetadataSelector.java
+++ b/Kitodo/src/main/java/org/kitodo/production/metadata/copier/MetadataSelector.java
@@ -28,7 +28,7 @@ public abstract class MetadataSelector extends DataSelector {
      *
      * @param path
      *            path to create a metadata selector from.
-     * @return a metadata selector instance representing the given paht
+     * @return a metadata selector instance representing the given path
      * @throws ConfigurationException
      *             if the path cannot be evaluated
      */

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
@@ -54,7 +54,7 @@ public class Issue {
      * Dates with issue on days of week without regular appearance.
      *
      * <p>
-     * Implementors note: SortedSet and SortedMap do not declare HashCode &
+     * Implementers note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<LocalDate> additions;
@@ -64,7 +64,7 @@ public class Issue {
      * = Sunday]
      *
      * <p>
-     * Implementors note: SortedSet and SortedMap do not declare HashCode &
+     * Implementers note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<Integer> daysOfWeek;
@@ -73,7 +73,7 @@ public class Issue {
      * Dates of days without issue on days of regular appearance (i.e. holidays)
      *
      * <p>
-     * Implementors note: SortedSet and SortedMap do not declare HashCode &
+     * Implementers note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<LocalDate> exclusions;

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
@@ -64,7 +64,7 @@ public class Issue {
      * = Sunday]
      *
      * <p>
-     * Implemention note: SortedSet and SortedMap do not declare HashCode &
+     * Implementation note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<Integer> daysOfWeek;
@@ -73,7 +73,7 @@ public class Issue {
      * Dates of days without issue on days of regular appearance (i.e. holidays)
      *
      * <p>
-     * Implemention note: SortedSet and SortedMap do not declare HashCode &
+     * Implementation note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<LocalDate> exclusions;

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
@@ -64,7 +64,7 @@ public class Issue {
      * = Sunday]
      *
      * <p>
-     * Implementers note: SortedSet and SortedMap do not declare HashCode &
+     * Implemention note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<Integer> daysOfWeek;
@@ -73,7 +73,7 @@ public class Issue {
      * Dates of days without issue on days of regular appearance (i.e. holidays)
      *
      * <p>
-     * Implementers note: SortedSet and SortedMap do not declare HashCode &
+     * Implemention note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<LocalDate> exclusions;

--- a/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/bibliography/course/Issue.java
@@ -54,7 +54,7 @@ public class Issue {
      * Dates with issue on days of week without regular appearance.
      *
      * <p>
-     * Implementers note: SortedSet and SortedMap do not declare HashCode &
+     * Implementation note: SortedSet and SortedMap do not declare HashCode &
      * Equals and cannot be used in a sensible way here.
      */
     private Set<LocalDate> additions;

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ImportService.java
@@ -1491,7 +1491,7 @@ public class ImportService {
      * as metadata values.
      * @param metadata map containing metadata to
      * @param templateId ID of template whose ruleset contains definition of 'recordIdentifier' functional metadata
-     * @param strict boolean parameter controling whether an exception should be thrown or not if no 'recordIdentifier' was found
+     * @param strict boolean parameter controlling whether an exception should be thrown or not if no 'recordIdentifier' was found
      * @return value of metadata configured as 'recordIdentifier'
      * @throws ConfigException when no 'recordIdentifier' metadata was found in given metadata map
      * @throws IOException when loading ruleset file fails

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LtpValidationConfigurationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LtpValidationConfigurationService.java
@@ -50,7 +50,7 @@ public class LtpValidationConfigurationService
     }
 
     /**
-     * Return a ltp validation configuration for a specific id but also load the list of attched folders,
+     * Return a ltp validation configuration for a specific id but also load the list of attached folders,
      * which is not loaded by default due to the lazy fetch strategy.
      * 
      * @param id the id of the validation configuration that is supposed to be loaded

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1428,9 +1428,8 @@ public class FileService {
 
     /**
      * Rename media files of current process according to their corresponding media units order attribute. Given Map
-     * "filenameMapping" is altered via side effect and does not need to be returned. Instead, the number of acutally
+     * "filenameMapping" is altered via side effect and does not need to be returned. Instead, the number of actually
      * changed filenames is returned to the calling method.
-     *
      * @param process Process object for which media files are renamed.
      * @param workpiece Workpiece object of process
      * @param filenameMapping Bidirectional map containing current filename mapping; empty until first renaming

--- a/Kitodo/src/main/resources/kitodo_config.properties
+++ b/Kitodo/src/main/resources/kitodo_config.properties
@@ -611,7 +611,7 @@ taskProcessPropertyColumns=
 # - you must provide the JKS keystore (file or URI) including the keystore password
 # - you must provide the JKS truststore (file or URI) including the truststore password
 # See https://github.com/kitodo/kitodo-production/tree/main/docs/gettingstarted/use_secured_activemq.md for
-# more information how to generate certificats and how to configure the ActiveMQ server side
+# more information how to generate certificates and how to configure the ActiveMQ server side
 #activeMQ.useSSL = false
 #activeMQ.keyStore = /usr/local/kitodo/certs/activemq-client.ks
 #activeMQ.keyStorePassword =
@@ -620,7 +620,7 @@ taskProcessPropertyColumns=
 
 # Define if an authentication and authorization should be used. If so a username and password must be provided
 # See https://github.com/kitodo/kitodo-production/tree/main/docs/gettingstarted/use_secured_activemq.md for
-# more information how to configure the authentification and authorization
+# more information how to configure the authentication and authorization
 #activeMQ.useAuth = false
 #activeMQ.authUsername =
 #activeMQ.authPassword =

--- a/Kitodo/src/main/resources/kitodo_projects.xml
+++ b/Kitodo/src/main/resources/kitodo_projects.xml
@@ -34,7 +34,7 @@
                 <item from="vorlage" ughbinding="true"
                       docstruct="topstruct" metadata="ListOfCreators">Autoren
                 </item>
-                <!-- identifer -->
+                <!-- identifier -->
                 <item from="werk" ughbinding="true" metadata="TSL_ATS" docstruct="topstruct">
                     ATS
                 </item>

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/metadataeditor_gallery_drag_drop.js
@@ -23,7 +23,7 @@
  */
 function registerMakeDragAndDroppable() {
 
-    // define debouce function that will allow to make components draggable in one go
+    // define debounce function that will allow to make components draggable in one go
     // after all of them have been updated via Primefaces when reloading the gallery
     function makeDebounced(func, timeout = 100) {
         let timer = null;

--- a/Kitodo/src/main/webapp/WEB-INF/resources/js/ol_custom.js
+++ b/Kitodo/src/main/webapp/WEB-INF/resources/js/ol_custom.js
@@ -294,7 +294,7 @@ class KitodoDetailMap {
     }
 
     /**
-     * Return extent array containg image dimensions.
+     * Return extent array containing image dimensions.
      * 
      * @param {Array} dimensions dimensions in pixel as [width, height]
      * @returns {Array} the extent array

--- a/Kitodo/src/test/java/org/kitodo/FileLoader.java
+++ b/Kitodo/src/test/java/org/kitodo/FileLoader.java
@@ -225,7 +225,7 @@ public class FileLoader {
         content.add(
             "        <item from=\"vorlage\" isdoctype=\"monograph|multivolume|periodical\" ughbinding=\"true\" docstruct=\"topstruct\" met"
                     + "adata=\"ListOfCreators\"> Autoren </item>");
-        content.add("        <!-- identifer -->");
+        content.add("        <!-- identifier -->");
         content.add(
             "        <item from=\"werk\" isnotdoctype=\"periodical\" ughbinding=\"true\" metadata=\"TSL_ATS\" docstruct=\"topstruct\">ATS<"
                     + "/item>");

--- a/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/helper/VariableReplacerTest.java
@@ -210,7 +210,7 @@ public class VariableReplacerTest {
         VariableReplacer variableReplacer = new VariableReplacer(workpiece, process, null);
 
         String replaced = variableReplacer.replace("-language $(meta.DocLanguage) -scriptType $(meta.slub_script)");
-        // missing meta data element will be replaced by emtpy string and a warning message appear in the log
+        // missing meta data element will be replaced by empty string and a warning message appear in the log
         String expected = "-language  -scriptType keine_OCR";
         assertEquals(expected, replaced, "String should contain expected metadata!");
     }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/CommentServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/CommentServiceIT.java
@@ -56,7 +56,7 @@ public class CommentServiceIT {
     }
 
     /**
-     * Tests wether comment is correctly saved and removed from database.
+     * Tests whether comment is correctly saved and removed from database.
      * 
      * @throws Exception
      *             when saving or deleting comment fails.

--- a/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/MetadataST.java
@@ -818,7 +818,7 @@ public class MetadataST extends BaseTestSelenium {
     }
 
     /*
-     * Verifies that an image can be openend in a separate window by clicking on the corresponding 
+     * Verifies that an image can be opened in a separate window by clicking on the corresponding 
      * context menu item of the first logical tree node.
      */
     @Test

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/LtpValidationConfigurationEditPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/LtpValidationConfigurationEditPage.java
@@ -192,7 +192,7 @@ public class LtpValidationConfigurationEditPage extends EditPage<LtpValidationCo
     /**
      * Return the currently selected mime type value (not label).
      * 
-     * @return the currrently selected mime type value (not label)
+     * @return the currently selected mime type value (not label)
      */
     public String getMimeType() throws Exception {
         return new Select(mimeTypeSelect).getFirstSelectedOption().getAttribute("value");

--- a/docs/developer/tests/README.md
+++ b/docs/developer/tests/README.md
@@ -9,7 +9,7 @@ When the application code changes, it should produce different results and cause
 tests to fail. If a unit test does not fail in this situation, it may indicate an issue
 with the test suite.
 
-To run a mutation test, you have to add the Pitest plugin to build/plugins in your moduls pom.xml.
+To run a mutation test, you have to add the Pitest plugin to build/plugins in your modules pom.xml.
 
 ```
 <plugin>

--- a/docs/gettingstarted/use_secured_activemq.md
+++ b/docs/gettingstarted/use_secured_activemq.md
@@ -83,11 +83,11 @@ Adjust the `conf/activemq.xml` file
     </broker>
 </beans>
 ```
-## Using authentification and authorization
+## Using authentication and authorization
 
 See https://activemq.apache.org/security
 
-### Define authentification
+### Define authentication
 
 Adjust the `conf/activemq.xml` file
 


### PR DESCRIPTION
Assisted-by: OpenCode / big-pickle (opencode)