### PR TITLE
Refresh current user object from the database during active user session

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportMets.java
@@ -77,7 +77,7 @@ public class ExportMets {
      *            Process object
      */
     public boolean startExport(Process process) throws DAOException, IOException, SAXException, FileStructureValidationException {
-        User user = ServiceManager.getUserService().getAuthenticatedUser();
+        User user = ServiceManager.getUserService().getCurrentUser();
         URI userHome = ServiceManager.getUserService().getHomeDirectory(user);
         boolean exportSuccessful = startExport(process, userHome);
         if (exportSuccessful) {
@@ -124,7 +124,7 @@ public class ExportMets {
      *            the folder to prove and maybe create it
      */
     protected void prepareUserDirectory(URI targetFolder) {
-        User user = ServiceManager.getUserService().getAuthenticatedUser();
+        User user = ServiceManager.getUserService().getCurrentUser();
         try {
             fileService.createDirectoryForUser(targetFolder, user.getLogin());
         } catch (IOException | RuntimeException e) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/IndexingForm.java
@@ -173,7 +173,7 @@ public class IndexingForm {
      */
     public void startAllIndexing() {
         indexingStartedTime = LocalDateTime.now();
-        indexingStartedUser = ServiceManager.getUserService().getAuthenticatedUser().getFullName();
+        indexingStartedUser = ServiceManager.getUserService().getCurrentUser().getFullName();
         for (IndexingRow indexingRow : indexingRows.values()) {
             if (!indexingRow.isIndexingInProgress()) {
                 indexingRow.callIndexing();

--- a/Kitodo/src/main/java/org/kitodo/production/helper/WebDav.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/WebDav.java
@@ -59,7 +59,7 @@ public class WebDav implements Serializable {
      * Retrieve all folders from one directory.
      */
     public List<URI> uploadAllFromHome(String inVerzeichnis) {
-        User currentUser = userService.getAuthenticatedUser();
+        User currentUser = userService.getCurrentUser();
         List<URI> files = new ArrayList<>();
         FilenameFilter filter = new FileNameEndsWithFilter("]");
 
@@ -95,7 +95,7 @@ public class WebDav implements Serializable {
      */
     public void removeAllFromHome(List<URI> uris, URI directory) {
         URI verzeichnisAlle;
-        User currentUser = userService.getAuthenticatedUser();
+        User currentUser = userService.getCurrentUser();
         try {
             verzeichnisAlle = userService.getHomeDirectory(currentUser).resolve(directory);
             for (URI name : uris) {
@@ -113,7 +113,7 @@ public class WebDav implements Serializable {
      *            Process object
      */
     public void uploadFromHome(Process process) {
-        User currentUser = userService.getAuthenticatedUser();
+        User currentUser = userService.getCurrentUser();
         uploadFromHome(currentUser, process);
     }
 
@@ -158,7 +158,7 @@ public class WebDav implements Serializable {
      */
     public void downloadToHome(Process process, boolean onlyRead) {
         saveTiffHeader(process);
-        User currentUser = userService.getAuthenticatedUser();
+        User currentUser = userService.getCurrentUser();
         URI source;
         URI userHome;
 

--- a/Kitodo/src/main/java/org/kitodo/production/helper/batch/BatchTaskHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/batch/BatchTaskHelper.java
@@ -166,7 +166,7 @@ public class BatchTaskHelper extends BatchHelper {
             }
             task.setEditType(TaskEditType.MANUAL_MULTI);
             task.setProcessingTime(new Date());
-            User user = ServiceManager.getUserService().getAuthenticatedUser();
+            User user = ServiceManager.getUserService().getCurrentUser();
             ServiceManager.getTaskService().replaceProcessingUser(task, user);
 
             try {

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Locale.LanguageRange;
+import java.util.NoSuchElementException;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -84,9 +85,12 @@ public class LegacyMetsModsDigitalDocumentHelper {
         this.workpiece = new Workpiece();
 
         try {
-            User user = ServiceManager.getUserService().getCurrentUser();
-            String metadataLanguage = user != null ? user.getMetadataLanguage()
-                    : Helper.getRequestParameter("Accept-Language");
+            String metadataLanguage = Helper.getRequestParameter("Accept-Language");
+            try {
+                metadataLanguage = ServiceManager.getUserService().getCurrentUser().getMetadataLanguage();
+            } catch (NoSuchElementException e) {
+                // ignore if no user is logged in
+            }
             this.priorityList = LanguageRange.parse(! metadataLanguage.isEmpty() ? metadataLanguage : "en");
         } catch (NullPointerException e) {
             /*

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyMetsModsDigitalDocumentHelper.java
@@ -84,7 +84,7 @@ public class LegacyMetsModsDigitalDocumentHelper {
         this.workpiece = new Workpiece();
 
         try {
-            User user = ServiceManager.getUserService().getAuthenticatedUser();
+            User user = ServiceManager.getUserService().getCurrentUser();
             String metadataLanguage = user != null ? user.getMetadataLanguage()
                     : Helper.getRequestParameter("Accept-Language");
             this.priorityList = LanguageRange.parse(! metadataLanguage.isEmpty() ? metadataLanguage : "en");

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale.LanguageRange;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.apache.logging.log4j.Level;
@@ -83,9 +84,12 @@ public class LegacyPrefsHelper {
                 List<LanguageRange> priorityList;
 
                 try {
-                    User user = ServiceManager.getUserService().getCurrentUser();
-                    String metadataLanguage = user != null ? user.getMetadataLanguage()
-                            : Helper.getRequestParameter("Accept-Language");
+                    String metadataLanguage = Helper.getRequestParameter("Accept-Language");
+                    try {
+                        metadataLanguage = ServiceManager.getUserService().getCurrentUser().getMetadataLanguage();
+                    } catch (NoSuchElementException e) {
+                        // ignore if no user is logged in
+                    }                    
                     priorityList = LanguageRange.parse(! metadataLanguage.isEmpty() ? metadataLanguage : "en");
                 } catch (NullPointerException e) {
                     /*

--- a/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/metadata/legacytypeimplementations/LegacyPrefsHelper.java
@@ -83,7 +83,7 @@ public class LegacyPrefsHelper {
                 List<LanguageRange> priorityList;
 
                 try {
-                    User user = ServiceManager.getUserService().getAuthenticatedUser();
+                    User user = ServiceManager.getUserService().getCurrentUser();
                     String metadataLanguage = user != null ? user.getMetadataLanguage()
                             : Helper.getRequestParameter("Accept-Language");
                     priorityList = LanguageRange.parse(! metadataLanguage.isEmpty() ? metadataLanguage : "en");

--- a/Kitodo/src/main/java/org/kitodo/production/model/LazyProcessModel.java
+++ b/Kitodo/src/main/java/org/kitodo/production/model/LazyProcessModel.java
@@ -187,7 +187,7 @@ public class LazyProcessModel extends LazyBeanModel {
                 .findProcessIdsWithChildren(processIds);
 
         List<Integer> userRoleIds = ServiceManager.getUserService()
-                .getAuthenticatedUser()
+                .getCurrentUser()
                 .getRoles()
                 .stream()
                 .map(Role::getId)

--- a/Kitodo/src/main/java/org/kitodo/production/services/calendar/CalendarService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/calendar/CalendarService.java
@@ -38,6 +38,7 @@ import org.kitodo.api.dataeditor.rulesetmanagement.StructuralElementViewInterfac
 import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
+import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.forms.createprocess.ProcessDetail;
 import org.kitodo.production.forms.createprocess.ProcessFieldedMetadata;
@@ -89,8 +90,8 @@ public class CalendarService {
         ruleset.load(new File(rulesetFullPath));
 
         // get the user’s metadata language
-        SecurityUserDetails authenticatedUser = ServiceManager.getUserService().getAuthenticatedUser();
-        List<Locale.LanguageRange> priorityList = Locale.LanguageRange.parse(authenticatedUser.getMetadataLanguage());
+        User user = ServiceManager.getUserService().getCurrentUser();
+        List<Locale.LanguageRange> priorityList = Locale.LanguageRange.parse(user.getMetadataLanguage());
 
         // get the basic rule set type of the newspaper
         String newspaperType = ProcessService.getBaseType(completeEdition);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/ClientService.java
@@ -110,7 +110,7 @@ public class ClientService extends BaseBeanService<Client, ClientDAO> {
         if (ServiceManager.getSecurityAccessService().hasAuthorityToViewClientList()) {
             return clients.stream().map(Client::getName).collect(Collectors.joining(COMMA_DELIMITER));
         } else {
-            return clients.stream().filter(client -> ServiceManager.getUserService().getAuthenticatedUser().getClients()
+            return clients.stream().filter(client -> ServiceManager.getUserService().getCurrentUser().getClients()
                     .contains(client)).map(Client::getName).collect(Collectors.joining(COMMA_DELIMITER));
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/TaskService.java
@@ -832,7 +832,7 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
      * @return list of tasks in work by other users
      */
     public static List<Task> getTasksInWorkByOtherUsers(List<Task> tasks) {
-        int authenticatedUserId = ServiceManager.getUserService().getAuthenticatedUser().getId();
+        int authenticatedUserId = ServiceManager.getUserService().getCurrentUser().getId();
         return tasks.stream()
                 .filter(t -> Objects.nonNull(t.getProcessingUser())
                         && authenticatedUserId != t.getProcessingUser().getId())
@@ -845,7 +845,7 @@ public class TaskService extends BaseBeanService<Task, TaskDAO> {
      * @return list of current task options for new correction comment
      */
     public static List<Task> getCurrentTaskOptions(Process process) {
-        int authenticatedUserId = ServiceManager.getUserService().getAuthenticatedUser().getId();
+        int authenticatedUserId = ServiceManager.getUserService().getCurrentUser().getId();
         // NOTE: checking for 'INWORK' tasks that do not have a 'processingUser' shouldn't be necessary, but the current
         // version of Kitodo.Production allows setting tasks to 'INWORK' without explicitly assigning a user to it via a
         // process' task list (e.g. administrative action)

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -48,6 +48,7 @@ import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.data.database.persistence.UserDAO;
 import org.kitodo.exceptions.FilterException;
 import org.kitodo.production.helper.Helper;
+import org.kitodo.production.helper.cache.RequestScopeCacheHelper;
 import org.kitodo.production.security.SecurityUserDetails;
 import org.kitodo.production.security.password.SecurityPasswordEncoder;
 import org.kitodo.production.services.ServiceManager;
@@ -64,6 +65,7 @@ public class UserService extends BaseBeanService<User, UserDAO> implements UserD
     private final SecurityPasswordEncoder passwordEncoder = new SecurityPasswordEncoder();
     private static final int DEFAULT_CLIENT_ID =
             ConfigCore.getIntParameterOrDefaultValue(ParameterCore.DEFAULT_CLIENT_ID);
+    private static final String CURRENT_USER_CACHE_KEY = "current_user";
 
     /**
      * Constructor.
@@ -212,17 +214,36 @@ public class UserService extends BaseBeanService<User, UserDAO> implements UserD
     }
 
     /**
-     * Get the current authenticated user as User bean.
+     * Return the current User object after loading it from the database (cached for each request).
+     * 
+     * <p>Previously, the user object was loaded from the spring security context. This meant that the user 
+     * object and associated beans (e.g. assigned clients, assigned projects) were cached for the full duration
+     * of the user session. If user details were changed by other users (e.g. administrators) while a user is 
+     * logged in, these would not be reflected immediately for this user, because the user object was never
+     * updated from the database during the user session.</p>
+     * 
+     * <p>Instead, the user object is now loaded exactly once from the database for each request. Any updates to
+     * user details or associated beans (e.g. assigned clients, assigned projects) are immediately reflected in 
+     * views even while the user is logged in.</p>
      *
      * @return the User object
      */
     public User getCurrentUser() {
-        SecurityUserDetails authenticatedUser = getAuthenticatedUser();
-        if (Objects.nonNull(authenticatedUser)) {
-            return new User(authenticatedUser);
-        } else {
+        User user = RequestScopeCacheHelper.getFromCache(CURRENT_USER_CACHE_KEY, () -> {
+            try {
+                SecurityUserDetails authenticatedUser = getAuthenticatedUser();
+                if (Objects.nonNull(authenticatedUser)) {
+                    return ServiceManager.getUserService().getById(authenticatedUser.getId());
+                }
+                return null;
+            } catch (DAOException e) {
+                return null;
+            }
+        }, User.class);
+        if (Objects.isNull(user)) {
             throw new NoSuchElementException("There is currently no authenticated user for this thread");
         }
+        return user;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -206,6 +206,9 @@ public class UserService extends BaseBeanService<User, UserDAO> implements UserD
 
     /**
      * Gets the current authenticated user of current threads security context.
+     * 
+     * <p>This user object is not updated throughout the user session. It contains the user object retrieved from the database at the time 
+     * of login. Do not use this object to query or modify user information or associated beans.</p>
      *
      * @return The SecurityUserDetails object or null if no user is authenticated.
      */

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -219,7 +219,7 @@ public class UserService extends BaseBeanService<User, UserDAO> implements UserD
     /**
      * Return the current User object after loading it from the database (cached for each request).
      * 
-     * <p>Previously, the user object was loaded from the spring security context. This meant that the user 
+     * <p>Previously, the user object was loaded from the Spring Security context. This meant that the user 
      * object and associated beans (e.g. assigned clients, assigned projects) were cached for the full duration
      * of the user session. If user details were changed by other users (e.g. administrators) while a user is 
      * logged in, these would not be reflected immediately for this user, because the user object was never

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/UserService.java
@@ -205,7 +205,7 @@ public class UserService extends BaseBeanService<User, UserDAO> implements UserD
     }
 
     /**
-     * Gets the current authenticated user of current threads security context.
+     * Gets the currently authenticated user from the current thread's security context.
      * 
      * <p>This user object is not updated throughout the user session. It contains the user object retrieved from the database at the time 
      * of login. Do not use this object to query or modify user information or associated beans.</p>

--- a/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
@@ -242,7 +242,7 @@ public class MetadataValidationService {
      * @return the metadata language
      */
     private List<LanguageRange> getMetadataLanguage() {
-        User user = ServiceManager.getUserService().getAuthenticatedUser();
+        User user = ServiceManager.getUserService().getCurrentUser();
         String metadataLanguage = user != null ? user.getMetadataLanguage()
                 : Helper.getRequestParameter("Accept-Language");
         return LanguageRange.parse(StringUtils.isNotBlank(metadataLanguage) ? metadataLanguage : "en");

--- a/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/validation/MetadataValidationService.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -242,9 +243,12 @@ public class MetadataValidationService {
      * @return the metadata language
      */
     private List<LanguageRange> getMetadataLanguage() {
-        User user = ServiceManager.getUserService().getCurrentUser();
-        String metadataLanguage = user != null ? user.getMetadataLanguage()
-                : Helper.getRequestParameter("Accept-Language");
+        String metadataLanguage = Helper.getRequestParameter("Accept-Language");
+        try {
+            metadataLanguage = ServiceManager.getUserService().getCurrentUser().getMetadataLanguage();
+        } catch (NoSuchElementException e) {
+            // ignore if no user is logged in
+        }
         return LanguageRange.parse(StringUtils.isNotBlank(metadataLanguage) ? metadataLanguage : "en");
     }
 

--- a/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/TitleRecordLinkTabIT.java
+++ b/Kitodo/src/test/java/org/kitodo/production/forms/copyprocess/TitleRecordLinkTabIT.java
@@ -103,8 +103,9 @@ public class TitleRecordLinkTabIT {
     @Test
     public void shouldPreventLinkingToParentProcessOfUnassignedProject() throws DAOException {
         Project firstProject = ServiceManager.getProjectService().getById(1);
-        SecurityUserDetails user = ServiceManager.getUserService().getAuthenticatedUser();
+        User user = ServiceManager.getUserService().getCurrentUser();
         user.getProjects().remove(firstProject);
+        ServiceManager.getUserService().save(user);
 
         TitleRecordLinkTab testedTitleRecordLinkTab = searchForHierarchyParent();
 
@@ -115,6 +116,7 @@ public class TitleRecordLinkTabIT {
 
         // re-add first project to user
         user.getProjects().add(firstProject);
+        ServiceManager.getUserService().save(user);
     }
 
     private TitleRecordLinkTab searchForHierarchyParent() throws DAOException {


### PR DESCRIPTION
This PR addresses the issue that some views are rendered on outdated information if user details or associated beans were updated by another user during an active user session, e.g., as discussed in #7189 for projects that are activated or deactivated while the user is logged in.

Previously, the user object was loaded from the spring security context. This meant that the user object and associated beans (e.g. assigned clients, assigned projects) were cached for the full duration of the user session. If user details were changed by other users (e.g. administrators) while a user is logged in, these would not be reflected immediately for this user, because the user object was never updated from the database during the user session.

Instead, the user object is now loaded exactly once from the database for each request. Any updates to user details or associated beans (e.g. assigned clients, assigned projects) are immediately reflected in views even while the user is logged in.

This PR only updates the user object and associated beans. It does not update permissions (spring security authorities) for the user. Users still need to logout and login again after roles or permissions were changed.