### PR TITLE
Processes of projects a user is not assigned to can be exported

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ProcessService.java
@@ -2561,10 +2561,6 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         if (!includeClosed) {
             query.restrictToNotCompletedProcesses();
         }
-        if (!includeInactiveProjects) {
-            query.addBooleanRestriction("project.active", Boolean.TRUE);
-        }
-
         if (allSelected) {
             if (Objects.nonNull(excludedProcessIds) && !excludedProcessIds.isEmpty()) {
                 query.addNotInCollectionRestriction("id", excludedProcessIds);
@@ -2574,6 +2570,11 @@ public class ProcessService extends BaseBeanService<Process, ProcessDAO> {
         }
 
         query.restrictToClient(sessionClientId);
+
+        Collection<Integer> projectIDs = ServiceManager.getUserService().getCurrentUser().getProjects().stream()
+                .filter(project -> includeInactiveProjects || project.isActive()).map(project -> project.getId())
+                .collect(Collectors.toList());
+        query.restrictToProjects(projectIDs);
         query.applyIndexRestriction(FIELD_ID);
         query.addInnerJoin("project proj");
         query.defineSorting("id", SortOrder.ASCENDING);


### PR DESCRIPTION
This PR fixes the issue that processes can be exported for projects even if a user is not assigned to said projects. You can reproduce this issue by:

1. Create a user that is not assigned to all projects of a client
2. Go to the process list
3. Select all processes by clicking on "Alle Treffer" 
4. Export processes via Excel/CSV export

The CSV/Excel file contains processes for projects the user has no access to.

@BartChris You are more involved in this export code. I simply copied the "project restriction" from the `ProcessService.findSelectedProcesses()` method and added it to the `ProcessService.createExportQuery()` method. That seems to fix the issue.