### PR TITLE
Handle 'IllegalArgumentException' when opening ruleset with missing ruleset file

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/RulesetEditView.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/RulesetEditView.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.PhaseId;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Named;
 
@@ -56,7 +58,7 @@ public class RulesetEditView extends ValidatableForm {
     private static final String AT_MARK = "@";
 
     /**
-     * Initialize Rulset form.
+     * Initialize Ruleset form.
      */
     public RulesetEditView() {
         super();
@@ -148,6 +150,9 @@ public class RulesetEditView extends ValidatableForm {
         if (Objects.nonNull(id) && !Objects.equals(id, 0)) {
             try {
                 this.ruleset = ServiceManager.getRulesetService().getById(id);
+                if (!hasValidRulesetFilePath(this.ruleset, ConfigCore.getParameter(ParameterCore.DIR_RULESETS))) {
+                    Helper.setErrorMessage("rulesetNotFound", new Object[] {this.ruleset.getFile()});
+                }
             } catch (DAOException e) {
                 Helper.setErrorMessage(ERROR_LOADING_ONE, new Object[] {ObjectType.RULESET.getTranslationSingular(), id }, logger, e);
             }
@@ -188,12 +193,21 @@ public class RulesetEditView extends ValidatableForm {
      * @return collection of strings containing metadata keys
      */
     public Collection<String> getFunctionalMetadataKeys(FunctionalMetadata functionalMetadata) {
+        // validate ruleset file against ruleset.xsd before trying to load functional metadata keys
         try {
+            ServiceManager.getFileStructureValidationService().validateRuleset(this.ruleset);
             return RulesetService.getFunctionalMetadataKeys(ruleset, functionalMetadata);
-        } catch (IOException e) {
-            Helper.setErrorMessage(e.getLocalizedMessage());
-            return new ArrayList<>();
+        } catch (FileStructureValidationException e) {
+            setValidationErrorTitle(Helper.getTranslation("validation.invalidRuleset"));
+            showValidationExceptionDialog(e, null);
+        } catch (IOException | IllegalArgumentException | SAXException e) {
+            logger.error(e.getLocalizedMessage());
+            FacesContext facesContext = FacesContext.getCurrentInstance();
+            if (Objects.nonNull(facesContext) && PhaseId.UPDATE_MODEL_VALUES.equals(facesContext.getCurrentPhaseId())) {
+                Helper.setErrorMessage(e.getLocalizedMessage());
+            }
         }
+        return new ArrayList<>();
     }
 
     /**

--- a/Kitodo/src/main/webapp/pages/rulesetEdit.xhtml
+++ b/Kitodo/src/main/webapp/pages/rulesetEdit.xhtml
@@ -152,7 +152,7 @@
 
     <ui:define name="dialog">
         <ui:include src="/WEB-INF/templates/includes/validationErrorsDialog.xhtml">
-            <ui:param name="validatableForm" value="#{RulesetForm}"/>
+            <ui:param name="validatableForm" value="#{RulesetEditView}"/>
         </ui:include>
     </ui:define>
 


### PR DESCRIPTION
Fixes #7207 by catching the `IllegalArgumentException` and displaying the error message in the corresponding message component.  

<img width="1495" height="275" alt="Bildschirmfoto 2026-08-27 um 16 31 54" src="https://github.com/user-attachments/assets/1edf37e4-2833-4231-a109-eb6b452f7e27" />

Since said `error-messages` component is only available to display error messages _after_ the  `RENDER_RESPONSE` is finished, we need to check for the correct JSF lifecycle phase before setting the error message with the `Helper.setErrorMessage` method.

Distinguishing between these cases is necessary because `IOException`s can occur
1. when the page is initially loaded with a specific ruleset file (`RENDER_RESPONSE` phase is **not** yet finished)
2. when selecting a different file from the list of available ruleset files (`RENDER_RESPONSE` phase **is** finished)

_Note:_ I will open backports of this fix for Kitodo `4.0.x` once this pull request is approved (no fix required for `3.9.x` since the bug does not occur there: the problem was originally caused by loading and displaying functional metadata in the ruleset edit page, which is not available in Kitodo `3.9.x`)