### PR TITLE
Fix selenium tests are sometimes redirected to indexing page

### DIFF
--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -201,7 +201,11 @@ public class IndexingService {
         BeanQuery beanQuery = new BeanQuery(Process.class);
         Long totalCount = ServiceManager.getProcessService().count(beanQuery.formCountQuery(), beanQuery
                 .getQueryParameters());
-        return totalCount != getAllIndexed();
+        Long indexedCount = getAllIndexed();
+        if (totalCount != indexedCount) {
+            logger.warn("index is considered corrupted with {} of {} processes indexed", indexedCount, totalCount);
+        }
+        return totalCount != indexedCount;
     }
 
     /**

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -203,7 +203,7 @@ public class IndexingService {
                 .getQueryParameters());
         long indexedCount = getAllIndexed();
         if (totalCount != indexedCount) {
-            logger.warn("index is considered corrupted with {} of {} processes indexed", indexedCount, totalCount);
+            logger.warn("Index is considered corrupted with {} of {} processes indexed", indexedCount, totalCount);
         }
         return totalCount != indexedCount;
     }

--- a/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
+++ b/Kitodo/src/main/java/org/kitodo/production/services/index/IndexingService.java
@@ -201,7 +201,7 @@ public class IndexingService {
         BeanQuery beanQuery = new BeanQuery(Process.class);
         Long totalCount = ServiceManager.getProcessService().count(beanQuery.formCountQuery(), beanQuery
                 .getQueryParameters());
-        Long indexedCount = getAllIndexed();
+        long indexedCount = getAllIndexed();
         if (totalCount != indexedCount) {
             logger.warn("index is considered corrupted with {} of {} processes indexed", indexedCount, totalCount);
         }

--- a/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/LoginPage.java
+++ b/Kitodo/src/test/java/org/kitodo/selenium/testframework/pages/LoginPage.java
@@ -11,6 +11,10 @@
 
 package org.kitodo.selenium.testframework.pages;
 
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.TimeUnit;
+
 import org.kitodo.data.database.beans.User;
 import org.kitodo.data.database.exceptions.DAOException;
 import org.kitodo.production.security.password.SecurityPasswordEncoder;
@@ -49,6 +53,10 @@ public class LoginPage extends Page<LoginPage> {
     }
 
     public void performLogin(User user) throws InterruptedException {
+        // wait until all processes that were added during database initialization are indexed
+        await().ignoreExceptions().pollInterval(100, TimeUnit.MILLISECONDS).atMost(5, TimeUnit.SECONDS)
+            .until(() -> !ServiceManager.getIndexingService().isIndexCorrupted());
+
         SecurityPasswordEncoder passwordEncoder = new SecurityPasswordEncoder();
         String password = passwordEncoder.decrypt(user.getPassword());
 


### PR DESCRIPTION
Some of the CI selenium test failures seem to be caused by a redirection to the indexing page upon login of a user. Redirection to the indexing page happens if  `IndexingService.isIndexCorrupted()` is considered true. I added a corresponding warning log message to verify this problem:

```
2026-09-08T19:16:14.0118160Z [DEBUG] 2026-09-08 19:16:13.960 [main] BaseTestSelenium - execute test: ImportingST#checkOptionalMetadataValidationDuringProcessCreation
2026-09-08T19:16:14.2118457Z [DEBUG] 2026-09-08 19:16:14.141 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:14.2119577Z [WARN ] 2026-09-08 19:16:14.146 [awaitility-thread] IndexingService - index is considered corrupted with 11 of 12 processes indexed
2026-09-08T19:16:14.3118106Z [DEBUG] 2026-09-08 19:16:14.247 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:14.3118926Z [WARN ] 2026-09-08 19:16:14.250 [awaitility-thread] IndexingService - index is considered corrupted with 11 of 12 processes indexed
2026-09-08T19:16:14.4119604Z [DEBUG] 2026-09-08 19:16:14.350 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:14.4120715Z [WARN ] 2026-09-08 19:16:14.353 [awaitility-thread] IndexingService - index is considered corrupted with 11 of 12 processes indexed
2026-09-08T19:16:14.5120900Z [DEBUG] 2026-09-08 19:16:14.454 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:14.5121982Z [WARN ] 2026-09-08 19:16:14.457 [awaitility-thread] IndexingService - index is considered corrupted with 11 of 12 processes indexed
2026-09-08T19:16:14.6122409Z [DEBUG] 2026-09-08 19:16:14.557 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:14.6124065Z [WARN ] 2026-09-08 19:16:14.560 [awaitility-thread] IndexingService - index is considered corrupted with 11 of 12 processes indexed
2026-09-08T19:16:14.7123025Z [DEBUG] 2026-09-08 19:16:14.661 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:14.7124165Z [WARN ] 2026-09-08 19:16:14.664 [awaitility-thread] IndexingService - index is considered corrupted with 11 of 12 processes indexed
2026-09-08T19:16:14.8124633Z [DEBUG] 2026-09-08 19:16:14.764 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:14.8125452Z [WARN ] 2026-09-08 19:16:14.769 [awaitility-thread] IndexingService - index is considered corrupted with 11 of 12 processes indexed
2026-09-08T19:16:14.9125787Z [DEBUG] 2026-09-08 19:16:14.869 [awaitility-thread] BaseDAO - SELECT COUNT(*) FROM Process AS process
2026-09-08T19:16:15.5461769Z [INFO] [DEBUG] 2026-09-08 19:16:15.545 [http-nio-8080-exec-9] BaseDAO - from User where ldapLogin = 'kowal' or login = 'kowal'
2026-09-08T19:16:15.5478332Z [INFO] [DEBUG] 2026-09-08 19:16:15.547 [http-nio-8080-exec-9] BaseDAO - from User where ldapLogin = 'kowal' or login = 'kowal'
```

My understanding of this problem is that for each selenium test class, various process entities are created and saved and indexed via `ProcessService.save(process)`. In some test classes (e.g. `MetadataImagePreviewST`) processes are created very late in the initialization procedure (`@BeforeAll` methods). Meaning, there is little time between the process creation and the user login attempt (and checking for `isIndexCorrupted()`). When saving a process, the generated document is submitted to OpenSearch/ElasticSearch. However, this doesn't mean that this process is immediately available in the index. Meaning, the total count of indexed processes might not match the total amount of processes in the database, which is what is checked by `isIndexCorrupted()`.

Waiting for `isIndexCorrupted() = false` before logging in should improve this situation.