### PR TITLE
[4.0] Catch 'IllegalStateException' when trying to open process in metadata editor

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -327,7 +327,7 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
             this.metadataFileValidationErrors.addAll(e.getValidationResult().getResultMessages());
             setValidationErrorTitle(Helper.getTranslation("validation.invalidMetadataFile"));
             showValidationExceptionDialog(e, this.referringView);
-        } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException e) {
+        } catch (IOException | DAOException | InvalidImagesException | NoSuchElementException | IllegalStateException e) {
             Helper.setErrorMessage(e.getLocalizedMessage(), logger, e);
         }
     }


### PR DESCRIPTION
Backport of #7196 for Kitodo `4.0.x`