### PR TITLE
[3.9] Update 'mariadb-java-client' to latest bugfix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <flyway-maven-plugin.version>9.22.3</flyway-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.3.0</spotbugs-maven-plugin.version>
         <pitest.version>1.4.10</pitest.version>
-        <mariadb-java-client.version>2.7.12</mariadb-java-client.version>
+        <mariadb-java-client.version>2.7.15</mariadb-java-client.version>
         <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
     </properties>
 


### PR DESCRIPTION
Update artifact `mariadb-java-client` to latest bugfix version `2.7.15`, that resolves some vulnerabilities ([CVE-2026-55858](https://www.cve.org/CVERecord?id=CVE-2026-55858), [CVE-2026-55857](https://www.cve.org/CVERecord?id=CVE-2026-55857) and [CVE-2026-55856](https://www.cve.org/CVERecord?id=CVE-2026-55856))

_Note:_ contrary to the corresponding pull requests for `main` and the `4.0.x` branches, (#7219 and #7228 respectively), this change updates to the latest bugfix of major version 2.x instead of upgrading to 3.x of `mariadb-java-client` because the later's compatibility with Kitodo 3.9 is not guaranteed, while the CVEs are resolved in `2.7.15`, too.