### PR TITLE
[3.9] Update com.fasterxml.jackson.core dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,12 +437,12 @@ from system library in Java 11+ -->
 	    <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.17.2</version>
+                <version>2.22.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.17.2</version>
+                <version>2.22.2</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Update `fasterxml.jackson` dependencies in `3.9.x` branch to latest supported versions