### PR TITLE
Fix NPE opening Metadata Editor with other Error

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/StructurePanel.java
@@ -1273,7 +1273,7 @@ public class StructurePanel implements Serializable {
      * @return whether both conditions are met and a structure element can be created from the current selection
      */
     public boolean isCreatingStructureFromSelectionPossible() {
-        int numberOfSelectedMedia = dataEditor.getSelectedMedia().size();
+        int numberOfSelectedMedia = Objects.nonNull(dataEditor.getSelectedMedia()) ? dataEditor.getSelectedMedia().size() : 0;
         boolean mediaSelected = numberOfSelectedMedia >= 1;
         boolean onlyMediaSelected = numberOfSelectedMedia == getSelectedLogicalNodes().size();
         return mediaSelected && onlyMediaSelected;


### PR DESCRIPTION
I noticed a NPE related to #7054 when opening the metadata editor for a process which is problematic for other reasons:

```java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because the return value of "org.kitodo.production.forms.dataeditor.DataEditorForm.getSelectedMedia()" is null
	at org.kitodo.production.forms.dataeditor.StructurePanel.isCreatingStructureFromSelectionPossible(StructurePanel.java:1276)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at jakarta.el.BeanELResolver.invoke(BeanELResolver.java:158)
	at jakarta.el.CompositeELResolver.invoke(CompositeELResolver.java:122)
	...
```

The problem is that the `selectedMedia` list is initialized inside a try-catch block. If there is an issue in the try-catch block before the initialization of `selectedMedia` is done, it remains null. Also, there might be other scenarios where this list is null.

In my particular case, the metadata editor fails with the following error (after this PR), because it contains various corrupted test images that I used for the LTP image validation implementation:

```
InvalidImagesException: Ambiguous canonical file name part in the same physical division: "CoRRUpTed" and "corrupted"!
```

You can reproduce this error by changing an image filepath inside the meta.xml of a process, e.g.:

```diff
            <mets:file ID="uuid-2305cc3d-b723-466a-b931-f79f03ec5c34" MIMETYPE="image/jpeg">
+                <mets:FLocat LOCTYPE="URL" xlink:href="jpgs/max/00000003_SOMETHING_.jpg"/>
-                <mets:FLocat LOCTYPE="URL" xlink:href="jpgs/max/00000003.jpg"/>
            </mets:file>
```