### PR TITLE
Update commons-configuration2 to 2.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.15.0</version>
+                <version>2.15.1</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Fixes some wrong / missing dependency information which can lead to runtime errors.