### PR TITLE
Always write log messages in English

### DIFF
--- a/Kitodo-ImageManagement/src/main/java/org/kitodo/imagemanagement/ImageManagement.java
+++ b/Kitodo-ImageManagement/src/main/java/org/kitodo/imagemanagement/ImageManagement.java
@@ -157,7 +157,7 @@ public class ImageManagement implements ImageManagementInterface {
                 Files.delete(tempFile.toPath());
                 logger.trace("Successfully deleted {}", tempFile);
             } catch (IOException e) {
-                logger.warn("Couldn’t delete {}", tempFile, e);
+                logger.warn("Couldn't delete {}", tempFile, e);
             }
         }
     }

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -164,7 +165,7 @@ public class ExportDms extends ExportMets {
         } catch (IOException | DAOException | SAXException | FileStructureValidationException e) {
             if (Objects.nonNull(exportDmsTask)) {
                 exportDmsTask.setException(e);
-                logger.error("Export canceled for process: '{}'", process.getTitle(), e);
+                logger.error(Helper.getTranslation(Locale.ENGLISH, ERROR_EXPORT, process.getTitle()), e);
             } else {
                 Helper.setErrorMessage(ERROR_EXPORT, new Object[] {process.getTitle() }, logger, e);
             }
@@ -307,7 +308,7 @@ public class ExportDms extends ExportMets {
         } catch (RuntimeException e) {
             if (Objects.nonNull(exportDmsTask)) {
                 exportDmsTask.setException(e);
-                logger.error("Export canceled for process: '{}'", process.getTitle(), e);
+                logger.error(Helper.getTranslation(Locale.ENGLISH, ERROR_EXPORT, process.getTitle()), e);
             } else {
                 Helper.setErrorMessage(ERROR_EXPORT, new Object[] {process.getTitle() }, logger, e);
             }

--- a/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
+++ b/Kitodo/src/main/java/org/kitodo/export/ExportDms.java
@@ -164,7 +164,7 @@ public class ExportDms extends ExportMets {
         } catch (IOException | DAOException | SAXException | FileStructureValidationException e) {
             if (Objects.nonNull(exportDmsTask)) {
                 exportDmsTask.setException(e);
-                logger.error(Helper.getTranslation(ERROR_EXPORT, process.getTitle()), e);
+                logger.error("Export canceled for process: '{}'", process.getTitle(), e);
             } else {
                 Helper.setErrorMessage(ERROR_EXPORT, new Object[] {process.getTitle() }, logger, e);
             }
@@ -307,7 +307,7 @@ public class ExportDms extends ExportMets {
         } catch (RuntimeException e) {
             if (Objects.nonNull(exportDmsTask)) {
                 exportDmsTask.setException(e);
-                logger.error(Helper.getTranslation(ERROR_EXPORT, process.getTitle()), e);
+                logger.error("Export canceled for process: '{}'", process.getTitle(), e);
             } else {
                 Helper.setErrorMessage(ERROR_EXPORT, new Object[] {process.getTitle() }, logger, e);
             }

--- a/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
+++ b/Kitodo/src/main/java/org/kitodo/production/helper/Helper.java
@@ -482,7 +482,22 @@ public class Helper {
      * @return translated String
      */
     public static String getTranslation(String title, String... insertions) {
-        String pattern = getString(desiredLanguage(), title);
+        return getTranslation(desiredLanguage(), title, insertions);
+    }
+
+    /**
+     * Get translation in the given language.
+     *
+     * @param locale
+     *            language in which the message should be translated
+     * @param title
+     *            String
+     * @param insertions
+     *            Strings
+     * @return translated String
+     */
+    public static String getTranslation(Locale locale, String title, String... insertions) {
+        String pattern = getString(locale, title);
         String message = pattern;
         try {
             message = MessageFormat.format(pattern, (Object[]) insertions);

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/FilterService.java
@@ -314,7 +314,7 @@ public class FilterService extends BaseBeanService<Filter, FilterDAO> {
                 userSpecifiedFilters.add(userSpecifiedFilter);
             }
         }
-        logger.debug("`{}´ -> {}", filter, userSpecifiedFilters);
+        logger.debug("\"{}\" -> {}", filter, userSpecifiedFilters);
         return userSpecifiedFilters;
     }
 

--- a/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/data/LdapServerService.java
@@ -202,16 +202,16 @@ public class LdapServerService extends BaseBeanService<LdapServer, LdapServerDAO
             /*
              * check if HomeDir exists, else create it
              */
-            logger.debug("HomeVerzeichnis pruefen");
+            logger.debug("Checking home directory");
 
             URI homePath = getUserHomeDirectory(user);
 
             if (!new File(homePath).exists()) {
-                logger.debug("HomeVerzeichnis existiert noch nicht");
+                logger.debug("Home directory does not exist yet");
                 ServiceManager.getFileService().createDirectoryForUser(homePath, user.getLogin());
-                logger.debug("HomeVerzeichnis angelegt");
+                logger.debug("Home directory created");
             } else {
-                logger.debug("HomeVerzeichnis existiert schon");
+                logger.debug("Home directory already exists");
             }
         } else {
             Helper.setMessage("ldapIsReadOnly");
@@ -427,7 +427,7 @@ public class LdapServerService extends BaseBeanService<LdapServer, LdapServerDAO
                 ctx.close();
                 return true;
             } catch (NamingException e) {
-                logger.debug("Benutzeranmeldung nicht korrekt oder Passwortänderung nicht möglich", e);
+                logger.debug("User login not correct or password change not possible", e);
                 return false;
             }
         }


### PR DESCRIPTION
Some log messages were hardcoded in German, or resolved through the message resource bundle in the user's UI language. This led to a mix of languages in the log file, which complicates monitoring. As discussed in kitodo/kitodo-production#6846, all log messages are now written in English.

- Replace five German log messages in LdapServerService with English
- Replace Helper.getTranslation(ERROR_EXPORT, ...) log calls in ExportDms with a static English message
- Replace non-ASCII characters in log messages (FilterService, ImageManagement)

Assisted-by: OpenCode / qwen3.8-27b-thinking (Alibaba Cloud)