### PR TITLE
Update flyway to 12.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <selenium.version>4.40.0</selenium.version>
         <spring.security.version>7.0.6</spring.security.version>
-        <flyway-maven-plugin.version>12.3.0</flyway-maven-plugin.version>
+        <flyway-maven-plugin.version>12.11.0</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>
         <pitest.version>1.4.10</pitest.version>


### PR DESCRIPTION
- Update to current latest 12.x version
- Fix message "[WARNING] Using MariaDB 11.8 which is newer than the version Flyway has been verified with. The latest verified version of MariaDB is 11.7." on Debian Trixie (Debian 13) as 12.3.0 did not official support MariaDB 11.8 (but works too).