### PR TITLE
Add log message before and after each selenium test execution

### DIFF
--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
@@ -22,7 +22,10 @@ import org.hibernate.Session;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.kitodo.ExecutionPermission;
 import org.kitodo.FileLoader;
 import org.kitodo.MockDatabase;
@@ -88,6 +91,20 @@ public class BaseTestSelenium {
         MockDatabase.stopNode();
         MockDatabase.stopDatabaseServer();
         MockDatabase.cleanDatabase();
+    }
+
+    @BeforeEach
+    public void debugLogBefore(TestInfo testInfo) {
+        String className = testInfo.getTestClass().get().getSimpleName();
+        String methodName = testInfo.getTestMethod().get().getName();
+        logger.debug("execute test: {}#{}", className, methodName);
+    }
+
+    @AfterEach
+    public void debugLogAfter(TestInfo testInfo) {
+        String className = testInfo.getTestClass().get().getSimpleName();
+        String methodName = testInfo.getTestMethod().get().getName();
+        logger.debug("finished test: {}#{}", className, methodName);
     }
 
     protected void pollAssertTrue(Callable<Boolean> conditionEvaluator) {


### PR DESCRIPTION
This PR adds "start" and "end" log statements to each selenium test execution, such that it is easier to see which exact selenium test case is executed in the logs.

```diff
...
[INFO] [DEBUG] 2026-08-26 14:17:32.126 [http-nio-8080-exec-9] CustomHttpSessionListener - Session expired: E0D75C46DCC52DA41C425B92D03779D9
[INFO] [DEBUG] 2026-08-26 14:17:32.129 [http-nio-8080-exec-7] CustomHttpSessionListener - Session created: 0EFBFBB1D7A0A5DC9AFB73EE58DDA2BC
[INFO] [INFO ] 2026-08-26 14:17:32.135 [Thread-7848] ServerConnectionChecker - Search server found: Connection established to http://localhost:9205
+ [DEBUG] 2026-08-26 14:17:32.179 [main] BaseTestSelenium - finished test: RemovingST#removeRoleTest
+ [DEBUG] 2026-08-26 14:17:32.180 [main] BaseTestSelenium - execute test: RemovingST#removeUserTest
[INFO] [DEBUG] 2026-08-26 14:17:32.875 [http-nio-8080-exec-1] BaseDAO - from User where ldapLogin = 'kowal' or login = 'kowal'
[INFO] [DEBUG] 2026-08-26 14:17:32.876 [http-nio-8080-exec-1] BaseDAO - from User where ldapLogin = 'kowal' or login = 'kowal'
[INFO] [DEBUG] 2026-08-26 14:17:32.880 [http-nio-8080-exec-1] BaseDAO - SELECT COUNT(*) FROM Process AS process
...
```