### PR TITLE
Reduce memory consumption on task state down and improve performance

### DIFF
--- a/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProcessDAO.java
+++ b/Kitodo-DataManagement/src/main/java/org/kitodo/data/database/persistence/ProcessDAO.java
@@ -11,6 +11,7 @@
 
 package org.kitodo.data.database.persistence;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -117,5 +118,26 @@ public class ProcessDAO extends BaseDAO<Process> {
                     "processIds", processIdChunk
                 ));
         }
+    }
+
+    /**
+     *  Updates the sort helper status of the process with the given ID directly in the database.
+     *
+     * @param processId ID of the process to update
+     * @param sortHelperStatus new sort helper status, may be {@code null}
+     */
+    public void updateSortHelperStatus(Integer processId, String sortHelperStatus)
+        throws DAOException {
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("sortHelperStatus", sortHelperStatus);
+        parameters.put("processId", processId);
+
+        executeUpdate("""
+            UPDATE Process p
+            SET p.sortHelperStatus = :sortHelperStatus
+            WHERE p.id = :processId
+            """, parameters);
+
     }
 }

--- a/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessEditViewTasksTab.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/process/ProcessEditViewTasksTab.java
@@ -119,9 +119,15 @@ public class ProcessEditViewTasksTab extends BaseTabEditView<Process> {
      */
     public void setTaskStatusDown(Task task) {
         final Stopwatch stopwatch = new Stopwatch(this, "setTaskStatusDown");
-        workflowControllerService.setTaskStatusDown(task);
-        ProcessService.deleteSymlinksFromUserHomes(task);
-        refreshParent();
+        try {
+            workflowControllerService.setTaskStatusDown(task);
+            ProcessService.deleteSymlinksFromUserHomes(task);
+            refreshParent();
+        } catch (DAOException e) {
+            Helper.setErrorMessage("errorChangeTaskStatus",
+                new Object[] {Helper.getTranslation("down"), task.getProcess().getId()},
+                logger, e);
+        }
         stopwatch.stop();
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -923,6 +923,11 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
                 .filter(t -> TaskStatus.INWORK.equals(t.getProcessingStatus())).collect(Collectors.toList());
     }
 
+    public void updateSortHelperStatus(Integer processId, String sortHelperStatus)
+        throws DAOException {
+        dao.updateSortHelperStatus(processId, sortHelperStatus);
+    }
+
     /**
      * Create and return String used as progress tooltip for a given process. Tooltip contains OPEN tasks and tasks
      * INWORK.

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -923,6 +923,12 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
                 .filter(t -> TaskStatus.INWORK.equals(t.getProcessingStatus())).collect(Collectors.toList());
     }
 
+    /**
+     * Updates the sort helper status of the process with the given ID directly in the database.
+     *
+     * @param processId ID of the process to update
+     * @param sortHelperStatus new sort helper status, may be {@code null}
+     */
     public void updateSortHelperStatus(Integer processId, String sortHelperStatus)
         throws DAOException {
         dao.updateSortHelperStatus(processId, sortHelperStatus);

--- a/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/workflow/WorkflowControllerService.java
@@ -128,7 +128,7 @@ public class WorkflowControllerService {
      * @param task
      *            to change status down
      */
-    public void setTaskStatusDown(Task task) {
+    public void setTaskStatusDown(Task task) throws DAOException {
         setTaskStatusDown(Collections.singletonList(task));
     }
 
@@ -138,16 +138,23 @@ public class WorkflowControllerService {
      * @param tasks
      *            to change status down
      */
-    public void setTaskStatusDown(List<Task> tasks) {
+    public void setTaskStatusDown(List<Task> tasks) throws DAOException {
+        User currentUser = getCurrentUser();
+        Date now = new Date();
+
         for (Task task : tasks) {
             task.setEditType(TaskEditType.ADMIN);
-            task.setProcessingTime(new Date());
-            taskService.replaceProcessingUser(task, getCurrentUser());
+            task.setProcessingTime(now);
+            taskService.replaceProcessingUser(task, currentUser);
             setProcessingStatusDown(task);
+            taskService.save(task);
+
             if (task.getProcessingStatus() == TaskStatus.LOCKED) {
                 List<Task> previousTasks = getPreviousTasks(task);
+
                 for (Task previousTask : previousTasks) {
                     setProcessingStatusDown(previousTask);
+                    taskService.save(previousTask);
                 }
             }
         }
@@ -183,7 +190,7 @@ public class WorkflowControllerService {
      * @param process
      *            object
      */
-    public void setTasksStatusDown(Process process) {
+    public void setTasksStatusDown(Process process) throws DAOException {
         List<Task> currentTask = ServiceManager.getProcessService().getCurrentTasks(process);
         if (currentTask.isEmpty()) {
             currentTask = getLastClosedTask(process);
@@ -836,11 +843,16 @@ public class WorkflowControllerService {
         for (Process processForStatus : processes) {
             try {
                 setTasksStatusDown(processForStatus);
-                ServiceManager.getProcessService().save(processForStatus);
+
                 updateProcessSortHelperStatus(processForStatus);
+
+                ServiceManager.getProcessService().updateSortHelperStatus(
+                    processForStatus.getId(),
+                    processForStatus.getSortHelperStatus()
+                );
             } catch (DAOException e) {
                 Helper.setErrorMessage("errorChangeTaskStatus",
-                        new Object[] {Helper.getTranslation("down"), processForStatus.getId() }, logger, e);
+                    new Object[] {Helper.getTranslation("down"), processForStatus.getId() }, logger, e);
             }
         }
     }


### PR DESCRIPTION
This Pull Request significantly improves the performance of the "Set Task state down" operation, especially if done in a batch via the process list. In my tests, when setting 3500 processes "down" runtime went down from around a minute to 16 seconds. 
The main change is to use more targeted persistence operations for the affected tasks and for `sortHelperStatus`, instead of calling `ServiceManager.getProcessService().save(processForStatus)`. Saving the whole process causes Hibernate to allocate and process large object graphs, resulting in significantly higher runtime and memory usage.

Adresses https://github.com/kitodo/kitodo-production/issues/5813