### PR TITLE
Generate selenium screenshots if tests fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,5 +67,11 @@ jobs:
       - name: run build
         run:
             mvn clean install -B '-Pall-tests,flyway,checkstyle,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
-
-
+      # upload selenium screenshots as downloadable artifact only if pipeline failed
+      - name: upload selenium screenshots
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: selenium-screenshots
+          path: $GITHUB_WORKSPACE/Kitodo/target/selenium-screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,5 +79,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: selenium-screenshots
-          path: $GITHUB_WORKSPACE/Kitodo/target/selenium-screenshots
+          path: ${{ github.workspace }}/Kitodo/target/selenium-screenshots
           if-no-files-found: ignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,12 @@ jobs:
       - name: run build
         run:
             mvn clean install -B '-Pall-tests,flyway,checkstyle,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
+      - name: list target directory
+        if: always()
+        run: ls -la $GITHUB_WORKSPACE/Kitodo/target
+      - name: list selenium screenshot directory
+        if: always()
+        run: ls -la $GITHUB_WORKSPACE/Kitodo/target/selenium-screenshots
       # upload selenium screenshots as downloadable artifact only if pipeline failed
       - name: upload selenium screenshots
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,12 +67,6 @@ jobs:
       - name: run build
         run:
             mvn clean install -B '-Pall-tests,flyway,checkstyle,!development' && xvfb-run --server-args="-screen 0 1600x1280x24" mvn clean install -B '-Pselenium,!development'
-      - name: list target directory
-        if: always()
-        run: ls -la $GITHUB_WORKSPACE/Kitodo/target
-      - name: list selenium screenshot directory
-        if: always()
-        run: ls -la $GITHUB_WORKSPACE/Kitodo/target/selenium-screenshots
       # upload selenium screenshots as downloadable artifact only if pipeline failed
       - name: upload selenium screenshots
         if: failure()

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/BaseTestSelenium.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.kitodo.ExecutionPermission;
 import org.kitodo.FileLoader;
 import org.kitodo.MockDatabase;
@@ -33,9 +34,11 @@ import org.kitodo.config.ConfigCore;
 import org.kitodo.config.enums.ParameterCore;
 import org.kitodo.data.database.beans.Process;
 import org.kitodo.data.database.persistence.HibernateUtil;
+import org.kitodo.selenium.testframework.helper.ScreenshotTestWatcher;
 
 import static org.awaitility.Awaitility.await;
 
+@ExtendWith(ScreenshotTestWatcher.class)
 public class BaseTestSelenium {
 
     private static final Logger logger = LogManager.getLogger(BaseTestSelenium.class);

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Junit TestWatcher implementation that monitors failed tests and generates a screenshot of the current browser window.
+ * JUnit TestWatcher implementation that monitors failed tests and generates a screenshot of the current browser window.
  */
 public class ScreenshotTestWatcher implements TestWatcher {
 

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
@@ -26,6 +26,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Junit TestWatcher implementation that monitors failed tests and generates a screenshot of the current browser window.
+ */
 public class ScreenshotTestWatcher implements TestWatcher {
 
     private static final Logger logger = LogManager.getLogger(ScreenshotTestWatcher.class);
@@ -35,6 +38,9 @@ public class ScreenshotTestWatcher implements TestWatcher {
         "target/selenium-screenshots"
     );
     
+    /**
+     * Is executed when a test case fails and saves a screenshot of the current browser window.
+     */
     public void testFailed(ExtensionContext context, @Nullable Throwable cause) {
         WebDriver driver = Browser.getDriver();
         if (!(driver instanceof TakesScreenshot)) {
@@ -42,22 +48,22 @@ public class ScreenshotTestWatcher implements TestWatcher {
             return;
         }
 
+        String className = context.getRequiredTestClass().getSimpleName();
+        String methodName = context.getTestMethod()
+                .map(method -> method.getName())
+                .orElse("unknown");
+
+        Path directory = Path.of(SCREENSHOT_DIRECTORY).toAbsolutePath().normalize();
+        Path filepath = directory.resolve(String.format("%s-%s-%d.png", className, methodName, System.currentTimeMillis()));
+
+        logger.debug("generating selenium screenshot at {} for failed test case {}#{}", filepath, className, methodName);
+        byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);       
+
         try {
-            byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
-
-            Path directory = Path.of(SCREENSHOT_DIRECTORY).toAbsolutePath().normalize();
             Files.createDirectories(directory);
-
-            String className = context.getRequiredTestClass().getSimpleName();
-            String methodName = context.getTestMethod()
-                    .map(method -> method.getName())
-                    .orElse("unknown");
-
-            Path filepath = directory.resolve(String.format("%s-%s-%d.png", className, methodName, System.currentTimeMillis()));
-            logger.debug("writing selenium screenshot to {}", filepath);
             Files.write(filepath, screenshot);
         } catch (IOException e) {
-            logger.error("error generating screenshot after test failure", e);
+            logger.error("error saving screenshot after test failure", e);
         }
 	}
 }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
@@ -41,6 +41,7 @@ public class ScreenshotTestWatcher implements TestWatcher {
     /**
      * Is executed when a test case fails and saves a screenshot of the current browser window.
      */
+    @Override
     public void testFailed(ExtensionContext context, @Nullable Throwable cause) {
         WebDriver driver = Browser.getDriver();
         if (!(driver instanceof TakesScreenshot)) {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * GPL3-License.txt file that was distributed with this source code.
+ */
+
+package org.kitodo.selenium.testframework.helper;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.kitodo.selenium.testframework.Browser;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.Nullable;
+
+public class ScreenshotTestWatcher implements TestWatcher {
+
+    private static final Logger logger = LogManager.getLogger(ScreenshotTestWatcher.class);
+
+    public static final String SCREENSHOT_DIRECTORY = System.getenv().getOrDefault(
+        "SELENIUM_SCREENSHOT_DIRECTORY", 
+        "target/selenium-screenshots"
+    );
+    
+    public void testFailed(ExtensionContext context, @Nullable Throwable cause) {
+        WebDriver driver = Browser.getDriver();
+        if (!(driver instanceof TakesScreenshot)) {
+            logger.warn("cannot take screenshot with driver that doesn't support screenshots: {}", driver);
+            return;
+        }
+
+        try {
+            byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+
+            Path directory = Path.of(SCREENSHOT_DIRECTORY).toAbsolutePath().normalize();
+            Files.createDirectories(directory);
+
+            String className = context.getRequiredTestClass().getSimpleName();
+            String methodName = context.getTestMethod()
+                    .map(method -> method.getName())
+                    .orElse("unknown");
+
+            String fileName = String.format("%s-%s-%d.png", className, methodName, System.currentTimeMillis());
+            Files.write(directory.resolve(fileName), screenshot);
+        } catch (IOException e) {
+            logger.error("error generating screenshot after test failure", e);
+        }
+	}
+}

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
@@ -40,6 +40,9 @@ public class ScreenshotTestWatcher implements TestWatcher {
     
     /**
      * Is executed when a test case fails and saves a screenshot of the current browser window.
+     * 
+     * @param context the current extension context
+	 * @param cause the throwable that caused test failure
      */
     @Override
     public void testFailed(ExtensionContext context, @Nullable Throwable cause) {

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
@@ -53,8 +53,9 @@ public class ScreenshotTestWatcher implements TestWatcher {
                     .map(method -> method.getName())
                     .orElse("unknown");
 
-            String fileName = String.format("%s-%s-%d.png", className, methodName, System.currentTimeMillis());
-            Files.write(directory.resolve(fileName), screenshot);
+            Path filepath = directory.resolve(String.format("%s-%s-%d.png", className, methodName, System.currentTimeMillis()));
+            logger.debug("writing selenium screenshot to {}", filepath);
+            Files.write(filepath, screenshot);
         } catch (IOException e) {
             logger.error("error generating screenshot after test failure", e);
         }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/helper/ScreenshotTestWatcher.java
@@ -19,12 +19,12 @@ import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jspecify.annotations.Nullable;
 
 /**
  * JUnit TestWatcher implementation that monitors failed tests and generates a screenshot of the current browser window.
@@ -45,7 +45,7 @@ public class ScreenshotTestWatcher implements TestWatcher {
 	 * @param cause the throwable that caused test failure
      */
     @Override
-    public void testFailed(ExtensionContext context, @Nullable Throwable cause) {
+    public void testFailed(ExtensionContext context, Throwable cause) {
         WebDriver driver = Browser.getDriver();
         if (!(driver instanceof TakesScreenshot)) {
             logger.warn("cannot take screenshot with driver that doesn't support screenshots: {}", driver);
@@ -54,7 +54,7 @@ public class ScreenshotTestWatcher implements TestWatcher {
 
         String className = context.getRequiredTestClass().getSimpleName();
         String methodName = context.getTestMethod()
-                .map(method -> method.getName())
+                .map(Method::getName)
                 .orElse("unknown");
 
         Path directory = Path.of(SCREENSHOT_DIRECTORY).toAbsolutePath().normalize();


### PR DESCRIPTION
This PR generates a screenshot of the current browser window in the directory `Kitodo/target/selenium-screenshots` for every selenium test that failed. Hopefully, this will help to better understand why certain tests fail sometimes. 

Keep in mind that a screenshot might not truly represent what happened in a specific error scenario because of timing problems. Maybe the browser was still loading at the the time of the error, but was fully loaded at the time of the screenshot. Hopefully, it still provides some additional insight.

Screenshots are also stored as a downloadable build artifact for failed GitHub CI workflows (only if there are any failed tests).