### PR TITLE
Allow digits in method, member, parameter and variable names

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -121,26 +121,26 @@
         </module>
 
         <module name="MemberName">
-            <property name="format" value="^[a-z][a-zA-Z]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
 
         <module name="ParameterName">
-            <property name="format" value="^[a-z][a-zA-Z]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
 
         <module name="LambdaParameterName">
-            <property name="format" value="^[a-z][a-zA-Z]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
 
         <module name="LocalVariableName">
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-zA-Z]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern"
                      value="Local variable name ''{0}'' must match pattern ''{1}''."/>
@@ -264,7 +264,7 @@
         </module>
 
         <module name="MethodName">
-            <property name="format" value="^[a-z][a-zA-Z]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
Checkstyle's MethodName format disallowed digits, so names like getFile2() or X509_getSerialNumber() failed the check even though digits are perfectly legal Java identifiers (JLS 3.8: identifiers consist of Java letters followed by Java letters or Java digits).

All mainstream Java style guides allow digits in identifier names:
- checkstyle's default format is ^[a-z][a-zA-Z0-9]*$ for MethodName, MemberName, ParameterName and LocalVariableName
- Google Java Style camelCase regex includes digits
- Sun/Oracle Code Conventions only require verbs in mixed case

Update MethodName, MemberName, ParameterName, LambdaParameterName and LocalVariableName from ^[a-z][a-zA-Z]*$ to ^[a-z][a-zA-Z0-9]*$ to match the checkstyle default and common conventions.

Assisted-by: OpenCode / big-pickle (opencode)