### PR TITLE
Avoid unnecessary case change

### DIFF
--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/conditions/LtpValidationConditionEvaluator.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/conditions/LtpValidationConditionEvaluator.java
@@ -119,7 +119,7 @@ public class LtpValidationConditionEvaluator {
             return getConditionIncorrectNumberOfValuesResult(value);
         }
 
-        if (value.toLowerCase().equals(condition.getValues().getFirst().toLowerCase())) {
+        if (value.equalsIgnoreCase(condition.getValues().getFirst())) {
             return new LtpValidationConditionResult(true, null, value);
         }
 

--- a/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
+++ b/Kitodo/src/main/java/org/kitodo/production/filters/FilterMenu.java
@@ -311,8 +311,8 @@ public class FilterMenu {
      */
     private FilterString checkFilterCategory(String categoryInput, List<FilterString> categories) {
         return categories.stream()
-                .filter(f -> f.getFilterGerman().equals(categoryInput.toLowerCase())
-                        || f.getFilterEnglish().equals(categoryInput.toLowerCase()))
+                .filter(f -> f.getFilterGerman().equalsIgnoreCase(categoryInput)
+                        || f.getFilterEnglish().equalsIgnoreCase(categoryInput))
                 .findFirst().orElse(null);
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationConfigurationEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/LtpValidationConfigurationEditView.java
@@ -265,7 +265,7 @@ public class LtpValidationConfigurationEditView extends BaseEditView {
     private boolean isSimpleCondition(LtpValidationCondition condition, String property,
             LtpValidationConditionOperation operation) {
         if (Objects.nonNull(condition) && Objects.nonNull(condition.getProperty())
-                && condition.getProperty().toLowerCase().equals(property.toLowerCase())
+                && condition.getProperty().equalsIgnoreCase(property)
                 && Objects.nonNull(condition.getOperation()) && condition.getOperation().equals(operation)) {
             return true;
         }


### PR DESCRIPTION
Fixes code style issue detected by Codacy.

**Issue description from Codacy**:
"Using toUpperCase() or toLowerCase() before equals() is less efficient and less readable compared to using equalsIgnoreCase(). The latter is optimized for case-insensitive comparison and leads to cleaner code."

**Fix by**:
"Replace expressions that use toUpperCase() or toLowerCase() followed by equals() with a direct call to equalsIgnoreCase()."