### PR TITLE
Update h2 database to 2.3.232

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <tomcat.baseversion>10</tomcat.baseversion>
         <tomcat.version>10.1.46</tomcat.version>
         <awaitility.version>4.0.3</awaitility.version>
-        <com.h2database.h2.version>2.2.224</com.h2database.h2.version>
+        <com.h2database.h2.version>2.3.232</com.h2database.h2.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-io.version>2.22.0</commons-io.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>


### PR DESCRIPTION
Update h2 database used in tests to release `2.3.232`. 

Updating to latest release `2.4.240` is currently not possible as this version throws `CONSTRAINT` error which are not always reproducible regarding the selenium test class but every time on `Mockbase.insertProject` (line 1004) method call.