### PR TITLE
[4.0] Avoid replacing process entity in metadata editor on save- #7227

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -593,8 +593,8 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
             try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
                 ServiceManager.getMetsService().save(workpiece, out);
                 // Force reload of the process to ensure consistency
-                process = ServiceManager.getProcessService().getById(process.getId());
-                ServiceManager.getProcessService().updateAmountOfInternalMetaInformation(process, true);
+                Process freshProcess = ServiceManager.getProcessService().getById(process.getId());
+                ServiceManager.getProcessService().updateAmountOfInternalMetaInformation(freshProcess, true);
                 unsavedUploadedMedia.clear();
                 deleteUnsavedDeletedMedia();
                 if (close) {

--- a/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
+++ b/Kitodo/src/main/java/org/kitodo/production/forms/dataeditor/DataEditorForm.java
@@ -588,12 +588,12 @@ public class DataEditorForm extends ValidatableForm implements MetadataTreeTable
             structurePanel.preserve();
             // reset "image filename renaming map" so nothing is reverted after saving!
             filenameMapping = new DualHashBidiMap<>();
-            ServiceManager.getProcessService().updateChildrenFromLogicalStructure(process, workpiece.getLogicalStructure());
+            // Force reload of the process to ensure consistency
+            Process freshProcess = ServiceManager.getProcessService().getById(process.getId());
+            ServiceManager.getProcessService().updateChildrenFromLogicalStructure(freshProcess, workpiece.getLogicalStructure());
             ServiceManager.getFileService().createBackupFile(process);
             try (OutputStream out = ServiceManager.getFileService().write(mainFileUri)) {
                 ServiceManager.getMetsService().save(workpiece, out);
-                // Force reload of the process to ensure consistency
-                Process freshProcess = ServiceManager.getProcessService().getById(process.getId());
                 ServiceManager.getProcessService().updateAmountOfInternalMetaInformation(freshProcess, true);
                 unsavedUploadedMedia.clear();
                 deleteUnsavedDeletedMedia();


### PR DESCRIPTION
Backport of https://github.com/kitodo/kitodo-production/pull/7227