### PR TITLE
Use parameterized log messages instead of string concatenations

### DIFF
--- a/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
+++ b/Kitodo-API/src/main/java/org/kitodo/serviceloader/KitodoServiceLoader.java
@@ -401,7 +401,7 @@ public class KitodoServiceLoader<T> {
             if (!jarsToBeAdded.isEmpty()) {
 
                 for (URL url : jarsToBeAdded) {
-                    logger.info("Loading module jar file from path " + url.toString());
+                    logger.info("Loading module jar file from path {}", url.toString());
                     KitodoServiceLoader.loadedJars.add(url.toString());
                 }
                 URL[] urls = new URL[jarsToBeAdded.size()];

--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/beans/ProcessKeywords.java
@@ -218,8 +218,8 @@ public class ProcessKeywords {
             String processId = Integer.toString(process.getId());
             Path path = Paths.get(KitodoConfig.getKitodoDataDirectory(), processId, "meta.xml");
             if (!Files.isReadable(path)) {
-                logger.info((Files.exists(path) ? "File not readable for indexing: "
-                        : "Missing metadata file for indexing: ") + path);
+                logger.info("{}{}", Files.exists(path) ? "File not readable for indexing: " : "Missing metadata file for indexing: ",
+                        path);
                 return Collections.emptySet();
             }
             logger.debug("Indexing {} in process {} \"{}\"", path, process.getId(), process.getTitle());

--- a/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveRepInfoParser.java
+++ b/Kitodo-LongTermPreservationValidation/src/main/java/org/kitodo/longtermpreservationvalidation/jhove/KitodoJhoveRepInfoParser.java
@@ -62,12 +62,11 @@ public class KitodoJhoveRepInfoParser {
                 } else if (valueList.getFirst() instanceof String) {
                     propertyMap.put(propertyKey, StringUtils.join(valueList, ","));
                 } else {
-                    logger.debug(
-                        "JHove RepInfo contains property list with unknown item type: " + valueList.getFirst().toString());
+                    logger.debug("JHove RepInfo contains property list with unknown item type: {}", valueList.getFirst().toString());
                 }
             }
         } else {
-            logger.debug("JHove RepInfo contains property list of unknown type: " + propertyValue.toString());
+            logger.debug("JHove RepInfo contains property list of unknown type: {}", propertyValue.toString());
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/editor/XMLEditor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/editor/XMLEditor.java
@@ -149,7 +149,7 @@ public class XMLEditor implements Serializable {
         } catch (TransformerConfigurationException e) {
             logger.error("ERROR: transformer configuration exception: {}", e.getMessage());
         } catch (FileNotFoundException e) {
-            logger.error("ERROR: file not found: " + e.getMessage());
+            logger.error("ERROR: file not found: {}", e.getMessage());
         } catch (IOException e) {
             logger.error("ERROR: could not save XML configuration: {}", e.getMessage());
         } catch (SAXException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/handler/RangeStreamContentHandler.java
+++ b/Kitodo/src/main/java/org/kitodo/production/handler/RangeStreamContentHandler.java
@@ -162,7 +162,7 @@ public class RangeStreamContentHandler extends BaseDynamicContentHandler {
         } else if (ranges.size() == 1) {
             // Return single part of file.
             Range r = ranges.getFirst();
-            logger.info("Returning part of file : from (" + r.getStart() + ") to (" + r.getEnd() + ")");
+            logger.info("Returning part of file : from ({}) to ({})", r.getStart(), r.getEnd());
             response.setContentType(streamedContent.getContentType());
             response.setHeader("Content-Range", "bytes " + r.getStart() + "-" + r.getEnd() + "/" + r.getTotal());
             response.setHeader("Content-Length", String.valueOf(r.getLength()));
@@ -177,7 +177,7 @@ public class RangeStreamContentHandler extends BaseDynamicContentHandler {
             ServletOutputStream servletOutputStream = (ServletOutputStream) outputStream;
             // Copy multi part range.
             for (Range r : ranges) {
-                logger.info("Return multi part of file : from (" + r.getStart() + ") to (" + r.getEnd() + ")");
+                logger.info("Return multi part of file : from ({}) to ({})", r.getStart(), r.getEnd());
                 // Add multipart boundary and header fields for every range.
                 servletOutputStream.println();
                 servletOutputStream.println("--" + MULTIPART_BOUNDARY);

--- a/Kitodo/src/main/java/org/kitodo/production/helper/CatalogConfigurationImporter.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/CatalogConfigurationImporter.java
@@ -125,7 +125,7 @@ public class CatalogConfigurationImporter {
             importConfiguration.setUsername(OPACConfig.getUsername(opacTitle));
             importConfiguration.setPassword(OPACConfig.getPassword(opacTitle));
         } catch (ConfigurationRuntimeException e) {
-            logger.info("No credentials configured for configuration '" + opacTitle + "'.");
+            logger.info("No credentials configured for configuration '{}'.", opacTitle);
         }
     }
 
@@ -232,8 +232,8 @@ public class CatalogConfigurationImporter {
                 mappingFiles.add(getConfiguredMappingFile(allMappingFiles, filename, configuration));
             }
         } catch (ConfigurationRuntimeException e) {
-            logger.info("No 'mappingFiles' element found in catalog configuration '" + configuration.getTitle()
-                    + "', trying to determine default mapping files.");
+            logger.info("No 'mappingFiles' element found in catalog configuration '{}', trying to determine default mapping files.",
+                    configuration.getTitle());
             String formatName = OPACConfig.getMetadataFormat(configuration.getTitle());
             MetadataFormat metadataFormat = MetadataFormat.getMetadataFormat(formatName);
             List<MetadataFormatConversion> defaultConversions = MetadataFormatConversion
@@ -359,7 +359,7 @@ public class CatalogConfigurationImporter {
                     }
                 }
             } catch (ConfigurationRuntimeException e) {
-                logger.error("Unable to import OPAC configuration '" + catalogName + "' (" + e.getMessage() + ")");
+                logger.error("Unable to import OPAC configuration '{}' ({})", catalogName, e.getMessage());
             }
         }
         return allMappingFiles;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/CustomListColumnInitializer.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/CustomListColumnInitializer.java
@@ -58,10 +58,8 @@ public class CustomListColumnInitializer {
         } catch (DAOException e) {
             logger.error("Unable to update custom list columns in database!");
         } catch (NoSuchElementException e) {
-            logger.info("Configuration key '"
-                    + ParameterCore.PROCESS_PROPERTIES
-                    + "' or '" + ParameterCore.TASK_CUSTOM_COLUMNS
-                    + "' not found in configuration => unable to load corresponding custom columns!");
+            logger.info("Configuration key '{}' or '{}' not found in configuration => unable to load corresponding custom columns!",
+                    ParameterCore.PROCESS_PROPERTIES, ParameterCore.TASK_CUSTOM_COLUMNS);
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/messages/CustomResourceBundle.java
@@ -95,7 +95,7 @@ abstract class CustomResourceBundle extends ResourceBundle {
             propertiesFileExistsMap.put(key, file.exists());
 
             if (!file.exists()) {
-                logger.info("Could not find external resource bundle '" + bundleName + "' at " + file);
+                logger.info("Could not find external resource bundle '{}' at {}", bundleName, file);
             }
         }
         return propertiesFileExistsMap.get(key);
@@ -119,7 +119,7 @@ abstract class CustomResourceBundle extends ResourceBundle {
             try {
                 return ResourceBundle.getBundle(bundleName, locale, urlLoader);
             } catch (MissingResourceException e) {
-                logger.error("Could not load external resource bundle '" + bundleName + "': " + e.getMessage());
+                logger.error("Could not load external resource bundle '{}': {}", bundleName, e.getMessage());
             }
         }
         return null;

--- a/Kitodo/src/main/java/org/kitodo/production/helper/validation/LtpValidationHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/validation/LtpValidationHelper.java
@@ -297,7 +297,7 @@ public class LtpValidationHelper {
      * @return the map of validation results for each file in the folder
      */
     public static Map<URI, LtpValidationResult> validateImageFolderForTask(Task task, Folder folder) {
-        logger.debug("validating images in folder: " + folder.getRelativePath());
+        logger.debug("validating images in folder: {}", folder.getRelativePath());
 
         Subfolder subfolder = new Subfolder(task.getProcess(), folder);
         Optional<FileType> fileType = subfolder.getFileFormat().getFileType();
@@ -445,7 +445,7 @@ public class LtpValidationHelper {
             return true;
         }
 
-        logger.debug("validate uploaded file: " + absoluteFilePath);
+        logger.debug("validate uploaded file: {}", absoluteFilePath);
         Optional<FileType> fileType = subfolder.getFileFormat().getFileType();
         List<LtpValidationCondition> conditions = folder.getLtpValidationConfiguration().getValidationConditions();
         LtpValidationResult result = ltpService.validate(absoluteFilePath, fileType.orElse(null), conditions);

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
@@ -71,7 +71,7 @@ public class ActiveMQDirector implements Runnable {
     }
 
     private Connection getConnectionFromActiveMQSslFactory(String server) throws Exception {
-        logger.trace("Using the ActiveMQSslConnectionFactory to establish a connection to \"" + server + "\"");
+        logger.trace("Using the ActiveMQSslConnectionFactory to establish a connection to \"{}\"", server);
         ActiveMQSslConnectionFactory factory = new ActiveMQSslConnectionFactory(server);
         factory.setKeyStore(ConfigCore.getParameter(ParameterCore.ACTIVE_MQ_KEYSTORE));
         factory.setKeyStorePassword(ConfigCore.getParameter(ParameterCore.ACTIVE_MQ_KEYSTORE_PASSWORD));
@@ -79,7 +79,7 @@ public class ActiveMQDirector implements Runnable {
         factory.setTrustStorePassword(ConfigCore.getParameter(ParameterCore.ACTIVE_MQ_TRUSTSTORE_PASSWORD));
 
         if (ConfigCore.getBooleanParameter(ParameterCore.ACTIVE_MQ_USE_AUTH, false))  {
-            logger.trace("Using authentication on connection \"" + server + "\"");
+            logger.trace("Using authentication on connection \"{}\"", server);
             factory.setUserName(ConfigCore.getParameter(ParameterCore.ACTIVE_MQ_AUTH_USERNAME));
             factory.setPassword(ConfigCore.getParameter(ParameterCore.ACTIVE_MQ_AUTH_PASSWORD));
         }
@@ -88,11 +88,11 @@ public class ActiveMQDirector implements Runnable {
     }
 
     private Connection getConnectionFromActiveMQFactory(String server) throws JMSException {
-        logger.trace("Using the ActiveMQConnectionFactory to establish a connection to \"" + server + "\"");
+        logger.trace("Using the ActiveMQConnectionFactory to establish a connection to \"{}\"", server);
         ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(server);
 
         if (ConfigCore.getBooleanParameter(ParameterCore.ACTIVE_MQ_USE_AUTH, false))  {
-            logger.trace("Using authentication on connection \"" + server + "\"");
+            logger.trace("Using authentication on connection \"{}\"", server);
             factory.setUserName(ConfigCore.getParameter(ParameterCore.ACTIVE_MQ_AUTH_USERNAME));
             factory.setPassword(ConfigCore.getParameter(ParameterCore.ACTIVE_MQ_AUTH_PASSWORD));
         }

--- a/Kitodo/src/main/java/org/kitodo/production/services/command/ImportingProcess.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/command/ImportingProcess.java
@@ -191,7 +191,7 @@ final class ImportingProcess {
             FileStructureValidationException {
 
         this.importingProcesses = importingProcesses;
-        logger.info("Starting to validate " + this.directoryName);
+        logger.info("Starting to validate {}", this.directoryName);
         Path metaFilePath = sourceDir.resolve(META_FILE_NAME);
         Workpiece workpiece = metsService.loadWorkpiece(metaFilePath.toUri());
         validateMetsFile(ruleset, strictValidation, workpiece);
@@ -204,8 +204,8 @@ final class ImportingProcess {
         baseType = workpiece.getLogicalStructure().getType();
         title = formProcessTitle(ruleset, workpiece);
 
-        logger.info("Validation of " + this.directoryName + (errors.isEmpty() ? " completed without errors"
-                : " completed with errors:" + lineSeparator() + String.join(lineSeparator(), errors)));
+        logger.info("Validation of {}{}", this.directoryName, errors.isEmpty() ? " completed without errors" : " completed with errors:"
+                + lineSeparator() + String.join(lineSeparator(), errors));
     }
 
     /**
@@ -444,7 +444,7 @@ final class ImportingProcess {
                     workpiece.getLogicalStructure().getMetadata());
             }
             processId = createDatabaseProcess();
-            logger.info("Created process #" + processId);
+            logger.info("Created process #{}", processId);
         } else if (action == 1) {
             createBaseDirectory(processId.toString());
             filesAndDirectoriesIterator = filesAndDirectories.iterator();
@@ -514,7 +514,7 @@ final class ImportingProcess {
         fileService.searchForMedia(process, workpiece);
         Path outputMetsFile = outputDir.resolve(META_FILE_NAME);
         metsService.saveWorkpiece(workpiece, outputMetsFile.toUri());
-        logger.info("Wrote METS file " + outputMetsFile);
+        logger.info("Wrote METS file {}", outputMetsFile);
     }
 
     private void addLinkInDatabase(Process parent, Integer childProcessId) throws DAOException {
@@ -548,7 +548,7 @@ final class ImportingProcess {
             } else {
                 Files.write(errorFile, errors, StandardCharsets.UTF_8);
             }
-            logger.info("Wrote errors file " + errorFile);
+            logger.info("Wrote errors file {}", errorFile);
         } else {
             copyDirectoryOrFile(filesAndDirectories.get(action - 2));
         }
@@ -579,7 +579,7 @@ final class ImportingProcess {
     private void createBaseDirectory(String directoryName) throws IOException {
         outputDir = copyToRoot.resolve(directoryName);
         Files.createDirectories(outputDir);
-        logger.info("Created process directory " + outputDir);
+        logger.info("Created process directory {}", outputDir);
     }
 
     /**
@@ -594,11 +594,11 @@ final class ImportingProcess {
         Path destinationItem = outputDir.resolve(relativeItem);
         if (Files.isDirectory(sourceItem)) {
             Files.createDirectories(destinationItem);
-            logger.info("Created directory " + destinationItem);
+            logger.info("Created directory {}", destinationItem);
         } else {
             Files.copy(sourceItem, destinationItem, StandardCopyOption.REPLACE_EXISTING,
                 StandardCopyOption.COPY_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
-            logger.info("Copied " + sourceItem + " as " + destinationItem);
+            logger.info("Copied {} as {}", sourceItem, destinationItem);
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/file/FileService.java
@@ -1518,12 +1518,12 @@ public class FileService {
             if (MetadataLock.isLocked(processId)) {
                 lockedProcesses.add(processId);
                 if (ConfigCore.getBooleanParameterOrDefaultValue(ParameterCore.ANONYMIZE)) {
-                    logger.error("Unable to lock process " + processId + " for media renaming because it is currently "
-                            + "being worked on by another user");
+                    logger.error("Unable to lock process {} for media renaming because it is currently being worked on "
+                                    + "by another user", processId);
                 } else {
                     User currentUser = MetadataLock.getLockUser(processId);
-                    logger.error("Unable to lock process " + processId + " for media renaming because it is currently "
-                            + "being worked on by another user (" + currentUser.getFullName() + ")");
+                    logger.error("Unable to lock process {} for media renaming because it is currently being worked on "
+                                    + "by another user ({})", processId, currentUser.getFullName());
                 }
             } else {
                 MetadataLock.setLocked(processId, ServiceManager.getUserService().getCurrentUser());
@@ -1542,7 +1542,7 @@ public class FileService {
      */
     public void revertRenaming(BidiMap<URI, URI> filenameMappings, Workpiece workpiece) {
         // revert media variant URIs for all media files in workpiece to previous, original values
-        logger.info("Reverting to original media filenames of process " + workpiece.getId());
+        logger.info("Reverting to original media filenames of process {}", workpiece.getId());
         for (PhysicalDivision physicalDivision : workpiece
                 .getAllPhysicalDivisionChildrenFilteredByTypes(PhysicalDivision.TYPES)) {
             for (Entry<MediaVariant, URI> mediaVariantURIEntry : physicalDivision.getMediaFiles().entrySet()) {

--- a/Kitodo/src/main/java/org/kitodo/production/thread/RenameMediaThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/RenameMediaThread.java
@@ -71,7 +71,7 @@ public class RenameMediaThread extends EmptyTask {
                         renamingMap);
                 try (OutputStream out = ServiceManager.getFileService().write(metaXmlUri)) {
                     ServiceManager.getMetsService().save(workpiece, out);
-                    logger.info("Renamed " + numberOfRenamedFiles + " media files for process " + process.getId());
+                    logger.info("Renamed {} media files for process {}", numberOfRenamedFiles, process.getId());
                 }
             } catch (IOException | URISyntaxException | SAXException | FileStructureValidationException e) {
                 logger.error(e.getMessage());

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/WebDriverProvider.java
@@ -63,7 +63,7 @@ public class WebDriverProvider {
             FileUtils.copyURLToFile(geckoUrl, geckoDriverTarFile);
             File theDir = new File(extractFolder);
             if (!theDir.mkdir()) {
-                logger.error("Unable to create directory '" + theDir.getPath() + "'!");
+                logger.error("Unable to create directory '{}'!", theDir.getPath());
             }
             extractTarFileToFolder(geckoDriverTarFile, theDir);
         } else {

--- a/Kitodo/src/test/java/org/kitodo/test/utils/ProcessTestUtils.java
+++ b/Kitodo/src/test/java/org/kitodo/test/utils/ProcessTestUtils.java
@@ -257,7 +257,7 @@ public class ProcessTestUtils {
      */
     public static void logTestProcessInfo(Process process) {
         logger.info(" ************* ");
-        logger.info(" Process '" + process.getTitle() + "' has ID " + process.getId());
+        logger.info(" Process '{}' has ID {}", process.getTitle(), process.getId());
         logger.info(" ************* ");
     }
 


### PR DESCRIPTION
Replaces string concatenation in log4j logs with parametrizd log messages.

**Issue description from IDE:**
"Non-constant concatenations are evaluated at runtime even when the logging message is not logged; this can negatively impact performance. It is recommended to use a parameterized log message instead, which will not be evaluated when logging is disabled."