### PR TITLE
Catch 'IllegalStateException' when trying to open process in metadata editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -327,7 +327,7 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
             this.metadataFileValidationErrors.addAll(e.getValidationResult().getResultMessages());
             setValidationErrorTitle(Helper.getTranslation("validation.invalidMetadataFile"));
             showValidationExceptionDialog(e, this.referringView);
-        } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException e) {
+        } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException | IllegalStateException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
     }


### PR DESCRIPTION
Fixes #7195 by properly displaying error message:

<img width="1499" height="729" alt="Bildschirmfoto 2026-08-21 um 10 51 41" src="https://github.com/user-attachments/assets/18353695-29c0-4031-bc33-630fce0c9ca7" />
