### PR TITLE
Fix flaky ImportingST tests in CI

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -171,6 +171,15 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
      */
     public List<String> getImportConfigurationsTitles() {
         clickElement(catalogSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
+        await("Wait for import configuration titles to be loaded")
+                .pollDelay(500, TimeUnit.MILLISECONDS)
+                .atMost(30, TimeUnit.SECONDS).ignoreExceptions()
+                .until(() -> {
+                    List<WebElement> items = Browser.getDriver()
+                            .findElement(By.id("catalogSearchForm:catalogueSelectMenu_items"))
+                            .findElements(By.className("ui-selectonemenu-list-item"));
+                    return !items.isEmpty() && items.stream().allMatch(item -> !item.getText().isEmpty());
+                });
         WebElement selectMenuItems = Browser.getDriver().findElement(By.id("catalogSearchForm:catalogueSelectMenu_items"));
         return selectMenuItems.findElements(By.className("ui-selectonemenu-list-item"))
                 .stream().map(WebElement::getText).collect(Collectors.toList());
@@ -383,7 +392,7 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
      * @param index index of checkbox to click
      */
     public void selectCheckBox(int index) {
-        metadataTable.findElements(By.className("ui-chkbox-icon")).get(index).click();
+        clickElement(metadataTable.findElements(By.className("ui-chkbox-box")).get(index));
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/ProcessFromTemplatePage.java
@@ -173,12 +173,12 @@ public class ProcessFromTemplatePage extends EditPage<ProcessFromTemplatePage> {
         clickElement(catalogSelect.findElement(By.cssSelector(CSS_SELECTOR_DROPDOWN_TRIGGER)));
         await("Wait for import configuration titles to be loaded")
                 .pollDelay(500, TimeUnit.MILLISECONDS)
-                .atMost(30, TimeUnit.SECONDS).ignoreExceptions()
+                .atMost(5, TimeUnit.SECONDS).ignoreExceptions()
                 .until(() -> {
                     List<WebElement> items = Browser.getDriver()
                             .findElement(By.id("catalogSearchForm:catalogueSelectMenu_items"))
                             .findElements(By.className("ui-selectonemenu-list-item"));
-                    return !items.isEmpty() && items.stream().allMatch(item -> !item.getText().isEmpty());
+                    return !items.isEmpty() && items.stream().noneMatch(item -> item.getText().isEmpty());
                 });
         WebElement selectMenuItems = Browser.getDriver().findElement(By.id("catalogSearchForm:catalogueSelectMenu_items"));
         return selectMenuItems.findElements(By.className("ui-selectonemenu-list-item"))

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/TopNavigationPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/TopNavigationPage.java
@@ -145,49 +145,55 @@ public class TopNavigationPage extends Page<TopNavigationPage> {
      * Hovers dashboard menu and clicks on link to help page.
      */
     void gotoHelp() {
-        RemoteWebDriver driver = Browser.getDriver();
-        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id("linkHelp")));
+        clickNavigationLink("linkHelp");
     }
 
     /**
      * Hovers dashboard menu and clicks on link to tasks page.
      */
     void gotoTasks() throws InterruptedException {
-        RemoteWebDriver driver = Browser.getDriver();
         Thread.sleep(Browser.getDelayAfterDelete());
-        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id("linkTasks")));
+        clickNavigationLink("linkTasks");
     }
 
     /**
      * Hovers dashboard menu and clicks on link to processes page.
      */
     void gotoProcesses() {
-        RemoteWebDriver driver = Browser.getDriver();
-        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id(LINK_PROCESSES_ID)));
+        clickNavigationLink(LINK_PROCESSES_ID);
     }
 
     /**
      * Hovers dashboard menu and clicks on link to projects page.
      */
     void gotoProjects() {
-        RemoteWebDriver driver = Browser.getDriver();
-        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id("linkProjects")));
+        clickNavigationLink("linkProjects");
     }
 
     /**
      * Hovers dashboard menu and clicks on link to users page.
      */
     void gotoUsers() {
-        RemoteWebDriver driver = Browser.getDriver();
-        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id("linkUsers")));
+        clickNavigationLink("linkUsers");
     }
 
     /**
      * Hovers dashboard menu and clicks on link to system page.
      */
     void gotoSystem() {
+        clickNavigationLink("linkSystem");
+    }
+
+    /**
+     * Waits until the navigation link with the given ID is present in the DOM and clicks it.
+     *
+     * @param linkId ID of the navigation link
+     */
+    private void clickNavigationLink(String linkId) {
         RemoteWebDriver driver = Browser.getDriver();
-        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id("linkSystem")));
+        WebDriverWait webDriverWait = new WebDriverWait(driver, Duration.ofSeconds(90));
+        webDriverWait.until(ExpectedConditions.presenceOfElementLocated(By.id(linkId)));
+        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id(linkId)));
     }
 
     /**

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/TopNavigationPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/TopNavigationPage.java
@@ -191,9 +191,9 @@ public class TopNavigationPage extends Page<TopNavigationPage> {
      */
     private void clickNavigationLink(String linkId) {
         RemoteWebDriver driver = Browser.getDriver();
-        WebDriverWait webDriverWait = new WebDriverWait(driver, Duration.ofSeconds(90));
+        WebDriverWait webDriverWait = new WebDriverWait(driver, Duration.ofSeconds(5));
         webDriverWait.until(ExpectedConditions.presenceOfElementLocated(By.id(linkId)));
-        ((JavascriptExecutor) driver).executeScript(ARGUMENTS_CLICK, driver.findElement(By.id(linkId)));
+        driver.executeScript(ARGUMENTS_CLICK, driver.findElement(By.id(linkId)));
     }
 
     /**


### PR DESCRIPTION
ImportingST.checkOptionalMetadataValidationDuringProcessCreation sometimes failed with NoSuchElementException for #linkProjects right after login, because the browser was still on the login page when the navigation link was looked up. The fixed delay of 2 seconds after login is not always enough on slow CI servers. All navigation methods in TopNavigationPage now wait until the corresponding link is present in the DOM before clicking it.

ImportingST.checkOrderOfImportConfigurations sometimes failed because the titles of the import configurations in the dropdown were read before the list items were populated. getImportConfigurationsTitles now waits until all list items have a non-empty title.

Assisted-by: OpenCode / big-pickle (opencode)