### PR TITLE
Update ActiveMQ client to 6.3.0

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQDirector.java
@@ -16,13 +16,13 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.jms.Connection;
-import javax.jms.DeliveryMode;
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
+import jakarta.jms.Connection;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.ActiveMQSslConnectionFactory;
@@ -46,7 +46,7 @@ public class ActiveMQDirector implements Runnable {
     private static final Logger logger = LogManager.getLogger(ActiveMQDirector.class);
 
     // When implementing new services, add them to this list
-    private static Collection<ActiveMQProcessor> services;
+    private static final Collection<ActiveMQProcessor> services;
 
     static {
         services = Arrays.asList(new FinalizeStepProcessor(), new TaskActionProcessor(),
@@ -118,7 +118,7 @@ public class ActiveMQDirector implements Runnable {
             }
 
             connection.start();
-            connection.setExceptionListener(exception -> logger.error(exception));
+            connection.setExceptionListener(logger::error);
             return connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         } catch (Exception e) {
             logger.fatal("Error connecting to ActiveMQ server, giving up.", e);

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/ActiveMQProcessor.java
@@ -16,11 +16,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.jms.JMSException;
-import javax.jms.MapMessage;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageListener;
+import jakarta.jms.JMSException;
+import jakarta.jms.MapMessage;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageListener;
 
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
@@ -50,7 +50,7 @@ public abstract class ActiveMQProcessor implements MessageListener {
     /**
      * The name of the queue from which this processor is processing messages.
      */
-    private String queueName;
+    private final String queueName;
 
     /**
      * The message consumer object that actually receives the messages and

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/CreateNewProcessOrder.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/CreateNewProcessOrder.java
@@ -25,7 +25,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.kitodo.api.MdSec;
@@ -98,7 +98,7 @@ public class CreateNewProcessOrder {
      *             if the ImportConfiguartionDAO is unable to find an import
      *             configuration with the given ID
      * @throws IllegalArgumentException
-     *             If a required field is missing in the Active MQ message
+     *             If a required field is missing in the Active MQ
      *             message, or contains inappropriate values.
      * @throws JMSException
      *             Defined by the JMS API. I have not seen any cases where this
@@ -127,7 +127,7 @@ public class CreateNewProcessOrder {
      *             if the ImportConfiguartionDAO is unable to find an import
      *             configuration with that ID
      */
-    private static final List<Pair<ImportConfiguration, String>> convertImports(@Nullable List<?> imports)
+    private static List<Pair<ImportConfiguration, String>> convertImports(@Nullable List<?> imports)
             throws DAOException {
 
         if (Objects.isNull(imports) || imports.isEmpty()) {
@@ -137,10 +137,9 @@ public class CreateNewProcessOrder {
         final ImportConfigurationService importConfigurationService = ServiceManager.getImportConfigurationService();
         List<Pair<ImportConfiguration, String>> result = new ArrayList<>();
         for (Object dubious : imports) {
-            if (!(dubious instanceof Map)) {
+            if (!(dubious instanceof Map<?, ?> map)) {
                 throw new IllegalArgumentException("Entry of \"imports\" is not a map");
             }
-            Map<?, ?> map = (Map<?, ?>) dubious;
             ImportConfiguration importconfiguration = importConfigurationService.getById(MapMessageObjectReader
                     .getMandatoryInteger(map, FIELD_IMPORT_CONFIG));
             String value = MapMessageObjectReader.getMandatoryString(map, FIELD_IMPORT_VALUE);
@@ -162,7 +161,7 @@ public class CreateNewProcessOrder {
      *             if the process count for the title is not exactly one
      */
     @CheckForNull
-    private static final Integer convertProcessId(String processId) throws DAOException, ProcessorException {
+    private static Integer convertProcessId(String processId) throws DAOException, ProcessorException {
         if (Objects.isNull(processId)) {
             return null;
         }
@@ -170,7 +169,7 @@ public class CreateNewProcessOrder {
             return Integer.valueOf(processId);
         } else {
             Collection<Process> parents = ServiceManager.getProcessService().findByTitle(processId);
-            if (parents.size() == 0) {
+            if (parents.isEmpty()) {
                 throw new ProcessorException("Parent process not found");
             } else if (parents.size() > 1) {
                 throw new ProcessorException("Parent process exists more than one");
@@ -184,7 +183,7 @@ public class CreateNewProcessOrder {
      * Converts metadata details into safe data objects. For {@code null}, it
      * will return an empty collection, never {@code null}.
      */
-    private static final HashSet<Metadata> convertMetadata(@Nullable Map<?, ?> metadata, @Nullable MdSec domain) {
+    private static HashSet<Metadata> convertMetadata(@Nullable Map<?, ?> metadata, @Nullable MdSec domain) {
 
         HashSet<Metadata> result = new HashSet<>();
         if (Objects.isNull(metadata)) {
@@ -193,10 +192,9 @@ public class CreateNewProcessOrder {
 
         for (Entry<?, ?> entry : metadata.entrySet()) {
             Object dubiousKey = entry.getKey();
-            if (!(dubiousKey instanceof String) || ((String) dubiousKey).isEmpty()) {
+            if (!(dubiousKey instanceof String key) || key.isEmpty()) {
                 throw new IllegalArgumentException("Invalid metadata key");
             }
-            String key = (String) dubiousKey;
 
             Object dubiousValuesList = entry.getValue();
             if (!(dubiousValuesList instanceof List)) {

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/CreateNewProcessesProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/CreateNewProcessesProcessor.java
@@ -22,13 +22,12 @@ import java.util.Locale.LanguageRange;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.jms.JMSException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import jakarta.jms.JMSException;
+
 import org.kitodo.api.Metadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.FunctionalMetadata;
 import org.kitodo.api.dataeditor.rulesetmanagement.RulesetManagementInterface;
@@ -56,7 +55,6 @@ import org.kitodo.production.services.ServiceManager;
 import org.kitodo.production.services.data.ImportService;
 import org.kitodo.production.services.data.ProcessService;
 import org.kitodo.production.services.data.RulesetService;
-import org.kitodo.production.services.data.TaskService;
 import org.kitodo.production.services.dataformat.MetsService;
 import org.kitodo.production.services.file.FileService;
 import org.xml.sax.SAXException;
@@ -65,8 +63,6 @@ import org.xml.sax.SAXException;
  * An Active MQ service interface to create new processes.
  */
 public class CreateNewProcessesProcessor extends ActiveMQProcessor {
-    private static final Logger logger = LogManager.getLogger(CreateNewProcessesProcessor.class);
-
     private static final int IMPORT_WITHOUT_ANY_HIERARCHY = 1;
     private static final String LAST_CHILD = Integer.toString(-1);
     private static final List<LanguageRange> METADATA_LANGUAGE = Locale.LanguageRange.parse("en");
@@ -76,7 +72,6 @@ public class CreateNewProcessesProcessor extends ActiveMQProcessor {
     private final MetsService metsService = ServiceManager.getMetsService();
     private final ProcessService processService = ServiceManager.getProcessService();
     private final RulesetService rulesetService = ServiceManager.getRulesetService();
-    private final TaskService taskService = ServiceManager.getTaskService();
 
     private RulesetManagementInterface rulesetManagement;
 

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/FinalizeStepProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/FinalizeStepProcessor.java
@@ -16,7 +16,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/KitodoScriptProcessor.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.kitodo.config.ConfigCore;

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/MapMessageObjectReader.java
@@ -25,8 +25,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.jms.JMSException;
-import javax.jms.MapMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.MapMessage;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +35,7 @@ import org.kitodo.utils.Guard;
 
 public class MapMessageObjectReader {
 
-    private MapMessage ticket;
+    private final MapMessage ticket;
     private static final Logger logger = LogManager.getLogger(MapMessageObjectReader.class);
     private static final String MANDATORY_ARGUMENT = "Mandatory argument ";
     private static final String MISSING_ARGUMENT = "Missing mandatory argument: \"";
@@ -134,10 +134,9 @@ public class MapMessageObjectReader {
         if (Objects.isNull(value)) {
             throw new IllegalArgumentException(MISSING_ARGUMENT + key + "\"");
         }
-        if (!(value instanceof String)) {
+        if (!(value instanceof String mandatoryString)) {
             throw new IllegalArgumentException(MANDATORY_ARGUMENT + key + " is not a string");
         }
-        String mandatoryString = (String) value;
         if (mandatoryString.isEmpty()) {
             throw new IllegalArgumentException(MISSING_ARGUMENT + key + "\"");
         }

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/TaskActionProcessor.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/TaskActionProcessor.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;

--- a/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/WebServiceResult.java
+++ b/Kitodo/src/main/java/org/kitodo/production/interfaces/activemq/WebServiceResult.java
@@ -15,8 +15,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
-import javax.jms.JMSException;
-import javax.jms.MapMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.MapMessage;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -26,9 +26,9 @@ import org.kitodo.production.enums.ReportLevel;
 public class WebServiceResult {
     private static final Logger logger = LogManager.getLogger(WebServiceResult.class);
 
-    private String queueName;
-    private String id;
-    private ReportLevel level;
+    private final String queueName;
+    private final String id;
+    private final ReportLevel level;
     private String message = null;
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/CreateNewProcessesProcessorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/CreateNewProcessesProcessorIT.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.jms.MapMessage;
+import jakarta.jms.MapMessage;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/TaskActionProcessorIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/interfaces/activemq/TaskActionProcessorIT.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Objects;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@ from system library in Java 11+ -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
-                <version>5.19.4</version>
+                <version>6.3.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- Update ActiveMQ from 5.19.4 to 6.3.0 which requires a change from JavaX to Jakarta namespace
- Did some code cleanup in the changed ActiveMQ use classes
- Did some tests (closing tasks in most cases) with ActiveMQ server 5.19.x and 6.3.0 without any issue. So updating ActiveMQ server to 6.3.0 is not necessary.