### PR TITLE
Keep the search server node running across selenium test classes

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/MockDatabase.java
+++ b/Kitodo/src/test/java/org/kitodo/MockDatabase.java
@@ -144,12 +144,14 @@ public class MockDatabase {
     }
 
     public static void startNode() throws Exception {
-        final String nodeName = "index";
-        final String port = "9205"; // defined in test resources file hibernate.cfg.xml
-        Environment environment = prepareEnvironment(port, nodeName, Paths.get("target", "classes"));
-        removeOldDataDirectories("target/" + nodeName);
-        node = new ExtendedNode(environment, Collections.singleton(Netty4Plugin.class));
-        node.start();
+        if (node == null) {
+            final String nodeName = "index";
+            final String port = "9205"; // defined in test resources file hibernate.cfg.xml
+            Environment environment = prepareEnvironment(port, nodeName, Paths.get("target", "classes"));
+            removeOldDataDirectories("target/" + nodeName);
+            node = new ExtendedNode(environment, Collections.singleton(Netty4Plugin.class));
+            node.start();
+        }
     }
 
     public static void stopNode() throws Exception {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
@@ -85,7 +85,11 @@ public class BaseTestSelenium {
 
         usersDirectory.delete();
 
-        MockDatabase.stopNode();
+        // The search server node is not stopped here, but kept running across
+        // all selenium test classes, because the Tomcat application would keep
+        // stale connections to a restarted index server and the first index
+        // query of every test class would stall. The node is stopped when the
+        // JVM terminates, so it is kept only within this surefire execution.
         MockDatabase.stopDatabaseServer();
         MockDatabase.cleanDatabase();
     }


### PR DESCRIPTION
The embedded OpenSearch node was restarted by every selenium test class (started in setUp, stopped in tearDown) while the Tomcat application kept running. The application's Hibernate Search client then kept stale HTTP connections to the killed node, and the first index query after each restart -- typically the isIndexCorrupted count in the login POST -- stalled for up to several minutes while the client retried those connections (observed 43 to 307 s across succeeding CI runs). The stall intermittently exceeded the navigation-link wait and made MetadataST, AddingST, ImportingST and MetadataImagePreviewST fail at random.

Start the node only if it is not running yet, and do not stop it in BaseTestSelenium.tearDown, so the node is started once per surefire execution and kept alive for the whole run. This eliminates the restart and the resulting stale-connection stalls. Per-class isolation is preserved, because setUp already drops and recreates the only Hibernate Search index (Process) and reinserts the base data for every test class.

MockDatabase.stopNode() is left in place for the other test frameworks, which still stop and start the node per class and are unaffected.

Assisted-by: OpenCode / big-pickle (opencode)