### PR TITLE
Bump actions/setup-java from 5 to 6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
 
 
     - name: set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         run:
             mysql -u root -proot kitodo < $GITHUB_WORKSPACE/Kitodo/setup/default.sql
       - name: set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
The new release was published a few days ago, see https://github.com/actions/setup-java/releases/tag/v6.0.0.