### PR TITLE
Enforce zero checkstyle violations

### DIFF
--- a/Kitodo/pom.xml
+++ b/Kitodo/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <maxAllowedViolations>2</maxAllowedViolations>
+        <maxAllowedViolations>0</maxAllowedViolations>
         <cargo.plugin.version>1.10.22</cargo.plugin.version>
         <jsf.projectStage>Production</jsf.projectStage>
         <myfaces.resourceMaxTimeExpires>604800000</myfaces.resourceMaxTimeExpires>

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/pagination/Paginator.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/pagination/Paginator.java
@@ -35,6 +35,7 @@ public class Paginator implements Iterator<String> {
      */
     private HalfInteger value;
 
+    @SuppressWarnings("checkstyle:MethodLength")
     private void parse(String initializer) {
 
         StringBuilder stringBuilder = new StringBuilder();

--- a/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
+++ b/Kitodo/src/main/java/org/kitodo/production/thread/ImportEadProcessesThread.java
@@ -125,6 +125,7 @@ public class ImportEadProcessesThread extends EmptyTask {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:MethodLength")
     public void run() {
         setAuthenticatedUser();
         List<Integer> newProcessIds = new ArrayList<>();

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -35,6 +35,8 @@
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
 
+        <module name="SuppressWarningsHolder"/>
+
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
             <property name="format"
@@ -282,4 +284,5 @@
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf"/>
     </module>
+    <module name="SuppressWarningsFilter"/>
 </module>


### PR DESCRIPTION
The Kitodo module allowed up to two checkstyle violations. With a non-zero maximum, the checkstyle check would not fail when new violations were introduced, as long as their number stayed below the limit, so partial test runs would not detect them. Reduce maxAllowedViolations to 0 so that every violation fails the build.

The two remaining MethodLength violations are in Paginator.parse() and ImportEadProcessesThread.run(), both intricate state machines that are hard to split without hurting readability. Exempt these two methods from the MethodLength check via
@SuppressWarnings("checkstyle:MethodLength"), enabled by the newly added SuppressWarningsHolder and SuppressWarningsFilter in the checkstyle configuration.

Assisted-by: OpenCode / big-pickle (opencode)