### PR TITLE
[3.9] ci: Replace Java distribution 'adopt' by 'temurin'

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: run build
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: check java version
         run:
             java --version


### PR DESCRIPTION
Backport of #7112 for Kitodo `3.9.x`