### PR TITLE
Update used spring security version to 7.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <mockito.version>5.21.0</mockito.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <selenium.version>4.40.0</selenium.version>
-        <spring.security.version>7.0.5</spring.security.version>
+        <spring.security.version>7.0.6</spring.security.version>
         <flyway-maven-plugin.version>12.3.0</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>


### PR DESCRIPTION
Should fix different reported CVEs in transient dependencies.

Can be back ported to the `4.0.x` branch too as there is the same version currently in use.