### PR TITLE
Fix exclusion query

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
@@ -79,6 +79,18 @@ public class BeanQuery {
         sorting = Pair.of(varName + ".id", "ASC");
     }
 
+    private String uniqueParameterName(String field) {
+        String baseName = varName(field);
+        String parameterName = baseName;
+        int count = 2;
+
+        while (parameters.containsKey(parameterName)) {
+            parameterName = baseName + count++;
+        }
+
+        return parameterName;
+    }
+
     /**
      * Requires that the hits in a specific field must have a specific value.
      * 
@@ -111,7 +123,7 @@ public class BeanQuery {
      *            value that the class field must accept one of
      */
     public void addInCollectionRestriction(String fieldName, Collection<?> values) {
-        String parameterName = varName(fieldName);
+        String parameterName = uniqueParameterName(fieldName);
         restrictions.add(varName + '.' + fieldName + " IN (:" + parameterName + ')');
         parameters.put(parameterName, values);
     }
@@ -140,7 +152,7 @@ public class BeanQuery {
      *            value that the field must not accept
      */
     public void addNotInCollectionRestriction(String field, Collection<Integer> values) {
-        String parameterName = varName(field) + "NotIn";
+        String parameterName = uniqueParameterName(field);
         restrictions.add(varName + '.' + field + " NOT IN (:" + parameterName + ')');
         parameters.put(parameterName, values);
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/BeanQuery.java
@@ -140,7 +140,7 @@ public class BeanQuery {
      *            value that the field must not accept
      */
     public void addNotInCollectionRestriction(String field, Collection<Integer> values) {
-        String parameterName = varName(field);
+        String parameterName = varName(field) + "NotIn";
         restrictions.add(varName + '.' + field + " NOT IN (:" + parameterName + ')');
         parameters.put(parameterName, values);
     }

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/BeanQueryTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/BeanQueryTest.java
@@ -87,8 +87,8 @@ public class BeanQueryTest {
         BeanQuery beanQuery = new BeanQuery(Process.class);
         beanQuery.addNotInCollectionRestriction("id", excludedProcessIds);
         assertThat("should construct HQL query with not in collection restriction", beanQuery.formQueryForAll(),
-            containsString("WHERE process.id NOT IN (:id)"));
-        assertThat("should define id as Collection<Integer>", beanQuery.getQueryParameters().get("id"), is(equalTo(
+            containsString("WHERE process.id NOT IN (:idNotIn)"));
+        assertThat("should define id as Collection<Integer>", beanQuery.getQueryParameters().get("idNotIn"), is(equalTo(
             excludedProcessIds)));
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/BeanQueryTest.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/BeanQueryTest.java
@@ -87,9 +87,27 @@ public class BeanQueryTest {
         BeanQuery beanQuery = new BeanQuery(Process.class);
         beanQuery.addNotInCollectionRestriction("id", excludedProcessIds);
         assertThat("should construct HQL query with not in collection restriction", beanQuery.formQueryForAll(),
-            containsString("WHERE process.id NOT IN (:idNotIn)"));
-        assertThat("should define id as Collection<Integer>", beanQuery.getQueryParameters().get("idNotIn"), is(equalTo(
+            containsString("WHERE process.id NOT IN (:id)"));
+        assertThat("should define id as Collection<Integer>", beanQuery.getQueryParameters().get("id"), is(equalTo(
             excludedProcessIds)));
+    }
+
+    @Test
+    public void shouldUseUniqueParameterNamesForCollectionRestrictions() {
+        Collection<Integer> selectedIds = Arrays.asList(2, 3, 5);
+        Collection<Integer> excludedIds = Arrays.asList(3);
+
+        BeanQuery beanQuery = new BeanQuery(Process.class);
+        beanQuery.addInCollectionRestriction("id", selectedIds);
+        beanQuery.addNotInCollectionRestriction("id", excludedIds);
+
+        assertThat(beanQuery.formQueryForAll(),
+            containsString("process.id IN (:id)"));
+        assertThat(beanQuery.formQueryForAll(),
+            containsString("process.id NOT IN (:id2)"));
+
+        assertThat(beanQuery.getQueryParameters().get("id"), is(equalTo(selectedIds)));
+        assertThat(beanQuery.getQueryParameters().get("id2"), is(equalTo(excludedIds)));
     }
 
     @Test

--- a/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/services/data/ProcessServiceIT.java
@@ -755,13 +755,13 @@ public class ProcessServiceIT {
         int clientId = selectedProcess1.getProject().getClient().getId();
 
         List<ProcessExportDTO> result = processService.getProcessesForExport(
-                null,
-                true,
-                true,
-                clientId,
-                false, // allSelected
-                List.of(selectedProcessId1, selectedProcessId2),
-                List.of()
+            null, // no filter
+            true, // include closed
+            true, // include inactive projects
+            clientId,
+            false, // allSelected
+            List.of(selectedProcessId1, selectedProcessId2), // selectedProcessIds
+            List.of() // excludedProcessIds
         );
 
         List<Integer> resultIds = result.stream()
@@ -778,16 +778,163 @@ public class ProcessServiceIT {
         Process process = processService.getById(1);
 
         List<ProcessExportDTO> result = processService.getProcessesForExport(
-                null,
-                true,
-                true,
-                process.getProject().getClient().getId(),
-                false, // allSelected
-                List.of(),
-                List.of()
+            null, // no filter
+            true, // include closed
+            true, // include inactive projects
+            process.getProject().getClient().getId(),
+            false, // allSelected
+            List.of(), // selectedProcessIds
+            List.of() // excludedProcessIds
         );
 
         assertTrue(result.isEmpty(), "Export should be empty when no processes are selected");
+    }
+
+    @Test
+    public void shouldExcludeDeselectedProcessesWhenAllAreSelected() throws Exception {
+       int includedProcessId = MockDatabase.insertTestProcess("Included Export Process", 1, 1, 1);
+       int excludedProcessId = MockDatabase.insertTestProcess("Excluded Export Process", 1, 1, 1);
+
+       try {
+           Process includedProcess = processService.getById(includedProcessId);
+           int clientId = includedProcess.getProject().getClient().getId();
+
+           List<ProcessExportDTO> result = processService.getProcessesForExport(
+               null, // no filter
+               true, // include closed
+               true, // include inactive projects
+               clientId,
+               true, // allSelected
+               List.of(), // selectedProcessIds
+               List.of(excludedProcessId) // excludedProcessIds
+           );
+
+           List<Integer> resultIds = result.stream()
+                .map(ProcessExportDTO::getId)
+                .toList();
+
+           assertTrue(resultIds.contains(includedProcessId),
+               "Selected process should be exported");
+           assertFalse(resultIds.contains(excludedProcessId),
+               "Deselected process should not be exported");
+        } finally {
+           ProcessTestUtils.removeTestProcess(includedProcessId);
+           ProcessTestUtils.removeTestProcess(excludedProcessId);
+        }
+    }
+
+    @Test
+    public void shouldExcludeDeselectedProcessesFromFilteredExport() throws Exception {
+        int includedProcessId = MockDatabase.insertTestProcess("Included Export Process", 1, 1, 1);
+        int excludedProcessId = MockDatabase.insertTestProcess("Excluded Export Process", 1, 1, 1);
+
+        try {
+           ProcessTestUtils.copyTestMetadataFile(includedProcessId, TEST_METADATA_FILE);
+           ProcessTestUtils.copyTestMetadataFile(excludedProcessId, TEST_METADATA_FILE);
+
+           Process includedProcess = processService.getById(includedProcessId);
+           int clientId = includedProcess.getProject().getClient().getId();
+           User userOne = ServiceManager.getUserService().getById(1);
+           awaitProcessesInMetadataIndex(userOne, includedProcessId, excludedProcessId);
+
+            List<ProcessExportDTO> result = processService.getProcessesForExport(
+                "\"TSL_ATS:Proc\"",   // no filter
+                true, // include closed
+                true, // include inactive projects
+                clientId,
+                true, // allSelected
+                List.of(), // selectedProcessIds
+                List.of(excludedProcessId) // excludedProcessIds
+            );
+
+            List<Integer> resultIds = result.stream()
+                .map(ProcessExportDTO::getId)
+                .toList();
+
+            assertTrue(resultIds.contains(includedProcessId),
+                "Selected process should be exported");
+            assertFalse(resultIds.contains(excludedProcessId),
+                "Deselected process should not be exported");
+        } finally {
+            ProcessTestUtils.removeTestProcess(includedProcessId);
+            ProcessTestUtils.removeTestProcess(excludedProcessId);
+        }
+    }
+
+    @Test
+    public void shouldExcludeDeselectedProcessesFromSelection() throws Exception {
+        int includedProcessId = MockDatabase.insertTestProcess("Included Selection Process", 1, 1, 1);
+        int excludedProcessId = MockDatabase.insertTestProcess("Excluded Selection Process", 1, 1, 1);
+
+        try {
+
+            List<Process> result = processService.findSelectedProcesses(
+                true, // showClosedProcesses
+                true, // showInactiveProjects
+                null, //filter
+                List.of(excludedProcessId) // excludedProcessIds
+            );
+
+            List<Integer> resultIds = result.stream()
+                .map(Process::getId)
+                .toList();
+
+            assertTrue(resultIds.contains(includedProcessId),
+                "Selected process should be returned");
+            assertFalse(resultIds.contains(excludedProcessId),
+                "Deselected process should not be returned");
+        } finally {
+            ProcessTestUtils.removeTestProcess(includedProcessId);
+            ProcessTestUtils.removeTestProcess(excludedProcessId);
+        }
+    }
+
+    @Test
+    public void shouldExcludeDeselectedProcessesFromFilteredSelection() throws Exception {
+        int includedProcessId = MockDatabase.insertTestProcess("Included Selection Process", 1, 1, 1);
+        int excludedProcessId = MockDatabase.insertTestProcess("Excluded Selection Process", 1, 1, 1);
+
+        try {
+            ProcessTestUtils.copyTestMetadataFile(includedProcessId, TEST_METADATA_FILE);
+            ProcessTestUtils.copyTestMetadataFile(excludedProcessId, TEST_METADATA_FILE);
+
+            User userOne = ServiceManager.getUserService().getById(1);
+            awaitProcessesInMetadataIndex(userOne, includedProcessId, excludedProcessId);
+            List<Process> result = processService.findSelectedProcesses(
+                true, // showClosedProcesses
+                true, // showInactiveProjects
+                "\"TSL_ATS:Proc\"", //filter
+                List.of(excludedProcessId)  // excludedProcessIds
+            );
+            List<Integer> resultIds = result.stream()
+                .map(Process::getId)
+                .toList();
+
+            assertTrue(resultIds.contains(includedProcessId),
+                "Process matching the filter should be selected");
+            assertFalse(resultIds.contains(excludedProcessId),
+                "Deselected process matching the filter should not be selected");
+        } finally {
+            ProcessTestUtils.removeTestProcess(includedProcessId);
+            ProcessTestUtils.removeTestProcess(excludedProcessId);
+        }
+    }
+
+    private void awaitProcessesInMetadataIndex(User user, int... processIds) {
+        await()
+            .alias("test processes to be available in the search index")
+            .until(() -> {
+                SecurityTestUtils.addUserDataToSecurityContext(user, 1);
+
+                List<Integer> indexedIds = processService.findByMetadata(
+                        Collections.singletonMap("TSL_ATS", "Proc"))
+                    .stream()
+                    .map(Process::getId)
+                    .toList();
+
+                return Arrays.stream(processIds)
+                    .allMatch(indexedIds::contains);
+            });
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/7165

This PR tries to adress the problem, that when all processes in the list are selected and then a part of them are deselected the constructed query does not deliver the correct result. The reason is, that we apply both a `NOT IN` as well as a `IN` restriction and both receive the same placeholder names:

```sql
process.id NOT IN (:id)
...
AND process.id IN (:id)
```

Since both restrictions refer to the same placeholder, one parameter value overwrites the other, resulting in contradictory query conditions and no matching processes. I tried to fix that by naming the `NOT IN` placeholder different.
