### PR TITLE
Update log4j to 2.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <primefaces.version>13.0.10</primefaces.version>
         <primefaces.extensions.version>12.0.11</primefaces.extensions.version>
         <saxon.version>9.9.1-8</saxon.version>
-        <log4j.version>2.25.4</log4j.version>
+        <log4j.version>2.25.5</log4j.version>
         <junit.version>6.1.3</junit.version>
         <opensearch.version>2.15.0</opensearch.version>
         <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>


### PR DESCRIPTION
Fix warning message from CodeQL "Apache Log4j API: Improper encoding of non-finite floating-point values during MapMessage JSON serialization"

Log4j 2.26.x is released too which introduce some changes for the upcoming 3.0.x release.