### PR TITLE
Avoid replacing process entity in metadata editor on save

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -593,8 +593,8 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
             try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
                 ServiceManager.getMetsService().save(workpiece, out);
                 // Force reload of the process to ensure consistency
-                process = ServiceManager.getProcessService().getById(process.getId());
-                ServiceManager.getProcessService().updateAmountOfInternalMetaInformation(process, true);
+                Process freshProcess = ServiceManager.getProcessService().getById(process.getId());
+                ServiceManager.getProcessService().updateAmountOfInternalMetaInformation(freshProcess, true);
                 unsavedUploadedMedia.clear();
                 deleteUnsavedDeletedMedia();
                 if (close) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -588,12 +588,12 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
             structurePanel.preserve();
             // reset "image filename renaming map" so nothing is reverted after saving!
             filenameMapping = new DualHashBidiMap<>();
-            ServiceManager.getProcessService().updateChildrenFromLogicalStructure(process, workpiece.getLogicalStructure());
+            // Force reload of the process to ensure consistency
+            Process freshProcess = ServiceManager.getProcessService().getById(process.getId());
+            ServiceManager.getProcessService().updateChildrenFromLogicalStructure(freshProcess, workpiece.getLogicalStructure());
             ServiceManager.getFileService().createBackupFile(process);
             try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
                 ServiceManager.getMetsService().save(workpiece, out);
-                // Force reload of the process to ensure consistency
-                Process freshProcess = ServiceManager.getProcessService().getById(process.getId());
                 ServiceManager.getProcessService().updateAmountOfInternalMetaInformation(freshProcess, true);
                 unsavedUploadedMedia.clear();
                 deleteUnsavedDeletedMedia();


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-production/issues/7226

As illustrated by example in the issue, the metadata editor might throw `LazyInitializationException`s during certain interactions after saving. The reason is, that we right now replace the process hold by the `viewscoped` bean on save which then leads to a `Process` with uninitialized lazy associations.
On the other hand a fresh process is needed when saving the `Process` entity to reflect changes in e.g the `Comment` entity, which might get changed independent of the process. (E.g.: Delete a comment and afterwards save in the editor). I therfor changed the code to retrieve a new `Process` instance for persistence but do not replace the `Process` instance held by the view-scoped metadata editor. 