### PR TITLE
Avoid null pointer dereferences (Coverity)

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/GalleryPanel.java
@@ -788,7 +788,11 @@ public class GalleryPanel {
                 if (Objects.nonNull(galleryStripe)) {
                     return dataEditor.isSelected(physicalDivision, galleryStripe.getStructure());
                 } else {
-                    return dataEditor.isSelected(physicalDivision, getLogicalStructureOfMedia(galleryMediaContent).getStructure());
+                    GalleryStripe logicalStructure = getLogicalStructureOfMedia(galleryMediaContent);
+                    if (Objects.nonNull(logicalStructure)) {
+                        return dataEditor.isSelected(physicalDivision, logicalStructure.getStructure());
+                    }
+                    return false;
                 }
             }
         }
@@ -898,13 +902,13 @@ public class GalleryPanel {
      * @param selectionType the type of selection based on the pressed modifier key
      */
     private void select(GalleryMediaContent currentSelection, GalleryStripe parentStripe, String selectionType) {
-        if (Objects.isNull(parentStripe)) {
-            parentStripe = getLogicalStructureOfMedia(currentSelection);
-        }
-
         if (Objects.isNull(currentSelection)) {
             Helper.setErrorMessage("Passed GalleryMediaContent must not be null.");
             return;
+        }
+
+        if (Objects.isNull(parentStripe)) {
+            parentStripe = getLogicalStructureOfMedia(currentSelection);
         }
 
         switch (selectionType) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MediaPartialsPanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/MediaPartialsPanel.java
@@ -138,18 +138,22 @@ public class MediaPartialsPanel implements Serializable {
     public List<SelectItem> getMediaPartialChildDivisionsOfSelection() {
         List<SelectItem> mediaPartialDivisions = new ArrayList<>();
         Pair<PhysicalDivision, LogicalDivision> lastSelection = dataEditor.getGalleryPanel().getLastSelection();
-        if (Objects.nonNull(lastSelection) && MediaUtil.isAudioOrVideo(
-                dataEditor.getGalleryPanel().getGalleryMediaContent(lastSelection.getKey()).getMediaViewMimeType())) {
-            mediaPartialDivisions.addAll(DataEditorService.getSortedAllowedSubstructuralElements(
-                    dataEditor.getRulesetManagement()
-                    .getStructuralElementView(lastSelection.getRight().getType(), dataEditor.getAcquisitionStage(),
-                            dataEditor.getPriorityList()), dataEditor.getProcess().getRuleset()));
-            Collection<String> mediaPartialDivisionIds = dataEditor.getRulesetManagement()
-                    .getFunctionalDivisions(FunctionalDivision.MEDIA_PARTIAL);
-            mediaPartialDivisions = mediaPartialDivisions.stream()
-                    .filter(selectItem -> selectItem.getValue() instanceof String)
-                    .filter(selectItem -> mediaPartialDivisionIds.contains((String) selectItem.getValue()))
-                    .collect(Collectors.toList());
+        if (Objects.nonNull(lastSelection)) {
+            GalleryMediaContent galleryMediaContent = dataEditor.getGalleryPanel()
+                    .getGalleryMediaContent(lastSelection.getKey());
+            if (Objects.nonNull(galleryMediaContent)
+                    && MediaUtil.isAudioOrVideo(galleryMediaContent.getMediaViewMimeType())) {
+                mediaPartialDivisions.addAll(DataEditorService.getSortedAllowedSubstructuralElements(
+                        dataEditor.getRulesetManagement()
+                        .getStructuralElementView(lastSelection.getRight().getType(), dataEditor.getAcquisitionStage(),
+                                dataEditor.getPriorityList()), dataEditor.getProcess().getRuleset()));
+                Collection<String> mediaPartialDivisionIds = dataEditor.getRulesetManagement()
+                        .getFunctionalDivisions(FunctionalDivision.MEDIA_PARTIAL);
+                mediaPartialDivisions = mediaPartialDivisions.stream()
+                        .filter(selectItem -> selectItem.getValue() instanceof String)
+                        .filter(selectItem -> mediaPartialDivisionIds.contains((String) selectItem.getValue()))
+                        .collect(Collectors.toList());
+            }
         }
         return mediaPartialDivisions;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/massimport/MassImportForm.java
@@ -117,21 +117,23 @@ public class MassImportForm extends BaseForm {
      */
     public void handleFileUpload(FileUploadEvent event) {
         file = event.getFile();
-        try {
-            List<String> csvLines = massImportService.getLines(file);
-            resetValues();
-            if (!csvLines.isEmpty()) {
-                importedCsvHeaderLine = csvLines.getFirst();
-                csvSeparator = ServiceManager.getMassImportService().guessCsvSeparator(csvLines);
-                updateMetadataKeys();
-                if (csvLines.size() > 1) {
-                    importedCsvLines = csvLines.subList(1, csvLines.size());
-                    parseCsvLines();
+        if (Objects.nonNull(file)) {
+            try {
+                List<String> csvLines = massImportService.getLines(file);
+                resetValues();
+                if (!csvLines.isEmpty()) {
+                    importedCsvHeaderLine = csvLines.getFirst();
+                    csvSeparator = ServiceManager.getMassImportService().guessCsvSeparator(csvLines);
+                    updateMetadataKeys();
+                    if (csvLines.size() > 1) {
+                        importedCsvLines = csvLines.subList(1, csvLines.size());
+                        parseCsvLines();
+                    }
                 }
+            } catch (IOException | CsvException | KitodoCsvImportException e) {
+                Helper.setErrorMessage(e);
+                records = new LinkedList<>();
             }
-        } catch (IOException | CsvException | KitodoCsvImportException e) {
-            Helper.setErrorMessage(e);
-            records = new LinkedList<>();
         }
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -1989,15 +1989,17 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
      */
     public static void downloadToHome(WebDav webDav, int processId) throws DAOException {
         Process process = ServiceManager.getProcessService().getById(processId);
-        if (ServiceManager.getProcessService().isImageFolderInUse(process)) {
-            Helper.setMessage(
-                    Helper.getTranslation("directory ") + " " + process.getTitle() + " "
-                            + Helper.getTranslation("isInUse"),
-                    ServiceManager.getUserService()
-                            .getFullName(ServiceManager.getProcessService().getImageFolderInUseUser(process)));
-            webDav.downloadToHome(process, true);
-        } else {
-            webDav.downloadToHome(process, false);
+        if (Objects.nonNull(process)) {
+            if (ServiceManager.getProcessService().isImageFolderInUse(process)) {
+                Helper.setMessage(
+                        Helper.getTranslation("directory ") + " " + process.getTitle() + " "
+                                + Helper.getTranslation("isInUse"),
+                        ServiceManager.getUserService()
+                                .getFullName(ServiceManager.getProcessService().getImageFolderInUseUser(process)));
+                webDav.downloadToHome(process, true);
+            } else {
+                webDav.downloadToHome(process, false);
+            }
         }
     }
 


### PR DESCRIPTION
Check return values that may be null before dereferencing them:

- GalleryPanel.select(): null-check the GalleryMediaContent before resolving its logical structure instead of after
- GalleryPanel.isSelected(): null-check the GalleryStripe returned by getLogicalStructureOfMedia()
- MediaPartialsPanel.getMediaPartialChildDivisionsOfSelection(): null-check the GalleryMediaContent returned by getGalleryMediaContent()
- MassImportForm.handleFileUpload(): null-check the uploaded file
- ProcessService.downloadToHome(): null-check the Process returned by getById()

CIDs: 487003, 486993, 486994, 486980, 486983, 415161

Assisted-by: OpenCode / big-pickle (opencode)